### PR TITLE
build: ignore clang-format changes in git history

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+#clang-format & other pre-commit checks
+7e81cb9587bc68598ed07f2d3c2eeeaa1947bb84


### PR DESCRIPTION
After #18 got merge, git blame shows me as the author on half of the lines. This PR will ignore code formatting changes and restore old history.