### PR TITLE
fix: disable failing python tests

### DIFF
--- a/tests/python_tests/test_eltwise_unary_datacopy.py
+++ b/tests/python_tests/test_eltwise_unary_datacopy.py
@@ -29,13 +29,16 @@ param_ids = [
 
 def test_unary_datacopy(format, testname, dest_acc):
 
+    if (format == "Float16" and dest_acc == "DEST_ACC"):
+        pytest.skip(reason = "This combination is not fully implemented in testing")
+
+    if( format in ["Float32", "Int32"] and dest_acc!="DEST_ACC"):
+        pytest.skip(reason = "Skipping test for 32 bit wide data without 32 bit accumulation in Dest")
+
     src_A,src_B = generate_stimuli(format)
     srcB = torch.full((1024,), 0)
     golden = generate_golden(src_A,format)
     write_stimuli_to_l1(src_A, src_B, format)
-
-    if( format in ["Float32", "Int32"] and dest_acc!="DEST_ACC"):
-        pytest.skip("SKipping test for 32 bit wide data without 32 bit accumulation in Dest")
 
     test_config = {
         "input_format": format,

--- a/tests/python_tests/test_eltwise_unary_datacopy.py
+++ b/tests/python_tests/test_eltwise_unary_datacopy.py
@@ -32,7 +32,7 @@ def test_unary_datacopy(format, testname, dest_acc):
     if (format == "Float16" and dest_acc == "DEST_ACC"):
         pytest.skip(reason = "This combination is not fully implemented in testing")
 
-    if( format in ["Float32", "Int32"] and dest_acc!="DEST_ACC"):
+    if(format in ["Float32", "Int32"] and dest_acc!="DEST_ACC"):
         pytest.skip(reason = "Skipping test for 32 bit wide data without 32 bit accumulation in Dest")
 
     src_A,src_B = generate_stimuli(format)

--- a/tests/python_tests/test_eltwise_unary_sfpu.py
+++ b/tests/python_tests/test_eltwise_unary_sfpu.py
@@ -41,7 +41,10 @@ param_ids = [
 def test_eltwise_unary_sfpu(format, mathop, testname, dest_acc, approx_mode):
 
     if( format in ["Float32", "Int32"] and dest_acc!="DEST_ACC"):
-        pytest.skip("SKipping test for 32 bit wide data without 32 bit accumulation in Dest")
+        pytest.skip(reason = "Skipping test for 32 bit wide data without 32 bit accumulation in Dest")
+
+    if (format == "Float16" and dest_acc == "DEST_ACC"):
+        pytest.skip(reason = "This combination is not fully implemented in testing")
 
     src_A,src_B = generate_stimuli(format,sfpu = True)
     golden = generate_golden(mathop, src_A, format)

--- a/tests/python_tests/test_fill_dest.py
+++ b/tests/python_tests/test_fill_dest.py
@@ -49,6 +49,9 @@ param_ids = [
 
 def test_fill_dest(format, testname, dest_acc):
 
+    if (format == "Float16" and dest_acc == "DEST_ACC"):
+        pytest.skip(reason = "This combination is not fully implemented in testing")
+
     pack_start_address = 0x1c000
     pack_addresses = [pack_start_address + 0x1000 * i for i in range(16)]
 

--- a/tests/python_tests/test_multiple_tiles_eltwise.py
+++ b/tests/python_tests/test_multiple_tiles_eltwise.py
@@ -58,6 +58,9 @@ param_ids = [
 )
 def test_multiple_tiles(format, testname, tile_cnt, mathop, dest_acc, math_fidelity):
 
+    if mathop in range(1, 4) and format == "Float16" and dest_acc == "DEST_ACC":
+        pytest.skip(reason = "This combination is not fully implemented in testing")
+
     # prepare setup for running kernels
 
     pack_start_address = 0x1a000 + 2*4096*tile_cnt

--- a/tests/python_tests/test_reduce.py
+++ b/tests/python_tests/test_reduce.py
@@ -76,6 +76,7 @@ param_ids = [
     ids=param_ids
 )
 
+@pytest.mark.skip(reason = "Not fully implemented")
 def test_reduce(reduce_dim, pool_type, format, testname, dest_acc):
     
     src_A, src_B = generate_stimuli(format)

--- a/tests/python_tests/test_sfpu_binary.py
+++ b/tests/python_tests/test_sfpu_binary.py
@@ -39,6 +39,7 @@ param_ids = [
     ids=param_ids
 )
 
+@pytest.mark.skip(reason = "Not fully implemented")
 def test_all(format, mathop, testname, dest_acc):
     
     src_A, src_B = generate_stimuli(format)


### PR DESCRIPTION
## Summary
As we set up new test infrastructure, we've encountered several tests that are currently failing. This PR disables these failing tests so that test runs only include those that are known to be correct and passing.

## Motivation
Running incomplete or misconfigured failing tests can create unnecessary confusion, especially for developers making unrelated changes. They might mistakenly believe their modifications introduced new failures, making debugging more difficult. By disabling these tests, we ensure that test failures are meaningful and actionable.

## Next Steps
Once the new test infrastructure is fully set up, we should revisit these disabled tests and re-enable them after proper fixes or updates.
Future work may involve categorizing or marking these tests separately for better tracking.
