### PR TITLE
[Test Infrastructure] Fixed bug in test_tilize_calculate_untilize_L1 

### DIFF
--- a/tests/helpers/src/brisc.cpp
+++ b/tests/helpers/src/brisc.cpp
@@ -33,6 +33,7 @@ void device_setup()
     // Initialize tensix semaphores
     TTI_SEMINIT(1, 0, ckernel::semaphore::UNPACK_TO_DEST);
     TTI_SEMINIT(1, 0, ckernel::semaphore::MATH_DONE);
+    TTI_SEMINIT(1, 0, ckernel::semaphore::PACK_DONE);
 }
 
 int main()

--- a/tests/helpers/src/trisc.cpp
+++ b/tests/helpers/src/trisc.cpp
@@ -33,13 +33,9 @@ int main()
     *mailbox                            = 0x2; // write value different than 1 to mailbox to indicate kernel is running
 
     std::fill(ckernel::regfile, ckernel::regfile + 64, 0);
-    *mailbox = 0x3;
     ckernel::reset_cfg_state_id();
-    *mailbox = 0x4;
     ckernel::reset_dest_offset_id();
-    *mailbox = 0x5;
     run_kernel();
-    *mailbox = 0x6;
     ckernel::tensix_sync();
     *mailbox = ckernel::KERNEL_COMPLETE; // 0x1
 

--- a/tests/python_tests/test_tilize_calculate_untilize_L1.py
+++ b/tests/python_tests/test_tilize_calculate_untilize_L1.py
@@ -111,7 +111,6 @@ def test_tilize_calculate_untilize_L1(
             else torch.bfloat16
         ),
     )
-   
 
     if formats.pack_dst in [DataFormat.Float16_b, DataFormat.Float16]:
         atol = 0.1

--- a/tests/python_tests/test_tilize_calculate_untilize_L1.py
+++ b/tests/python_tests/test_tilize_calculate_untilize_L1.py
@@ -67,7 +67,7 @@ param_ids = generate_param_ids(all_params)
     clean_params(all_params),
     ids=param_ids,
 )
-@pytest.mark.skip(reason="Not fully implemented")
+
 def test_tilize_calculate_untilize_L1(
     testname, formats, dest_acc, mathop, math_fidelity, tile_cnt
 ):
@@ -111,7 +111,7 @@ def test_tilize_calculate_untilize_L1(
             else torch.bfloat16
         ),
     )
-    print(res_tensor.view(32, 32))
+   
 
     if formats.pack_dst in [DataFormat.Float16_b, DataFormat.Float16]:
         atol = 0.1

--- a/tests/python_tests/test_tilize_calculate_untilize_L1.py
+++ b/tests/python_tests/test_tilize_calculate_untilize_L1.py
@@ -67,7 +67,6 @@ param_ids = generate_param_ids(all_params)
     clean_params(all_params),
     ids=param_ids,
 )
-
 def test_tilize_calculate_untilize_L1(
     testname, formats, dest_acc, mathop, math_fidelity, tile_cnt
 ):

--- a/tests/sources/tilize_calculate_untilize_L1.cpp
+++ b/tests/sources/tilize_calculate_untilize_L1.cpp
@@ -44,8 +44,24 @@ void run_kernel()
     _llk_unpack_tilize_init_(UNPACK_B_IN, UNPACK_B_OUT, 1, FACE_R_DIM, false);
     _llk_unpack_tilize_(L1_ADDRESS(buffer_B), 0, UNPACK_B_IN, 1, FACE_R_DIM, 4, false);
 
-    t6_semaphore_wait_on_zero<p_stall::STALL_SYNC>(semaphore::PACK_DONE);
-    t6_semaphore_get<>(semaphore::PACK_DONE);
+    /*
+    In this test we fuse two LLK pipeline runs, one is to unpack untilized buffers/operands from L1 (39-45) and pack them in tilized format(130-145).
+    The next run unpacks these two tilized operands, performs a math compute and pack them out in utilized format.
+    Since we have set all three TRISCs to run at the same time, fusing these two runs will cause a race condition where unpacker will immediately read from
+    L1 before the packer has completed writing to L1. To prevent the unpacker from prematurely reading from L1 before packer has completed write
+    the unpacker needs to wait for packer to finish writing to L1 before it starts reading from L1 for the second iteration of LLK pipeline.
+
+    Synchronization is accomplished between the packer and unpacker operations using the PACK_DONE semaphore.
+    The packer first writes data to L1 and signals the unpacker by incrementing the semaphore (PACK_DONE = 1).
+    The unpacker waits for the semaphore to be set to 1 before reading the data from L1.
+    This ensures that the unpacker does not read premature or incorrect data, preventing data race conditions.
+    Once the unpacker starts reading, it decrements the semaphore (PACK_DONE = 0) signalling it has started processing data.
+    */
+
+    t6_semaphore_wait_on_zero<p_stall::STALL_SYNC>(
+        semaphore::PACK_DONE); // Unpacker waits on signal when packer will increment semaphore to 1 (waits while semaphore == 0), utilizing SEMWAIT.
+    t6_semaphore_get<>(semaphore::PACK_DONE); // It will acquire the semaphore t6_semaphore_get (decrementing the semaphore back to 0) signalling it has begun
+                                              // processing data from L1
     _llk_unpack_AB_hw_configure_<is_fp32_dest_acc_en, StochRndType::None>(UNPACK_A_IN, UNPACK_B_IN, UNPACK_A_OUT, UNPACK_B_OUT, FACE_R_DIM, 0, 4);
     _llk_unpack_AB_init_<>();
     _llk_unpack_AB_<>(L1_ADDRESS(buffer_A_tilized), L1_ADDRESS(buffer_B_tilized));
