### PR TITLE
#16439: Disable instruction coalescing feature

### DIFF
--- a/tt_llk_blackhole/common/inc/ckernel.h
+++ b/tt_llk_blackhole/common/inc/ckernel.h
@@ -698,7 +698,9 @@ inline void load_replay_buf(F fn)
     // Send in the user's desired instructions
     fn();
 
-    enable_gathering();
+    // Workaround for tt-metal#16439, making sure gathering is disabled
+    // WE DON'T UNDERSTAND WHY ENABLING GATHERING DOESN'T WORK
+    // enable_gathering();
 }
 
 // Same as above, but used if start/len/exec_while_loading are not known
@@ -714,7 +716,9 @@ inline void load_replay_buf(uint start, uint len, bool exec_while_loading, F fn)
     // Send in the user's desired instructions
     fn();
 
-    enable_gathering();
+    // Workaround for tt-metal#16439, making sure gathering is disabled
+    // WE DON'T UNDERSTAND WHY ENABLING GATHERING DOESN'T WORK
+    // enable_gathering();
 }
 
 enum class CSR : uint16_t


### PR DESCRIPTION
### Ticket
[tt-metal#16439](https://github.com/tenstorrent/tt-metal/issues/16439)
[tt-metal#18550](https://github.com/tenstorrent/tt-metal/issues/18550)

### Problem description
Hangs are present in ResNet 50 and Stable Diffusion 1.4. These issues are blocking further model bringup work. The hangs are reproducible with matmul tests, namely `test_benchmark.py` and `test_benchmark.cpp`. 

### What's changed
We are disabling instruction coalescing in Blackhole inside `load_replay_buf` calls. This will unblock RN and SD work. 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
