### PR TITLE
Fix: Use TT_* instruction type instead of TTI_* as the parameter is not compile time known

### DIFF
--- a/tt_llk_wormhole_b0/common/inc/cunpack_common.h
+++ b/tt_llk_wormhole_b0/common/inc/cunpack_common.h
@@ -351,8 +351,8 @@ inline void configure_unpack_AB(
     }
 
     uint unpA_x_end = (unpA_face_r_dim == 0) ? 1 : (unpA_face_r_dim << 4) - 1;
-    TTI_SETADCXX(p_setadc::UNP_A, unpA_x_end, 0x0);
-    TTI_SETADCXX(p_setadc::UNP_B, (unpB_face_r_dim << 4) - 1, 0x0);
+    TT_SETADCXX(p_setadc::UNP_A, unpA_x_end, 0x0);
+    TT_SETADCXX(p_setadc::UNP_B, (unpB_face_r_dim << 4) - 1, 0x0);
 
     // Program base address for all 2 sections (each section address is loaded to corresponding context)
     // Load dummy data to unused location if face height is 0


### PR DESCRIPTION
General rule is:

TT_* type of instruction is used when not all arguments are known at compile time.
TTI_* type of instruction is used when all argument are compile time constants.

Former is slower and more general, latter results in more optimal and faster code.

Note: Could be that using non const (non constexpr) variable in TTI_* type of instruction works in cases when compiler deduces that some variable depends only on compile time known values. But, this is unsafe to rely on.