### PR TITLE
[Test Infra] Added Support for Independent Source Register Formats and Custom Test Combinations

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -38,7 +38,13 @@ OPTIONS_LINK=-fexceptions -Wl,-z,max-page-size=16 -Wl,-z,common-page-size=16 -no
 INCLUDES = -I../$(ARCH_LLK_ROOT)/llk_lib -I../$(ARCH_LLK_ROOT)/common/inc -I../$(ARCH_LLK_ROOT)/common/inc/sfpu -I../$(ARCH_LLK_ROOT)/hw_specific/inc
 INCLUDES += -Ifirmware/riscv/common -Ifirmware/riscv/$(CHIP_ARCH)/ -Isfpi/include -Ihelpers/include
 
-FORMAT_ARG:=-D$(unpack_src) -D$(unpack_dst) -D$(fpu) -D$(pack_src) -D$(pack_dst)
+ifeq ($(and $(unpack_B_src),$(unpack_B_dst)),)
+    FORMAT_ARG = -D$(unpack_A_src) -D$(unpack_A_dst) -D$(fpu) -D$(pack_src) -D$(pack_dst)
+else
+    FORMAT_ARG := -D$(unpack_A_src) -D$(unpack_A_dst) -D$(unpack_B_src) -D$(unpack_B_dst) -D$(fpu) -D$(pack_src) -D$(pack_dst)
+endif
+
+# FORMAT_ARG:=-D$(unpack_A_src) -D$(unpack_A_dst) -D$(unpack_B_src) -D$(unpack_B_dst) -D$(fpu) -D$(pack_src) -D$(pack_dst)
 
 ifeq ($(mathop),)
     MATHOP_ARG =

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -38,13 +38,7 @@ OPTIONS_LINK=-fexceptions -Wl,-z,max-page-size=16 -Wl,-z,common-page-size=16 -no
 INCLUDES = -I../$(ARCH_LLK_ROOT)/llk_lib -I../$(ARCH_LLK_ROOT)/common/inc -I../$(ARCH_LLK_ROOT)/common/inc/sfpu -I../$(ARCH_LLK_ROOT)/hw_specific/inc
 INCLUDES += -Ifirmware/riscv/common -Ifirmware/riscv/$(CHIP_ARCH)/ -Isfpi/include -Ihelpers/include
 
-ifeq ($(and $(unpack_B_src),$(unpack_B_dst)),)
-    FORMAT_ARG = -D$(unpack_A_src) -D$(unpack_A_dst) -D$(fpu) -D$(pack_src) -D$(pack_dst)
-else
-    FORMAT_ARG := -D$(unpack_A_src) -D$(unpack_A_dst) -D$(unpack_B_src) -D$(unpack_B_dst) -D$(fpu) -D$(pack_src) -D$(pack_dst)
-endif
-
-# FORMAT_ARG:=-D$(unpack_A_src) -D$(unpack_A_dst) -D$(unpack_B_src) -D$(unpack_B_dst) -D$(fpu) -D$(pack_src) -D$(pack_dst)
+FORMAT_ARG := -D$(unpack_A_src) -D$(unpack_A_dst) -D$(unpack_B_src) -D$(unpack_B_dst) -D$(fpu) -D$(pack_src) -D$(pack_dst)
 
 ifeq ($(mathop),)
     MATHOP_ARG =

--- a/tests/helpers/include/params.h
+++ b/tests/helpers/include/params.h
@@ -27,45 +27,84 @@ constexpr std::underlying_type_t<DataFormat> get_data_format(DataFormat format)
 }
 } // namespace
 
-#define UNPACK_SRC_CASE(data_format) constexpr auto UNPACK_IN = get_data_format(DataFormat::data_format);
+#define UNPACK_A_SRC_CASE(data_format) constexpr auto UNPACK_A_IN = get_data_format(DataFormat::data_format);
 
-#if defined(UNPACK_SRC_FLOAT16_B)
-UNPACK_SRC_CASE(Float16_b)
+#if defined(UNPACK_A_SRC_FLOAT16_B)
+UNPACK_A_SRC_CASE(Float16_b)
 #endif
-#if defined(UNPACK_SRC_FLOAT16)
-UNPACK_SRC_CASE(Float16)
+#if defined(UNPACK_A_SRC_FLOAT16)
+UNPACK_A_SRC_CASE(Float16)
 #endif
-#if defined(UNPACK_SRC_FLOAT32)
-UNPACK_SRC_CASE(Float32)
+#if defined(UNPACK_A_SRC_FLOAT32)
+UNPACK_A_SRC_CASE(Float32)
 #endif
-#if defined(UNPACK_SRC_INT32)
-UNPACK_SRC_CASE(Int32)
+#if defined(UNPACK_A_SRC_INT32)
+UNPACK_A_SRC_CASE(Int32)
 #endif
-#if defined(UNPACK_SRC_BFP8_B)
-UNPACK_SRC_CASE(Bfp8_b)
-#endif
-
-#undef UNPACK_SRC_CASE
-
-#define UNPACK_DST_CASE(data_format) constexpr auto UNPACK_OUT = get_data_format(DataFormat::data_format);
-
-#if defined(UNPACK_DST_FLOAT16_B)
-UNPACK_DST_CASE(Float16_b)
-#endif
-#if defined(UNPACK_DST_FLOAT16)
-UNPACK_DST_CASE(Float16)
-#endif
-#if defined(UNPACK_DST_FLOAT32)
-UNPACK_DST_CASE(Float32)
-#endif
-#if defined(UNPACK_DST_INT32)
-UNPACK_DST_CASE(Int32)
-#endif
-#if defined(UNPACK_DST_BFP8_B)
-UNPACK_DST_CASE(Bfp8_b)
+#if defined(UNPACK_A_SRC_BFP8_B)
+UNPACK_A_SRC_CASE(Bfp8_b)
 #endif
 
-#undef UNPACK_DST_CASE
+#undef UNPACK_A_SRC_CASE
+
+#define UNPACK_B_SRC_CASE(data_format) constexpr auto UNPACK_B_IN = get_data_format(DataFormat::data_format);
+
+#if defined(UNPACK_B_SRC_FLOAT16_B)
+UNPACK_B_SRC_CASE(Float16_b)
+#endif
+#if defined(UNPACK_B_SRC_FLOAT16)
+UNPACK_B_SRC_CASE(Float16)
+#endif
+#if defined(UNPACK_B_SRC_FLOAT32)
+UNPACK_B_SRC_CASE(Float32)
+#endif
+#if defined(UNPACK_B_SRC_INT32)
+UNPACK_B_SRC_CASE(Int32)
+#endif
+#if defined(UNPACK_B_SRC_BFP8_B)
+UNPACK_B_SRC_CASE(Bfp8_b)
+#endif
+
+#undef UNPACK_B_SRC_CASE
+
+#define UNPACK_A_DST_CASE(data_format) constexpr auto UNPACK_A_OUT = get_data_format(DataFormat::data_format);
+#if defined(UNPACK_A_DST_FLOAT16_B)
+UNPACK_A_DST_CASE(Float16_b)
+#endif
+#if defined(UNPACK_A_DST_FLOAT16)
+UNPACK_A_DST_CASE(Float16)
+#endif
+#if defined(UNPACK_A_DST_FLOAT32)
+UNPACK_A_DST_CASE(Float32)
+#endif
+#if defined(UNPACK_A_DST_INT32)
+UNPACK_A_DST_CASE(Int32)
+#endif
+#if defined(UNPACK_A_DST_BFP8_B)
+UNPACK_A_DST_CASE(Bfp8_b)
+#endif
+
+#undef UNPACK_A_DST_CASE
+
+#define UNPACK_B_DST_CASE(data_format) constexpr auto UNPACK_B_OUT = get_data_format(DataFormat::data_format);
+#if defined(UNPACK_B_DST_FLOAT16_B)
+UNPACK_B_DST_CASE(Float16_b)
+#endif
+#if defined(UNPACK_B_DST_FLOAT16)
+UNPACK_B_DST_CASE(Float16)
+#endif
+#if defined(UNPACK_B_DST_FLOAT32)
+UNPACK_B_DST_CASE(Float32)
+#endif
+#if defined(UNPACK_B_DST_INT32)
+UNPACK_B_DST_CASE(Int32)
+#endif
+#if defined(UNPACK_B_DST_BFP8_B)
+UNPACK_B_DST_CASE(Bfp8_b)
+#endif
+
+#undef UNPACK_B_DST_CASE
+
 
 #define PACK_SRC_CASE(data_format) constexpr auto PACK_IN = get_data_format(DataFormat::data_format);
 

--- a/tests/python_tests/helpers/__init__.py
+++ b/tests/python_tests/helpers/__init__.py
@@ -1,9 +1,19 @@
 # SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 # SPDX-License-Identifier: Apache-2.0
 
-from .format_config import FormatConfig, DataFormat, create_formats
+from .format_config import FormatConfig, DataFormat, create_formats_for_testing
 from .stimuli_generator import flatten_list, generate_stimuli
