### PR TITLE
[Blackhole] Fix undefined numbers appearing in div SFPU OP

### DIFF
--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_recip.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_recip.h
@@ -69,7 +69,14 @@ inline void _calculate_reciprocal_(const int iterations)
         }
         v_endif;
 
-        dst_reg[0] = reinterpret<vFloat>(float_to_fp16b(out, 0));
+        if constexpr (APPROXIMATION_MODE)
+        {
+            dst_reg[0] = out;
+        }
+        else
+        {
+            dst_reg[0] = reinterpret<vFloat>(float_to_fp16b(out, 0));
+        }
 
         dst_reg++;
     }

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_recip.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_recip.h
@@ -69,7 +69,7 @@ inline void _calculate_reciprocal_(const int iterations)
         }
         v_endif;
 
-        dst_reg[0] = out;
+        dst_reg[0] = reinterpret<vFloat>(float_to_fp16b(out, 0));
 
         dst_reg++;
     }


### PR DESCRIPTION
Div OP, which uses reciprocal underneath, produces unexpected numbers on Blackhole in specific situations.

Issue and fix reported in https://github.com/tenstorrent/tt-metal/issues/18496.
Investigation and fix provided by @umadevimcw in the original issue.