### PR TITLE
#18064: Guard CSRRS by disabling branch prediction

### DIFF
--- a/tt_llk_blackhole/common/inc/ckernel.h
+++ b/tt_llk_blackhole/common/inc/ckernel.h
@@ -589,9 +589,15 @@ inline void disable_gathering() {
     // Disable gathering: set bit 18
     asm(R"ASM(
         .option push
+        li   t1, 0x2
+        csrrs zero, 0x7c0, t1
         li   t1, 0x1
         slli t1, t1, 18
+        fence
         csrrs zero, 0x7c0, t1
+        li   t1, 0x2
+        csrrc zero, 0x7c0, t1
+        fence
         .option pop
          )ASM"
     :::"t1");


### PR DESCRIPTION
Due to a HW bug in CSR writes, we need to guard them by first disabling branch prediction, and then re-enabling it. This is a workaround for https://github.com/tenstorrent/tt-metal/issues/18064#issuecomment-2685621251 and is proposed as a fix by the HW team.