### PR TITLE
SFPIADD doesn't take two cycles.

### DIFF
--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_add_int32.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_add_int32.h
@@ -51,8 +51,6 @@ inline void _add_int32_(const uint dst_offset)
         }
 
         TTI_SFPIADD(0 /*imm*/, 1 /*lreg_c*/, 0 /*lreg_dest*/, 4 /*imod*/);
-        // MAD has a 2-cycle pipeline latency so we need one cycle latency until next instr can consume the result
-        TTI_NOP;
 
         // LREG_0 -> dest as int32
         if constexpr (SIGN_MAGNITUDE_FORMAT)

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_sub_int32.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_sub_int32.h
@@ -52,8 +52,6 @@ inline void _sub_int32_(const uint dst_offset)
 
         // Set instruction modifier to 6 to get B's 2's complement
         TTI_SFPIADD(0 /*imm*/, 1 /*lreg_c*/, 0 /*lreg_dest*/, 6 /*imod*/);
-        // MAD has a 2-cycle pipeline latency so we need one cycle latency until next instr can consume the result
-        TTI_NOP;
 
         // LREG_0 -> dest as int32
         if constexpr (SIGN_MAGNITUDE_FORMAT)

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_add_int32.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_add_int32.h
@@ -34,8 +34,6 @@ inline void _add_int32_(const uint dst_offset)
         // operand B - int32
         TT_SFPLOAD(1, sfpload_instr_mod, 3, dst_offset * 64);
         TTI_SFPIADD(0, 1, 0, 4);
-        // MAD has a 2-cycle pipeline latency so we need one cycle latency until next instr can consume the result
-        TTI_NOP;
         // LREG_0 -> dest as int32
         TTI_SFPSTORE(0, sfpload_instr_mod, 3, 0);
         dst_reg++;

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_sub_int32.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_sub_int32.h
@@ -35,8 +35,6 @@ inline void _sub_int32_(const uint dst_offset)
         TT_SFPLOAD(0 /*lreg*/, sfpload_instr_mod, 3 /*addr_mode*/, dst_offset * 64 /*dest*/);
         // Use 6 as imod to convert operand B to 2's complement
         TTI_SFPIADD(0 /*imm*/, 1 /*lreg*/, 0 /*ldest*/, 6 /*imod*/);
-        // MAD has a 2-cycle pipeline latency so we need one cycle latency until next instr can consume the result
-        TTI_NOP;
         // LREG_0 -> dest as int32
         TTI_SFPSTORE(0 /*lreg_ind*/, sfpload_instr_mod, 3 /*addr_mode*/, 0 /*dest*/);
         dst_reg++;


### PR DESCRIPTION
I don't have access to any documentation for this instruction, but from my own testing I don't think two cycles are used.  Probably confusion with SFPMAD?