@@ -134,9 +150,11 @@ void run_kernel()
 
     _llk_packer_wait_for_math_done_();
     _llk_pack_<DstSync::SyncFull, UNTILIZE, is_fp32_dest_acc_en>(operand_B_dst_index, L1_ADDRESS(buffer_B_tilized));
-    _llk_pack_dest_section_done_<DstSync::SyncFull, is_fp32_dest_acc_en>();
+    _llk_pack_dest_section_done_<DstSync::SyncFull, is_fp32_dest_acc_en>(); // Packer will execute _llk_pack_dest_section_done_ function which ensures the write
+                                                                            // to L1 is fully is complete.
+    t6_semaphore_post<>(semaphore::PACK_DONE); // The packer signals to the unpacker that it has finished writing to L1 by posting (incrementing) the semaphore.
+                                               // Now unpacker's wait condition is satisfied, allowing it to begin processing data from L1.
 
-    t6_semaphore_post<>(semaphore::PACK_DONE);
 #ifdef ARCH_BLACKHOLE
     _llk_pack_hw_configure_<UNTILIZE, is_fp32_dest_acc_en, !TILIZE>(PACK_IN, PACK_OUT, 16 * 16 * 4);
     _llk_pack_init_<UNTILIZE, false, DstTileFaceLayout::RowMajor, false, !TILIZE>(PACK_OUT);

--- a/tests/sources/tilize_calculate_untilize_L1.cpp
+++ b/tests/sources/tilize_calculate_untilize_L1.cpp
@@ -25,6 +25,7 @@ volatile uint32_t* const buffer_B = reinterpret_cast<volatile uint32_t*>(0x1b000
 
 volatile uint32_t* const buffer_A_tilized = reinterpret_cast<volatile uint32_t*>(0x1c000);
 volatile uint32_t* const buffer_B_tilized = reinterpret_cast<volatile uint32_t*>(0x1d000);
+volatile std::uint32_t* const mailbox = reinterpret_cast<volatile std::uint32_t*>(0x19FF4);
 
 #ifdef LLK_TRISC_UNPACK
 
@@ -36,7 +37,6 @@ volatile uint32_t* const buffer_B_tilized = reinterpret_cast<volatile uint32_t*>
 
 void run_kernel()
 {
-    volatile std::uint32_t* const mailbox = reinterpret_cast<volatile std::uint32_t*>(0x19FF4);
     _llk_unpack_tilize_hw_configure_<is_fp32_dest_acc_en, StochRndType::None>(UNPACK_A_IN, UNPACK_A_OUT, FACE_R_DIM, 0, 4);
 
     _llk_unpack_tilize_init_(UNPACK_A_IN, UNPACK_A_OUT, 1, FACE_R_DIM, false);
@@ -110,7 +110,6 @@ void run_kernel()
 void run_kernel()
 {
     volatile uint32_t* const buffer_Dest    = reinterpret_cast<volatile uint32_t*>(0x1e000);
-    volatile std::uint32_t* const mailbox = reinterpret_cast<volatile std::uint32_t*>(0x19FF4);
     const std::uint32_t ct_dim              = 1;
     const std::uint32_t operand_A_dst_index = 1;
     const std::uint32_t operand_B_dst_index = 2;


### PR DESCRIPTION
### Problem description
Once TRISCs were synced to run at the same time in order to resolve hangs because unpack was lagging behind pack and math TRISCs, `test_tilize_calculate_utilize.py` started to fail because it attempted to fuse two LLK pipeline runs. This means that in the first run we unpack from two buffers in L1 and after math we pack to two other buffers in L1. Then in the second run we unpack from these two buffers that pack wrote to, however `unpacker` started to read from the buffers before the `packer` completed writing to L1. 

This worked previously because the `unpacker` was severely lagging behind `packer` and `math` (approximately 700 cycles), and this lag allowed for `packer` to finish writing to L1 before the `unpacker` would start reading. Since `unpacker` is synced with `packer` we must make `unpacker` wait for packer to finish before it begins reading from L1.

### What's changed
Implemented semaphore/ flag to control the execution flow required between different components of the system. In `tilize_calculate_untilize_L1.cpp` file we use `packer` mailbox as a semaphore flag for inter-process communication mechanism with the `unpacker`. The mailbox is a shared memory location that packer processor writes to, and unpacker processor reads from. The packer will update the value it stores in its mailbox to signal that it has written to L1. Meanwhile the unpacker will wait/stall until packer signals that it has finished before it begins.

The use of `__atomic_load_n` with `__ATOMIC_SEQ_CST` means that the value is being read atomically with a memory synchronization order, ensuring data consistency and avoiding race conditions without the need for complex locking mechanisms.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