-from .format_arg_mapping import format_dict, format_sizes, ApproxMode, MathOperation, ReduceDimArgs, ReducePoolArgs, DestAccumulation, Fidelity, TileCount
+from .format_arg_mapping import (
+    format_dict,
+    format_sizes,
+    ApproxMode,
+    MathOperation,
+    ReduceDimArgs,
+    ReducePoolArgs,
+    DestAccumulation,
+    Fidelity,
+    TileCount,
+)
 from .pack import pack_bfp16, pack_fp16, pack_fp32, pack_int32, pack_bfp8_b
 from .unpack import (
     unpack_fp16,

--- a/tests/python_tests/helpers/__init__.py
+++ b/tests/python_tests/helpers/__init__.py
@@ -3,7 +3,7 @@
 
 from .format_config import FormatConfig, DataFormat, create_formats
 from .stimuli_generator import flatten_list, generate_stimuli
-from .format_arg_mapping import format_dict, mathop_args_dict, format_sizes
+from .format_arg_mapping import format_dict, format_sizes, ApproxMode, MathOperation, ReduceDimArgs, ReducePoolArgs, DestAccumulation, Fidelity, TileCount
 from .pack import pack_bfp16, pack_fp16, pack_fp32, pack_int32, pack_bfp8_b
 from .unpack import (
     unpack_fp16,

--- a/tests/python_tests/helpers/__init__.py
+++ b/tests/python_tests/helpers/__init__.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 # SPDX-License-Identifier: Apache-2.0
 
-from .format_config import FormatConfig, DataFormat
+from .format_config import FormatConfig, DataFormat, create_formats
 from .stimuli_generator import flatten_list, generate_stimuli
 from .format_arg_mapping import format_dict, mathop_args_dict, format_sizes
 from .pack import pack_bfp16, pack_fp16, pack_fp32, pack_int32, pack_bfp8_b

--- a/tests/python_tests/helpers/device.py
+++ b/tests/python_tests/helpers/device.py
@@ -44,7 +44,7 @@ def run_elf_files(testname, core_loc="0,0", run_brisc=True):
         run_elf(f"{ELF_LOCATION}{testname}_trisc{i}.elf", core_loc, risc_id=i + 1)
 
 
-def write_stimuli_to_l1(buffer_A, buffer_B, stimuli_format, core_loc="0,0", tile_cnt=1):
+def write_stimuli_to_l1(buffer_A, buffer_B, stimuli_A_format, stimuli_B_format, core_loc="0,0", tile_cnt=1):
 
     BUFFER_SIZE = 4096
     TILE_SIZE = 1024
@@ -71,10 +71,11 @@ def write_stimuli_to_l1(buffer_A, buffer_B, stimuli_format, core_loc="0,0", tile
             DataFormat.Int32: pack_int32,
         }
 
-        pack_function = packers.get(stimuli_format)
+        pack_function_A = packers.get(stimuli_A_format)
+        pack_function_B = packers.get(stimuli_B_format)
 
-        write_to_device(core_loc, buffer_A_address, pack_function(buffer_A_tile))
-        write_to_device(core_loc, buffer_B_address, pack_function(buffer_B_tile))
+        write_to_device(core_loc, buffer_A_address, pack_function_A(buffer_A_tile))
+        write_to_device(core_loc, buffer_B_address, pack_function_B(buffer_B_tile))
 
         buffer_A_address += BUFFER_SIZE
         buffer_B_address += BUFFER_SIZE
@@ -104,7 +105,7 @@ def get_result_from_device(
         num_args = len(inspect.signature(unpack_func).parameters)
         if num_args > 1:
             return unpack_func(
-                read_data_bytes, formats.unpack_src, formats.pack_dst
+                read_data_bytes, formats.unpack_A_src, formats.pack_dst
             )  # Bug patchup in (unpack.py): in case unpack_src is Bfp8_b != pack_dst, L1 must be read in different order to extract correct results
         else:
             return unpack_func(read_data_bytes)

--- a/tests/python_tests/helpers/device.py
+++ b/tests/python_tests/helpers/device.py
@@ -44,15 +44,15 @@ def run_elf_files(testname, core_loc="0,0", run_brisc=True):
         run_elf(f"{ELF_LOCATION}{testname}_trisc{i}.elf", core_loc, risc_id=i + 1)
 
 
-def write_stimuli_to_l1(buffer_A, buffer_B, stimuli_A_format, stimuli_B_format, core_loc="0,0", tile_cnt=1):
+def write_stimuli_to_l1(buffer_A, buffer_B, stimuli_A_format, stimuli_B_format, core_loc="0,0", tile_cnt=TileCount.One):
 
     BUFFER_SIZE = 4096
     TILE_SIZE = 1024
 
     buffer_A_address = 0x1A000
-    buffer_B_address = 0x1A000 + BUFFER_SIZE * tile_cnt
+    buffer_B_address = 0x1A000 + BUFFER_SIZE * tile_cnt.value
 
-    for i in range(tile_cnt):
+    for i in range(tile_cnt.value):
 
         start_index = TILE_SIZE * i
         end_index = start_index + TILE_SIZE

--- a/tests/python_tests/helpers/format_arg_mapping.py
+++ b/tests/python_tests/helpers/format_arg_mapping.py
@@ -94,10 +94,6 @@ class MathOperation(Enum):
     ReduceCol = "REDUCE_COL_OPERATION"
     ReduceRow = "REDUCE_ROW_OPERATION"
     ReduceScalar = "REDUCE_SCALAR_OPERATION"
-    
-    ADD = 1
-    SUB = 2
-    MUL = 3
 
 class ReduceDimArgs(Enum):
     ReduceCol = "ReduceDim::REDUCE_COL"

--- a/tests/python_tests/helpers/format_arg_mapping.py
+++ b/tests/python_tests/helpers/format_arg_mapping.py
@@ -76,6 +76,7 @@ format_sizes = {
     DataFormat.Int32: 1024,
 }
 
+
 class MathOperation(Enum):
     """
     An enumeration class that holds all the math operations supported by the LLKs.
@@ -95,38 +96,40 @@ class MathOperation(Enum):
     ReduceRow = "REDUCE_ROW_OPERATION"
     ReduceScalar = "REDUCE_SCALAR_OPERATION"
 
+
 class ReduceDimArgs(Enum):
     ReduceCol = "ReduceDim::REDUCE_COL"
     ReduceRow = "ReduceDim::REDUCE_ROW"
     ReduceScalar = "ReduceDim::REDUCE_SCALAR"
     NoReduceDim = " "
 
+
 class ReducePoolArgs(Enum):
     Max = "PoolType::MAX"
     Sum = "PoolType::SUM"
     Avg = "PoolType::AVG"
-    
+
+
 class DestAccumulation(Enum):
     Yes = "DEST_ACC"
     No = ""
 
+
 class ApproxMode(Enum):
     Yes = "true"
     No = "false"
-    
+
+
 class Fidelity(Enum):
     LoFi = 0
     HiFi2 = 2
     HiFi3 = 3
     HiFi4 = 4
     Inavlid = 5
-    
+
+
 class TileCount(Enum):
     One = 1
     Two = 2
     Three = 3
     Four = 4
-    
-    
-
-    

--- a/tests/python_tests/helpers/format_arg_mapping.py
+++ b/tests/python_tests/helpers/format_arg_mapping.py
@@ -12,19 +12,6 @@ format_dict = {
     DataFormat.Int32: torch.int32,
 }
 
-
-mathop_args_dict = {
-    "elwadd": "ELTWISE_BINARY_ADD",
-    "elwsub": "ELTWISE_BINARY_SUB",
-    "elwmul": "ELTWISE_BINARY_MUL",
-    "sqrt": "SFPU_OP_SQRT",
-    "square": "SFPU_OP_SQUARE",
-    "log": "SFPU_OP_LOG",
-    "reduce_col": "REDUCE_COL_OPERATION",
-    "reduce_row": "REDUCE_ROW_OPERATION",
-    "reduce_scalar": "REDUCE_SCALAR_OPERATION",
-}
-
 unpack_A_src_dict = {
     DataFormat.Float32: "UNPACK_A_SRC_FLOAT32",
     DataFormat.Float16: "UNPACK_A_SRC_FLOAT16",
@@ -89,15 +76,61 @@ format_sizes = {
     DataFormat.Int32: 1024,
 }
 
-reduce_dim_args = {
-    "reduce_col": "ReduceDim::REDUCE_COL",
-    "reduce_row": "ReduceDim::REDUCE_ROW",
-    "reduce_scalar": "ReduceDim::REDUCE_SCALAR",
-    "no_reduce_dim": " ",
-}
+class MathOperation(Enum):
+    """
+    An enumeration class that holds all the math operations supported by the LLKs.
+    Used to avoid hardcoding the operation strings in the test scripts using strings. This avoid typos and future errors.
+    MathOperations(Enum) class instances can be compared via unique values.
+    When you have a set of related constants and you want to leverage the benefits of enumeration (unique members, comparisons, introspection, etc.).
+    It's a good choice for things like state machines, categories, or settings where values should not be changed or duplicated.
+    """
 
-reduce_pool_args = {
-    "max": "PoolType::MAX",
-    "sum": "PoolType::SUM",
-    "avg": "PoolType::AVG",
-}
+    Elwadd = "ELTWISE_BINARY_ADD"
+    Elwsub = "ELTWISE_BINARY_SUB"
+    Elwmul = "ELTWISE_BINARY_MUL"
+    Sqrt = "SFPU_OP_SQRT"
+    Square = "SFPU_OP_SQUARE"
+    Log = "SFPU_OP_LOG"
+    ReduceCol = "REDUCE_COL_OPERATION"
+    ReduceRow = "REDUCE_ROW_OPERATION"
+    ReduceScalar = "REDUCE_SCALAR_OPERATION"
+    
+    ADD = 1
+    SUB = 2
+    MUL = 3
+
+class ReduceDimArgs(Enum):
+    ReduceCol = "ReduceDim::REDUCE_COL"
+    ReduceRow = "ReduceDim::REDUCE_ROW"
+    ReduceScalar = "ReduceDim::REDUCE_SCALAR"
+    NoReduceDim = " "
+
+class ReducePoolArgs(Enum):
+    Max = "PoolType::MAX"
+    Sum = "PoolType::SUM"
+    Avg = "PoolType::AVG"
+    
+class DestAccumulation(Enum):
+    Yes = "DEST_ACC"
+    No = ""
+
+class ApproxMode(Enum):
+    Yes = "true"
+    No = "false"
+    
+class Fidelity(Enum):
+    LoFi = 0
+    HiFi2 = 2
+    HiFi3 = 3
+    HiFi4 = 4
+    Inavlid = 5
+    
+class TileCount(Enum):
+    One = 1
+    Two = 2
+    Three = 3
+    Four = 4
+    
+    
+
+    

--- a/tests/python_tests/helpers/format_arg_mapping.py
+++ b/tests/python_tests/helpers/format_arg_mapping.py
@@ -25,20 +25,36 @@ mathop_args_dict = {
     "reduce_scalar": "REDUCE_SCALAR_OPERATION",
 }
 
-unpack_src_dict = {
-    DataFormat.Float32: "UNPACK_SRC_FLOAT32",
-    DataFormat.Float16: "UNPACK_SRC_FLOAT16",
-    DataFormat.Float16_b: "UNPACK_SRC_FLOAT16_B",
-    DataFormat.Bfp8_b: "UNPACK_SRC_BFP8_B",
-    DataFormat.Int32: "UNPACK_SRC_INT32",
+unpack_A_src_dict = {
+    DataFormat.Float32: "UNPACK_A_SRC_FLOAT32",
+    DataFormat.Float16: "UNPACK_A_SRC_FLOAT16",
+    DataFormat.Float16_b: "UNPACK_A_SRC_FLOAT16_B",
+    DataFormat.Bfp8_b: "UNPACK_A_SRC_BFP8_B",
+    DataFormat.Int32: "UNPACK_A_SRC_INT32",
 }
 
-unpack_dst_dict = {
-    DataFormat.Float32: "UNPACK_DST_FLOAT32",
-    DataFormat.Float16: "UNPACK_DST_FLOAT16",
-    DataFormat.Float16_b: "UNPACK_DST_FLOAT16_B",
-    DataFormat.Bfp8_b: "UNPACK_DST_BFP8_B",
-    DataFormat.Int32: "UNPACK_DST_INT32",
+unpack_A_dst_dict = {
+    DataFormat.Float32: "UNPACK_A_DST_FLOAT32",
+    DataFormat.Float16: "UNPACK_A_DST_FLOAT16",
+    DataFormat.Float16_b: "UNPACK_A_DST_FLOAT16_B",
+    DataFormat.Bfp8_b: "UNPACK_A_DST_BFP8_B",
+    DataFormat.Int32: "UNPACK_A_DST_INT32",
+}
+
+unpack_B_src_dict = {
+    DataFormat.Float32: "UNPACK_B_SRC_FLOAT32",
+    DataFormat.Float16: "UNPACK_B_SRC_FLOAT16",
+    DataFormat.Float16_b: "UNPACK_B_SRC_FLOAT16_B",
+    DataFormat.Bfp8_b: "UNPACK_B_SRC_BFP8_B",
+    DataFormat.Int32: "UNPACK_B_SRC_INT32",
+}
+
+unpack_B_dst_dict = {
+    DataFormat.Float32: "UNPACK_B_DST_FLOAT32",
+    DataFormat.Float16: "UNPACK_B_DST_FLOAT16",
+    DataFormat.Float16_b: "UNPACK_B_DST_FLOAT16_B",
+    DataFormat.Bfp8_b: "UNPACK_B_DST_BFP8_B",
+    DataFormat.Int32: "UNPACK_B_DST_INT32",
 }
 
 math_dict = {

--- a/tests/python_tests/helpers/format_config.py
+++ b/tests/python_tests/helpers/format_config.py
@@ -1,8 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
+from typing import List, Optional, Tuple
 
 
 class DataFormat(Enum):
@@ -24,25 +25,88 @@ class DataFormat(Enum):
 @dataclass
 class FormatConfig:
     """
-    A data class that holds configuration details for formats passed to LLKs.
+    A data class that holds configuration details for formats passed to LLKs.tions).
 
     Attributes:
-    unpack_src (DataFormat): The source format for the Unpacker.
-    unpack_dst (DataFormat): The destination format for the Unpacker.
-    math (DataFormat): The format used for _llk_math_ functions.
+    unpack_A_src (DataFormat): The source format for source register A in the Unpacker, which is the format of our data in L1.
+    unpack_A_dst (DataFormat): The destination format for source register A in the Unpacker, which is the format of our data in the source register.
+    unpack_B_src (Optional[DataFormat]): The source format for source register B in the Unpacker, which is the format of our data in L1. Optional; defaults to `unpack_A_src` if `same_src_format=True`.
+    unpack_B_dst (Optional[DataFormat]): The destination format for source register B in the Unpacker, which is the format of our data in the source register. Optional; defaults to `unpack_A_dst` if `same_src_format=True`.
     pack_src (DataFormat): The source format for the Packer.
     pack_dst (DataFormat): The destination format for the Packer.
+    math (DataFormat): The format used for _llk_math_ functions.
+    
+    Optional Parameters:
+    same_src_format (bool): If `True`, the formats for source registers A and B will be the same for unpack operations. 
+    If `False`, source registers A and B have different formats formats must be specified. Defaults to `True`.
+                             
+    unpack_B_src (Optional[DataFormat]): The source format for source register B in the Unpacker which is the format of our data in L1, used only if `same_src_format=False` i.e when source regosters don't share the same formats we distinguish source register A and B formats.
+    unpack_B_dst (Optional[DataFormat]): The destination format for source register B in the Unpacker, which is the format of our data in src register used only if `same_src_format=False` i.e when source registers don't share the same formats we distinguish source register A and B formats.
 
     Example:
-    >>> formats = FormatConfig(unpack_src=DataFormat.Float32, unpack_dst=DataFormat.Float16, math=DataFormat.Float32, pack_src=DataFormat.Float16, pack_dst=DataFormat.Float32)
-    >>> print(formats.unpack_src)
+    >>> formats = FormatConfig(
+    >>>     unpack_A_src=DataFormat.Float32, 
+    >>>     unpack_A_dst=DataFormat.Float16, 
+    >>>     pack_src=DataFormat.Float16, 
+    >>>     pack_dst=DataFormat.Float32,
+    >>>     math=DataFormat.Float32    # same_src_format defaults to True, thus our source registers have same formats and we don't need to define formats for source register B
+    >>> )
+    >>> print(formats.unpack_A_src)
     DataFormat.Float32
-    >>> print(formats.pack_src)
-    DataFormat.Float16
+    >>> print(formats.unpack_B_src)
+    DataFormat.Float32                 # B formats match A if same_src_format=True
     """
 
-    unpack_src: DataFormat
-    unpack_dst: DataFormat
-    math: DataFormat
+    unpack_A_src: DataFormat
+    unpack_A_dst: DataFormat
+    unpack_B_src: Optional[DataFormat] 
+    unpack_B_dst: Optional[DataFormat]
     pack_src: DataFormat
     pack_dst: DataFormat
+    math: DataFormat 
+
+    def __init__(self, unpack_A_src: DataFormat, unpack_A_dst: DataFormat,
+                 pack_src: DataFormat, pack_dst: DataFormat,
+                 math: DataFormat, same_src_format: bool = True,
+                 unpack_B_src: Optional[DataFormat] = None,
+                 unpack_B_dst: Optional[DataFormat] = None):
+        
+        self.unpack_A_src = unpack_A_src
+        self.unpack_A_dst = unpack_A_dst
+        self.pack_src = pack_src
+        self.pack_dst = pack_dst
+        self.math = math
+        if not same_src_format:
+            self.unpack_B_src = unpack_B_src
+            self.unpack_B_dst = unpack_B_dst
+        else:
+            self.unpack_B_src = unpack_A_src
+            self.unpack_B_dst = unpack_A_dst
+        
+def create_formats(formats: List[Tuple[DataFormat]]) -> List[FormatConfig]:
+    """
+    A function that creates a list of FormatConfig objects from a list of DataFormat objects.
+    This function is useful for creating a list of FormatConfig objects for testing multiple formats combinations 
+    and cases which the user has defined and wants to specifically test instead of a full format flush.
+
+    Args:
+    formats (List[Tuple[DataFormat]]): A list of tuples of DataFormat objects for which FormatConfig objects need to be created.
+
+    Returns:
+    List[FormatConfig]: A list of FormatConfig objects created from the list of DataFormat objects passed as input.
+
+    Example:
+    >>> formats = [(DataFormat.Float16, DataFormat.Float32, DataFormat.Float16, DataFormat.Float32, DataFormat.Float32)]
+    >>> format_configs = create_formats(formats)
+    >>> print(format_configs[0].unpack_A_src)
+    DataFormat.Float16
+    >>> print(format_configs[0].unpack_B_src)
+    DataFormat.Float16
+    """
+    format_configs = []
+    for format_tuple in formats:
+        if len(format_tuple) == 5:
+            format_configs.append(FormatConfig(unpack_A_src=format_tuple[0], unpack_A_dst=format_tuple[1], pack_src=format_tuple[2], pack_dst=format_tuple[3], math=format_tuple[4]))
+        else:
+            format_configs.append(FormatConfig(unpack_A_src=format_tuple[0], unpack_A_dst=format_tuple[1], unpack_B_src=format_tuple[2], unpack_B_dst=format_tuple[3], pack_src=format_tuple[4], pack_dst=format_tuple[5], math=format_tuple[6], same_src_format=False))
+    return format_configs

--- a/tests/python_tests/helpers/format_config.py
+++ b/tests/python_tests/helpers/format_config.py
@@ -72,7 +72,9 @@ class FormatConfig:
         pack_src: DataFormat,
         pack_dst: DataFormat,
         math: DataFormat,
-        same_src_format: bool = True,
+        same_src_format: bool = True,  # if True, source registers A and B have the same formats, don't need to pass next 2 parameters
+        # if our src registers have the same formats, then we only pass 5 formats into the FormatConfig object
+        # and we set unpack_B_src and unpack_B_dst the same format as input formats for source register A
         unpack_B_src: Optional[DataFormat] = None,
         unpack_B_dst: Optional[DataFormat] = None,
     ):

--- a/tests/python_tests/helpers/format_config.py
+++ b/tests/python_tests/helpers/format_config.py
@@ -35,19 +35,19 @@ class FormatConfig:
     pack_src (DataFormat): The source format for the Packer.
     pack_dst (DataFormat): The destination format for the Packer.
     math (DataFormat): The format used for _llk_math_ functions.
-    
+
     Optional Parameters:
-    same_src_format (bool): If `True`, the formats for source registers A and B will be the same for unpack operations. 
+    same_src_format (bool): If `True`, the formats for source registers A and B will be the same for unpack operations.
     If `False`, source registers A and B have different formats formats must be specified. Defaults to `True`.
-                             
+
     unpack_B_src (Optional[DataFormat]): The source format for source register B in the Unpacker which is the format of our data in L1, used only if `same_src_format=False` i.e when source regosters don't share the same formats we distinguish source register A and B formats.
     unpack_B_dst (Optional[DataFormat]): The destination format for source register B in the Unpacker, which is the format of our data in src register used only if `same_src_format=False` i.e when source registers don't share the same formats we distinguish source register A and B formats.
 
     Example:
     >>> formats = FormatConfig(
-    >>>     unpack_A_src=DataFormat.Float32, 
-    >>>     unpack_A_dst=DataFormat.Float16, 
-    >>>     pack_src=DataFormat.Float16, 
+    >>>     unpack_A_src=DataFormat.Float32,
+    >>>     unpack_A_dst=DataFormat.Float16,
+    >>>     pack_src=DataFormat.Float16,
     >>>     pack_dst=DataFormat.Float32,
     >>>     math=DataFormat.Float32    # same_src_format defaults to True, thus our source registers have same formats and we don't need to define formats for source register B
     >>> )
@@ -59,18 +59,24 @@ class FormatConfig:
 
     unpack_A_src: DataFormat
     unpack_A_dst: DataFormat
-    unpack_B_src: Optional[DataFormat] 
+    unpack_B_src: Optional[DataFormat]
     unpack_B_dst: Optional[DataFormat]
     pack_src: DataFormat
     pack_dst: DataFormat
-    math: DataFormat 
+    math: DataFormat
 
-    def __init__(self, unpack_A_src: DataFormat, unpack_A_dst: DataFormat,
-                 pack_src: DataFormat, pack_dst: DataFormat,
-                 math: DataFormat, same_src_format: bool = True,
-                 unpack_B_src: Optional[DataFormat] = None,
-                 unpack_B_dst: Optional[DataFormat] = None):
-        
+    def __init__(
+        self,
+        unpack_A_src: DataFormat,
+        unpack_A_dst: DataFormat,
+        pack_src: DataFormat,
+        pack_dst: DataFormat,
+        math: DataFormat,
+        same_src_format: bool = True,
+        unpack_B_src: Optional[DataFormat] = None,
+        unpack_B_dst: Optional[DataFormat] = None,
+    ):
+
         self.unpack_A_src = unpack_A_src
         self.unpack_A_dst = unpack_A_dst
         self.pack_src = pack_src
@@ -82,12 +88,13 @@ class FormatConfig:
         else:
             self.unpack_B_src = unpack_A_src
             self.unpack_B_dst = unpack_A_dst
-        
-def create_formats(formats: List[Tuple[DataFormat]]) -> List[FormatConfig]:
+
+
+def create_formats_for_testing(formats: List[Tuple[DataFormat]]) -> List[FormatConfig]:
     """
-    A function that creates a list of FormatConfig objects from a list of DataFormat objects.
-    This function is useful for creating a list of FormatConfig objects for testing multiple formats combinations 
-    and cases which the user has defined and wants to specifically test instead of a full format flush.
+    A function that creates a list of FormatConfig objects from a list of DataFormat objects that client wants to test.
+    This function is useful for creating a list of FormatConfig objects for testing multiple formats combinations
+    and cases which the user has specifically defined and wants to particularly test instead of a full format flush.
 
     Args:
     formats (List[Tuple[DataFormat]]): A list of tuples of DataFormat objects for which FormatConfig objects need to be created.
@@ -97,7 +104,7 @@ def create_formats(formats: List[Tuple[DataFormat]]) -> List[FormatConfig]:
 
     Example:
     >>> formats = [(DataFormat.Float16, DataFormat.Float32, DataFormat.Float16, DataFormat.Float32, DataFormat.Float32)]
-    >>> format_configs = create_formats(formats)
+    >>> format_configs = create_formats_for_testing(formats)
     >>> print(format_configs[0].unpack_A_src)
     DataFormat.Float16
     >>> print(format_configs[0].unpack_B_src)
@@ -106,7 +113,26 @@ def create_formats(formats: List[Tuple[DataFormat]]) -> List[FormatConfig]:
     format_configs = []
     for format_tuple in formats:
         if len(format_tuple) == 5:
-            format_configs.append(FormatConfig(unpack_A_src=format_tuple[0], unpack_A_dst=format_tuple[1], pack_src=format_tuple[2], pack_dst=format_tuple[3], math=format_tuple[4]))
+            format_configs.append(
+                FormatConfig(
+                    unpack_A_src=format_tuple[0],
+                    unpack_A_dst=format_tuple[1],
+                    pack_src=format_tuple[2],
+                    pack_dst=format_tuple[3],
+                    math=format_tuple[4],
+                )
+            )
         else:
-            format_configs.append(FormatConfig(unpack_A_src=format_tuple[0], unpack_A_dst=format_tuple[1], unpack_B_src=format_tuple[2], unpack_B_dst=format_tuple[3], pack_src=format_tuple[4], pack_dst=format_tuple[5], math=format_tuple[6], same_src_format=False))
+            format_configs.append(
+                FormatConfig(
+                    unpack_A_src=format_tuple[0],
+                    unpack_A_dst=format_tuple[1],
+                    unpack_B_src=format_tuple[2],
+                    unpack_B_dst=format_tuple[3],
+                    pack_src=format_tuple[4],
+                    pack_dst=format_tuple[5],
+                    math=format_tuple[6],
+                    same_src_format=False,
+                )
+            )
     return format_configs

--- a/tests/python_tests/helpers/param_config.py
+++ b/tests/python_tests/helpers/param_config.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 from dataclasses import dataclass
 from typing import List, Optional
+from .format_arg_mapping import *
 from .format_config import FormatConfig, DataFormat
 
 
@@ -62,7 +63,7 @@ def generate_params(
     included_params,
     testnames: List[str],
     format_combos: List[FormatConfig],
-    dest_acc: Optional[List[str]] = None,
+    dest_acc: Optional[DestAccumulation] = None,
     approx_mode: Optional[List[str]] = None,
     mathop: Optional[List[str]] = None,
     math_fidelity: Optional[List[int]] = None,

--- a/tests/python_tests/helpers/param_config.py
+++ b/tests/python_tests/helpers/param_config.py
@@ -17,7 +17,10 @@ def manage_included_params(func):
 
 @manage_included_params
 def generate_format_combinations(
-    included_params, formats: List[DataFormat], all_same: bool, same_src_reg_format: bool = True
+    included_params,
+    formats: List[DataFormat],
+    all_same: bool,
+    same_src_reg_format: bool = True,
 ) -> List[FormatConfig]:
     """
     Generates a list of FormatConfig instances based on the given formats and the 'all_same' flag.
@@ -47,9 +50,26 @@ def generate_format_combinations(
      FormatConfig(unpack_src=DataFormat.Float32, unpack_dst=DataFormat.Float32, math=DataFormat.Float32, pack_src=DataFormat.Float32, pack_dst=DataFormat.Float32)]
     """
     if all_same:
-        return [FormatConfig(unpack_A_src= fmt, unpack_A_dst= fmt, math= fmt, pack_src= fmt, pack_dst= fmt, same_src_format= same_src_reg_format) for fmt in formats]
+        return [
+            FormatConfig(
+                unpack_A_src=fmt,
+                unpack_A_dst=fmt,
+                math=fmt,
+                pack_src=fmt,
+                pack_dst=fmt,
+                same_src_format=same_src_reg_format,
+            )
+            for fmt in formats
+        ]
     return [
-        FormatConfig(unpack_A_src= unpack_src, unpack_A_dst= unpack_dst, math= math, pack_src= pack_src, pack_dst= pack_dst, same_src_format= same_src_reg_format)
+        FormatConfig(
+            unpack_A_src=unpack_src,
+            unpack_A_dst=unpack_dst,
+            math=math,
+            pack_src=pack_src,
+            pack_dst=pack_dst,
+            same_src_format=same_src_reg_format,
+        )
         for unpack_src in formats
         for unpack_dst in formats
         for math in formats
@@ -82,12 +102,12 @@ def generate_params(
     List[tuple]: A list of tuples, where each tuple represents a combination of parameters with any `None` values filtered out.
 
     Example:
-    >>> testnames = ["Test1", "Test2"]
+    >>> testnames = ["multiple_tiles_eltwise_test", "matmul_test"]
     >>> format_combos = [FormatConfig(DataFormat.Float16, DataFormat.Float16, DataFormat.Float16, DataFormat.Float16, DataFormat.Float16)]
-    >>> generate_params(testnames, format_combos, dest_acc=["DEST_ACC"], approx_mode=["Approx1"])
+    >>> generate_params(testnames, format_combos, dest_acc=[DestAccumulation.Yes], approx_mode=[ApproxMode.Yes])
     [
-        ("Test1", FormatConfig(DataFormat.Float16, DataFormat.Float16, DataFormat.Float16, DataFormat.Float16, DataFormat.Float16), "DEST_ACC", "Approx1", None, None, None, None, None),
-        ("Test2", FormatConfig(DataFormat.Float16, DataFormat.Float16, DataFormat.Float16, DataFormat.Float16, DataFormat.Float16), "DEST_ACC", "Approx1", None, None, None, None, None)
+        ("multiple_tiles_eltwise_test", FormatConfig(DataFormat.Float16, DataFormat.Float16, DataFormat.Float16, DataFormat.Float16, DataFormat.Float16), DestAccumulation.Yes, ApproxMode.Yes, None, None, None, None, None),
+        ("matmul_test", FormatConfig(DataFormat.Float16, DataFormat.Float16, DataFormat.Float16, DataFormat.Float16, DataFormat.Float16), DestAccumulation.Yes, ApproxMode.No, None, None, None, None, None)
     ]
     """
 
@@ -147,13 +167,13 @@ def clean_params(included_params, all_params: List[tuple]) -> List[tuple]:
 
     Example:
     >>> all_params = [
-    ...     ("Test1", FormatConfig(DataFormat.Float16, DataFormat.Float16, DataFormat.Float16, DataFormat.Float16, DataFormat.Float16), "Acc1", "Approx1", None, None, None, None, None),
-    ...     ("Test2", FormatConfig(DataFormat.Float16, DataFormat.Float16, DataFormat.Float16, DataFormat.Float16, DataFormat.Float16), "Acc1", "Approx1", None, None, None, None, None)
+    ...     ("matmul_test", FormatConfig(DataFormat.Float16, DataFormat.Float16, DataFormat.Float16, DataFormat.Float16, DataFormat.Float16), DestAccumulation.No, ApproxMode.Yes, None, None, None, None, None),
+    ...     ("fill_dest_test", FormatConfig(DataFormat.Float16, DataFormat.Float16, DataFormat.Float16, DataFormat.Float16, DataFormat.Float16), DestAccumulation.No, ApproxMode.Yes, None, None, None, None, None)
     ... ]
     >>> clean_params(all_params)
     [
-        ("Test1", FormatConfig(DataFormat.Float16, DataFormat.Float16, DataFormat.Float16, DataFormat.Float16, DataFormat.Float16), "Acc1", "Approx1"),
-        ("Test2", FormatConfig(DataFormat.Float16, DataFormat.Float16, DataFormat.Float16, DataFormat.Float16, DataFormat.Float16), "Acc1", "Approx1")
+        ("matmul_test", FormatConfig(DataFormat.Float16, DataFormat.Float16, DataFormat.Float16, DataFormat.Float16, DataFormat.Float16), DestAccumulation.No, ApproxMode.Yes),
+        ("fill_dest_test", FormatConfig(DataFormat.Float16, DataFormat.Float16, DataFormat.Float16, DataFormat.Float16, DataFormat.Float16), DestAccumulation.No, ApproxMode.Yes)
     ]
     """
 
@@ -180,13 +200,13 @@ def generate_param_ids(included_params, all_params: List[tuple]) -> List[str]:
 
     Example:
     >>> all_params = [
-    ...     ("Test1", FormatConfig("Float16", "Float16", "Float16", "Float16", "Float16"), "Acc1", "Approx1", "Add", 1, 4, "Dim1", "Pool1"),
-    ...     ("Test2", FormatConfig("Float32", "Float32", "Float32", "Float32", "Float32"), "Acc2", None, "Mul", 2, 6, "Dim2", None)
+    ...     ("multiple_tiles_eltwise_test", FormatConfig(DataFormat.Float16, DataFormat.Float16, DataFormat.Float16, DataFormat.Float16, DataFormat.Float16), DestAccumulation.No, ApproxMode.Yes, MathOperation.Elwadd, TileCount.One, Fidelity.HiFi4, ReduceDimArgs.ReduceCol, ReducePoolArgs.Max),
+    ...     ("reduce_test", FormatConfig(DataFormat.Float32, DataFormat.Float32, DataFormat.Float32, DataFormat.Float32, DataFormat.Float32), DestAccumulation.No, None, MathOperation.Elwmul, None, None, ReduceDimArgs.ReduceCol, ReducePollArgs.Avg)
     ... ]
     >>> generate_param_ids(all_params)
     [
-        'unpack_src=Float16 | unpack_dst=Float16 | math=Add | pack_src=Float16 | pack_dst=Float16 | dest_acc=Acc1 | approx_mode=Approx1 | mathop=Add | math_fidelity=1 | tile_cnt=4 | reduce_dim=Dim1 | pool_type=Pool1',
-        'unpack_src=Float32 | unpack_dst=Float32 | math=Mul | pack_src=Float32 | pack_dst=Float32 | dest_acc=Acc2 | mathop=Mul | math_fidelity=2 | tile_cnt=6 | reduce_dim=Dim2'
+        'unpack_src=Float16 | unpack_dst=Float16 | math=Add | pack_src=Float16 | pack_dst=Float16 | dest_acc=No | approx_mode=true | mathop=ElwAdd | tile_cnt=1 | math_fidelity=HiFi4 | reduce_dim=ReduceCol | pool_type=Max',
+        'unpack_src=Float32 | unpack_dst=Float32 | math=Mul | pack_src=Float32 | pack_dst=Float32 | dest_acc=No | mathop=ElwMul | reduce_dim=ReduceCol | pool_type=Avg'
     ]
     """
 
@@ -216,27 +236,28 @@ def generate_param_ids(included_params, all_params: List[tuple]) -> List[str]:
             result.append(f"unpack_B_dst={format_config.unpack_B_dst.value}")
 
         # Add the rest of the required parameters
-        result.extend([
-            f"math={format_config.math.value}",
-            f"pack_src={format_config.pack_src.value}",
-            f"pack_dst={format_config.pack_dst.value}",
-        ])
+        result.extend(
+            [
+                f"math={format_config.math.value}",
+                f"pack_src={format_config.pack_src.value}",
+                f"pack_dst={format_config.pack_dst.value}",
+            ]
+        )
 
-        # Include optional parameters based on `included_params`
-        param_names = [
-            ("dest_acc", params[0] if params[0] else None),
-            ("approx_mode", params[1] if params[1] else None),
-            ("mathop", params[2] if params[2] else None),
-            ("math_fidelity", params[3] if params[3] else None),
-            ("tile_cnt", params[4] if params[4] else None),
-            ("reduce_dim", params[5] if params[5] else None),
-            ("pool_type", params[6] if params[6] else None),
-        ]
-
-        # Loop through the parameters and add them to the result if they are not None
-        for param_name, value in param_names:
-            if value is not None and param_name in included_params:
-                result.append(f"{param_name}={value}")
+        if params[0]:
+            result.append(f"dest_acc={params[0].name}")
+        if params[1]:
+            result.append(f"approx_mode={params[1].value}")
+        if params[2]:
+            result.append(f"mathop={params[2].name}")
+        if params[3]:
+            result.append(f"math_fidelity={params[3].name}")
+        if params[4]:
+            result.append(f"tile_cnt={params[4].value}")
+        if params[5]:
+            result.append(f"reduce_dim={params[5].name}")
+        if params[6]:
+            result.append(f"pool_type={params[6].name}")
 
         return " | ".join(result)
 

--- a/tests/python_tests/helpers/stimuli_generator.py
+++ b/tests/python_tests/helpers/stimuli_generator.py
@@ -36,15 +36,16 @@ def generate_random_face(
 
 
 def generate_random_face_ab(
-    stimuli_format, const_face=False, const_value_A=1, const_value_B=2
+    stimuli_format_A, stimuli_format_B, const_face=False, const_value_A=1, const_value_B=2
 ):
     return generate_random_face(
-        stimuli_format, const_value_A, const_face
-    ), generate_random_face(stimuli_format, const_value_B, const_face)
+        stimuli_format_A, const_value_A, const_face
+    ), generate_random_face(stimuli_format_B, const_value_B, const_face)
 
 
 def generate_stimuli(
-    stimuli_format=DataFormat.Float16_b,
+    stimuli_format_A=DataFormat.Float16_b,
+    stimuli_format_B=DataFormat.Float16_b,
     tile_cnt=1,
     sfpu=False,
     const_face=False,
@@ -57,20 +58,25 @@ def generate_stimuli(
 
     for _ in range(4 * tile_cnt):
         face_a, face_b = generate_random_face_ab(
-            stimuli_format, const_face, const_value_A, const_value_B
+            stimuli_format_A, stimuli_format_B, const_face, const_value_A, const_value_B
         )
         srcA.extend(face_a.tolist())
         srcB.extend(face_b.tolist())
 
     if not sfpu:
-        dtype = (
-            format_dict[stimuli_format]
-            if stimuli_format != DataFormat.Bfp8_b
+        dtype_A = (
+            format_dict[stimuli_format_A]
+            if stimuli_format_A != DataFormat.Bfp8_b
             else torch.bfloat16
         )
-        return torch.tensor(srcA, dtype=dtype), torch.tensor(srcB, dtype=dtype)
+        dtype_B = (
+            format_dict[stimuli_format_B]
+            if stimuli_format_B != DataFormat.Bfp8_b
+            else torch.bfloat16
+        )
+        return torch.tensor(srcA, dtype=dtype_A), torch.tensor(srcB, dtype=dtype_B)
     else:
-        srcA = generate_random_face(stimuli_format, const_value_A, const_face)
+        srcA = generate_random_face(stimuli_format_A, const_value_A, const_face)
         srcB = torch.zeros(256)
         srcA = torch.cat((srcA, torch.zeros(1024 - 256)))
         return srcA, srcB

--- a/tests/python_tests/helpers/stimuli_generator.py
+++ b/tests/python_tests/helpers/stimuli_generator.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import torch
-from .format_arg_mapping import format_dict
+from .format_arg_mapping import format_dict, TileCount
 from .format_config import DataFormat
 
 
@@ -46,7 +46,7 @@ def generate_random_face_ab(
 def generate_stimuli(
     stimuli_format_A=DataFormat.Float16_b,
     stimuli_format_B=DataFormat.Float16_b,
-    tile_cnt=1,
+    tile_cnt=TileCount.One,
     sfpu=False,
     const_face=False,
     const_value_A=1,
@@ -56,7 +56,7 @@ def generate_stimuli(
     srcA = []
     srcB = []
 
-    for _ in range(4 * tile_cnt):
+    for _ in range(4 * tile_cnt.value):
         face_a, face_b = generate_random_face_ab(
             stimuli_format_A, stimuli_format_B, const_face, const_value_A, const_value_B
         )

--- a/tests/python_tests/helpers/test_config.py
+++ b/tests/python_tests/helpers/test_config.py
@@ -2,8 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from .format_arg_mapping import (
-    unpack_src_dict,
-    unpack_dst_dict,
+    unpack_A_dst_dict,
+    unpack_A_src_dict,
+    unpack_B_dst_dict,
+    unpack_B_src_dict,
     pack_src_dict,
     pack_dst_dict,
     math_dict,
@@ -19,7 +21,9 @@ def generate_make_command(test_config):
     testname = test_config.get("testname")
     dest_acc = test_config.get("dest_acc", " ")  # default is not 32 bit dest_acc
 
-    make_cmd += f"unpack_src={unpack_src_dict[formats.unpack_src]} unpack_dst={unpack_dst_dict[formats.unpack_dst]} fpu={math_dict[formats.math]} pack_src={pack_src_dict[formats.pack_src]} pack_dst={pack_dst_dict[formats.pack_dst]} "
+    
+    make_cmd += f"unpack_A_src={unpack_A_src_dict[formats.unpack_A_src]} unpack_A_dst={unpack_A_dst_dict[formats.unpack_A_dst]} unpack_B_src={unpack_B_src_dict[formats.unpack_B_src]} unpack_B_dst={unpack_B_dst_dict[formats.unpack_B_dst]} "
+    make_cmd += f"fpu={math_dict[formats.math]} pack_src={pack_src_dict[formats.pack_src]} pack_dst={pack_dst_dict[formats.pack_dst]} "
 
     make_cmd += f"testname={testname} dest_acc={dest_acc} "
     mathop = test_config.get("mathop", "no_mathop")

--- a/tests/python_tests/helpers/test_config.py
+++ b/tests/python_tests/helpers/test_config.py
@@ -1,7 +1,9 @@
 # SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 # SPDX-License-Identifier: Apache-2.0
 
+import sys
 from .format_arg_mapping import (
+    TileCount,
     unpack_A_dst_dict,
     unpack_A_src_dict,
     unpack_B_dst_dict,
@@ -9,9 +11,12 @@ from .format_arg_mapping import (
     pack_src_dict,
     pack_dst_dict,
     math_dict,
-    mathop_args_dict,
-    reduce_dim_args,
-    reduce_pool_args,
+    Fidelity,
+    DestAccumulation,
+    ApproxMode,
+    MathOperation,
+    ReduceDimArgs,
+    ReducePoolArgs,
 )
 
 
@@ -19,43 +24,37 @@ def generate_make_command(test_config):
     make_cmd = f"make --silent --always-make "
     formats = test_config.get("formats")
     testname = test_config.get("testname")
-    dest_acc = test_config.get("dest_acc", " ")  # default is not 32 bit dest_acc
+    dest_acc = test_config.get("dest_acc", DestAccumulation.No)  # default is not 32 bit dest_acc
 
     
     make_cmd += f"unpack_A_src={unpack_A_src_dict[formats.unpack_A_src]} unpack_A_dst={unpack_A_dst_dict[formats.unpack_A_dst]} unpack_B_src={unpack_B_src_dict[formats.unpack_B_src]} unpack_B_dst={unpack_B_dst_dict[formats.unpack_B_dst]} "
     make_cmd += f"fpu={math_dict[formats.math]} pack_src={pack_src_dict[formats.pack_src]} pack_dst={pack_dst_dict[formats.pack_dst]} "
 
-    make_cmd += f"testname={testname} dest_acc={dest_acc} "
+    make_cmd += f"testname={testname} dest_acc={dest_acc.value} "
     mathop = test_config.get("mathop", "no_mathop")
-    approx_mode = test_config.get("approx_mode", "false")
-    math_fidelity = test_config.get("math_fidelity", 0)
+    approx_mode = test_config.get("approx_mode", ApproxMode.No)
+    math_fidelity = test_config.get("math_fidelity", Fidelity.LoFi)
 
-    make_cmd += f" math_fidelity={math_fidelity} approx_mode={approx_mode} "
+    make_cmd += f" math_fidelity={math_fidelity.value} approx_mode={approx_mode.value} "
 
-    reduce_dim = test_config.get("reduce_dim", "no_reduce_dim")
-    pool_type = test_config.get("pool_type", "no_reduce_dim")
+    reduce_dim = test_config.get("reduce_dim", ReduceDimArgs.NoReduceDim)
+    pool_type = test_config.get("pool_type", ReduceDimArgs.NoReduceDim)
 
     if mathop != "no_mathop":
-        if isinstance(mathop, str):  # single tile option
-            if mathop in ["reduce_col", "reduce_row", "reduce_scalar"]:
-                make_cmd += f"mathop={mathop} "
-                make_cmd += f"reduce_dim={reduce_dim_args[reduce_dim]} "
-                make_cmd += f"pool_type={reduce_pool_args[pool_type]} "
+        if testname != "multiple_tiles_eltwise_test":  # single tile option
+            if mathop in [MathOperation.ReduceCol, MathOperation.ReduceRow, MathOperation.ReduceScalar]:
+                make_cmd += f"mathop={mathop.value} "
+                make_cmd += f"reduce_dim={reduce_dim.value} "
+                make_cmd += f"pool_type={pool_type.value} "
             else:
-                make_cmd += f"mathop={mathop_args_dict[mathop]} "
-        else:  # multiple tiles handles mathop as int
-            mathop_map = {
-                1: "ELTWISE_BINARY_ADD",
-                2: "ELTWISE_BINARY_SUB",
-                3: "ELTWISE_BINARY_MUL",
-            }
-            make_cmd += f"mathop={mathop_map.get(mathop, 'ELTWISE_BINARY_MUL')} "
-
-            kern_cnt = str(test_config.get("kern_cnt"))
+                make_cmd += f"mathop={mathop.value} "
+        else:  # multiple tiles handles mathop as int. we don't access value but return ENUM directly which is position in the class + 1
+            make_cmd += f"mathop={list(MathOperation).index(mathop)+1} "
+            kern_cnt = test_config.get("kern_cnt", TileCount.One)
             pack_addr_cnt = str(test_config.get("pack_addr_cnt"))
             pack_addrs = test_config.get("pack_addrs")
 
-            make_cmd += f" kern_cnt={kern_cnt} pack_addr_cnt={pack_addr_cnt} pack_addrs={pack_addrs}"
+            make_cmd += f"kern_cnt={kern_cnt.value} pack_addr_cnt={pack_addr_cnt} pack_addrs={pack_addrs} "
 
     print(make_cmd)
     return make_cmd

--- a/tests/python_tests/helpers/test_config.py
+++ b/tests/python_tests/helpers/test_config.py
@@ -24,9 +24,10 @@ def generate_make_command(test_config):
     make_cmd = f"make --silent --always-make "
     formats = test_config.get("formats")
     testname = test_config.get("testname")
-    dest_acc = test_config.get("dest_acc", DestAccumulation.No)  # default is not 32 bit dest_acc
+    dest_acc = test_config.get(
+        "dest_acc", DestAccumulation.No
+    )  # default is not 32 bit dest_acc
 
-    
     make_cmd += f"unpack_A_src={unpack_A_src_dict[formats.unpack_A_src]} unpack_A_dst={unpack_A_dst_dict[formats.unpack_A_dst]} unpack_B_src={unpack_B_src_dict[formats.unpack_B_src]} unpack_B_dst={unpack_B_dst_dict[formats.unpack_B_dst]} "
     make_cmd += f"fpu={math_dict[formats.math]} pack_src={pack_src_dict[formats.pack_src]} pack_dst={pack_dst_dict[formats.pack_dst]} "
 
@@ -42,16 +43,20 @@ def generate_make_command(test_config):
 
     if mathop != "no_mathop":
         if testname != "multiple_tiles_eltwise_test":  # single tile option
-            if mathop in [MathOperation.ReduceCol, MathOperation.ReduceRow, MathOperation.ReduceScalar]:
+            if mathop in [
+                MathOperation.ReduceCol,
+                MathOperation.ReduceRow,
+                MathOperation.ReduceScalar,
+            ]:
                 make_cmd += f"mathop={mathop.value} "
                 make_cmd += f"reduce_dim={reduce_dim.value} "
                 make_cmd += f"pool_type={pool_type.value} "
             else:
                 make_cmd += f"mathop={mathop.value} "
         else:  # multiple tiles handles mathop as int. we don't access value but return ENUM directly which is position in the class + 1
-            
+
             make_cmd += f"mathop={mathop.value} "
-            
+
             kern_cnt = str(test_config.get("kern_cnt", TileCount.One).value)
             pack_addr_cnt = str(test_config.get("pack_addr_cnt"))
             pack_addrs = test_config.get("pack_addrs")

--- a/tests/python_tests/helpers/test_config.py
+++ b/tests/python_tests/helpers/test_config.py
@@ -49,12 +49,14 @@ def generate_make_command(test_config):
             else:
                 make_cmd += f"mathop={mathop.value} "
         else:  # multiple tiles handles mathop as int. we don't access value but return ENUM directly which is position in the class + 1
-            make_cmd += f"mathop={list(MathOperation).index(mathop)+1} "
-            kern_cnt = test_config.get("kern_cnt", TileCount.One)
+            
+            make_cmd += f"mathop={mathop.value} "
+            
+            kern_cnt = str(test_config.get("kern_cnt", TileCount.One).value)
             pack_addr_cnt = str(test_config.get("pack_addr_cnt"))
             pack_addrs = test_config.get("pack_addrs")
 
-            make_cmd += f"kern_cnt={kern_cnt.value} pack_addr_cnt={pack_addr_cnt} pack_addrs={pack_addrs} "
+            make_cmd += f"kern_cnt={kern_cnt} pack_addr_cnt={pack_addr_cnt} pack_addrs={pack_addrs} "
 
     print(make_cmd)
     return make_cmd

--- a/tests/python_tests/test_eltwise_unary_datacopy.py
+++ b/tests/python_tests/test_eltwise_unary_datacopy.py
@@ -12,6 +12,27 @@ def generate_golden(operand1, format):
 
 
 full_sweep = False
+#  This is an example of how users can define and create their own format combinations for testing specific cases they're interested in
+generate_format_selection = create_formats( 
+    [ 
+        (
+        DataFormat.Float16,         # index 0 is for unpack_A_src
+        DataFormat.Float16_b,       # index 1 is for unpack_A_dst
+        DataFormat.Bfp8_b,          # index 2 is for pack_src (if src registers have same formats)
+        DataFormat.Int32,           # index 3 is for pack_dst
+        DataFormat.Float32,         # index 4 is for math format
+        ), 
+        (
+        DataFormat.Float32,         # index 0 is for unpack_A_src
+        DataFormat.Float32,         # index 1 is for unpack_A_dst
+        DataFormat.Bfp8_b,          # index 2 is for unpack_B_src (inputs to src registers have different formats)
+        DataFormat.Int32,           # index 3 is for unpack_B_dst (inputs to src registers have different formats)
+        DataFormat.Float32,         # index 4 is for pack_src (if src registers have same formats)
+        DataFormat.Int32,           # index 5 is for pack_dst
+        DataFormat.Float32,         # index 6 is for math format
+        )
+    ]
+)
 
 all_format_combos = generate_format_combinations(
     formats=[

--- a/tests/python_tests/test_eltwise_unary_datacopy.py
+++ b/tests/python_tests/test_eltwise_unary_datacopy.py
@@ -66,13 +66,6 @@ def test_unary_datacopy(testname, formats, dest_acc):
             reason="Skipping test for 32 bit wide data without 32 bit accumulation in Dest"
         )
 
-    #  When running hundreds of tests, failing tests may cause incorrect behavior in subsequent passing tests.
-    #  To ensure accurate results, for now we reset board after each test.
-    #  Fix this: so we only reset after failing tests
-    if full_sweep:
-        run_shell_command(f"cd .. && make clean")
-        run_shell_command(f"tt-smi -r 0")
-
     src_A, src_B = generate_stimuli(formats.unpack_A_src, formats.unpack_B_src)
     srcB = torch.full((1024,), 0)
     golden = generate_golden(src_A, formats.pack_dst)

--- a/tests/python_tests/test_eltwise_unary_datacopy.py
+++ b/tests/python_tests/test_eltwise_unary_datacopy.py
@@ -13,6 +13,7 @@ def generate_golden(operand1, format):
 
 full_sweep = False
 #  This is an example of how users can define and create their own format combinations for testing specific cases they're interested in
+# Note these combinations might fail because we don't have date inference model to adjust unsupported format combinations
 generate_format_selection = create_formats_for_testing(
     [
         (

--- a/tests/python_tests/test_eltwise_unary_datacopy.py
+++ b/tests/python_tests/test_eltwise_unary_datacopy.py
@@ -13,24 +13,24 @@ def generate_golden(operand1, format):
 
 full_sweep = False
 #  This is an example of how users can define and create their own format combinations for testing specific cases they're interested in
-generate_format_selection = create_formats( 
-    [ 
+generate_format_selection = create_formats_for_testing(
+    [
         (
-        DataFormat.Float16,         # index 0 is for unpack_A_src
-        DataFormat.Float16_b,       # index 1 is for unpack_A_dst
-        DataFormat.Bfp8_b,          # index 2 is for pack_src (if src registers have same formats)
-        DataFormat.Int32,           # index 3 is for pack_dst
-        DataFormat.Float32,         # index 4 is for math format
-        ), 
+            DataFormat.Float16,  # index 0 is for unpack_A_src
+            DataFormat.Float16_b,  # index 1 is for unpack_A_dst
+            DataFormat.Bfp8_b,  # index 2 is for pack_src (if src registers have same formats)
+            DataFormat.Int32,  # index 3 is for pack_dst
+            DataFormat.Float32,  # index 4 is for math format
+        ),
         (
-        DataFormat.Float32,         # index 0 is for unpack_A_src
-        DataFormat.Float32,         # index 1 is for unpack_A_dst
-        DataFormat.Bfp8_b,          # index 2 is for unpack_B_src (inputs to src registers have different formats)
-        DataFormat.Int32,           # index 3 is for unpack_B_dst (inputs to src registers have different formats)
-        DataFormat.Float32,         # index 4 is for pack_src (if src registers have same formats)
-        DataFormat.Int32,           # index 5 is for pack_dst
-        DataFormat.Float32,         # index 6 is for math format
-        )
+            DataFormat.Float32,  # index 0 is for unpack_A_src
+            DataFormat.Float32,  # index 1 is for unpack_A_dst
+            DataFormat.Bfp8_b,  # index 2 is for unpack_B_src (inputs to src registers have different formats)
+            DataFormat.Int32,  # index 3 is for unpack_B_dst (inputs to src registers have different formats)
+            DataFormat.Float32,  # index 4 is for pack_src (if src registers have same formats)
+            DataFormat.Int32,  # index 5 is for pack_dst
+            DataFormat.Float32,  # index 6 is for math format
+        ),
     ]
 )
 
@@ -43,7 +43,7 @@ all_format_combos = generate_format_combinations(
         DataFormat.Int32,
     ],
     all_same=True,
-    same_src_reg_format= True # setting src_A and src_B register to have same format
+    same_src_reg_format=True,  # setting src_A and src_B register to have same format
 )  # Generate format combinations with all formats being the same (flag set to True), refer to `param_config.py` for more details.
 dest_acc = [DestAccumulation.No, DestAccumulation.Yes]
 testname = ["eltwise_unary_datacopy_test"]

--- a/tests/python_tests/test_eltwise_unary_datacopy.py
+++ b/tests/python_tests/test_eltwise_unary_datacopy.py
@@ -12,6 +12,7 @@ def generate_golden(operand1, format):
 
 
 full_sweep = False
+
 all_format_combos = generate_format_combinations(
     formats=[
         DataFormat.Float32,
@@ -21,6 +22,7 @@ all_format_combos = generate_format_combinations(
         DataFormat.Int32,
     ],
     all_same=True,
+    same_src_reg_format= True # setting src_A and src_B register to have same format
 )  # Generate format combinations with all formats being the same (flag set to True), refer to `param_config.py` for more details.
 dest_acc = ["", "DEST_ACC"]
 testname = ["eltwise_unary_datacopy_test"]
@@ -33,10 +35,10 @@ param_ids = generate_param_ids(all_params)
 )
 def test_unary_datacopy(testname, formats, dest_acc):
 
-    if formats.unpack_src == DataFormat.Float16 and dest_acc == "DEST_ACC":
+    if formats.unpack_A_src == DataFormat.Float16 and dest_acc == "DEST_ACC":
         pytest.skip(reason="This combination is not fully implemented in testing")
     if (
-        formats.unpack_src in [DataFormat.Float32, DataFormat.Int32]
+        formats.unpack_A_src in [DataFormat.Float32, DataFormat.Int32]
         and dest_acc != "DEST_ACC"
     ):
         pytest.skip(
@@ -50,10 +52,10 @@ def test_unary_datacopy(testname, formats, dest_acc):
         run_shell_command(f"cd .. && make clean")
         run_shell_command(f"tt-smi -r 0")
 
-    src_A, src_B = generate_stimuli(formats.unpack_src)
+    src_A, src_B = generate_stimuli(formats.unpack_A_src, formats.unpack_B_src)
     srcB = torch.full((1024,), 0)
     golden = generate_golden(src_A, formats.pack_dst)
-    write_stimuli_to_l1(src_A, src_B, formats.unpack_src)
+    write_stimuli_to_l1(src_A, src_B, formats.unpack_A_src, formats.unpack_B_src)
 
     test_config = {
         "formats": formats,

--- a/tests/python_tests/test_eltwise_unary_datacopy.py
+++ b/tests/python_tests/test_eltwise_unary_datacopy.py
@@ -45,7 +45,7 @@ all_format_combos = generate_format_combinations(
     all_same=True,
     same_src_reg_format= True # setting src_A and src_B register to have same format
 )  # Generate format combinations with all formats being the same (flag set to True), refer to `param_config.py` for more details.
-dest_acc = ["", "DEST_ACC"]
+dest_acc = [DestAccumulation.No, DestAccumulation.Yes]
 testname = ["eltwise_unary_datacopy_test"]
 all_params = generate_params(testname, all_format_combos, dest_acc)
 param_ids = generate_param_ids(all_params)
@@ -56,11 +56,11 @@ param_ids = generate_param_ids(all_params)
 )
 def test_unary_datacopy(testname, formats, dest_acc):
 
-    if formats.unpack_A_src == DataFormat.Float16 and dest_acc == "DEST_ACC":
+    if formats.unpack_A_src == DataFormat.Float16 and dest_acc == DestAccumulation.Yes:
         pytest.skip(reason="This combination is not fully implemented in testing")
     if (
         formats.unpack_A_src in [DataFormat.Float32, DataFormat.Int32]
-        and dest_acc != "DEST_ACC"
+        and dest_acc != DestAccumulation.Yes
     ):
         pytest.skip(
             reason="Skipping test for 32 bit wide data without 32 bit accumulation in Dest"

--- a/tests/python_tests/test_eltwise_unary_sfpu.py
+++ b/tests/python_tests/test_eltwise_unary_sfpu.py
@@ -25,7 +25,9 @@ def generate_golden(operation, operand1, data_format):
 
 full_sweep = False
 all_format_combos = generate_format_combinations(
-    [DataFormat.Float16_b, DataFormat.Float16, DataFormat.Float32], all_same=True, same_src_reg_format= True # setting src_A and src_B register to have same format
+    [DataFormat.Float16_b, DataFormat.Float16, DataFormat.Float32],
+    all_same=True,
+    same_src_reg_format=True,  # setting src_A and src_B register to have same format
 )  # Generate format combinations with all formats being the same (flag set to True), refer to `param_config.py` for more details.
 all_params = generate_params(
     ["eltwise_unary_sfpu_test"],
@@ -56,8 +58,9 @@ def test_eltwise_unary_sfpu(testname, formats, dest_acc, approx_mode, mathop):  
     ):
         pytest.skip(reason="This combination is not fully implemented in testing")
 
-
-    src_A, src_B = generate_stimuli(formats.unpack_A_src, formats.unpack_B_src,sfpu=True)
+    src_A, src_B = generate_stimuli(
+        formats.unpack_A_src, formats.unpack_B_src, sfpu=True
+    )
     golden = generate_golden(mathop, src_A, formats.pack_dst)
     write_stimuli_to_l1(src_A, src_B, formats.unpack_A_src, formats.unpack_B_src)
 

--- a/tests/python_tests/test_eltwise_unary_sfpu.py
+++ b/tests/python_tests/test_eltwise_unary_sfpu.py
@@ -14,9 +14,9 @@ def generate_golden(operation, operand1, data_format):
         .to(format_dict[data_format] if data_format != "Bfp8_b" else torch.bfloat16)
     )
     ops = {
-        "sqrt": lambda x: math.sqrt(x),
-        "square": lambda x: x * x,
-        "log": lambda x: math.log(x) if x != 0 else float("nan"),
+        MathOperation.Sqrt: lambda x: math.sqrt(x),
+        MathOperation.Square: lambda x: x * x,
+        MathOperation.Log: lambda x: math.log(x) if x != 0 else float("nan"),
     }
     if operation not in ops:
         raise ValueError("Unsupported operation!")
@@ -30,9 +30,9 @@ all_format_combos = generate_format_combinations(
 all_params = generate_params(
     ["eltwise_unary_sfpu_test"],
     all_format_combos,
-    dest_acc=["", "DEST_ACC"],
-    approx_mode=["false", "true"],
-    mathop=["sqrt", "log", "square"],
+    dest_acc=[DestAccumulation.No, DestAccumulation.Yes],
+    approx_mode=[ApproxMode.No, ApproxMode.Yes],
+    mathop=[MathOperation.Sqrt, MathOperation.Log, MathOperation.Square],
 )
 param_ids = generate_param_ids(all_params)
 
@@ -45,14 +45,14 @@ param_ids = generate_param_ids(all_params)
 def test_eltwise_unary_sfpu(testname, formats, dest_acc, approx_mode, mathop):  #
     if (
         formats.unpack_A_src in [DataFormat.Float32, DataFormat.Int32]
-        and dest_acc != "DEST_ACC"
+        and dest_acc != DestAccumulation.Yes
     ):
         pytest.skip(
             reason="Skipping test for 32 bit wide data without 32 bit accumulation in Dest"
         )
     if formats.unpack_A_src == DataFormat.Float16 and (
-        (dest_acc == "" and get_chip_architecture() == "blackhole")
-        or (dest_acc == "DEST_ACC" and get_chip_architecture() == "wormhole")
+        (dest_acc == DestAccumulation.No and get_chip_architecture() == "blackhole")
+        or (dest_acc == DestAccumulation.Yes and get_chip_architecture() == "wormhole")
     ):
         pytest.skip(reason="This combination is not fully implemented in testing")
 

--- a/tests/python_tests/test_eltwise_unary_sfpu.py
+++ b/tests/python_tests/test_eltwise_unary_sfpu.py
@@ -56,12 +56,6 @@ def test_eltwise_unary_sfpu(testname, formats, dest_acc, approx_mode, mathop):  
     ):
         pytest.skip(reason="This combination is not fully implemented in testing")
 
-    #  When running hundreds of tests, failing tests may cause incorrect behavior in subsequent passing tests.
-    #  To ensure accurate results, for now we reset board after each test.
-    #  Fix this: so we only reset after failing tests
-    if full_sweep:
-        run_shell_command(f"cd .. && make clean")
-        run_shell_command(f"tt-smi -r 0")
 
     src_A, src_B = generate_stimuli(formats.unpack_A_src, formats.unpack_B_src,sfpu=True)
     golden = generate_golden(mathop, src_A, formats.pack_dst)

--- a/tests/python_tests/test_eltwise_unary_sfpu.py
+++ b/tests/python_tests/test_eltwise_unary_sfpu.py
@@ -25,7 +25,7 @@ def generate_golden(operation, operand1, data_format):
 
 full_sweep = False
 all_format_combos = generate_format_combinations(
-    [DataFormat.Float16_b, DataFormat.Float16, DataFormat.Float32], all_same=True
+    [DataFormat.Float16_b, DataFormat.Float16, DataFormat.Float32], all_same=True, same_src_reg_format= True # setting src_A and src_B register to have same format
 )  # Generate format combinations with all formats being the same (flag set to True), refer to `param_config.py` for more details.
 all_params = generate_params(
     ["eltwise_unary_sfpu_test"],
@@ -44,13 +44,13 @@ param_ids = generate_param_ids(all_params)
 )
 def test_eltwise_unary_sfpu(testname, formats, dest_acc, approx_mode, mathop):  #
     if (
-        formats.unpack_src in [DataFormat.Float32, DataFormat.Int32]
+        formats.unpack_A_src in [DataFormat.Float32, DataFormat.Int32]
         and dest_acc != "DEST_ACC"
     ):
         pytest.skip(
             reason="Skipping test for 32 bit wide data without 32 bit accumulation in Dest"
         )
-    if formats.unpack_src == DataFormat.Float16 and (
+    if formats.unpack_A_src == DataFormat.Float16 and (
         (dest_acc == "" and get_chip_architecture() == "blackhole")
         or (dest_acc == "DEST_ACC" and get_chip_architecture() == "wormhole")
     ):
@@ -63,9 +63,9 @@ def test_eltwise_unary_sfpu(testname, formats, dest_acc, approx_mode, mathop):  
         run_shell_command(f"cd .. && make clean")
         run_shell_command(f"tt-smi -r 0")
 
-    src_A, src_B = generate_stimuli(formats.unpack_src, sfpu=True)
+    src_A, src_B = generate_stimuli(formats.unpack_A_src, formats.unpack_B_src,sfpu=True)
     golden = generate_golden(mathop, src_A, formats.pack_dst)
-    write_stimuli_to_l1(src_A, src_B, formats.unpack_src)
+    write_stimuli_to_l1(src_A, src_B, formats.unpack_A_src, formats.unpack_B_src)
 
     test_config = {
         "formats": formats,

--- a/tests/python_tests/test_fill_dest.py
+++ b/tests/python_tests/test_fill_dest.py
@@ -57,13 +57,6 @@ def test_fill_dest(testname, formats, dest_acc):
     if formats.unpack_A_src == DataFormat.Float16 and dest_acc == DestAccumulation.Yes:
         pytest.skip(reason="This combination is not fully implemented in testing")
 
-    #  When running hundreds of tests, failing tests may cause incorrect behavior in subsequent passing tests.
-    #  To ensure accurate results, for now we reset board after each test.
-    #  Fix this: so we only reset after failing tests
-    if full_sweep:
-        run_shell_command(f"cd .. && make clean")
-        run_shell_command(f"tt-smi -r 0")
-
     pack_start_address = 0x1C000
     pack_addresses = [pack_start_address + 0x1000 * i for i in range(16)]
 

--- a/tests/python_tests/test_fill_dest.py
+++ b/tests/python_tests/test_fill_dest.py
@@ -44,7 +44,9 @@ all_format_combos = generate_format_combinations(
     [DataFormat.Float16_b, DataFormat.Float16, DataFormat.Bfp8_b], all_same=True
 )  # Generate format combinations with all formats being the same (flag set to True), refer to `param_config.py` for more details.
 all_params = generate_params(
-    ["fill_dest_test"], all_format_combos, dest_acc=[DestAccumulation.No, DestAccumulation.Yes]
+    ["fill_dest_test"],
+    all_format_combos,
+    dest_acc=[DestAccumulation.No, DestAccumulation.Yes],
 )
 param_ids = generate_param_ids(all_params)
 

--- a/tests/python_tests/test_fill_dest.py
+++ b/tests/python_tests/test_fill_dest.py
@@ -54,7 +54,7 @@ param_ids = generate_param_ids(all_params)
 )
 def test_fill_dest(testname, formats, dest_acc):
 
-    if formats.unpack_src == DataFormat.Float16 and dest_acc == "DEST_ACC":
+    if formats.unpack_A_src == DataFormat.Float16 and dest_acc == "DEST_ACC":
         pytest.skip(reason="This combination is not fully implemented in testing")
 
     #  When running hundreds of tests, failing tests may cause incorrect behavior in subsequent passing tests.
@@ -67,9 +67,9 @@ def test_fill_dest(testname, formats, dest_acc):
     pack_start_address = 0x1C000
     pack_addresses = [pack_start_address + 0x1000 * i for i in range(16)]
 
-    src_A, src_B = generate_stimuli(formats.unpack_src)
+    src_A, src_B = generate_stimuli(formats.unpack_A_src, formats.unpack_B_src)
     golden = generate_golden([2] * 16, src_A, src_B, formats.pack_dst)
-    write_stimuli_to_l1(src_A, src_B, formats.unpack_src)
+    write_stimuli_to_l1(src_A, src_B, formats.unpack_A_src, formats.unpack_B_src)
 
     test_config = {
         "formats": formats,

--- a/tests/python_tests/test_fill_dest.py
+++ b/tests/python_tests/test_fill_dest.py
@@ -44,7 +44,7 @@ all_format_combos = generate_format_combinations(
     [DataFormat.Float16_b, DataFormat.Float16, DataFormat.Bfp8_b], all_same=True
 )  # Generate format combinations with all formats being the same (flag set to True), refer to `param_config.py` for more details.
 all_params = generate_params(
-    ["fill_dest_test"], all_format_combos, dest_acc=["", "DEST_ACC"]
+    ["fill_dest_test"], all_format_combos, dest_acc=[DestAccumulation.No, DestAccumulation.Yes]
 )
 param_ids = generate_param_ids(all_params)
 
@@ -54,7 +54,7 @@ param_ids = generate_param_ids(all_params)
 )
 def test_fill_dest(testname, formats, dest_acc):
 
-    if formats.unpack_A_src == DataFormat.Float16 and dest_acc == "DEST_ACC":
+    if formats.unpack_A_src == DataFormat.Float16 and dest_acc == DestAccumulation.Yes:
         pytest.skip(reason="This combination is not fully implemented in testing")
 
     #  When running hundreds of tests, failing tests may cause incorrect behavior in subsequent passing tests.

--- a/tests/python_tests/test_matmul.py
+++ b/tests/python_tests/test_matmul.py
@@ -24,7 +24,7 @@ def generate_golden(operand1, operand2, data_format, math_fidelity):
 
 
 all_format_combos = generate_format_combinations(
-    [DataFormat.Float16_b], all_same=True
+    [DataFormat.Float16_b], all_same=True, same_src_reg_format= True 
 )  # Generate format combinations with all formats being the same (flag set to True), refer to `param_config.py` for more details.
 all_params = generate_params(
     ["matmul_test"], all_format_combos, dest_acc=["", "DEST_ACC"], math_fidelity=[3, 4]
@@ -40,17 +40,17 @@ param_ids = generate_param_ids(all_params)
 def test_matmul(testname, formats, dest_acc, math_fidelity):
 
     src_A = torch.tensor(
-        [torch.rand(1, dtype=format_dict[formats.unpack_src]).item()] * 1024,
+        [torch.rand(1, dtype=format_dict[formats.unpack_A_src]).item()] * 1024,
         dtype=torch.bfloat16,
     )
     src_B = torch.tensor(
-        [torch.rand(1, dtype=format_dict[formats.unpack_src]).item()] * 1024,
+        [torch.rand(1, dtype=format_dict[formats.unpack_B_src]).item()] * 1024,
         dtype=torch.bfloat16,
     )
 
     golden_tensor = generate_golden(src_A, src_B, formats.pack_dst, math_fidelity)
 
-    write_stimuli_to_l1(tilize(src_A), tilize(src_B), formats.unpack_src)
+    write_stimuli_to_l1(tilize(src_A), tilize(src_B), formats.unpack_A_src, formats.unpack_B_src)
 
     test_config = {
         "formats": formats,

--- a/tests/python_tests/test_matmul.py
+++ b/tests/python_tests/test_matmul.py
@@ -24,10 +24,13 @@ def generate_golden(operand1, operand2, data_format, math_fidelity):
 
 
 all_format_combos = generate_format_combinations(
-    [DataFormat.Float16_b], all_same=True, same_src_reg_format= True 
+    [DataFormat.Float16_b], all_same=True, same_src_reg_format=True
 )  # Generate format combinations with all formats being the same (flag set to True), refer to `param_config.py` for more details.
 all_params = generate_params(
-    ["matmul_test"], all_format_combos, dest_acc=[DestAccumulation.No, DestAccumulation.Yes], math_fidelity=[Fidelity.HiFi3, Fidelity.HiFi4]
+    ["matmul_test"],
+    all_format_combos,
+    dest_acc=[DestAccumulation.No, DestAccumulation.Yes],
+    math_fidelity=[Fidelity.HiFi3, Fidelity.HiFi4],
 )
 param_ids = generate_param_ids(all_params)
 
@@ -50,7 +53,9 @@ def test_matmul(testname, formats, dest_acc, math_fidelity):
 
     golden_tensor = generate_golden(src_A, src_B, formats.pack_dst, math_fidelity)
 
-    write_stimuli_to_l1(tilize(src_A), tilize(src_B), formats.unpack_A_src, formats.unpack_B_src)
+    write_stimuli_to_l1(
+        tilize(src_A), tilize(src_B), formats.unpack_A_src, formats.unpack_B_src
+    )
 
     test_config = {
         "formats": formats,

--- a/tests/python_tests/test_matmul.py
+++ b/tests/python_tests/test_matmul.py
@@ -9,11 +9,11 @@ from helpers import *
 def generate_golden(operand1, operand2, data_format, math_fidelity):
 
     if data_format == DataFormat.Float16_b:
-        if math_fidelity in [Fidelity.Zero, Fidelity.Two]:  # LoFi or HiFi2
+        if math_fidelity in [Fidelity.LoFi, Fidelity.HiFi2]:  # LoFi or HiFi2
             for element in operand2:
                 element = element.to(torch.int32)
                 element &= 0xFFFE
-        if math_fidelity == Fidelity.Zero:  # LoFi
+        if math_fidelity == Fidelity.LoFi:  # LoFi
             for element in operand1:
                 element = element.to(torch.int32)
                 element &= 0xFFF8
@@ -27,7 +27,7 @@ all_format_combos = generate_format_combinations(
     [DataFormat.Float16_b], all_same=True, same_src_reg_format= True 
 )  # Generate format combinations with all formats being the same (flag set to True), refer to `param_config.py` for more details.
 all_params = generate_params(
-    ["matmul_test"], all_format_combos, dest_acc=[DestAccumulation.No, DestAccumulation.Yes], math_fidelity=[Fidelity.Three, Fidelity.Four]
+    ["matmul_test"], all_format_combos, dest_acc=[DestAccumulation.No, DestAccumulation.Yes], math_fidelity=[Fidelity.HiFi3, Fidelity.HiFi4]
 )
 param_ids = generate_param_ids(all_params)
 

--- a/tests/python_tests/test_matmul.py
+++ b/tests/python_tests/test_matmul.py
@@ -9,11 +9,11 @@ from helpers import *
 def generate_golden(operand1, operand2, data_format, math_fidelity):
 
     if data_format == DataFormat.Float16_b:
-        if math_fidelity in [0, 2]:  # LoFi or HiFi2
+        if math_fidelity in [Fidelity.Zero, Fidelity.Two]:  # LoFi or HiFi2
             for element in operand2:
                 element = element.to(torch.int32)
                 element &= 0xFFFE
-        if math_fidelity == 0:  # LoFi
+        if math_fidelity == Fidelity.Zero:  # LoFi
             for element in operand1:
                 element = element.to(torch.int32)
                 element &= 0xFFF8
@@ -27,7 +27,7 @@ all_format_combos = generate_format_combinations(
     [DataFormat.Float16_b], all_same=True, same_src_reg_format= True 
 )  # Generate format combinations with all formats being the same (flag set to True), refer to `param_config.py` for more details.
 all_params = generate_params(
-    ["matmul_test"], all_format_combos, dest_acc=["", "DEST_ACC"], math_fidelity=[3, 4]
+    ["matmul_test"], all_format_combos, dest_acc=[DestAccumulation.No, DestAccumulation.Yes], math_fidelity=[Fidelity.Three, Fidelity.Four]
 )
 param_ids = generate_param_ids(all_params)
 

--- a/tests/python_tests/test_multiple_tiles_eltwise.py
+++ b/tests/python_tests/test_multiple_tiles_eltwise.py
@@ -43,7 +43,6 @@ def generate_golden(op, operand1, operand2, data_format, math_fidelity):
     return res.tolist()
 
 
-
 full_sweep = False
 all_format_combos = generate_format_combinations(
     [DataFormat.Float16_b, DataFormat.Float16, DataFormat.Bfp8_b], all_same=True
@@ -54,7 +53,7 @@ all_params = generate_params(
     dest_acc=[DestAccumulation.No, DestAccumulation.Yes],
     mathop=[MathOperation.Elwadd, MathOperation.Elwsub, MathOperation.Elwmul],
     math_fidelity=[Fidelity.LoFi, Fidelity.HiFi2, Fidelity.HiFi3, Fidelity.HiFi4],
-    tile_cnt=[TileCount.One, TileCount.Two, TileCount.Three]
+    tile_cnt=[TileCount.One, TileCount.Two, TileCount.Three],
 )
 param_ids = generate_param_ids(all_params)
 
@@ -77,10 +76,12 @@ def test_multiple_tiles(testname, formats, dest_acc, mathop, math_fidelity, tile
     pack_addresses_formatted = format_kernel_list(pack_addresses, as_hex=True)
 
     src_A, src_B = generate_stimuli(
-        formats.unpack_A_src, formats.unpack_B_src,tile_cnt=tile_cnt
+        formats.unpack_A_src, formats.unpack_B_src, tile_cnt=tile_cnt
     )  # , const_face=True, const_value_A=3, const_value_B=2)
     golden = generate_golden(mathop, src_A, src_B, formats.pack_dst, math_fidelity)
-    write_stimuli_to_l1(src_A, src_B, formats.unpack_A_src, formats.unpack_B_src, "0,0", tile_cnt)
+    write_stimuli_to_l1(
+        src_A, src_B, formats.unpack_A_src, formats.unpack_B_src, "0,0", tile_cnt
+    )
 
     if mathop != MathOperation.Elwmul:
         math_fidelity = Fidelity.LoFi

--- a/tests/python_tests/test_multiple_tiles_eltwise.py
+++ b/tests/python_tests/test_multiple_tiles_eltwise.py
@@ -64,7 +64,7 @@ param_ids = generate_param_ids(all_params)
 def test_multiple_tiles(testname, formats, dest_acc, mathop, math_fidelity, tile_cnt):
     if (
         mathop in range(1, 4)
-        and formats.unpack_src == DataFormat.Float16
+        and formats.unpack_A_src == DataFormat.Float16
         and dest_acc == "DEST_ACC"
     ):
         pytest.skip(reason="This combination is not fully implemented in testing")
@@ -81,10 +81,10 @@ def test_multiple_tiles(testname, formats, dest_acc, mathop, math_fidelity, tile
     pack_addresses_formatted = format_kernel_list(pack_addresses, as_hex=True)
 
     src_A, src_B = generate_stimuli(
-        formats.unpack_src, tile_cnt=tile_cnt
+        formats.unpack_A_src, formats.unpack_B_src,tile_cnt=tile_cnt
     )  # , const_face=True, const_value_A=3, const_value_B=2)
     golden = generate_golden(mathop, src_A, src_B, formats.pack_dst, math_fidelity)
-    write_stimuli_to_l1(src_A, src_B, formats.unpack_src, "0,0", tile_cnt)
+    write_stimuli_to_l1(src_A, src_B, formats.unpack_A_src, formats.unpack_B_src, "0,0", tile_cnt)
 
     if mathop != 3:
         math_fidelity = 0

--- a/tests/python_tests/test_multiple_tiles_eltwise.py
+++ b/tests/python_tests/test_multiple_tiles_eltwise.py
@@ -72,13 +72,6 @@ def test_multiple_tiles(testname, formats, dest_acc, mathop, math_fidelity, tile
     ):
         pytest.skip(reason="This combination is not fully implemented in testing")
 
-    #  When running hundreds of tests, failing tests may cause incorrect behavior in subsequent passing tests.
-    #  To ensure accurate results, for now we reset board after each test.
-    #  Fix this: so we only reset after failing tests
-    if full_sweep:
-        run_shell_command(f"cd .. && make clean")
-        run_shell_command(f"tt-smi -r 0")
-
     pack_start_address = 0x1A000 + 2 * 4096 * tile_cnt.value
     pack_addresses = [pack_start_address + 0x1000 * i for i in range(tile_cnt.value)]
     pack_addresses_formatted = format_kernel_list(pack_addresses, as_hex=True)

--- a/tests/python_tests/test_pack_untilize.py
+++ b/tests/python_tests/test_pack_untilize.py
@@ -26,13 +26,6 @@ param_ids = generate_param_ids(all_params)
 @pytest.mark.parametrize("testname, formats", clean_params(all_params), ids=param_ids)
 def test_pack_untilize(testname, formats):
 
-    #  When running hundreds of tests, failing tests may cause incorrect behavior in subsequent passing tests.
-    #  To ensure accurate results, for now we reset board after each test.
-    #  Fix this: so we only reset after failing tests
-    if full_sweep:
-        run_shell_command(f"cd .. && make clean")
-        run_shell_command(f"tt-smi -r 0")
-
     src_A, src_B = generate_stimuli(formats.unpack_A_src, formats.unpack_B_src)
     src_A = torch.cat(
         [

--- a/tests/python_tests/test_pack_untilize.py
+++ b/tests/python_tests/test_pack_untilize.py
@@ -33,10 +33,10 @@ def test_pack_untilize(testname, formats):
         run_shell_command(f"cd .. && make clean")
         run_shell_command(f"tt-smi -r 0")
 
-    src_A, src_B = generate_stimuli(formats.unpack_src)
+    src_A, src_B = generate_stimuli(formats.unpack_A_src, formats.unpack_B_src)
     src_A = torch.cat(
         [
-            torch.full((256,), i, dtype=format_dict[formats.unpack_src])
+            torch.full((256,), i, dtype=format_dict[formats.unpack_A_src])
             for i in range(1, 5)
         ]
     )
@@ -44,7 +44,7 @@ def test_pack_untilize(testname, formats):
 
     golden_tensor = generate_golden(src_A, formats.pack_dst)
 
-    write_stimuli_to_l1(src_A, src_B, formats.unpack_src)
+    write_stimuli_to_l1(src_A, src_B, formats.unpack_A_src, formats.unpack_B_src)
 
     test_config = {
         "formats": formats,

--- a/tests/python_tests/test_reduce.py
+++ b/tests/python_tests/test_reduce.py
@@ -82,7 +82,10 @@ def test_reduce(testname, formats, dest_acc, reduce_dim, pool_type):
 
     src_A, src_B = generate_stimuli(formats.unpack_A_src, formats.unpack_B_src)
 
-    if pool_type in [ReducePoolArgs.Max, ReducePoolArgs.Sum]:  # result in srcA should be divided by 1
+    if pool_type in [
+        ReducePoolArgs.Max,
+        ReducePoolArgs.Sum,
+    ]:  # result in srcA should be divided by 1
         src_B = torch.full((1024,), 1)
     else:
         # reduce average divides by length of elements in array we reduce

--- a/tests/python_tests/test_reduce.py
+++ b/tests/python_tests/test_reduce.py
@@ -87,7 +87,7 @@ def test_reduce(testname, formats, dest_acc, reduce_dim, pool_type):
         run_shell_command(f"cd .. && make clean")
         run_shell_command(f"tt-smi -r 0")
 
-    src_A, src_B = generate_stimuli(formats.unpack_src)
+    src_A, src_B = generate_stimuli(formats.unpack_A_src, formats.unpack_B_src)
 
     if pool_type in ["max", "sum"]:  # result in srcA should be divided by 1
         src_B = torch.full((1024,), 1)
@@ -99,7 +99,7 @@ def test_reduce(testname, formats, dest_acc, reduce_dim, pool_type):
             src_B = torch.full((1024,), torch.sqrt(torch.tensor(1 / 1024)))
 
     golden_tensor = generate_golden(src_A, reduce_dim, pool_type, formats.pack_dst)
-    write_stimuli_to_l1(src_A, src_B, formats.unpack_src)
+    write_stimuli_to_l1(src_A, src_B, formats.unpack_A_src, formats.unpack_B_src)
 
     test_config = {
         "formats": formats,

--- a/tests/python_tests/test_reduce.py
+++ b/tests/python_tests/test_reduce.py
@@ -80,13 +80,6 @@ param_ids = generate_param_ids(all_params)
 @pytest.mark.skip(reason="Not fully implemented")
 def test_reduce(testname, formats, dest_acc, reduce_dim, pool_type):
 
-    #  When running hundreds of tests, failing tests may cause incorrect behavior in subsequent passing tests.
-    #  To ensure accurate results, for now we reset board after each test.
-    #  Fix this: so we only reset after failing tests
-    if full_sweep:
-        run_shell_command(f"cd .. && make clean")
-        run_shell_command(f"tt-smi -r 0")
-
     src_A, src_B = generate_stimuli(formats.unpack_A_src, formats.unpack_B_src)
 
     if pool_type in [ReducePoolArgs.Max, ReducePoolArgs.Sum]:  # result in srcA should be divided by 1

--- a/tests/python_tests/test_reduce.py
+++ b/tests/python_tests/test_reduce.py
@@ -27,7 +27,7 @@ def generate_golden(operand1, reduce_dim, pool_type, data_format):
         else:
             pytest.skip("Nonexisting pool type")
 
-    if reduce_dim == "reduce_col":
+    if reduce_dim == ReduceDimArgs.ReduceCol:
         left_half = torch.cat((f0, f2), 0)
         right_half = torch.cat((f1, f3), 0)
 
@@ -37,7 +37,7 @@ def generate_golden(operand1, reduce_dim, pool_type, data_format):
         result[0][0:16] = left_half_max.view(1, 16)
         result[0][16:32] = right_half_max.view(1, 16)
 
-    elif reduce_dim == "reduce_row":
+    elif reduce_dim == ReduceDimArgs.ReduceRow:
         top_half = torch.cat((f0, f1), 1)
         bottom_half = torch.cat((f2, f3), 1)
 
@@ -46,7 +46,7 @@ def generate_golden(operand1, reduce_dim, pool_type, data_format):
 
         result[:16, 0] = top_half_max.view(16)
         result[16:32, 0] = bottom_half_max.view(16)
-    elif reduce_dim == "reduce_scalar":
+    elif reduce_dim == ReduceDimArgs.ReduceScalar:
 
         result[0][0] = apply_pooling(operand1.view(1024), pool_type, dim=0)
 
@@ -65,9 +65,9 @@ all_format_combos = generate_format_combinations(
 all_params = generate_params(
     ["reduce_test"],
     all_format_combos,
-    dest_acc=[""],
-    reduce_dim=["reduce_col"],
-    pool_type=["max", "sum", "avg"],
+    dest_acc=[DestAccumulation.No],
+    reduce_dim=[ReduceDimArgs.ReduceCol],
+    pool_type=[ReducePoolArgs.Max, ReducePoolArgs.Sum, ReducePoolArgs.Avg],
 )
 param_ids = generate_param_ids(all_params)
 
@@ -89,11 +89,11 @@ def test_reduce(testname, formats, dest_acc, reduce_dim, pool_type):
 
     src_A, src_B = generate_stimuli(formats.unpack_A_src, formats.unpack_B_src)
 
-    if pool_type in ["max", "sum"]:  # result in srcA should be divided by 1
+    if pool_type in [ReducePoolArgs.Max, ReducePoolArgs.Sum]:  # result in srcA should be divided by 1
         src_B = torch.full((1024,), 1)
     else:
         # reduce average divides by length of elements in array we reduce
-        if reduce_dim in ["reduce_col", "reduce_row"]:
+        if reduce_dim in [ReduceDimArgs.ReduceCol, ReduceDimArgs.ReduceRow]:
             src_B = torch.full((1024,), 1 / 32)
         else:
             src_B = torch.full((1024,), torch.sqrt(torch.tensor(1 / 1024)))

--- a/tests/python_tests/test_sfpu_binary.py
+++ b/tests/python_tests/test_sfpu_binary.py
@@ -56,13 +56,6 @@ def test_all(testname, formats, dest_acc, mathop):
             "Skipping test for 32 bit wide data without 32 bit accumulation in Dest"
         )
 
-    #  When running hundreds of tests, failing tests may cause incorrect behavior in subsequent passing tests.
-    #  To ensure accurate results, for now we reset board after each test.
-    #  Fix this: so we only reset after failing tests
-    if full_sweep:
-        run_shell_command(f"cd .. && make clean")
-        run_shell_command(f"tt-smi -r 0")
-
     src_A, src_B = generate_stimuli(formats.unpack_A_src, formats.unpack_B_src)
     golden = generate_golden(mathop, src_A, src_B, formats.pack_dst)
     write_stimuli_to_l1(src_A, src_B, formats.unpack_A_src, formats.unpack_B_src)

--- a/tests/python_tests/test_sfpu_binary.py
+++ b/tests/python_tests/test_sfpu_binary.py
@@ -49,7 +49,7 @@ param_ids = generate_param_ids(all_params)
 @pytest.mark.skip(reason="Not fully implemented")
 def test_all(testname, formats, dest_acc, mathop):
     if (
-        formats.unpack_src in [DataFormat.Float32, DataFormat.Int32]
+        formats.unpack_A_src in [DataFormat.Float32, DataFormat.Int32]
         and dest_acc != "DEST_ACC"
     ):
         pytest.skip(
@@ -63,9 +63,9 @@ def test_all(testname, formats, dest_acc, mathop):
         run_shell_command(f"cd .. && make clean")
         run_shell_command(f"tt-smi -r 0")
 
-    src_A, src_B = generate_stimuli(formats.unpack_src)
+    src_A, src_B = generate_stimuli(formats.unpack_A_src, formats.unpack_B_src)
     golden = generate_golden(mathop, src_A, src_B, formats.pack_dst)
-    write_stimuli_to_l1(src_A, src_B, formats.unpack_src)
+    write_stimuli_to_l1(src_A, src_B, formats.unpack_A_src, formats.unpack_B_src)
 
     test_config = {
         "formats": formats,

--- a/tests/python_tests/test_sfpu_binary.py
+++ b/tests/python_tests/test_sfpu_binary.py
@@ -37,8 +37,8 @@ all_format_combos = generate_format_combinations(
 all_params = generate_params(
     ["sfpu_binary_test"],
     all_format_combos,
-    dest_acc=["DEST_ACC"],
-    mathop=["elwadd", "elwsub", "elwmul"],
+    dest_acc=[DestAccumulation.Yes],
+    mathop=[MathOperation.Elwadd, MathOperation.Elwsub, MathOperation.Elwmul],
 )
 param_ids = generate_param_ids(all_params)
 
@@ -50,7 +50,7 @@ param_ids = generate_param_ids(all_params)
 def test_all(testname, formats, dest_acc, mathop):
     if (
         formats.unpack_A_src in [DataFormat.Float32, DataFormat.Int32]
-        and dest_acc != "DEST_ACC"
+        and dest_acc != DestAccumulation.Yes
     ):
         pytest.skip(
             "Skipping test for 32 bit wide data without 32 bit accumulation in Dest"

--- a/tests/python_tests/test_tilize_calculate_untilize_L1.py
+++ b/tests/python_tests/test_tilize_calculate_untilize_L1.py
@@ -19,11 +19,11 @@ def generate_golden(op, operand1, operand2, data_format, math_fidelity):
     )
 
     if data_format == DataFormat.Float16_b:
-        if math_fidelity in [0, 2]:  # LoFi or HiFi2
+        if math_fidelity in [Fidelity.Zero, Fidelity.Two]:  # LoFi or HiFi2
             for element in operand2:
                 element = element.to(torch.int32)
                 element &= 0xFFFE
-        if math_fidelity == 0:  # LoFi
+        if math_fidelity == Fidelity.Zero:  # LoFi
             for element in operand1:
                 element = element.to(torch.int32)
                 element &= 0xFFF8
@@ -33,11 +33,11 @@ def generate_golden(op, operand1, operand2, data_format, math_fidelity):
     tensor2_float = tilize(tensor2_float, data_format)
 
     # Second step is to perform the operation
-    if op == "elwadd":
+    if op == MathOperation.Elwadd:
         res = tensor1_float + tensor2_float
-    elif op == "elwsub":
+    elif op == MathOperation.Elwsub:
         res = tensor1_float - tensor2_float
-    elif op == "elwmul":
+    elif op == MathOperation.Elwmul:
         res = tensor1_float * tensor2_float
     else:
         raise ValueError("Unsupported operation!")
@@ -54,10 +54,10 @@ all_format_combos = generate_format_combinations(
 all_params = generate_params(
     ["tilize_calculate_untilize_L1"],
     all_format_combos,
-    dest_acc=[""],
-    mathop=["elwadd", "elwsub", "elwmul"],
-    math_fidelity=[4],
-    tile_cnt=range(1, 2),
+    dest_acc=[DestAccumulation.No],
+    mathop=[MathOperation.Elwadd, MathOperation.Elwsub, MathOperation.Elwmul],
+    math_fidelity=[Fidelity.Four],
+    tile_cnt=[TileCount.One],
 )
 param_ids = generate_param_ids(all_params)
 

--- a/tests/python_tests/test_tilize_calculate_untilize_L1.py
+++ b/tests/python_tests/test_tilize_calculate_untilize_L1.py
@@ -77,14 +77,14 @@ def test_tilize_calculate_untilize_L1(
         run_shell_command(f"cd .. && make clean")
         run_shell_command(f"tt-smi -r 0")
 
-    src_A, src_B = generate_stimuli(formats.unpack_src, tile_cnt)
+    src_A, src_B = generate_stimuli(formats.unpack_A_src, formats.unpack_B_src, tile_cnt)
 
     golden_tensor = generate_golden(
         mathop, src_A, src_B, formats.pack_dst, math_fidelity
     )
     print(golden_tensor.view(32, 32))
 
-    write_stimuli_to_l1(src_A, src_B, formats.unpack_src, "0,0", tile_cnt)
+    write_stimuli_to_l1(src_A, src_B, formats.unpack_A_src, formats.unpack_B_src, "0,0", tile_cnt)
 
     test_config = {
         "formats": formats,

--- a/tests/python_tests/test_tilize_calculate_untilize_L1.py
+++ b/tests/python_tests/test_tilize_calculate_untilize_L1.py
@@ -70,12 +70,6 @@ param_ids = generate_param_ids(all_params)
 def test_tilize_calculate_untilize_L1(
     testname, formats, dest_acc, mathop, math_fidelity, tile_cnt
 ):
-    #  When running hundreds of tests, failing tests may cause incorrect behavior in subsequent passing tests.
-    #  To ensure accurate results, for now we reset board after each test.
-    #  Fix this: so we only reset after failing tests
-    if full_sweep:
-        run_shell_command(f"cd .. && make clean")
-        run_shell_command(f"tt-smi -r 0")
 
     src_A, src_B = generate_stimuli(formats.unpack_A_src, formats.unpack_B_src, tile_cnt)
 

--- a/tests/python_tests/test_tilize_calculate_untilize_L1.py
+++ b/tests/python_tests/test_tilize_calculate_untilize_L1.py
@@ -71,14 +71,18 @@ def test_tilize_calculate_untilize_L1(
     testname, formats, dest_acc, mathop, math_fidelity, tile_cnt
 ):
 
-    src_A, src_B = generate_stimuli(formats.unpack_A_src, formats.unpack_B_src, tile_cnt)
+    src_A, src_B = generate_stimuli(
+        formats.unpack_A_src, formats.unpack_B_src, tile_cnt
+    )
 
     golden_tensor = generate_golden(
         mathop, src_A, src_B, formats.pack_dst, math_fidelity
     )
     print(golden_tensor.view(32, 32))
 
-    write_stimuli_to_l1(src_A, src_B, formats.unpack_A_src, formats.unpack_B_src, "0,0", tile_cnt)
+    write_stimuli_to_l1(
+        src_A, src_B, formats.unpack_A_src, formats.unpack_B_src, "0,0", tile_cnt
+    )
 
     test_config = {
         "formats": formats,

--- a/tests/python_tests/test_tilize_calculate_untilize_L1.py
+++ b/tests/python_tests/test_tilize_calculate_untilize_L1.py
@@ -19,11 +19,11 @@ def generate_golden(op, operand1, operand2, data_format, math_fidelity):
     )
 
     if data_format == DataFormat.Float16_b:
-        if math_fidelity in [Fidelity.Zero, Fidelity.Two]:  # LoFi or HiFi2
+        if math_fidelity in [Fidelity.LoFi, Fidelity.HiFi2]:  # LoFi or HiFi2
             for element in operand2:
                 element = element.to(torch.int32)
                 element &= 0xFFFE
-        if math_fidelity == Fidelity.Zero:  # LoFi
+        if math_fidelity == Fidelity.LoFi:  # LoFi
             for element in operand1:
                 element = element.to(torch.int32)
                 element &= 0xFFF8
@@ -56,7 +56,7 @@ all_params = generate_params(
     all_format_combos,
     dest_acc=[DestAccumulation.No],
     mathop=[MathOperation.Elwadd, MathOperation.Elwsub, MathOperation.Elwmul],
-    math_fidelity=[Fidelity.Four],
+    math_fidelity=[Fidelity.HiFi4],
     tile_cnt=[TileCount.One],
 )
 param_ids = generate_param_ids(all_params)

--- a/tests/python_tests/test_unpack_tilize.py
+++ b/tests/python_tests/test_unpack_tilize.py
@@ -22,13 +22,6 @@ param_ids = generate_param_ids(all_params)
 @pytest.mark.parametrize("testname, formats", clean_params(all_params), ids=param_ids)
 def test_unpack_tilize(testname, formats):
 
-    #  When running hundreds of tests, failing tests may cause incorrect behavior in subsequent passing tests.
-    #  To ensure accurate results, for now we reset board after each test.
-    #  Fix this: so we only reset after failing tests
-    if full_sweep:
-        run_shell_command(f"cd .. && make clean")
-        run_shell_command(f"tt-smi -r 0")
-
     src_A, src_B = generate_stimuli(formats.unpack_A_src, formats.unpack_B_src)
     src_B = torch.full((1024,), 0)
 

--- a/tests/python_tests/test_unpack_tilize.py
+++ b/tests/python_tests/test_unpack_tilize.py
@@ -29,12 +29,12 @@ def test_unpack_tilize(testname, formats):
         run_shell_command(f"cd .. && make clean")
         run_shell_command(f"tt-smi -r 0")
 
-    src_A, src_B = generate_stimuli(formats.unpack_src)
+    src_A, src_B = generate_stimuli(formats.unpack_A_src, formats.unpack_B_src)
     src_B = torch.full((1024,), 0)
 
     golden_tensor = generate_golden(src_A, formats.pack_dst)
 
-    write_stimuli_to_l1(src_A, src_B, formats.unpack_src)
+    write_stimuli_to_l1(src_A, src_B, formats.unpack_A_src, formats.unpack_B_src)
 
     test_config = {
         "formats": formats,

--- a/tests/python_tests/test_unpack_untilize.py
+++ b/tests/python_tests/test_unpack_untilize.py
@@ -25,13 +25,6 @@ param_ids = generate_param_ids(all_params)
 @pytest.mark.parametrize("testname, formats", clean_params(all_params), ids=param_ids)
 def test_unpack_untilze(testname, formats):
 
-    #  When running hundreds of tests, failing tests may cause incorrect behavior in subsequent passing tests.
-    #  To ensure accurate results, for now we reset board after each test.
-    #  Fix this: so we only reset after failing tests
-    if full_sweep:
-        run_shell_command(f"cd .. && make clean")
-        run_shell_command(f"tt-smi -r 0")
-
     src_A, src_B = generate_stimuli(formats.unpack_A_src, formats.unpack_B_src)
     src_B = torch.full((1024,), 0)
 

--- a/tests/python_tests/test_unpack_untilize.py
+++ b/tests/python_tests/test_unpack_untilize.py
@@ -32,12 +32,12 @@ def test_unpack_untilze(testname, formats):
         run_shell_command(f"cd .. && make clean")
         run_shell_command(f"tt-smi -r 0")
 
-    src_A, src_B = generate_stimuli(formats.unpack_src)
+    src_A, src_B = generate_stimuli(formats.unpack_A_src, formats.unpack_B_src)
     src_B = torch.full((1024,), 0)
 
     golden_tensor = generate_golden(src_A, formats.pack_dst)
 
-    write_stimuli_to_l1(src_A, src_B, formats.unpack_src)
+    write_stimuli_to_l1(src_A, src_B, formats.unpack_A_src, formats.unpack_B_src)
 
     test_config = {
         "formats": formats,

--- a/tests/setup_env.sh
+++ b/tests/setup_env.sh
@@ -85,7 +85,7 @@ if [[ "$REUSE" == false ]]; then
 
     # **************** DOWNLOAD & INSTALL SFPI ****************************
     echo "Downloading SFPI release..."
-    wget https://github.com/tenstorrent/sfpi/releases/download/v6.4.0-sfpi/sfpi-release.tgz -O sfpi-release.tgz
+    wget https://github.com/tenstorrent/sfpi/releases/download/v6.5.0-sfpi/sfpi-release.tgz -O sfpi-release.tgz
     if [ ! -f "sfpi-release.tgz" ]; then
         echo "SFPI release not found!"
         exit 1

--- a/tests/sources/eltwise_unary_datacopy_test.cpp
+++ b/tests/sources/eltwise_unary_datacopy_test.cpp
@@ -20,7 +20,7 @@ const bool is_fp32_dest_acc_en = true;
 const bool is_fp32_dest_acc_en = false;
 #endif
 
-#if defined(UNPACK_SRC_INT32) || defined(UNPACK_SRC_FLOAT32)
+#if defined(UNPACK_A_SRC_INT32) || defined(UNPACK_A_SRC_FLOAT32)
 const bool unpack_to_dest = true;
 #else
 const bool unpack_to_dest = false;
@@ -36,9 +36,9 @@ void run_kernel()
 {
     volatile uint32_t* const buffer_A = reinterpret_cast<volatile uint32_t*>(0x1a000);
 
-    _llk_unpack_A_init_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(0, 0, FACE_R_DIM, 4, UNPACK_IN, UNPACK_OUT);
-    _llk_unpack_A_hw_configure_<is_fp32_dest_acc_en, StochRndType::None>(UNPACK_IN, UNPACK_OUT, FACE_R_DIM, 0, 4);
-    _llk_unpack_A_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(L1_ADDRESS(buffer_A), 0, UNPACK_IN, UNPACK_OUT);
+    _llk_unpack_A_init_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(0, 0, FACE_R_DIM, 4, UNPACK_A_IN, UNPACK_A_OUT);
+    _llk_unpack_A_hw_configure_<is_fp32_dest_acc_en, StochRndType::None>(UNPACK_A_IN, UNPACK_A_OUT, FACE_R_DIM, 0, 4);
+    _llk_unpack_A_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(L1_ADDRESS(buffer_A), 0, UNPACK_A_IN, UNPACK_A_OUT);
 }
 
 #endif
@@ -69,7 +69,7 @@ void run_kernel()
     _llk_math_hw_configure_<false, false>(MATH_FORMAT, MATH_FORMAT);
     _llk_math_wait_for_dest_available_<DstSync::SyncFull>();
     _llk_math_eltwise_unary_datacopy_<DataCopyType::A2D, DstSync::SyncFull, BroadcastType::NONE, is_fp32_dest_acc_en, unpack_to_dest>(
-        0, UNPACK_OUT, UNPACK_OUT);
+        0, UNPACK_A_OUT, UNPACK_A_OUT);
     _llk_math_dest_section_done_<DstSync::SyncFull, is_fp32_dest_acc_en>();
 }
 

--- a/tests/sources/eltwise_unary_sfpu_test.cpp
+++ b/tests/sources/eltwise_unary_sfpu_test.cpp
@@ -32,9 +32,9 @@ void run_kernel()
 {
     volatile uint32_t* const buffer_A = reinterpret_cast<volatile uint32_t*>(0x1a000);
 
-    _llk_unpack_A_hw_configure_<is_fp32_dest_acc_en, StochRndType::None>(UNPACK_IN, UNPACK_OUT, FACE_R_DIM, 0, 4);
-    _llk_unpack_A_init_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(0, 0, FACE_R_DIM, 4, UNPACK_IN, UNPACK_OUT);
-    _llk_unpack_A_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(L1_ADDRESS(buffer_A), 0, UNPACK_IN, UNPACK_OUT);
+    _llk_unpack_A_hw_configure_<is_fp32_dest_acc_en, StochRndType::None>(UNPACK_A_IN, UNPACK_A_OUT, FACE_R_DIM, 0, 4);
+    _llk_unpack_A_init_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(0, 0, FACE_R_DIM, 4, UNPACK_A_IN, UNPACK_A_OUT);
+    _llk_unpack_A_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(L1_ADDRESS(buffer_A), 0, UNPACK_A_IN, UNPACK_A_OUT);
 }
 
 #endif

--- a/tests/sources/fill_dest_test.cpp
+++ b/tests/sources/fill_dest_test.cpp
@@ -32,7 +32,7 @@ void run_kernel()
 
     for (uint index = 0; index < 16; index++)
     {
-        _llk_unpack_AB_hw_configure_<is_fp32_dest_acc_en, StochRndType::None>(UNPACK_IN, UNPACK_IN, UNPACK_OUT, UNPACK_OUT);
+        _llk_unpack_AB_hw_configure_<is_fp32_dest_acc_en, StochRndType::None>(UNPACK_A_IN, UNPACK_B_IN, UNPACK_B_OUT, UNPACK_B_OUT);
         _llk_unpack_AB_init_<>();
         _llk_unpack_AB_<>(L1_ADDRESS(buffer_A), L1_ADDRESS(buffer_B));
     }

--- a/tests/sources/matmul_test.cpp
+++ b/tests/sources/matmul_test.cpp
@@ -37,7 +37,7 @@ void run_kernel()
     std::uint32_t tile_size = 128;
 
     _llk_unpack_AB_matmul_hw_configure_<is_fp32_dest_acc_en, StochRndType::None>(
-        UNPACK_IN, UNPACK_IN, UNPACK_OUT, UNPACK_OUT, FACE_R_DIM, FACE_R_DIM, 0, 4, 4, tile_size, tile_size);
+        UNPACK_A_IN, UNPACK_B_IN, UNPACK_A_OUT, UNPACK_B_OUT, FACE_R_DIM, FACE_R_DIM, 0, 4, 4, tile_size, tile_size);
     _llk_unpack_AB_matmul_init_<>(0, ct_dim, rt_dim, kt_dim, FACE_R_DIM, FACE_R_DIM, 4, 4, false, false);
     _llk_unpack_AB_matmul_<>(
         L1_ADDRESS(buffer_A), L1_ADDRESS(buffer_B), 0, 0, tile_size, tile_size, FACE_R_DIM, FACE_R_DIM, false, false, ct_dim, rt_dim, kt_dim);

--- a/tests/sources/multiple_tiles_eltwise_test.cpp
+++ b/tests/sources/multiple_tiles_eltwise_test.cpp
@@ -38,7 +38,7 @@ void run_kernel()
 
     for (int index = 0; index < KERN_CNT; index++)
     {
-        _llk_unpack_AB_hw_configure_<is_fp32_dest_acc_en, StochRndType::None>(UNPACK_IN, UNPACK_IN, UNPACK_OUT, UNPACK_OUT);
+        _llk_unpack_AB_hw_configure_<is_fp32_dest_acc_en, StochRndType::None>(UNPACK_A_IN, UNPACK_B_IN, UNPACK_A_OUT, UNPACK_A_OUT);
         _llk_unpack_AB_init_<>();
         _llk_unpack_AB_<>(L1_ADDRESS(buffer_A[index]), L1_ADDRESS(buffer_B[index]));
     }

--- a/tests/sources/pack_untilize_test.cpp
+++ b/tests/sources/pack_untilize_test.cpp
@@ -30,9 +30,9 @@ void run_kernel()
     volatile uint32_t* const buffer_A = reinterpret_cast<volatile uint32_t*>(0x1a000);
     const bool unpack_to_dest         = false;
 
-    _llk_unpack_A_init_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(0, 0, FACE_R_DIM, 4, UNPACK_IN, UNPACK_OUT);
-    _llk_unpack_A_hw_configure_<is_fp32_dest_acc_en, StochRndType::None>(UNPACK_IN, UNPACK_OUT, FACE_R_DIM, 0, 4);
-    _llk_unpack_A_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(L1_ADDRESS(buffer_A), 0, UNPACK_IN, UNPACK_OUT);
+    _llk_unpack_A_init_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(0, 0, FACE_R_DIM, 4, UNPACK_A_IN, UNPACK_A_OUT);
+    _llk_unpack_A_hw_configure_<is_fp32_dest_acc_en, StochRndType::None>(UNPACK_A_IN, UNPACK_A_OUT, FACE_R_DIM, 0, 4);
+    _llk_unpack_A_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(L1_ADDRESS(buffer_A), 0, UNPACK_A_IN, UNPACK_A_OUT);
 }
 
 #endif

--- a/tests/sources/reduce_test.cpp
+++ b/tests/sources/reduce_test.cpp
@@ -38,7 +38,7 @@ void run_kernel()
     volatile uint32_t* const buffer_B = reinterpret_cast<volatile uint32_t*>(0x1b000);
 
     _llk_unpack_AB_hw_configure_<is_fp32_dest_acc_en, StochRndType::None>(
-        UNPACK_IN, UNPACK_IN, UNPACK_OUT, UNPACK_OUT, FACE_R_DIM, within_face_16x16_transpose);
+        UNPACK_A_IN, UNPACK_B_IN, UNPACK_A_OUT, UNPACK_B_OUT, FACE_R_DIM, within_face_16x16_transpose);
     _llk_unpack_AB_init_<>(FACE_C_DIM, 4, false, within_face_16x16_transpose, 0);
     _llk_unpack_AB_<>(L1_ADDRESS(buffer_A), L1_ADDRESS(buffer_B), within_face_16x16_transpose);
 }

--- a/tests/sources/sfpu_binary_test.cpp
+++ b/tests/sources/sfpu_binary_test.cpp
@@ -30,9 +30,9 @@ void run_kernel()
 {
     volatile uint32_t* buffer_A = reinterpret_cast<volatile uint32_t*>(0x1a000);
 
-    _llk_unpack_A_hw_configure_<is_fp32_dest_acc_en, StochRndType::None>(UNPACK_IN, UNPACK_OUT, FACE_R_DIM, 0, 4);
-    _llk_unpack_A_init_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(0, 0, FACE_R_DIM, 4, UNPACK_IN, UNPACK_OUT);
-    _llk_unpack_A_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(L1_ADDRESS(buffer_A), 0, UNPACK_IN, UNPACK_OUT);
+    _llk_unpack_A_hw_configure_<is_fp32_dest_acc_en, StochRndType::None>(UNPACK_A_IN, UNPACK_A_OUT, FACE_R_DIM, 0, 4);
+    _llk_unpack_A_init_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(0, 0, FACE_R_DIM, 4, UNPACK_A_IN, UNPACK_A_OUT);
+    _llk_unpack_A_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(L1_ADDRESS(buffer_A), 0, UNPACK_A_IN, UNPACK_A_OUT);
 }
 
 #endif

--- a/tests/sources/tilize_calculate_untilize_L1.cpp
+++ b/tests/sources/tilize_calculate_untilize_L1.cpp
@@ -36,15 +36,15 @@ volatile uint32_t* const buffer_B_tilized = reinterpret_cast<volatile uint32_t*>
 
 void run_kernel()
 {
-    _llk_unpack_tilize_hw_configure_<is_fp32_dest_acc_en, StochRndType::None>(UNPACK_IN, UNPACK_OUT, FACE_R_DIM, 0, 4);
+    _llk_unpack_tilize_hw_configure_<is_fp32_dest_acc_en, StochRndType::None>(UNPACK_A_IN, UNPACK_A_OUT, FACE_R_DIM, 0, 4);
 
-    _llk_unpack_tilize_init_(UNPACK_IN, UNPACK_OUT, 1, FACE_R_DIM, false);
-    _llk_unpack_tilize_(L1_ADDRESS(buffer_A), 0, UNPACK_IN, 1, FACE_R_DIM, 4, false);
+    _llk_unpack_tilize_init_(UNPACK_A_IN, UNPACK_A_OUT, 1, FACE_R_DIM, false);
+    _llk_unpack_tilize_(L1_ADDRESS(buffer_A), 0, UNPACK_A_IN, 1, FACE_R_DIM, 4, false);
 
-    _llk_unpack_tilize_init_(UNPACK_IN, UNPACK_OUT, 1, FACE_R_DIM, false);
-    _llk_unpack_tilize_(L1_ADDRESS(buffer_B), 0, UNPACK_IN, 1, FACE_R_DIM, 4, false);
+    _llk_unpack_tilize_init_(UNPACK_B_IN, UNPACK_B_OUT, 1, FACE_R_DIM, false);
+    _llk_unpack_tilize_(L1_ADDRESS(buffer_B), 0, UNPACK_B_IN, 1, FACE_R_DIM, 4, false);
 
-    _llk_unpack_AB_hw_configure_<is_fp32_dest_acc_en, StochRndType::None>(UNPACK_IN, UNPACK_IN, UNPACK_OUT, UNPACK_OUT, FACE_R_DIM, 0, 4);
+    _llk_unpack_AB_hw_configure_<is_fp32_dest_acc_en, StochRndType::None>(UNPACK_A_IN, UNPACK_B_IN, UNPACK_A_OUT, UNPACK_B_OUT, FACE_R_DIM, 0, 4);
     _llk_unpack_AB_init_<>();
     _llk_unpack_AB_<>(L1_ADDRESS(buffer_A_tilized), L1_ADDRESS(buffer_B_tilized));
 }

--- a/tests/sources/unpack_tilize_test.cpp
+++ b/tests/sources/unpack_tilize_test.cpp
@@ -28,9 +28,9 @@ void run_kernel()
 {
     volatile uint32_t* const buffer_A = reinterpret_cast<volatile uint32_t*>(0x1a000);
 
-    _llk_unpack_tilize_hw_configure_<is_fp32_dest_acc_en, StochRndType::None>(UNPACK_IN, UNPACK_OUT, FACE_R_DIM, 0, 4);
-    _llk_unpack_tilize_init_(UNPACK_IN, UNPACK_OUT, 1, FACE_R_DIM, false);
-    _llk_unpack_tilize_(L1_ADDRESS(buffer_A), 0, UNPACK_IN, 1, FACE_R_DIM, 4, false);
+    _llk_unpack_tilize_hw_configure_<is_fp32_dest_acc_en, StochRndType::None>(UNPACK_A_IN, UNPACK_A_OUT, FACE_R_DIM, 0, 4);
+    _llk_unpack_tilize_init_(UNPACK_A_IN, UNPACK_A_OUT, 1, FACE_R_DIM, false);
+    _llk_unpack_tilize_(L1_ADDRESS(buffer_A), 0, UNPACK_A_IN, 1, FACE_R_DIM, 4, false);
 }
 
 #endif

--- a/tests/sources/unpack_untilize_test.cpp
+++ b/tests/sources/unpack_untilize_test.cpp
@@ -30,8 +30,8 @@ void run_kernel()
 {
     volatile uint32_t* const buffer_A = reinterpret_cast<volatile uint32_t*>(0x1a000);
 
-    _llk_unpack_untilize_hw_configure_<is_fp32_dest_acc_en, StochRndType::None>(UNPACK_IN, UNPACK_OUT, FACE_R_DIM, 0, 4);
-    _llk_unpack_untilize_init_(UNPACK_IN, 1024, FACE_R_DIM, 4);
+    _llk_unpack_untilize_hw_configure_<is_fp32_dest_acc_en, StochRndType::None>(UNPACK_A_IN, UNPACK_A_OUT, FACE_R_DIM, 0, 4);
+    _llk_unpack_untilize_init_(UNPACK_A_IN, 1024, FACE_R_DIM, 4);
     _llk_unpack_untilize_pass_<true>(L1_ADDRESS(buffer_A), 1);
     _llk_unpack_untilize_pass_<false>(L1_ADDRESS(buffer_A), 1);
 }


### PR DESCRIPTION
### What's changed
#### Updated FormatConfig class for different source register formats:
* Previously, the source registers A and B were assumed to have the same format, leading to the FormatConfig class having only two formats (input and output for both registers, i.e., `unpack_src`, `unpack_dst`).
* Now, the source registers can have different formats. This reflects the real-world scenario where data input into L1 may have different formats, and after unpacker LLK operations, these are stored into the source registers.
* The `FormatConfig` class has been updated to support four formats: input and output for both `srcReg A`, `srcReg B`.
* A new convenience flag, `same_src_format`, has been added to allow setting the formats for `srcReg A`, `srcReg B` to be the same (default behavior) or different.

#### Added user-defined format combinations for testing:
* Introduced functionality that allows the client/user to define their own format combinations for testing.
* This is handled through the `create_formats_for_testing(...)` function, which takes user-defined format combinations and generates instances of the `FormatConfig class`.
* The benefit of this feature is that it abstracts the configuration details, making it easier for users to run tests without having to manually configure format setups for each test. Users can simply pass in the formats they want to test, simplifying the process.

#### Implemented Enum classes for better consistency and readability:
* Replaced string-based comparisons in the tests and LLKs with Enum classes, improving code readability and reducing the likelihood of errors due to typos or hardcoded strings.
* Enum classes now encapsulate the constants used for formats and other relevant settings, providing unique members that can be compared and introspected. This ensures better maintainability and reduces potential bugs from string misuse.

#### Fixes
* Fixed parameter output representation in `param_config.py`. Previously some data parameters were not being represented in the test output string.  
* Added changes to docstrings in functions to match the new implementation of `Enum` class instances for test parameters instead of strings.

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [x] All tests that pass on main branch, continue to pass with the changes implemented
