### PR TITLE
chore: ignore formatting in blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,5 @@
+# clang-format and black formatting
+7e81cb9587bc68598ed07f2d3c2eeeaa1947bb84
+d72939c0844b72bb8d448b3a7aa793916372e01b
+20b90c2bfcd598d95eaa0ba45cceccd89880960d
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,3 +37,17 @@ To set up pre-commit on your local machine, follow these steps:
    ```bash
    pre-commit run --all-files
    ```
+
+### Ignoring formatting commits in git blame
+
+In order to ignore specific commits from git blame, we need to configure git to use ignore file when executing the git blame command.
+```bash
+# Set the blame.ignoreRevsFile configuration in your local git config
+git config blame.ignoreRevsFile .git-blame-ignore-revs
+```
+This command tells git to reference the specified file for commits to ignore when you run git blame. This configuration can also be set globally or system-wide by using `--global` or `--system`.
+Once you've configured git blame with the ignore-revs file, you can run git blame as you normally would:
+```bash
+git blame <file>
+```
+With the configuration set, `git blame` will skip over the commits listed in the `.git-blame-ignore-revs` file, giving you a clearer picture of who made meaningful changes to the file.


### PR DESCRIPTION
This PR adds configuration settings to ignore recent code formatting changes from git blame, giving clearer picture of who made meaningful changes to the file.