### PR TITLE
Cleanup of superfluous includes and removal of `using namespace sfpi`

### DIFF
--- a/tt_llk_blackhole/common/inc/ckernel_sfpi.h
+++ b/tt_llk_blackhole/common/inc/ckernel_sfpi.h
@@ -18,7 +18,6 @@
 #endif
 
 using namespace ckernel;
-using namespace sfpi;
 
 namespace sfpi_test
 {
@@ -157,7 +156,7 @@ sfpi_test_noinline void test3()
     v_if (sfpi::dst_reg[0] == 6.0F)
     {
         // This will be an int w/ 2 loads
-        vInt a     = 0x3F80A3D7; // 1.005
+        vInt a           = 0x3F80A3D7; // 1.005
         sfpi::dst_reg[3] = a;
     }
     v_endif;
@@ -165,7 +164,7 @@ sfpi_test_noinline void test3()
     v_if (sfpi::dst_reg[0] == 7.0F)
     {
         // This will be an int w/ 1 load (not sign extended)
-        vInt a     = 0x8F80;
+        vInt a           = 0x8F80;
         sfpi::dst_reg[3] = a | 0x3f800000;
     }
     v_endif;
@@ -173,7 +172,7 @@ sfpi_test_noinline void test3()
     v_if (sfpi::dst_reg[0] == 8.0F)
     {
         // This will be a ushort w/ 1 load (not sign extended)
-        vUInt a    = 0x8F80U;
+        vUInt a          = 0x8F80U;
         sfpi::dst_reg[3] = a | 0x3f800000;
     }
     v_endif;
@@ -187,7 +186,7 @@ sfpi_test_noinline void test3()
 
     v_if (sfpi::dst_reg[0] == 10.0F)
     {
-        vUInt a    = static_cast<unsigned short>(0x3f80);
+        vUInt a          = static_cast<unsigned short>(0x3f80);
         sfpi::dst_reg[3] = a | 0x3f800000;
     }
     v_endif;
@@ -201,7 +200,7 @@ sfpi_test_noinline void test3()
 
     v_if (sfpi::dst_reg[0] == 12.0F)
     {
-        vUInt a    = 0x3F80A3D7;
+        vUInt a          = 0x3F80A3D7;
         sfpi::dst_reg[3] = a;
     }
     v_endif;
@@ -637,7 +636,7 @@ sfpi_test_noinline void test5()
     {
         sfpi::vFloat c = -5.0F;
         sfpi::vFloat d;
-        d          = a * b + c - 0.5F;
+        d                = a * b + c - 0.5F;
         sfpi::dst_reg[5] = d;
     }
     v_elseif (sfpi::dst_reg[0] == 22.0F)
@@ -848,7 +847,7 @@ sfpi_test_noinline void test6()
             v_endif;
 
             sfpi::vFloat b = 128.0F;
-            vInt c   = 29;
+            vInt c         = 29;
             v_if (a >= c)
             {
                 b = 256.0F;
@@ -1136,9 +1135,9 @@ sfpi_test_noinline void test7()
     }
     v_elseif (sfpi::dst_reg[0] == 9.0F)
     {
-        vInt exp       = 0x007F;   // Exponent in low bits
+        vInt exp             = 0x007F;   // Exponent in low bits
         sfpi::vFloat sgn_man = -1664.0F; // 1024 + 512 + 128 or 1101
-        sgn_man        = setexp(sgn_man, exp);
+        sgn_man              = setexp(sgn_man, exp);
         sfpi::dst_reg[7]     = sgn_man;
     }
     v_endif;
@@ -1155,7 +1154,7 @@ sfpi_test_noinline void test7()
     v_elseif (sfpi::dst_reg[0] == 11.0F)
     {
         sfpi::vFloat tmp  = 1024.0F;
-        vInt man    = 0x75019a;
+        vInt man          = 0x75019a;
         sfpi::vFloat tmp2 = setman(tmp, man);
         sfpi::dst_reg[7]  = tmp2;
     }
@@ -1208,7 +1207,7 @@ sfpi_test_noinline void test7()
     // and things get flipped around when joined by ||
     v_if (v >= 29.0f && v < 32.0f)
     {
-        vInt t       = vConstTileId >> 1;
+        vInt t             = vConstTileId >> 1;
         sfpi::vFloat total = 16.0F;
 
         v_if (t <= 30)
@@ -1700,7 +1699,8 @@ sfpi_test_noinline void test9()
     v_endif;
 
     v_if (
-        (sfpi::dst_reg[0] == 23.0 || sfpi::dst_reg[0] == 24.0 || sfpi::dst_reg[0] == 25.0 || sfpi::dst_reg[0] == 26.0 || sfpi::dst_reg[0] == 27.0 || sfpi::dst_reg[0] == 28.0) &&
+        (sfpi::dst_reg[0] == 23.0 || sfpi::dst_reg[0] == 24.0 || sfpi::dst_reg[0] == 25.0 || sfpi::dst_reg[0] == 26.0 || sfpi::dst_reg[0] == 27.0 ||
+         sfpi::dst_reg[0] == 28.0) &&
         (sfpi::dst_reg[0] != 23.0 && sfpi::dst_reg[0] != 25.0 && sfpi::dst_reg[0] != 27.0f))
     {
         sfpi::dst_reg[9] = 64.0f;
@@ -1839,51 +1839,51 @@ sfpi_test_noinline void test11()
     {
         // Use L0
         sfpi::vFloat h    = -0.3F;
-        vUInt l2a   = 0xA010; // Mulitply by -0.25, add 0.5
-        h           = lut_sign(h, l0a, l1a, l2a);
+        vUInt l2a         = 0xA010; // Mulitply by -0.25, add 0.5
+        h                 = lut_sign(h, l0a, l1a, l2a);
         sfpi::dst_reg[11] = h;
     }
     v_elseif (sfpi::dst_reg[0] == 2.0F)
     {
         // Use L0
         sfpi::vFloat h    = -0.3F;
-        vUInt l2a   = 0xA010; // Mulitply by -0.25, add 0.5
-        h           = lut(h, l0a, l1a, l2a);
+        vUInt l2a         = 0xA010; // Mulitply by -0.25, add 0.5
+        h                 = lut(h, l0a, l1a, l2a);
         sfpi::dst_reg[11] = h;
     }
     v_elseif (sfpi::dst_reg[0] == 3.0F)
     {
         // Use L0
-        sfpi::vFloat h  = -0.3F;
-        vUInt l2a = 0xA010; // Mulitply by -0.25, add 0.5
+        sfpi::vFloat h = -0.3F;
+        vUInt l2a      = 0xA010; // Mulitply by -0.25, add 0.5
         // Test used a bias on Grayskull, not supported on Wormhole
-        h           = lut_sign(h, l0a, l1a, l2a);
+        h                 = lut_sign(h, l0a, l1a, l2a);
         sfpi::dst_reg[11] = h;
     }
     v_elseif (sfpi::dst_reg[0] == 4.0F)
     {
         // Use L0
-        sfpi::vFloat h  = -0.3F;
-        vUInt l2a = 0xA010; // Mulitply by -0.25, add 0.5
+        sfpi::vFloat h = -0.3F;
+        vUInt l2a      = 0xA010; // Mulitply by -0.25, add 0.5
         // Test used a bias on Grayskull, not supported on Wormhole
-        h           = lut(h, l0a, l1a, l2a);
+        h                 = lut(h, l0a, l1a, l2a);
         sfpi::dst_reg[11] = h;
     }
     v_elseif (sfpi::dst_reg[0] == 5.0F)
     {
         // Use L1
-        sfpi::vFloat h  = 1.0F;
-        vUInt l2a = 0xA010; // Mulitply by -0.25, add 0.5
+        sfpi::vFloat h = 1.0F;
+        vUInt l2a      = 0xA010; // Mulitply by -0.25, add 0.5
         // Test used a bias on Grayskull, not supported on Wormhole
-        h           = lut(h, l0a, l1a, l2a);
+        h                 = lut(h, l0a, l1a, l2a);
         sfpi::dst_reg[11] = h;
     }
     v_elseif (sfpi::dst_reg[0] == 6.0F)
     {
         // Use L2
         sfpi::vFloat h    = 4.0F;
-        vUInt l2a   = 0xA010; // Mulitply by -0.25, add 0.5
-        h           = lut_sign(h, l0a, l1a, l2a);
+        vUInt l2a         = 0xA010; // Mulitply by -0.25, add 0.5
+        h                 = lut_sign(h, l0a, l1a, l2a);
         sfpi::dst_reg[11] = h;
     }
     v_endif;
@@ -1905,51 +1905,51 @@ sfpi_test_noinline void test11()
         {
             // Use L0
             sfpi::vFloat h    = -0.3F;
-            vUInt l2b   = 0x9000;
-            h           = lut_sign(h, l0b, l1b, l2b);
+            vUInt l2b         = 0x9000;
+            h                 = lut_sign(h, l0b, l1b, l2b);
             sfpi::dst_reg[11] = h;
         }
         v_elseif (sfpi::dst_reg[0] == 8.0F)
         {
             // Use L0
             sfpi::vFloat h    = -0.3F;
-            vUInt l2b   = 0x9000;
-            h           = lut(h, l0b, l1b, l2b);
+            vUInt l2b         = 0x9000;
+            h                 = lut(h, l0b, l1b, l2b);
             sfpi::dst_reg[11] = h;
         }
         v_elseif (sfpi::dst_reg[0] == 9.0F)
         {
             // Use L0
-            sfpi::vFloat h  = -0.3F;
-            vUInt l2b = 0x9000;
+            sfpi::vFloat h = -0.3F;
+            vUInt l2b      = 0x9000;
             // Test used a bias on Grayskull, not supported on Wormhole
-            h           = lut_sign(h, l0b, l1b, l2b);
+            h                 = lut_sign(h, l0b, l1b, l2b);
             sfpi::dst_reg[11] = h;
         }
         v_elseif (sfpi::dst_reg[0] == 10.0F)
         {
             // Use L0
-            sfpi::vFloat h  = -0.3F;
-            vUInt l2b = 0x9000;
+            sfpi::vFloat h = -0.3F;
+            vUInt l2b      = 0x9000;
             // Test used a bias on Grayskull, not supported on Wormhole
-            h           = lut(h, l0b, l1b, l2b);
+            h                 = lut(h, l0b, l1b, l2b);
             sfpi::dst_reg[11] = h;
         }
         v_elseif (sfpi::dst_reg[0] == 11.0F)
         {
             // Use L1
-            sfpi::vFloat h  = 1.0F;
-            vUInt l2b = 0x9000;
+            sfpi::vFloat h = 1.0F;
+            vUInt l2b      = 0x9000;
             // Test used a bias on Grayskull, not supported on Wormhole
-            h           = lut(h, l0b, l1b, l2b);
+            h                 = lut(h, l0b, l1b, l2b);
             sfpi::dst_reg[11] = h;
         }
         v_elseif (sfpi::dst_reg[0] == 12.0F)
         {
             // Use L2
             sfpi::vFloat h    = 4.0F;
-            vUInt l2b   = 0x9000;
-            h           = lut_sign(h, l0b, l1b, l2b);
+            vUInt l2b         = 0x9000;
+            h                 = lut_sign(h, l0b, l1b, l2b);
             sfpi::dst_reg[11] = h;
         }
         v_endif;
@@ -1963,25 +1963,25 @@ sfpi_test_noinline void test11()
         v_if (sfpi::dst_reg[0] == 13.0f)
         {
             sfpi::vFloat h    = -0.25f;
-            h           = lut2(h, l0, l1, l2);
+            h                 = lut2(h, l0, l1, l2);
             sfpi::dst_reg[11] = h; // .25 * 2 + 3 = -3.5 (sign retain)
         }
         v_elseif (sfpi::dst_reg[0] == 14.0f)
         {
             sfpi::vFloat h    = 1.25f;
-            h           = lut2(h, l0, l1, l2);
+            h                 = lut2(h, l0, l1, l2);
             sfpi::dst_reg[11] = h; // 1.25 * 4 + 5 = 10 (sign retain)
         }
         v_elseif (sfpi::dst_reg[0] == 15.0f)
         {
             sfpi::vFloat h    = -2.25f;
-            h           = lut2(h, l0, l1, l2);
+            h                 = lut2(h, l0, l1, l2);
             sfpi::dst_reg[11] = h; // 2.25 * 6 + 7 = 13.5 + 7 = -20.5 (sign retain)
         }
         v_elseif (sfpi::dst_reg[0] == 16.0f)
         {
             sfpi::vFloat h    = -0.25f;
-            h           = lut2_sign(h, l0, l1, l2);
+            h                 = lut2_sign(h, l0, l1, l2);
             sfpi::dst_reg[11] = h; // .25 * 2 + 3 = 3.5 (sign update)
         }
         v_endif;
@@ -1998,25 +1998,25 @@ sfpi_test_noinline void test11()
         v_if (sfpi::dst_reg[0] == 17.0f)
         {
             sfpi::vFloat h    = -0.25f;
-            h           = lut2(h, a0, a1, a2, b0, b1, b2);
+            h                 = lut2(h, a0, a1, a2, b0, b1, b2);
             sfpi::dst_reg[11] = h; // .25 * 2 + 3 = -3.5 (sign retain)
         }
         v_elseif (sfpi::dst_reg[0] == 18.0f)
         {
             sfpi::vFloat h    = 1.25f;
-            h           = lut2(h, a0, a1, a2, b0, b1, b2);
+            h                 = lut2(h, a0, a1, a2, b0, b1, b2);
             sfpi::dst_reg[11] = h; // 1.25 * 4 + 5 = 10 (sign retain)
         }
         v_elseif (sfpi::dst_reg[0] == 19.0f)
         {
             sfpi::vFloat h    = -3.0f;
-            h           = lut2(h, a0, a1, a2, b0, b1, b2);
+            h                 = lut2(h, a0, a1, a2, b0, b1, b2);
             sfpi::dst_reg[11] = h; // 3 * 6 + 7 = 18 + 7 = -25.0 (sign retain)
         }
         v_elseif (sfpi::dst_reg[0] == 20.0f)
         {
             sfpi::vFloat h    = -0.25f;
-            h           = lut2_sign(h, a0, a1, a2, b0, b1, b2);
+            h                 = lut2_sign(h, a0, a1, a2, b0, b1, b2);
             sfpi::dst_reg[11] = h; // .25 * 2 + 3 = 3.5 (sign update)
         }
         v_endif;
@@ -2034,43 +2034,43 @@ sfpi_test_noinline void test11()
         v_if (sfpi::dst_reg[0] == 21.0f)
         {
             sfpi::vFloat h    = -0.25f;
-            h           = lut2(h, a01, a23, a34, b01, b23, b34);
+            h                 = lut2(h, a01, a23, a34, b01, b23, b34);
             sfpi::dst_reg[11] = h; // .25 * 2 + 3 = -3.5 (sign retain)
         }
         v_elseif (sfpi::dst_reg[0] == 22.0f)
         {
             sfpi::vFloat h    = 0.75f;
-            h           = lut2(h, a01, a23, a34, b01, b23, b34);
+            h                 = lut2(h, a01, a23, a34, b01, b23, b34);
             sfpi::dst_reg[11] = h; // .75 * 4 + 5 = 8
         }
         v_elseif (sfpi::dst_reg[0] == 23.0f)
         {
             sfpi::vFloat h    = -1.25f;
-            h           = lut2(h, a01, a23, a34, b01, b23, b34);
+            h                 = lut2(h, a01, a23, a34, b01, b23, b34);
             sfpi::dst_reg[11] = h; // 1.25 * 6 + 7 = 7.5 + 7 = -14.5 (sign retain)
         }
         v_elseif (sfpi::dst_reg[0] == 24.0f)
         {
             sfpi::vFloat h    = -1.75f;
-            h           = lut2(h, a01, a23, a34, b01, b23, b34);
+            h                 = lut2(h, a01, a23, a34, b01, b23, b34);
             sfpi::dst_reg[11] = h; // 1.75 * 8 + 9 = 14 + 9 = -23 (sign retain)
         }
         v_elseif (sfpi::dst_reg[0] == 25.0f)
         {
             sfpi::vFloat h    = 2.5f;
-            h           = lut2(h, a01, a23, a34, b01, b23, b34);
+            h                 = lut2(h, a01, a23, a34, b01, b23, b34);
             sfpi::dst_reg[11] = h; // 2.5 * 10 + 11 = 25 + 11 = 36.0
         }
         v_elseif (sfpi::dst_reg[0] == 26.0f)
         {
             sfpi::vFloat h    = 3.5f;
-            h           = lut2(h, a01, a23, a34, b01, b23, b34);
+            h                 = lut2(h, a01, a23, a34, b01, b23, b34);
             sfpi::dst_reg[11] = h; // 3.5 * 12 + 13 = 42 + 13 = 55.0
         }
         v_elseif (sfpi::dst_reg[0] == 27.0f)
         {
             sfpi::vFloat h    = -0.25f;
-            h           = lut2_sign(h, a01, a23, a34, b01, b23, b34);
+            h                 = lut2_sign(h, a01, a23, a34, b01, b23, b34);
             sfpi::dst_reg[11] = h; // .25 * 2 + 3 = 3.5 (sign update)
         }
         v_endif;
@@ -2106,25 +2106,25 @@ sfpi_test_noinline void test11()
         v_if (sfpi::dst_reg[0] == 28.0f)
         {
             sfpi::vFloat h    = -1.75f;
-            h           = lut2(h, a01, a23, a34, b01, b23, b34, 2);
+            h                 = lut2(h, a01, a23, a34, b01, b23, b34, 2);
             sfpi::dst_reg[11] = h; // 1.75 * 8 + 9 = 14 + 9 = -23 (sign retain)
         }
         v_elseif (sfpi::dst_reg[0] == 29.0f)
         {
             sfpi::vFloat h    = 3.5f;
-            h           = lut2(h, a01, a23, a34, b01, b23, b34, 2);
+            h                 = lut2(h, a01, a23, a34, b01, b23, b34, 2);
             sfpi::dst_reg[11] = h; // 3.5 * 10 + 11 = 35 + 11 = 46.0
         }
         v_elseif (sfpi::dst_reg[0] == 30.0f)
         {
             sfpi::vFloat h    = 4.5f;
-            h           = lut2(h, a01, a23, a34, b01, b23, b34, 2);
+            h                 = lut2(h, a01, a23, a34, b01, b23, b34, 2);
             sfpi::dst_reg[11] = h; // 4.5 * 12 + 13 = 54 + 13 = 67.0
         }
         v_elseif (sfpi::dst_reg[0] == 31.0f)
         {
             sfpi::vFloat h    = -0.25f;
-            h           = lut2_sign(h, a01, a23, a34, b01, b23, b34, 2);
+            h                 = lut2_sign(h, a01, a23, a34, b01, b23, b34, 2);
             sfpi::dst_reg[11] = h; // .25 * 2 + 3 = 3.5 (sign update)
         }
         v_endif;
@@ -2240,15 +2240,15 @@ sfpi_test_noinline void test12(int imm)
     v_elseif (sfpi::dst_reg[0] == 12.0F)
     {
         sfpi::vFloat tmp  = 1024.0F;
-        int man     = 0x75019a + 35 - imm;
+        int man           = 0x75019a + 35 - imm;
         sfpi::vFloat tmp2 = setman(tmp, man);
         sfpi::dst_reg[12] = tmp2;
     }
     v_elseif (sfpi::dst_reg[0] == 13.0F)
     {
-        int exp        = 0x007F + 35 - imm; // Exponent in low bits
+        int exp              = 0x007F + 35 - imm; // Exponent in low bits
         sfpi::vFloat sgn_man = -1664.0F;          // 1024 + 512 + 128 or 1101
-        sgn_man        = setexp(sgn_man, exp);
+        sgn_man              = setexp(sgn_man, exp);
         sfpi::dst_reg[12]    = sgn_man;
     }
     v_endif;
@@ -2294,7 +2294,7 @@ sfpi_test_noinline void test12(int imm)
         sfpi::vFloat a          = 130.0F;
         sfpi::dst_reg[imm - 23] = a;
         __builtin_rvtt_sfpnop(); // XXXXXX remove me when compiler is fixed
-        a           = sfpi::dst_reg[12];
+        a                 = sfpi::dst_reg[12];
         sfpi::dst_reg[12] = a + 1.0F;
     }
     v_endif;
@@ -2493,7 +2493,7 @@ sfpi_test_noinline void test13(int imm)
     // EXEXP liveness across SETCC
     {
         sfpi::vFloat a = 160.0F;
-        vInt b   = 128;
+        vInt b         = 128;
         v_if (sfpi::dst_reg[0] == 12.0F)
         {
             b = exexp_nodebias(a);
@@ -2512,7 +2512,7 @@ sfpi_test_noinline void test13(int imm)
     // EXMAN liveness across SETCC
     {
         sfpi::vFloat a = 160.0F;
-        vInt b   = 0x80000;
+        vInt b         = 0x80000;
         v_if (sfpi::dst_reg[0] == 14.0F)
         {
             b = exman8(a);
@@ -2638,8 +2638,8 @@ sfpi_test_noinline void test14(int imm)
         v_else
         {
             sfpi::vFloat c = vConst0 * vConst0 + vConst0;
-            b        = -a;
-            a        = c;
+            b              = -a;
+            a              = c;
         }
         v_endif;
         v_if (sfpi::dst_reg[0] == 0.0F || sfpi::dst_reg[0] == 1.0F)
@@ -2662,8 +2662,8 @@ sfpi_test_noinline void test14(int imm)
             v_if ((tmp = lz(a)) != 0)
             {
                 sfpi::vFloat c = vConst0 * vConst0 + vConst0;
-                b        = -a;
-                a        = c;
+                b              = -a;
+                a              = c;
             }
             v_endif;
         }
@@ -2688,8 +2688,8 @@ sfpi_test_noinline void test14(int imm)
             v_if ((tmp = exexp(a)) >= 0)
             {
                 sfpi::vFloat c = vConst0 * vConst0 + vConst0;
-                b        = -a;
-                a        = c;
+                b              = -a;
+                a              = c;
             }
             v_endif;
         }
@@ -2707,7 +2707,7 @@ sfpi_test_noinline void test14(int imm)
     // MOV liveness across IADD
     {
         sfpi::vFloat b = 300.0F;
-        vInt tmp = 5;
+        vInt tmp       = 5;
 
         v_if (sfpi::dst_reg[0] == 6.0F)
         {
@@ -2715,8 +2715,8 @@ sfpi_test_noinline void test14(int imm)
             v_if (tmp >= 2)
             {
                 sfpi::vFloat c = vConst0 * vConst0 + vConst0;
-                b        = -a;
-                a        = c;
+                b              = -a;
+                a              = c;
             }
             v_endif;
         }
@@ -2908,9 +2908,9 @@ sfpi_test_noinline void test14(int imm)
     {
         // Out of regs doing this the typical way
         sfpi::vFloat condition = sfpi::dst_reg[0] - 20.0F;
-        vInt a           = 10;
-        vInt b           = 20;
-        vInt c           = 30;
+        vInt a                 = 10;
+        vInt b                 = 20;
+        vInt c                 = 30;
 
         v_if (condition == 0.0F)
         {
@@ -2946,9 +2946,9 @@ sfpi_test_noinline void test14(int imm)
     {
         // Out of regs doing this the typical way
         sfpi::vFloat condition = sfpi::dst_reg[0] - 22.0F;
-        vInt a           = 10;
-        vInt b           = 20;
-        vInt c           = 30;
+        vInt a                 = 10;
+        vInt b                 = 20;
+        vInt c                 = 30;
 
         v_if (condition == 0.0F)
         {
@@ -2984,9 +2984,9 @@ sfpi_test_noinline void test14(int imm)
     {
         // Out of regs doing this the typical way
         sfpi::vFloat condition = sfpi::dst_reg[0] - 24.0F;
-        vInt a           = 10;
-        vInt b           = 20;
-        vInt c           = 30;
+        vInt a                 = 10;
+        vInt b                 = 20;
+        vInt c                 = 30;
 
         v_if (condition == 0.0F)
         {

--- a/tt_llk_blackhole/common/inc/ckernel_sfpi.h
+++ b/tt_llk_blackhole/common/inc/ckernel_sfpi.h
@@ -1632,7 +1632,7 @@ sfpi_test_noinline void test9()
         // Relies on if chain above...
         v_if (sfpi::dst_reg[0] >= 7.0F)
         {
-            b = reinterpret<vUInt>(lz(a));
+            b = sfpi::reinterpret<vUInt>(lz(a));
             v_if (b != 32)
             {
                 sfpi::dst_reg[9] = 60.0F;
@@ -1789,27 +1789,27 @@ sfpi_test_noinline void test10()
     v_if (sfpi::dst_reg[0] == 7.0F)
     {
         sfpi::vFloat a    = sfpi::dst_reg[0];
-        sfpi::dst_reg[10] = setsgn(a, 1);
+        sfpi::dst_reg[10] = sfpi::setsgn(a, 1);
     }
     v_elseif (sfpi::dst_reg[0] == 8.0F)
     {
         sfpi::vFloat a = sfpi::dst_reg[0];
         sfpi::vFloat b = -128.0;
-        sfpi::vFloat r = setsgn(b, a);
+        sfpi::vFloat r = sfpi::setsgn(b, a);
 
         sfpi::dst_reg[10] = r;
     }
     v_elseif (sfpi::dst_reg[0] == 9.0F)
     {
         sfpi::vFloat a    = -256.0F;
-        sfpi::dst_reg[10] = setsgn(a, 0);
+        sfpi::dst_reg[10] = sfpi::setsgn(a, 0);
     }
     v_elseif (sfpi::dst_reg[0] == 10.0F)
     {
         sfpi::vFloat a = sfpi::dst_reg[0];
         a += 20.0f;
         sfpi::vFloat b = -512.0F;
-        sfpi::vFloat r = setsgn(a, b);
+        sfpi::vFloat r = sfpi::setsgn(a, b);
 
         sfpi::dst_reg[10] = r;
     }
@@ -2234,7 +2234,7 @@ sfpi_test_noinline void test12(int imm)
     v_if (sfpi::dst_reg[0] == 11.0F)
     {
         sfpi::vFloat a    = 128.0;
-        sfpi::vFloat r    = setsgn(a, imm - 36);
+        sfpi::vFloat r    = sfpi::setsgn(a, imm - 36);
         sfpi::dst_reg[12] = r;
     }
     v_elseif (sfpi::dst_reg[0] == 12.0F)
@@ -2570,7 +2570,7 @@ sfpi_test_noinline void test13(int imm)
         sfpi::vFloat b = 220.0F;
         v_if (sfpi::dst_reg[0] == 20.0F)
         {
-            b = setsgn(a, 1);
+            b = sfpi::setsgn(a, 1);
         }
         v_endif;
         v_if (sfpi::dst_reg[0] == 20.0F || sfpi::dst_reg[0] == 21.0F)

--- a/tt_llk_blackhole/common/inc/ckernel_sfpi.h
+++ b/tt_llk_blackhole/common/inc/ckernel_sfpi.h
@@ -30,9 +30,9 @@ sfpi_inline void copy_result_to_dreg0(int addr)
 // Test infrastructure is set up to test float values, not ints
 // Viewing the ints as floats leads to a mess (eg, denorms)
 // Instead, compare in the kernel to the expected result and write a sentinal
-// value for "pass" and the vInt v value for "fail"
+// value for "pass" and the sfpi::vInt v value for "fail"
 // Assumes this code is called in an "inner" if
-sfpi_inline void set_expected_result(int addr, float sentinel, int expected, vInt v)
+sfpi_inline void set_expected_result(int addr, float sentinel, int expected, sfpi::vInt v)
 {
     // Poor man's equals
     // Careful, the register is 19 bits and the immediate is sign extended 12
@@ -48,7 +48,7 @@ sfpi_inline void set_expected_result(int addr, float sentinel, int expected, vIn
     v_endif;
 }
 
-sfpi_inline vInt test_interleaved_scalar_vector_cond(bool scalar_bool, sfpi::vFloat vec, float a, float b)
+sfpi_inline sfpi::vInt test_interleaved_scalar_vector_cond(bool scalar_bool, sfpi::vFloat vec, float a, float b)
 {
     if (scalar_bool)
     {
@@ -77,7 +77,7 @@ sfpi_inline vType reduce_bool4(vType a, vType b, vType c, vType d, int reference
     }
     v_endif;
 
-    vUInt result = 0;
+    sfpi::vUInt result = 0;
     v_if (result1 == 1 && result2 == 1)
     {
         result = 1;
@@ -147,7 +147,7 @@ sfpi_test_noinline void test3()
     v_if (sfpi::dst_reg[0] == 5.0F)
     {
         // This will be a short w/ 1 load
-        vInt a = 0x3F80;
+        sfpi::vInt a = 0x3F80;
         a |= 0x3f800000;
         sfpi::dst_reg[3] = a;
     }
@@ -156,7 +156,7 @@ sfpi_test_noinline void test3()
     v_if (sfpi::dst_reg[0] == 6.0F)
     {
         // This will be an int w/ 2 loads
-        vInt a           = 0x3F80A3D7; // 1.005
+        sfpi::vInt a     = 0x3F80A3D7; // 1.005
         sfpi::dst_reg[3] = a;
     }
     v_endif;
@@ -164,7 +164,7 @@ sfpi_test_noinline void test3()
     v_if (sfpi::dst_reg[0] == 7.0F)
     {
         // This will be an int w/ 1 load (not sign extended)
-        vInt a           = 0x8F80;
+        sfpi::vInt a     = 0x8F80;
         sfpi::dst_reg[3] = a | 0x3f800000;
     }
     v_endif;
@@ -172,7 +172,7 @@ sfpi_test_noinline void test3()
     v_if (sfpi::dst_reg[0] == 8.0F)
     {
         // This will be a ushort w/ 1 load (not sign extended)
-        vUInt a          = 0x8F80U;
+        sfpi::vUInt a    = 0x8F80U;
         sfpi::dst_reg[3] = a | 0x3f800000;
     }
     v_endif;
@@ -186,7 +186,7 @@ sfpi_test_noinline void test3()
 
     v_if (sfpi::dst_reg[0] == 10.0F)
     {
-        vUInt a          = static_cast<unsigned short>(0x3f80);
+        sfpi::vUInt a    = static_cast<unsigned short>(0x3f80);
         sfpi::dst_reg[3] = a | 0x3f800000;
     }
     v_endif;
@@ -200,7 +200,7 @@ sfpi_test_noinline void test3()
 
     v_if (sfpi::dst_reg[0] == 12.0F)
     {
-        vUInt a          = 0x3F80A3D7;
+        sfpi::vUInt a    = 0x3F80A3D7;
         sfpi::dst_reg[3] = a;
     }
     v_endif;
@@ -719,7 +719,7 @@ sfpi_test_noinline void test6()
         {
             sfpi::dst_reg[6] = 256.0F;
 
-            vInt a;
+            sfpi::vInt a;
             v_if (sfpi::dst_reg[0] == 0.0F)
             {
                 a = 28;
@@ -734,7 +734,7 @@ sfpi_test_noinline void test6()
             }
             v_endif;
 
-            vInt b;
+            sfpi::vInt b;
             // IADD imm
             b = a - 29;
             v_if (b >= 0)
@@ -753,7 +753,7 @@ sfpi_test_noinline void test6()
         {
             sfpi::dst_reg[6] = 256.0F;
 
-            vInt a;
+            sfpi::vInt a;
             v_if (sfpi::dst_reg[0] == 3.0F)
             {
                 a = 28;
@@ -768,7 +768,7 @@ sfpi_test_noinline void test6()
             }
             v_endif;
 
-            vInt b = -29;
+            sfpi::vInt b = -29;
             // IADD reg
             b = a + b;
             v_if (b < 0)
@@ -787,7 +787,7 @@ sfpi_test_noinline void test6()
         {
             sfpi::dst_reg[6] = 16.0F;
 
-            vInt a = 3;
+            sfpi::vInt a = 3;
             v_if (sfpi::dst_reg[0] == 6.0F)
             {
                 a = 28;
@@ -831,7 +831,7 @@ sfpi_test_noinline void test6()
         {
             sfpi::dst_reg[6] = 16.0F;
 
-            vInt a = 3;
+            sfpi::vInt a = 3;
             v_if (sfpi::dst_reg[0] == 9.0F)
             {
                 a = 28;
@@ -847,7 +847,7 @@ sfpi_test_noinline void test6()
             v_endif;
 
             sfpi::vFloat b = 128.0F;
-            vInt c         = 29;
+            sfpi::vInt c   = 29;
             v_if (a >= c)
             {
                 b = 256.0F;
@@ -872,96 +872,96 @@ sfpi_test_noinline void test6()
 
     v_if (sfpi::dst_reg[0] == 12.0F)
     {
-        vInt v = 25;
+        sfpi::vInt v = 25;
         set_expected_result(6, 4.0F, 25, v);
     }
     v_elseif (sfpi::dst_reg[0] == 13.0F)
     {
-        vInt a = 20;
-        a      = a + 12;
+        sfpi::vInt a = 20;
+        a            = a + 12;
         set_expected_result(6, 8.0F, 32, a);
     }
     v_elseif (sfpi::dst_reg[0] == 14.0F)
     {
-        vInt a = 18;
-        vInt b = -6;
-        a      = a + b;
+        sfpi::vInt a = 18;
+        sfpi::vInt b = -6;
+        a            = a + b;
         set_expected_result(6, 16.0F, 12, a);
     }
     v_elseif (sfpi::dst_reg[0] == 15.0F)
     {
-        vInt a = 14;
-        vInt b = -5;
-        a      = b + a;
+        sfpi::vInt a = 14;
+        sfpi::vInt b = -5;
+        a            = b + a;
         set_expected_result(6, 32.0F, 9, a);
     }
     v_endif;
 
     v_if (sfpi::dst_reg[0] == 16.0F)
     {
-        vInt v = 25;
+        sfpi::vInt v = 25;
         set_expected_result(6, 4.0F, 25, v);
     }
     v_elseif (sfpi::dst_reg[0] == 17.0F)
     {
-        vInt a = 20;
-        a      = a - 12;
+        sfpi::vInt a = 20;
+        a            = a - 12;
         set_expected_result(6, 8.0F, 8, a);
     }
     v_elseif (sfpi::dst_reg[0] == 18.0F)
     {
-        vInt a = 18;
-        vInt b = 6;
-        a      = a - b;
+        sfpi::vInt a = 18;
+        sfpi::vInt b = 6;
+        a            = a - b;
         set_expected_result(6, 16.0F, 12, a);
     }
     v_elseif (sfpi::dst_reg[0] == 19.0F)
     {
-        vInt a = 14;
-        vInt b = 5;
-        a      = b - a;
+        sfpi::vInt a = 14;
+        sfpi::vInt b = 5;
+        a            = b - a;
         set_expected_result(6, 32.0F, -9, a);
     }
     v_endif;
 
     v_if (sfpi::dst_reg[0] == 20.0F)
     {
-        vUInt v = 25;
-        set_expected_result(6, 4.0F, 25, reinterpret<vInt>(v));
+        sfpi::vUInt v = 25;
+        set_expected_result(6, 4.0F, 25, reinterpret<sfpi::vInt>(v));
     }
     v_elseif (sfpi::dst_reg[0] == 21.0F)
     {
-        vUInt a = 20;
-        a       = a - 12;
-        set_expected_result(6, 8.0F, 8, reinterpret<vInt>(a));
+        sfpi::vUInt a = 20;
+        a             = a - 12;
+        set_expected_result(6, 8.0F, 8, reinterpret<sfpi::vInt>(a));
     }
     v_elseif (sfpi::dst_reg[0] == 22.0F)
     {
-        vUInt a = 18;
-        vUInt b = 6;
-        a       = a - b;
-        set_expected_result(6, 16.0F, 12, reinterpret<vInt>(a));
+        sfpi::vUInt a = 18;
+        sfpi::vUInt b = 6;
+        a             = a - b;
+        set_expected_result(6, 16.0F, 12, reinterpret<sfpi::vInt>(a));
     }
     v_elseif (sfpi::dst_reg[0] == 23.0F)
     {
-        vUInt a = 14;
-        vUInt b = 5;
-        a       = b - a;
-        set_expected_result(6, 32.0F, -9, reinterpret<vInt>(a));
+        sfpi::vUInt a = 14;
+        sfpi::vUInt b = 5;
+        a             = b - a;
+        set_expected_result(6, 32.0F, -9, reinterpret<sfpi::vInt>(a));
     }
     v_endif;
 
     v_if (sfpi::dst_reg[0] == 24.0F)
     {
-        vInt a = 10;
-        vInt b = 20;
+        sfpi::vInt a = 10;
+        sfpi::vInt b = 20;
         a -= b;
         set_expected_result(6, 64.0F, -10, a);
     }
     v_elseif (sfpi::dst_reg[0] == 25.0F)
     {
-        vInt a = 10;
-        vInt b = 20;
+        sfpi::vInt a = 10;
+        sfpi::vInt b = 20;
         a += b;
         set_expected_result(6, 128.0F, 30, a);
     }
@@ -970,13 +970,13 @@ sfpi_test_noinline void test6()
     // Pseudo-16 bit via hidden loadi
     v_if (sfpi::dst_reg[0] == 26.0F)
     {
-        vInt a = 10;
+        sfpi::vInt a = 10;
         a += 4096;
         set_expected_result(6, 256.0F, 4106, a);
     }
     v_elseif (sfpi::dst_reg[0] == 27.0F)
     {
-        vInt a = 4096;
+        sfpi::vInt a = 4096;
         v_if (a >= 4096)
         {
             sfpi::dst_reg[6] = 512.0f;
@@ -991,7 +991,7 @@ sfpi_test_noinline void test6()
 
     v_if (sfpi::dst_reg[0] >= 28.0F)
     {
-        vInt a = vConstTileId;
+        sfpi::vInt a = vConstTileId;
         v_if (sfpi::dst_reg[0] == 28.0F)
         {
             set_expected_result(6, 256.0F, 56, a);
@@ -1100,7 +1100,7 @@ sfpi_test_noinline void test7()
         }
         v_endif;
 
-        vInt v;
+        sfpi::vInt v;
         v = exexp(tmp);
         v_if (v < 0)
         {
@@ -1135,7 +1135,7 @@ sfpi_test_noinline void test7()
     }
     v_elseif (sfpi::dst_reg[0] == 9.0F)
     {
-        vInt exp             = 0x007F;   // Exponent in low bits
+        sfpi::vInt exp       = 0x007F;   // Exponent in low bits
         sfpi::vFloat sgn_man = -1664.0F; // 1024 + 512 + 128 or 1101
         sgn_man              = setexp(sgn_man, exp);
         sfpi::dst_reg[7]     = sgn_man;
@@ -1154,7 +1154,7 @@ sfpi_test_noinline void test7()
     v_elseif (sfpi::dst_reg[0] == 11.0F)
     {
         sfpi::vFloat tmp  = 1024.0F;
-        vInt man          = 0x75019a;
+        sfpi::vInt man    = 0x75019a;
         sfpi::vFloat tmp2 = setman(tmp, man);
         sfpi::dst_reg[7]  = tmp2;
     }
@@ -1207,7 +1207,7 @@ sfpi_test_noinline void test7()
     // and things get flipped around when joined by ||
     v_if (v >= 29.0f && v < 32.0f)
     {
-        vInt t             = vConstTileId >> 1;
+        sfpi::vInt t       = vConstTileId >> 1;
         sfpi::vFloat total = 16.0F;
 
         v_if (t <= 30)
@@ -1260,70 +1260,70 @@ sfpi_test_noinline void test8()
     sfpi::dst_reg[8] = -sfpi::dst_reg[0];
     v_if (sfpi::dst_reg[0] == 1.0F)
     {
-        vUInt a = 0x05FF;
-        vUInt b = 0x0AAA;
+        sfpi::vUInt a = 0x05FF;
+        sfpi::vUInt b = 0x0AAA;
         b &= a;
-        set_expected_result(8, 16.0F, 0x00AA, static_cast<vInt>(b));
+        set_expected_result(8, 16.0F, 0x00AA, static_cast<sfpi::vInt>(b));
     }
     v_elseif (sfpi::dst_reg[0] == 2.0F)
     {
-        vUInt a = 0x05FF;
-        vUInt b = 0x0AAA;
-        vUInt c = a & b;
-        set_expected_result(8, 16.0F, 0x00AA, static_cast<vInt>(c));
+        sfpi::vUInt a = 0x05FF;
+        sfpi::vUInt b = 0x0AAA;
+        sfpi::vUInt c = a & b;
+        set_expected_result(8, 16.0F, 0x00AA, static_cast<sfpi::vInt>(c));
     }
     v_elseif (sfpi::dst_reg[0] == 3.0F)
     {
-        vInt a = 0x05FF;
-        vInt b = 0x0AAA;
+        sfpi::vInt a = 0x05FF;
+        sfpi::vInt b = 0x0AAA;
         b &= a;
         set_expected_result(8, 16.0F, 0x00AA, b);
     }
     v_elseif (sfpi::dst_reg[0] == 4.0F)
     {
-        vInt a = 0x05FF;
-        vInt b = 0x0AAA;
-        vInt c = a & b;
+        sfpi::vInt a = 0x05FF;
+        sfpi::vInt b = 0x0AAA;
+        sfpi::vInt c = a & b;
         set_expected_result(8, 16.0F, 0x00AA, c);
     }
     v_endif;
 
     v_if (sfpi::dst_reg[0] == 5.0F)
     {
-        vUInt a = 0x0111;
-        vUInt b = 0x0444;
+        sfpi::vUInt a = 0x0111;
+        sfpi::vUInt b = 0x0444;
         b |= a;
-        set_expected_result(8, 20.0F, 0x0555, static_cast<vInt>(b));
+        set_expected_result(8, 20.0F, 0x0555, static_cast<sfpi::vInt>(b));
     }
     v_elseif (sfpi::dst_reg[0] == 6.0F)
     {
-        vUInt a = 0x0111;
-        vUInt b = 0x0444;
-        vUInt c = b | a;
-        set_expected_result(8, 20.0F, 0x0555, static_cast<vInt>(c));
+        sfpi::vUInt a = 0x0111;
+        sfpi::vUInt b = 0x0444;
+        sfpi::vUInt c = b | a;
+        set_expected_result(8, 20.0F, 0x0555, static_cast<sfpi::vInt>(c));
     }
     v_elseif (sfpi::dst_reg[0] == 7.0F)
     {
-        vInt a = 0x0111;
-        vInt b = 0x0444;
+        sfpi::vInt a = 0x0111;
+        sfpi::vInt b = 0x0444;
         b |= a;
         set_expected_result(8, 20.0F, 0x0555, b);
     }
     v_elseif (sfpi::dst_reg[0] == 8.0F)
     {
-        vInt a = 0x0111;
-        vInt b = 0x0444;
-        vInt c = b | a;
+        sfpi::vInt a = 0x0111;
+        sfpi::vInt b = 0x0444;
+        sfpi::vInt c = b | a;
         set_expected_result(8, 20.0F, 0x0555, c);
     }
     v_endif;
 
     v_if (sfpi::dst_reg[0] == 9.0F)
     {
-        vUInt a = 0x0AAA;
-        a       = ~a;
+        sfpi::vUInt a = 0x0AAA;
+        a             = ~a;
         a &= 0x0FFF; // Tricky since ~ flips upper bits that immediates can't access
-        set_expected_result(8, 22.0F, 0x0555, static_cast<vInt>(a));
+        set_expected_result(8, 22.0F, 0x0555, static_cast<sfpi::vInt>(a));
     }
     v_elseif (sfpi::dst_reg[0] == 10.0F)
     {
@@ -1337,12 +1337,12 @@ sfpi_test_noinline void test8()
     }
     v_elseif (sfpi::dst_reg[0] == 12.0F)
     {
-        vInt a = 100;
+        sfpi::vInt a = 100;
         set_expected_result(8, 24.0F, 100, sfpi::abs(a));
     }
     v_elseif (sfpi::dst_reg[0] == 13.0F)
     {
-        vInt a = -100;
+        sfpi::vInt a = -100;
         set_expected_result(8, 26.0F, 100, sfpi::abs(a));
     }
     v_endif;
@@ -1375,9 +1375,9 @@ sfpi_test_noinline void test8()
     // and things get flipped around when joined by ||
     v_if (sfpi::dst_reg[0] >= 20.0f && sfpi::dst_reg[0] < 23.0f)
     {
-        vInt t    = vConstTileId >> 1;
-        vInt low  = 20;
-        vInt high = 21;
+        sfpi::vInt t    = vConstTileId >> 1;
+        sfpi::vInt low  = 20;
+        sfpi::vInt high = 21;
 
         sfpi::dst_reg[8] = 16.0f;
 
@@ -1505,26 +1505,26 @@ sfpi_test_noinline void test8()
 
     v_if (sfpi::dst_reg[0] == 29.0F)
     {
-        vInt a = 0xA5A5;
-        vInt b = 0xFF00;
-        vInt c = a ^ b;
+        sfpi::vInt a = 0xA5A5;
+        sfpi::vInt b = 0xFF00;
+        sfpi::vInt c = a ^ b;
         set_expected_result(8, 32.0F, 0x5AA5, c);
     }
     v_endif;
 
     v_if (sfpi::dst_reg[0] == 30.0F)
     {
-        vUInt a = 0xA5A5;
-        vUInt b = 0xFF00;
-        vUInt c = a ^ b;
+        sfpi::vUInt a = 0xA5A5;
+        sfpi::vUInt b = 0xFF00;
+        sfpi::vUInt c = a ^ b;
         set_expected_result(8, 64.0F, 0x5AA5, c);
     }
     v_endif;
 
     v_if (sfpi::dst_reg[0] == 31.0F)
     {
-        vInt a = 0xA5A5;
-        vInt b = 0xFF00;
+        sfpi::vInt a = 0xA5A5;
+        sfpi::vInt b = 0xFF00;
         b ^= a;
         set_expected_result(8, 32.0F, 0x5AA5, b);
     }
@@ -1608,31 +1608,31 @@ sfpi_test_noinline void test9()
 
     v_if (sfpi::dst_reg[0] == 7.0F)
     {
-        vInt a = 0;
-        vInt b = lz(a);
+        sfpi::vInt a = 0;
+        sfpi::vInt b = lz(a);
         set_expected_result(9, 38.0F, 0x20, b);
     }
     v_elseif (sfpi::dst_reg[0] == 8.0F)
     {
-        vInt a = 0xFFFFFFFF;
-        vInt b = lz(a);
+        sfpi::vInt a = 0xFFFFFFFF;
+        sfpi::vInt b = lz(a);
         set_expected_result(9, 55.0F, 0x0, b);
     }
     v_elseif (sfpi::dst_reg[0] == 9.0F)
     {
-        vUInt a = 0xFFFFU;
-        vInt b  = lz(a);
+        sfpi::vUInt a = 0xFFFFU;
+        sfpi::vInt b  = lz(a);
         set_expected_result(9, 30.0F, 0x10, b);
     }
     v_elseif (sfpi::dst_reg[0] < 13.0F)
     {
         sfpi::vFloat a = sfpi::dst_reg[0] - 11.0F;
-        vUInt b;
+        sfpi::vUInt b;
 
         // Relies on if chain above...
         v_if (sfpi::dst_reg[0] >= 7.0F)
         {
-            b = sfpi::reinterpret<vUInt>(lz(a));
+            b = sfpi::reinterpret<sfpi::vUInt>(lz(a));
             v_if (b != 32)
             {
                 sfpi::dst_reg[9] = 60.0F;
@@ -1745,42 +1745,42 @@ sfpi_test_noinline void test10()
     sfpi::dst_reg[10] = -sfpi::dst_reg[0];
     v_if (sfpi::dst_reg[0] == 1.0F)
     {
-        vUInt a    = 0x015;
-        vInt shift = 6;
-        vUInt b    = shft(a, shift);
+        sfpi::vUInt a    = 0x015;
+        sfpi::vInt shift = 6;
+        sfpi::vUInt b    = shft(a, shift);
         // Could write better tests if we could return and test the int result
-        set_expected_result(10, 20.0F, 0x0540, static_cast<vInt>(b));
+        set_expected_result(10, 20.0F, 0x0540, static_cast<sfpi::vInt>(b));
     }
     v_elseif (sfpi::dst_reg[0] == 2.0F)
     {
-        vUInt a = 0x2AAA;
-        vUInt b = shft(a, -4);
-        set_expected_result(10, 22.0F, 0x02AA, static_cast<vInt>(b));
+        sfpi::vUInt a = 0x2AAA;
+        sfpi::vUInt b = shft(a, -4);
+        set_expected_result(10, 22.0F, 0x02AA, static_cast<sfpi::vInt>(b));
     }
     v_elseif (sfpi::dst_reg[0] == 3.0F)
     {
-        vUInt a    = 0xAAAAU;
-        vInt shift = -6;
-        vUInt b    = shft(a, shift);
-        set_expected_result(10, 24.0F, 0x02AA, static_cast<vInt>(b));
+        sfpi::vUInt a    = 0xAAAAU;
+        sfpi::vInt shift = -6;
+        sfpi::vUInt b    = shft(a, shift);
+        set_expected_result(10, 24.0F, 0x02AA, static_cast<sfpi::vInt>(b));
     }
     v_elseif (sfpi::dst_reg[0] == 4.0F)
     {
-        vUInt a = 0x005A;
-        vUInt b = shft(a, 4);
-        set_expected_result(10, 26.0F, 0x05A0, static_cast<vInt>(b));
+        sfpi::vUInt a = 0x005A;
+        sfpi::vUInt b = shft(a, 4);
+        set_expected_result(10, 26.0F, 0x05A0, static_cast<sfpi::vInt>(b));
     }
     v_elseif (sfpi::dst_reg[0] == 5.0F)
     {
-        vInt a = 25;
-        a      = a + 5;
+        sfpi::vInt a = 25;
+        a            = a + 5;
         a += 7;
         set_expected_result(10, 28.0F, 0x25, a);
     }
     v_elseif (sfpi::dst_reg[0] == 6.0F)
     {
-        vInt a = 28;
-        vInt b = 100;
+        sfpi::vInt a = 28;
+        sfpi::vInt b = 100;
         a += b;
         set_expected_result(10, 30.0F, 0x80, a);
     }
@@ -1833,13 +1833,13 @@ sfpi_test_noinline void test11()
     // SFPLUT, SFPLOADL<n>
     sfpi::dst_reg[11] = -sfpi::dst_reg[0];
 
-    vUInt l0a = 0xFF30; // Multiply by 0.0, add 0.125
-    vUInt l1a = 0X3020; // Multiply by 0.125, add 0.25
+    sfpi::vUInt l0a = 0xFF30; // Multiply by 0.0, add 0.125
+    sfpi::vUInt l1a = 0X3020; // Multiply by 0.125, add 0.25
     v_if (sfpi::dst_reg[0] == 1.0F)
     {
         // Use L0
         sfpi::vFloat h    = -0.3F;
-        vUInt l2a         = 0xA010; // Mulitply by -0.25, add 0.5
+        sfpi::vUInt l2a   = 0xA010; // Mulitply by -0.25, add 0.5
         h                 = lut_sign(h, l0a, l1a, l2a);
         sfpi::dst_reg[11] = h;
     }
@@ -1847,15 +1847,15 @@ sfpi_test_noinline void test11()
     {
         // Use L0
         sfpi::vFloat h    = -0.3F;
-        vUInt l2a         = 0xA010; // Mulitply by -0.25, add 0.5
+        sfpi::vUInt l2a   = 0xA010; // Mulitply by -0.25, add 0.5
         h                 = lut(h, l0a, l1a, l2a);
         sfpi::dst_reg[11] = h;
     }
     v_elseif (sfpi::dst_reg[0] == 3.0F)
     {
         // Use L0
-        sfpi::vFloat h = -0.3F;
-        vUInt l2a      = 0xA010; // Mulitply by -0.25, add 0.5
+        sfpi::vFloat h  = -0.3F;
+        sfpi::vUInt l2a = 0xA010; // Mulitply by -0.25, add 0.5
         // Test used a bias on Grayskull, not supported on Wormhole
         h                 = lut_sign(h, l0a, l1a, l2a);
         sfpi::dst_reg[11] = h;
@@ -1863,8 +1863,8 @@ sfpi_test_noinline void test11()
     v_elseif (sfpi::dst_reg[0] == 4.0F)
     {
         // Use L0
-        sfpi::vFloat h = -0.3F;
-        vUInt l2a      = 0xA010; // Mulitply by -0.25, add 0.5
+        sfpi::vFloat h  = -0.3F;
+        sfpi::vUInt l2a = 0xA010; // Mulitply by -0.25, add 0.5
         // Test used a bias on Grayskull, not supported on Wormhole
         h                 = lut(h, l0a, l1a, l2a);
         sfpi::dst_reg[11] = h;
@@ -1872,8 +1872,8 @@ sfpi_test_noinline void test11()
     v_elseif (sfpi::dst_reg[0] == 5.0F)
     {
         // Use L1
-        sfpi::vFloat h = 1.0F;
-        vUInt l2a      = 0xA010; // Mulitply by -0.25, add 0.5
+        sfpi::vFloat h  = 1.0F;
+        sfpi::vUInt l2a = 0xA010; // Mulitply by -0.25, add 0.5
         // Test used a bias on Grayskull, not supported on Wormhole
         h                 = lut(h, l0a, l1a, l2a);
         sfpi::dst_reg[11] = h;
@@ -1882,7 +1882,7 @@ sfpi_test_noinline void test11()
     {
         // Use L2
         sfpi::vFloat h    = 4.0F;
-        vUInt l2a         = 0xA010; // Mulitply by -0.25, add 0.5
+        sfpi::vUInt l2a   = 0xA010; // Mulitply by -0.25, add 0.5
         h                 = lut_sign(h, l0a, l1a, l2a);
         sfpi::dst_reg[11] = h;
     }
@@ -1897,7 +1897,7 @@ sfpi_test_noinline void test11()
         // These are fakedout w/ emule
         TTI_SFPLOADI(0, SFPLOADI_MOD0_USHORT, 0xFF20); // Mulitply by 0.0, add 0.25
         TTI_SFPLOADI(1, SFPLOADI_MOD0_USHORT, 0x2010); // Mulitply by 0.25, add 0.5
-        vUInt l0b, l1b;
+        sfpi::vUInt l0b, l1b;
         l0b = l_reg[LRegs::LReg0];
         l1b = l_reg[LRegs::LReg1];
 
@@ -1905,7 +1905,7 @@ sfpi_test_noinline void test11()
         {
             // Use L0
             sfpi::vFloat h    = -0.3F;
-            vUInt l2b         = 0x9000;
+            sfpi::vUInt l2b   = 0x9000;
             h                 = lut_sign(h, l0b, l1b, l2b);
             sfpi::dst_reg[11] = h;
         }
@@ -1913,15 +1913,15 @@ sfpi_test_noinline void test11()
         {
             // Use L0
             sfpi::vFloat h    = -0.3F;
-            vUInt l2b         = 0x9000;
+            sfpi::vUInt l2b   = 0x9000;
             h                 = lut(h, l0b, l1b, l2b);
             sfpi::dst_reg[11] = h;
         }
         v_elseif (sfpi::dst_reg[0] == 9.0F)
         {
             // Use L0
-            sfpi::vFloat h = -0.3F;
-            vUInt l2b      = 0x9000;
+            sfpi::vFloat h  = -0.3F;
+            sfpi::vUInt l2b = 0x9000;
             // Test used a bias on Grayskull, not supported on Wormhole
             h                 = lut_sign(h, l0b, l1b, l2b);
             sfpi::dst_reg[11] = h;
@@ -1929,8 +1929,8 @@ sfpi_test_noinline void test11()
         v_elseif (sfpi::dst_reg[0] == 10.0F)
         {
             // Use L0
-            sfpi::vFloat h = -0.3F;
-            vUInt l2b      = 0x9000;
+            sfpi::vFloat h  = -0.3F;
+            sfpi::vUInt l2b = 0x9000;
             // Test used a bias on Grayskull, not supported on Wormhole
             h                 = lut(h, l0b, l1b, l2b);
             sfpi::dst_reg[11] = h;
@@ -1938,8 +1938,8 @@ sfpi_test_noinline void test11()
         v_elseif (sfpi::dst_reg[0] == 11.0F)
         {
             // Use L1
-            sfpi::vFloat h = 1.0F;
-            vUInt l2b      = 0x9000;
+            sfpi::vFloat h  = 1.0F;
+            sfpi::vUInt l2b = 0x9000;
             // Test used a bias on Grayskull, not supported on Wormhole
             h                 = lut(h, l0b, l1b, l2b);
             sfpi::dst_reg[11] = h;
@@ -1948,7 +1948,7 @@ sfpi_test_noinline void test11()
         {
             // Use L2
             sfpi::vFloat h    = 4.0F;
-            vUInt l2b         = 0x9000;
+            sfpi::vUInt l2b   = 0x9000;
             h                 = lut_sign(h, l0b, l1b, l2b);
             sfpi::dst_reg[11] = h;
         }
@@ -1957,9 +1957,9 @@ sfpi_test_noinline void test11()
 
     // lut2 3 entry 16 bit
     {
-        vUInt l0 = (sfpi::s2vFloat16a(2.0f).get() << 16) | sfpi::s2vFloat16a(3.0f).get();
-        vUInt l1 = (sfpi::s2vFloat16a(4.0f).get() << 16) | sfpi::s2vFloat16a(5.0f).get();
-        vUInt l2 = (sfpi::s2vFloat16a(6.0f).get() << 16) | sfpi::s2vFloat16a(7.0f).get();
+        sfpi::vUInt l0 = (sfpi::s2vFloat16a(2.0f).get() << 16) | sfpi::s2vFloat16a(3.0f).get();
+        sfpi::vUInt l1 = (sfpi::s2vFloat16a(4.0f).get() << 16) | sfpi::s2vFloat16a(5.0f).get();
+        sfpi::vUInt l2 = (sfpi::s2vFloat16a(6.0f).get() << 16) | sfpi::s2vFloat16a(7.0f).get();
         v_if (sfpi::dst_reg[0] == 13.0f)
         {
             sfpi::vFloat h    = -0.25f;
@@ -2024,13 +2024,13 @@ sfpi_test_noinline void test11()
 
     // lut2 6 entry 16 bit mode 1
     {
-        vUInt a01 = (sfpi::s2vFloat16a(4.0f).get() << 16) | sfpi::s2vFloat16a(2.0f).get();
-        vUInt a23 = (sfpi::s2vFloat16a(8.0f).get() << 16) | sfpi::s2vFloat16a(6.0f).get();
+        sfpi::vUInt a01 = (sfpi::s2vFloat16a(4.0f).get() << 16) | sfpi::s2vFloat16a(2.0f).get();
+        sfpi::vUInt a23 = (sfpi::s2vFloat16a(8.0f).get() << 16) | sfpi::s2vFloat16a(6.0f).get();
         ;
-        vUInt a34 = (sfpi::s2vFloat16a(12.0f).get() << 16) | sfpi::s2vFloat16a(10.0f).get();
-        vUInt b01 = (sfpi::s2vFloat16a(5.0f).get() << 16) | sfpi::s2vFloat16a(3.0f).get();
-        vUInt b23 = (sfpi::s2vFloat16a(9.0f).get() << 16) | sfpi::s2vFloat16a(7.0f).get();
-        vUInt b34 = (sfpi::s2vFloat16a(13.0f).get() << 16) | sfpi::s2vFloat16a(11.0f).get();
+        sfpi::vUInt a34 = (sfpi::s2vFloat16a(12.0f).get() << 16) | sfpi::s2vFloat16a(10.0f).get();
+        sfpi::vUInt b01 = (sfpi::s2vFloat16a(5.0f).get() << 16) | sfpi::s2vFloat16a(3.0f).get();
+        sfpi::vUInt b23 = (sfpi::s2vFloat16a(9.0f).get() << 16) | sfpi::s2vFloat16a(7.0f).get();
+        sfpi::vUInt b34 = (sfpi::s2vFloat16a(13.0f).get() << 16) | sfpi::s2vFloat16a(11.0f).get();
         v_if (sfpi::dst_reg[0] == 21.0f)
         {
             sfpi::vFloat h    = -0.25f;
@@ -2078,13 +2078,13 @@ sfpi_test_noinline void test11()
 
     // lut2 6 entry 16 bit mode 2
     {
-        vUInt a01 = (sfpi::s2vFloat16a(4.0f).get() << 16) | sfpi::s2vFloat16a(2.0f).get();
-        vUInt a23 = (sfpi::s2vFloat16a(8.0f).get() << 16) | sfpi::s2vFloat16a(6.0f).get();
+        sfpi::vUInt a01 = (sfpi::s2vFloat16a(4.0f).get() << 16) | sfpi::s2vFloat16a(2.0f).get();
+        sfpi::vUInt a23 = (sfpi::s2vFloat16a(8.0f).get() << 16) | sfpi::s2vFloat16a(6.0f).get();
         ;
-        vUInt a34 = (sfpi::s2vFloat16a(12.0f).get() << 16) | sfpi::s2vFloat16a(10.0f).get();
-        vUInt b01 = (sfpi::s2vFloat16a(5.0f).get() << 16) | sfpi::s2vFloat16a(3.0f).get();
-        vUInt b23 = (sfpi::s2vFloat16a(9.0f).get() << 16) | sfpi::s2vFloat16a(7.0f).get();
-        vUInt b34 = (sfpi::s2vFloat16a(13.0f).get() << 16) | sfpi::s2vFloat16a(11.0f).get();
+        sfpi::vUInt a34 = (sfpi::s2vFloat16a(12.0f).get() << 16) | sfpi::s2vFloat16a(10.0f).get();
+        sfpi::vUInt b01 = (sfpi::s2vFloat16a(5.0f).get() << 16) | sfpi::s2vFloat16a(3.0f).get();
+        sfpi::vUInt b23 = (sfpi::s2vFloat16a(9.0f).get() << 16) | sfpi::s2vFloat16a(7.0f).get();
+        sfpi::vUInt b34 = (sfpi::s2vFloat16a(13.0f).get() << 16) | sfpi::s2vFloat16a(11.0f).get();
 
         // Can't fit all the tests into 32 elements, skipping a few that are
         // the most redundant to prior tests here
@@ -2183,13 +2183,13 @@ sfpi_test_noinline void test12(int imm)
     }
     v_elseif (sfpi::dst_reg[0] == 3.0F)
     {
-        vInt a = 5;
+        sfpi::vInt a = 5;
         a += imm; // SFPIADD_I
         set_expected_result(12, 25.0F, 40, a);
     }
     v_elseif (sfpi::dst_reg[0] == 4.0F)
     {
-        vInt a = 5;
+        sfpi::vInt a = 5;
         a -= imm; // SFPIADD_I
         set_expected_result(12, -25.0F, -30, a);
     }
@@ -2209,15 +2209,15 @@ sfpi_test_noinline void test12(int imm)
 
     v_if (sfpi::dst_reg[0] == 7.0F)
     {
-        vUInt a = 0x4000;
+        sfpi::vUInt a = 0x4000;
         a >>= imm - 25;
-        set_expected_result(12, 64.0F, 0x0010, reinterpret<vInt>(a));
+        set_expected_result(12, 64.0F, 0x0010, reinterpret<sfpi::vInt>(a));
     }
     v_elseif (sfpi::dst_reg[0] == 8.0F)
     {
-        vUInt a = 1;
+        sfpi::vUInt a = 1;
         a <<= imm - 25;
-        set_expected_result(12, 128.0F, 0x0400, reinterpret<vInt>(a));
+        set_expected_result(12, 128.0F, 0x0400, reinterpret<sfpi::vInt>(a));
     }
     v_elseif (sfpi::dst_reg[0] == 9.0F)
     {
@@ -2384,8 +2384,8 @@ sfpi_test_noinline void test13(int imm)
 
     // NOT liveness across SETCC
     {
-        vInt a = 0xFAAA;
-        vInt b = 0x07BB;
+        sfpi::vInt a = 0xFAAA;
+        sfpi::vInt b = 0x07BB;
         v_if (sfpi::dst_reg[0] == 2.0F)
         {
             b = ~a;
@@ -2411,8 +2411,8 @@ sfpi_test_noinline void test13(int imm)
 
     // LZ liveness across SETCC
     {
-        vInt a = 0x0080;
-        vInt b = 0x07BB;
+        sfpi::vInt a = 0x0080;
+        sfpi::vInt b = 0x07BB;
         v_if (sfpi::dst_reg[0] == 4.0F)
         {
             b = lz(a);
@@ -2493,7 +2493,7 @@ sfpi_test_noinline void test13(int imm)
     // EXEXP liveness across SETCC
     {
         sfpi::vFloat a = 160.0F;
-        vInt b         = 128;
+        sfpi::vInt b   = 128;
         v_if (sfpi::dst_reg[0] == 12.0F)
         {
             b = exexp_nodebias(a);
@@ -2512,7 +2512,7 @@ sfpi_test_noinline void test13(int imm)
     // EXMAN liveness across SETCC
     {
         sfpi::vFloat a = 160.0F;
-        vInt b         = 0x80000;
+        sfpi::vInt b   = 0x80000;
         v_if (sfpi::dst_reg[0] == 14.0F)
         {
             b = exman8(a);
@@ -2655,7 +2655,7 @@ sfpi_test_noinline void test14(int imm)
     {
         sfpi::vFloat a = 250.0F;
         sfpi::vFloat b = 260.0F;
-        vInt tmp;
+        sfpi::vInt tmp;
 
         v_if (sfpi::dst_reg[0] == 2.0F)
         {
@@ -2681,7 +2681,7 @@ sfpi_test_noinline void test14(int imm)
     {
         sfpi::vFloat a = 270.0F;
         sfpi::vFloat b = 280.0F;
-        vInt tmp;
+        sfpi::vInt tmp;
 
         v_if (sfpi::dst_reg[0] == 4.0F)
         {
@@ -2707,7 +2707,7 @@ sfpi_test_noinline void test14(int imm)
     // MOV liveness across IADD
     {
         sfpi::vFloat b = 300.0F;
-        vInt tmp       = 5;
+        sfpi::vInt tmp = 5;
 
         v_if (sfpi::dst_reg[0] == 6.0F)
         {
@@ -2732,8 +2732,8 @@ sfpi_test_noinline void test14(int imm)
 
     // IADD_I liveness
     {
-        vInt a = 10;
-        vInt b = 20;
+        sfpi::vInt a = 10;
+        sfpi::vInt b = 20;
         v_if (sfpi::dst_reg[0] == 8.0F)
         {
             b = a + 30;
@@ -2840,8 +2840,8 @@ sfpi_test_noinline void test14(int imm)
     // Destination as source, 2 arguments in the wrong order
     // Confirm b is correct
     {
-        vInt a = 10;
-        vInt b = 20;
+        sfpi::vInt a = 10;
+        sfpi::vInt b = 20;
         v_if (sfpi::dst_reg[0] == 16.0f)
         {
             b = b - a;
@@ -2873,8 +2873,8 @@ sfpi_test_noinline void test14(int imm)
     // Destination as source, 2 arguments in the wrong order
     // Confirm a is correct
     {
-        vInt a = 10;
-        vInt b = 20;
+        sfpi::vInt a = 10;
+        sfpi::vInt b = 20;
         v_if (sfpi::dst_reg[0] == 16.0f)
         {
             b = b - a;
@@ -2908,9 +2908,9 @@ sfpi_test_noinline void test14(int imm)
     {
         // Out of regs doing this the typical way
         sfpi::vFloat condition = sfpi::dst_reg[0] - 20.0F;
-        vInt a                 = 10;
-        vInt b                 = 20;
-        vInt c                 = 30;
+        sfpi::vInt a           = 10;
+        sfpi::vInt b           = 20;
+        sfpi::vInt c           = 30;
 
         v_if (condition == 0.0F)
         {
@@ -2946,9 +2946,9 @@ sfpi_test_noinline void test14(int imm)
     {
         // Out of regs doing this the typical way
         sfpi::vFloat condition = sfpi::dst_reg[0] - 22.0F;
-        vInt a                 = 10;
-        vInt b                 = 20;
-        vInt c                 = 30;
+        sfpi::vInt a           = 10;
+        sfpi::vInt b           = 20;
+        sfpi::vInt c           = 30;
 
         v_if (condition == 0.0F)
         {
@@ -2984,9 +2984,9 @@ sfpi_test_noinline void test14(int imm)
     {
         // Out of regs doing this the typical way
         sfpi::vFloat condition = sfpi::dst_reg[0] - 24.0F;
-        vInt a                 = 10;
-        vInt b                 = 20;
-        vInt c                 = 30;
+        sfpi::vInt a           = 10;
+        sfpi::vInt b           = 20;
+        sfpi::vInt c           = 30;
 
         v_if (condition == 0.0F)
         {
@@ -3132,33 +3132,33 @@ sfpi_test_noinline void test15()
 
     sfpi::dst_reg[15] = -sfpi::dst_reg[0];
     {
-        vUInt a = vConstTileId + 0x100;
-        vUInt b = vConstTileId + 0x200;
-        vUInt c = vConstTileId + 0x300;
-        vUInt d = vConstTileId + 0x400;
+        sfpi::vUInt a = vConstTileId + 0x100;
+        sfpi::vUInt b = vConstTileId + 0x200;
+        sfpi::vUInt c = vConstTileId + 0x300;
+        sfpi::vUInt d = vConstTileId + 0x400;
 
         subvec_transp(a, b, c, d);
 
-        vUInt base = vConstTileId >> 4;
+        sfpi::vUInt base = vConstTileId >> 4;
         base <<= 8;
         base += 0x100;
 
         // Load expected value, subtract actual value. result is 0 if correct
-        vUInt eff  = 0xF;
-        vUInt cmpa = base | (vConstTileId & eff);
+        sfpi::vUInt eff  = 0xF;
+        sfpi::vUInt cmpa = base | (vConstTileId & eff);
         cmpa -= a;
-        vUInt cmpb = base | ((vConstTileId & eff) + 0x10);
+        sfpi::vUInt cmpb = base | ((vConstTileId & eff) + 0x10);
         cmpb -= b;
-        vUInt cmpc = base | ((vConstTileId & eff) + 0x20);
+        sfpi::vUInt cmpc = base | ((vConstTileId & eff) + 0x20);
         cmpc -= c;
-        vUInt cmpd = base | ((vConstTileId & eff) + 0x30);
+        sfpi::vUInt cmpd = base | ((vConstTileId & eff) + 0x30);
         cmpd -= d;
 
         // The above completes this test, now to make the results reportable
         // in less than 4 full width vectors
 
         // Reduce across a, b, c, d
-        vUInt result = reduce_bool4(cmpa, cmpb, cmpc, cmpd, 0);
+        sfpi::vUInt result = reduce_bool4(cmpa, cmpb, cmpc, cmpd, 0);
 
         // We care about xyz
         // Use the thing we're testing to test the result by putting xyz result
@@ -3166,7 +3166,7 @@ sfpi_test_noinline void test15()
         subvec_transp(result, cmpb, cmpc, cmpd);
 
         // Reduce result (only care about first subbvec, rest along for the ride)
-        vUInt final = reduce_bool4(result, cmpb, cmpc, cmpd, 1);
+        sfpi::vUInt final = reduce_bool4(result, cmpb, cmpc, cmpd, 1);
 
         v_if (sfpi::dst_reg[0] < 8.0F)
         {
@@ -3177,10 +3177,10 @@ sfpi_test_noinline void test15()
 
     {
         // subvec_shflror1
-        vUInt src = vConstTileId;
-        vUInt dst = subvec_shflror1(src);
+        sfpi::vUInt src = vConstTileId;
+        sfpi::vUInt dst = subvec_shflror1(src);
 
-        vUInt cmpdst = vConstTileId - 2;
+        sfpi::vUInt cmpdst = vConstTileId - 2;
         // first element in the subvec
         v_if ((vConstTileId & 0xF) == 0)
         {
@@ -3189,12 +3189,12 @@ sfpi_test_noinline void test15()
         v_endif;
         dst -= cmpdst;
 
-        vUInt tmp1 = 1;
-        vUInt tmp2 = 1;
-        vUInt tmp3 = 1;
+        sfpi::vUInt tmp1 = 1;
+        sfpi::vUInt tmp2 = 1;
+        sfpi::vUInt tmp3 = 1;
         subvec_transp(tmp1, dst, tmp2, tmp3);
 
-        vUInt final = reduce_bool4(dst, tmp1, tmp2, tmp3, 0);
+        sfpi::vUInt final = reduce_bool4(dst, tmp1, tmp2, tmp3, 0);
         v_if (sfpi::dst_reg[0] >= 8.0F && sfpi::dst_reg[0] < 16.0F)
         {
             set_expected_result(15, 16.0F, 1, final);
@@ -3204,10 +3204,10 @@ sfpi_test_noinline void test15()
 
     {
         // subvec_shflshr1
-        vUInt src = vConstTileId;
-        vUInt dst = subvec_shflshr1(src);
+        sfpi::vUInt src = vConstTileId;
+        sfpi::vUInt dst = subvec_shflshr1(src);
 
-        vUInt cmpdst = vConstTileId - 2;
+        sfpi::vUInt cmpdst = vConstTileId - 2;
         // first element in the subvec
         v_if ((vConstTileId & 0xF) == 0)
         {
@@ -3216,12 +3216,12 @@ sfpi_test_noinline void test15()
         v_endif;
         dst -= cmpdst;
 
-        vUInt tmp1 = 1;
-        vUInt tmp2 = 1;
-        vUInt tmp3 = 1;
+        sfpi::vUInt tmp1 = 1;
+        sfpi::vUInt tmp2 = 1;
+        sfpi::vUInt tmp3 = 1;
         subvec_transp(tmp1, tmp2, dst, tmp3);
 
-        vUInt final = reduce_bool4(tmp1, dst, tmp2, tmp3, 0);
+        sfpi::vUInt final = reduce_bool4(tmp1, dst, tmp2, tmp3, 0);
         v_if (sfpi::dst_reg[0] >= 16.0F && sfpi::dst_reg[0] < 24.0F)
         {
             set_expected_result(15, 24.0F, 1, final);
@@ -3233,7 +3233,7 @@ sfpi_test_noinline void test15()
     // interesting if/when we implement LOADMACRO
     v_if (sfpi::dst_reg[0] == 16.0F) {
         // Wrapper doesn't emit shft2 bit shift, test directly
-        vUInt a = 0x005A;
+        sfpi::vUInt a = 0x005A;
 
         a.get() = __builtin_rvtt_sfpshft2_i(a.get(), 4);
         set_expected_result(16, 10.0F, 0x05A0, a);
@@ -3242,8 +3242,8 @@ sfpi_test_noinline void test15()
 
     v_if (sfpi::dst_reg[0] == 17.0F) {
         // Wrapper doesn't emit shft2 bit shift, test directly
-        vUInt a = 0x005A;
-        vUInt b = 4;
+        sfpi::vUInt a = 0x005A;
+        sfpi::vUInt b = 4;
 
         a.get() = __builtin_rvtt_sfpshft2_v(a.get(), b.get());
         set_expected_result(16, 20.0F, 0x05A0, a);
@@ -3328,7 +3328,7 @@ void test16()
     v_endif;
     v_if (sfpi::dst_reg[0] == 14.0F)
     {
-        vUInt descale = 8;
+        sfpi::vUInt descale = 8;
         set_expected_result(16, 80.0f, 0xeb, int32_to_uint8(0xea00, descale));
     }
     v_endif;
@@ -3339,7 +3339,7 @@ void test16()
     v_endif;
     v_if (sfpi::dst_reg[0] == 16.0F)
     {
-        vUInt descale = 8;
+        sfpi::vUInt descale = 8;
         set_expected_result(16, 112.0f, 0xf, int32_to_int8(0xea0, descale));
     }
     v_endif;
@@ -3370,8 +3370,8 @@ void test17()
     // Test sign-magnitude for ints
     v_if (sfpi::dst_reg[0] == 2.0F)
     {
-        vUInt x = -1;
-        vUInt y = -2;
+        sfpi::vUInt x = -1;
+        sfpi::vUInt y = -2;
         vec_min_max(x, y);
         set_expected_result(17, 23.0f, -1, x);
     }

--- a/tt_llk_blackhole/common/inc/ckernel_sfpi.h
+++ b/tt_llk_blackhole/common/inc/ckernel_sfpi.h
@@ -208,13 +208,13 @@ sfpi_test_noinline void test3()
 
     v_if (sfpi::dst_reg[0] == 13.0F)
     {
-        sfpi::dst_reg[3] = s2sfpi::vFloat16b(0.005f);
+        sfpi::dst_reg[3] = sfpi::s2vFloat16b(0.005f);
     }
     v_endif;
 
     v_if (sfpi::dst_reg[0] == 14.0F)
     {
-        sfpi::dst_reg[3] = s2sfpi::vFloat16a(0x3c05);
+        sfpi::dst_reg[3] = sfpi::s2vFloat16a(0x3c05);
     }
     v_endif;
 
@@ -1666,10 +1666,10 @@ sfpi_test_noinline void test9()
 
         sfpi::vFloat x = 1.0F;
 
-        x *= s2sfpi::vFloat16a(2.0);
-        x *= s2sfpi::vFloat16a(-3.0);
-        x += s2sfpi::vFloat16a(4.0);
-        x += s2sfpi::vFloat16a(-4.0);
+        x *= sfpi::s2vFloat16a(2.0);
+        x *= sfpi::s2vFloat16a(-3.0);
+        x += sfpi::s2vFloat16a(4.0);
+        x += sfpi::s2vFloat16a(-4.0);
 
         sfpi::dst_reg[9] = x;
     }
@@ -1957,9 +1957,9 @@ sfpi_test_noinline void test11()
 
     // lut2 3 entry 16 bit
     {
-        vUInt l0 = (s2sfpi::vFloat16a(2.0f).get() << 16) | s2sfpi::vFloat16a(3.0f).get();
-        vUInt l1 = (s2sfpi::vFloat16a(4.0f).get() << 16) | s2sfpi::vFloat16a(5.0f).get();
-        vUInt l2 = (s2sfpi::vFloat16a(6.0f).get() << 16) | s2sfpi::vFloat16a(7.0f).get();
+        vUInt l0 = (sfpi::s2vFloat16a(2.0f).get() << 16) | sfpi::s2vFloat16a(3.0f).get();
+        vUInt l1 = (sfpi::s2vFloat16a(4.0f).get() << 16) | sfpi::s2vFloat16a(5.0f).get();
+        vUInt l2 = (sfpi::s2vFloat16a(6.0f).get() << 16) | sfpi::s2vFloat16a(7.0f).get();
         v_if (sfpi::dst_reg[0] == 13.0f)
         {
             sfpi::vFloat h    = -0.25f;
@@ -2024,13 +2024,13 @@ sfpi_test_noinline void test11()
 
     // lut2 6 entry 16 bit mode 1
     {
-        vUInt a01 = (s2sfpi::vFloat16a(4.0f).get() << 16) | s2sfpi::vFloat16a(2.0f).get();
-        vUInt a23 = (s2sfpi::vFloat16a(8.0f).get() << 16) | s2sfpi::vFloat16a(6.0f).get();
+        vUInt a01 = (sfpi::s2vFloat16a(4.0f).get() << 16) | sfpi::s2vFloat16a(2.0f).get();
+        vUInt a23 = (sfpi::s2vFloat16a(8.0f).get() << 16) | sfpi::s2vFloat16a(6.0f).get();
         ;
-        vUInt a34 = (s2sfpi::vFloat16a(12.0f).get() << 16) | s2sfpi::vFloat16a(10.0f).get();
-        vUInt b01 = (s2sfpi::vFloat16a(5.0f).get() << 16) | s2sfpi::vFloat16a(3.0f).get();
-        vUInt b23 = (s2sfpi::vFloat16a(9.0f).get() << 16) | s2sfpi::vFloat16a(7.0f).get();
-        vUInt b34 = (s2sfpi::vFloat16a(13.0f).get() << 16) | s2sfpi::vFloat16a(11.0f).get();
+        vUInt a34 = (sfpi::s2vFloat16a(12.0f).get() << 16) | sfpi::s2vFloat16a(10.0f).get();
+        vUInt b01 = (sfpi::s2vFloat16a(5.0f).get() << 16) | sfpi::s2vFloat16a(3.0f).get();
+        vUInt b23 = (sfpi::s2vFloat16a(9.0f).get() << 16) | sfpi::s2vFloat16a(7.0f).get();
+        vUInt b34 = (sfpi::s2vFloat16a(13.0f).get() << 16) | sfpi::s2vFloat16a(11.0f).get();
         v_if (sfpi::dst_reg[0] == 21.0f)
         {
             sfpi::vFloat h    = -0.25f;
@@ -2078,13 +2078,13 @@ sfpi_test_noinline void test11()
 
     // lut2 6 entry 16 bit mode 2
     {
-        vUInt a01 = (s2sfpi::vFloat16a(4.0f).get() << 16) | s2sfpi::vFloat16a(2.0f).get();
-        vUInt a23 = (s2sfpi::vFloat16a(8.0f).get() << 16) | s2sfpi::vFloat16a(6.0f).get();
+        vUInt a01 = (sfpi::s2vFloat16a(4.0f).get() << 16) | sfpi::s2vFloat16a(2.0f).get();
+        vUInt a23 = (sfpi::s2vFloat16a(8.0f).get() << 16) | sfpi::s2vFloat16a(6.0f).get();
         ;
-        vUInt a34 = (s2sfpi::vFloat16a(12.0f).get() << 16) | s2sfpi::vFloat16a(10.0f).get();
-        vUInt b01 = (s2sfpi::vFloat16a(5.0f).get() << 16) | s2sfpi::vFloat16a(3.0f).get();
-        vUInt b23 = (s2sfpi::vFloat16a(9.0f).get() << 16) | s2sfpi::vFloat16a(7.0f).get();
-        vUInt b34 = (s2sfpi::vFloat16a(13.0f).get() << 16) | s2sfpi::vFloat16a(11.0f).get();
+        vUInt a34 = (sfpi::s2vFloat16a(12.0f).get() << 16) | sfpi::s2vFloat16a(10.0f).get();
+        vUInt b01 = (sfpi::s2vFloat16a(5.0f).get() << 16) | sfpi::s2vFloat16a(3.0f).get();
+        vUInt b23 = (sfpi::s2vFloat16a(9.0f).get() << 16) | sfpi::s2vFloat16a(7.0f).get();
+        vUInt b34 = (sfpi::s2vFloat16a(13.0f).get() << 16) | sfpi::s2vFloat16a(11.0f).get();
 
         // Can't fit all the tests into 32 elements, skipping a few that are
         // the most redundant to prior tests here

--- a/tt_llk_blackhole/common/inc/ckernel_sfpi.h
+++ b/tt_llk_blackhole/common/inc/ckernel_sfpi.h
@@ -25,7 +25,7 @@ namespace sfpi_test
 
 sfpi_inline void copy_result_to_dreg0(int addr)
 {
-    dst_reg[0] = dst_reg[addr];
+    sfpi::dst_reg[0] = sfpi::dst_reg[addr];
 }
 
 // Test infrastructure is set up to test float values, not ints
@@ -40,16 +40,16 @@ sfpi_inline void set_expected_result(int addr, float sentinel, int expected, vIn
     // bits so comparing bit patterns w/ the MSB set won't work
     v_if (v >= expected && v < expected + 1)
     {
-        dst_reg[addr] = sentinel;
+        sfpi::dst_reg[addr] = sentinel;
     }
     v_else
     {
-        dst_reg[addr] = v;
+        sfpi::dst_reg[addr] = v;
     }
     v_endif;
 }
 
-sfpi_inline vInt test_interleaved_scalar_vector_cond(bool scalar_bool, vFloat vec, float a, float b)
+sfpi_inline vInt test_interleaved_scalar_vector_cond(bool scalar_bool, sfpi::vFloat vec, float a, float b)
 {
     if (scalar_bool)
     {
@@ -91,13 +91,13 @@ sfpi_inline vType reduce_bool4(vType a, vType b, vType c, vType d, int reference
 sfpi_test_noinline void test1()
 {
     // Test SFPLOADI, SFPSTORE
-    dst_reg[0] = 1.3f;
+    sfpi::dst_reg[0] = 1.3f;
 }
 
 sfpi_test_noinline void test2()
 {
     // Test SFPLOAD, SFPMOV
-    dst_reg[2] = -dst_reg[0];
+    sfpi::dst_reg[2] = -sfpi::dst_reg[0];
 
     // Out: ramp down from 0 to -63
     copy_result_to_dreg0(2);
@@ -107,190 +107,190 @@ sfpi_test_noinline void test3()
 {
     // Test SFPENCC, SFPSETCC, SFPCOMPC, LOADI, MAD (in conditionals)
     // Note: WH complains about the integer tests storing into float formated
-    // dst_reg w/ exponent of 0, so some tests use SFPOR to pass the result
+    // sfpi::dst_reg w/ exponent of 0, so some tests use SFPOR to pass the result
     // through violating the spirit of testing one thing at a time
 
-    v_if (dst_reg[0] == 0.0F)
+    v_if (sfpi::dst_reg[0] == 0.0F)
     {
         // 1 load
-        dst_reg[3] = 10.0F;
+        sfpi::dst_reg[3] = 10.0F;
     }
     v_else
     {
         // 1 load
-        dst_reg[3] = 20.0F;
+        sfpi::dst_reg[3] = 20.0F;
     }
     v_endif;
 
-    v_if (dst_reg[0] == 2.0F)
+    v_if (sfpi::dst_reg[0] == 2.0F)
     {
         // 1 load
-        vFloat a   = 30.0F;
-        dst_reg[3] = a;
+        sfpi::vFloat a   = 30.0F;
+        sfpi::dst_reg[3] = a;
     }
     v_endif;
 
-    v_if (dst_reg[0] == 3.0F)
+    v_if (sfpi::dst_reg[0] == 3.0F)
     {
         // 2 loads
-        dst_reg[3] = 1.005f;
+        sfpi::dst_reg[3] = 1.005f;
     }
     v_endif;
 
-    v_if (dst_reg[0] == 4.0F)
+    v_if (sfpi::dst_reg[0] == 4.0F)
     {
         // 2 loads
-        vFloat a   = 1.005f;
-        dst_reg[3] = a;
+        sfpi::vFloat a   = 1.005f;
+        sfpi::dst_reg[3] = a;
     }
     v_endif;
 
-    v_if (dst_reg[0] == 5.0F)
+    v_if (sfpi::dst_reg[0] == 5.0F)
     {
         // This will be a short w/ 1 load
         vInt a = 0x3F80;
         a |= 0x3f800000;
-        dst_reg[3] = a;
+        sfpi::dst_reg[3] = a;
     }
     v_endif;
 
-    v_if (dst_reg[0] == 6.0F)
+    v_if (sfpi::dst_reg[0] == 6.0F)
     {
         // This will be an int w/ 2 loads
         vInt a     = 0x3F80A3D7; // 1.005
-        dst_reg[3] = a;
+        sfpi::dst_reg[3] = a;
     }
     v_endif;
 
-    v_if (dst_reg[0] == 7.0F)
+    v_if (sfpi::dst_reg[0] == 7.0F)
     {
         // This will be an int w/ 1 load (not sign extended)
         vInt a     = 0x8F80;
-        dst_reg[3] = a | 0x3f800000;
+        sfpi::dst_reg[3] = a | 0x3f800000;
     }
     v_endif;
 
-    v_if (dst_reg[0] == 8.0F)
+    v_if (sfpi::dst_reg[0] == 8.0F)
     {
         // This will be a ushort w/ 1 load (not sign extended)
         vUInt a    = 0x8F80U;
-        dst_reg[3] = a | 0x3f800000;
+        sfpi::dst_reg[3] = a | 0x3f800000;
     }
     v_endif;
 
-    v_if (dst_reg[0] == 9.0F)
+    v_if (sfpi::dst_reg[0] == 9.0F)
     {
         // This will be an int w/ 2 loads
-        dst_reg[3] = 0x3F80A3D7; // 1.005
+        sfpi::dst_reg[3] = 0x3F80A3D7; // 1.005
     }
     v_endif;
 
-    v_if (dst_reg[0] == 10.0F)
+    v_if (sfpi::dst_reg[0] == 10.0F)
     {
         vUInt a    = static_cast<unsigned short>(0x3f80);
-        dst_reg[3] = a | 0x3f800000;
+        sfpi::dst_reg[3] = a | 0x3f800000;
     }
     v_endif;
 
-    v_if (dst_reg[0] == 11.0F)
+    v_if (sfpi::dst_reg[0] == 11.0F)
     {
         // This will be a short w/ 1 load (sign extended)
-        dst_reg[3] = static_cast<short>(0x8f80);
+        sfpi::dst_reg[3] = static_cast<short>(0x8f80);
     }
     v_endif;
 
-    v_if (dst_reg[0] == 12.0F)
+    v_if (sfpi::dst_reg[0] == 12.0F)
     {
         vUInt a    = 0x3F80A3D7;
-        dst_reg[3] = a;
+        sfpi::dst_reg[3] = a;
     }
     v_endif;
 
-    v_if (dst_reg[0] == 13.0F)
+    v_if (sfpi::dst_reg[0] == 13.0F)
     {
-        dst_reg[3] = s2vFloat16b(0.005f);
+        sfpi::dst_reg[3] = s2sfpi::vFloat16b(0.005f);
     }
     v_endif;
 
-    v_if (dst_reg[0] == 14.0F)
+    v_if (sfpi::dst_reg[0] == 14.0F)
     {
-        dst_reg[3] = s2vFloat16a(0x3c05);
+        sfpi::dst_reg[3] = s2sfpi::vFloat16a(0x3c05);
     }
     v_endif;
 
-    v_if (dst_reg[0] == 15.0F)
+    v_if (sfpi::dst_reg[0] == 15.0F)
     {
-        dst_reg[3] = 25.0; // double
+        sfpi::dst_reg[3] = 25.0; // double
     }
     v_endif;
 
-    v_if (dst_reg[0] == 16.0F)
+    v_if (sfpi::dst_reg[0] == 16.0F)
     {
-        vFloat a   = 28.0; // double
-        dst_reg[3] = a;
+        sfpi::vFloat a   = 28.0; // double
+        sfpi::dst_reg[3] = a;
     }
     v_endif;
 
-    v_if (dst_reg[0] == 17.0F)
+    v_if (sfpi::dst_reg[0] == 17.0F)
     {
-        dst_reg[3] = vConst0p8373;
+        sfpi::dst_reg[3] = vConst0p8373;
     }
     v_endif;
 
     // Below are from the limits test.  Test the compiler's ability to use
     // fp16a, fp16b or fp32 as needed
 
-    v_if (dst_reg[0] == 18.0F)
+    v_if (sfpi::dst_reg[0] == 18.0F)
     {
-        dst_reg[3] = 1.9921875f; // 0x3fff0000
+        sfpi::dst_reg[3] = 1.9921875f; // 0x3fff0000
     }
     v_endif;
 
-    v_if (dst_reg[0] == 19.0F)
+    v_if (sfpi::dst_reg[0] == 19.0F)
     {
-        dst_reg[3] = 1.99609375f; // 0x3fff8000
+        sfpi::dst_reg[3] = 1.99609375f; // 0x3fff8000
     }
     v_endif;
 
-    v_if (dst_reg[0] == 20.0F)
+    v_if (sfpi::dst_reg[0] == 20.0F)
     {
         // This is fp16b w/ large exp, with pass_offset != 0 the mantissa will overflow, use fp32
-        dst_reg[3] = 130560.0f; // 0x47ff0000
+        sfpi::dst_reg[3] = 130560.0f; // 0x47ff0000
     }
     v_endif;
 
-    v_if (dst_reg[0] == 21.0F)
+    v_if (sfpi::dst_reg[0] == 21.0F)
     {
         // This is fp16b w/ large exp, with pass_offset != 0 the mantissa will overflow, use fp32
-        dst_reg[3] = 130592.0f; // 0x47ff1000
+        sfpi::dst_reg[3] = 130592.0f; // 0x47ff1000
     }
     v_endif;
 
-    v_if (dst_reg[0] == 22.0F)
+    v_if (sfpi::dst_reg[0] == 22.0F)
     {
         // This is fp16a w/ largest exp, with pass_offset != 0 the exponent will overflow, use fp32
-        dst_reg[3] = 65408.0f; // 0x477f8000
+        sfpi::dst_reg[3] = 65408.0f; // 0x477f8000
     }
     v_endif;
 
-    v_if (dst_reg[0] == 23.0F)
+    v_if (sfpi::dst_reg[0] == 23.0F)
     {
         // This is fp16a w/ largest exp, with pass_offset != 0 the exponent will overflow, use fp32
-        dst_reg[3] = 130816.0f; // 0x47ff8000
+        sfpi::dst_reg[3] = 130816.0f; // 0x47ff8000
     }
     v_endif;
 
-    v_if (dst_reg[0] == 24.0F)
+    v_if (sfpi::dst_reg[0] == 24.0F)
     {
         // This is fp16a w/ smallest exp, with pass offset != 0 the exponent will underflow, use fp32
-        dst_reg[3] = 0.000121831894f; // 0x38ff8000
+        sfpi::dst_reg[3] = 0.000121831894f; // 0x38ff8000
     }
     v_endif;
 
-    v_if (dst_reg[0] == 25.0F)
+    v_if (sfpi::dst_reg[0] == 25.0F)
     {
         // This is fp16a w/ smallest exp, with pass offset != 0 the exponent will underflow, use fp32
-        dst_reg[3] = 0.000060915947f; // 0x387f8000
+        sfpi::dst_reg[3] = 0.000060915947f; // 0x387f8000
     }
     v_endif;
 
@@ -323,13 +323,13 @@ sfpi_test_noinline void test4()
     // Test vector loads
     // Operators &&, ||, !
 
-    vFloat v = dst_reg[0];
+    sfpi::vFloat v = sfpi::dst_reg[0];
 
-    dst_reg[4] = v;
+    sfpi::dst_reg[4] = v;
 
     v_if (v < 2.0F)
     {
-        dst_reg[4] = 64.0F;
+        sfpi::dst_reg[4] = 64.0F;
     }
     v_endif;
     // [0,1] = 64.0
@@ -340,17 +340,17 @@ sfpi_test_noinline void test4()
         {
             v_if (v >= 3.0F)
             {
-                dst_reg[4] = 65.0F;
+                sfpi::dst_reg[4] = 65.0F;
             }
             v_else
             {
-                dst_reg[4] = 66.0F;
+                sfpi::dst_reg[4] = 66.0F;
             }
             v_endif;
 
             v_if (v == 5.0F)
             {
-                dst_reg[4] = 67.0F;
+                sfpi::dst_reg[4] = 67.0F;
             }
             v_endif;
         }
@@ -367,25 +367,25 @@ sfpi_test_noinline void test4()
         {
             v_if (v == 6.0F)
             {
-                dst_reg[4] = 68.0F;
+                sfpi::dst_reg[4] = 68.0F;
             }
             v_elseif (v != 8.0F)
             {
-                dst_reg[4] = 69.0F;
+                sfpi::dst_reg[4] = 69.0F;
             }
             v_else
             {
-                dst_reg[4] = 70.0F;
+                sfpi::dst_reg[4] = 70.0F;
             }
             v_endif;
         }
         v_elseif (v == 9.0F)
         {
-            dst_reg[4] = 71.0F;
+            sfpi::dst_reg[4] = 71.0F;
         }
         v_elseif (v == 10.0F)
         {
-            dst_reg[4] = 72.0F;
+            sfpi::dst_reg[4] = 72.0F;
         }
 
         v_endif;
@@ -396,11 +396,11 @@ sfpi_test_noinline void test4()
     {
         v_if (v < 18.0F && v >= 12.0F && v != 15.0F)
         {
-            dst_reg[4] = 120.0F;
+            sfpi::dst_reg[4] = 120.0F;
         }
         v_else
         {
-            dst_reg[4] = -dst_reg[0];
+            sfpi::dst_reg[4] = -sfpi::dst_reg[0];
         }
         v_endif;
     }
@@ -410,11 +410,11 @@ sfpi_test_noinline void test4()
     {
         v_if (v == 19.0F || v == 21.0F)
         {
-            dst_reg[4] = 160.0F;
+            sfpi::dst_reg[4] = 160.0F;
         }
         v_else
         {
-            dst_reg[4] = 180.0F;
+            sfpi::dst_reg[4] = 180.0F;
         }
         v_endif;
     }
@@ -423,29 +423,29 @@ sfpi_test_noinline void test4()
     // Test ! on OP
     v_if (!(v != 23.0F))
     {
-        dst_reg[4] = 200.0F;
+        sfpi::dst_reg[4] = 200.0F;
     }
     v_endif;
 
     v_if (!(v >= 25.0F) && !(v < 24.0F))
     {
-        dst_reg[4] = 220.0F;
+        sfpi::dst_reg[4] = 220.0F;
     }
     v_endif;
 
     // Test ! on Boolean
     v_if (!((v < 25.0F) || (v >= 26.0F)))
     {
-        dst_reg[4] = 240.0F;
+        sfpi::dst_reg[4] = 240.0F;
     }
     v_endif;
 
     v_if ((v >= 26.0F) && (v < 29.0F))
     {
-        dst_reg[4] = 260.0F;
+        sfpi::dst_reg[4] = 260.0F;
         v_if (!((v >= 27.0F) && (v < 28.0F)))
         {
-            dst_reg[4] = 270.0F;
+            sfpi::dst_reg[4] = 270.0F;
         }
         v_endif;
     }
@@ -454,8 +454,8 @@ sfpi_test_noinline void test4()
     // Test || after && to be sure PUSHC works properly
     v_if ((v >= 28.0F) && (v == 29.0F || v == 30.0F || v == 31.0F))
     {
-        vFloat x = 30.0F;
-        vFloat y = 280.0F;
+        sfpi::vFloat x = 30.0F;
+        sfpi::vFloat y = 280.0F;
         v_if (v < x)
         {
             y += 10.0F;
@@ -471,7 +471,7 @@ sfpi_test_noinline void test4()
             y += 40.0F;
         }
         v_endif;
-        dst_reg[4] = y;
+        sfpi::dst_reg[4] = y;
     }
     v_endif;
 
@@ -508,39 +508,39 @@ sfpi_test_noinline void test4()
 sfpi_test_noinline void test5()
 {
     // Test SFPMAD, SFPMOV, vConsts
-    dst_reg[5] = -dst_reg[0];
+    sfpi::dst_reg[5] = -sfpi::dst_reg[0];
 
     vConstFloatPrgm0 = .5F;
     vConstFloatPrgm1 = 1.5F;
     vConstIntPrgm2   = 0xBFC00000; // -1.5F
 
-    v_if (dst_reg[0] == 0.0F)
+    v_if (sfpi::dst_reg[0] == 0.0F)
     {
-        dst_reg[5] = vConst0 * vConst0 + vConst0p8373;
+        sfpi::dst_reg[5] = vConst0 * vConst0 + vConst0p8373;
     }
-    v_elseif (dst_reg[0] == 1.0F)
+    v_elseif (sfpi::dst_reg[0] == 1.0F)
     {
-        dst_reg[5] = vConst0 * vConst0 + vConst0;
+        sfpi::dst_reg[5] = vConst0 * vConst0 + vConst0;
     }
-    v_elseif (dst_reg[0] == 2.0F)
+    v_elseif (sfpi::dst_reg[0] == 2.0F)
     {
-        dst_reg[5] = vConst0 * vConst0 + vConstNeg1;
+        sfpi::dst_reg[5] = vConst0 * vConst0 + vConstNeg1;
     }
-    v_elseif (dst_reg[0] == 3.0F)
+    v_elseif (sfpi::dst_reg[0] == 3.0F)
     {
-        dst_reg[5] = vConst0 * vConst0 + vConstFloatPrgm0;
+        sfpi::dst_reg[5] = vConst0 * vConst0 + vConstFloatPrgm0;
     }
-    v_elseif (dst_reg[0] == 4.0F)
+    v_elseif (sfpi::dst_reg[0] == 4.0F)
     {
-        dst_reg[5] = vConst0 * vConst0 + vConstFloatPrgm1;
+        sfpi::dst_reg[5] = vConst0 * vConst0 + vConstFloatPrgm1;
     }
-    v_elseif (dst_reg[0] == 5.0F)
+    v_elseif (sfpi::dst_reg[0] == 5.0F)
     {
-        dst_reg[5] = vConst0 * vConst0 + vConstFloatPrgm2;
+        sfpi::dst_reg[5] = vConst0 * vConst0 + vConstFloatPrgm2;
     }
-    v_elseif (dst_reg[0] == 6.0F)
+    v_elseif (sfpi::dst_reg[0] == 6.0F)
     {
-        dst_reg[5] = vConst0 * vConst0 + vConst1;
+        sfpi::dst_reg[5] = vConst0 * vConst0 + vConst1;
     }
     v_endif;
     // [0] = 0.8373
@@ -552,25 +552,25 @@ sfpi_test_noinline void test5()
     // [6] = 1.0
 
     // Fill holes in the tests; grayskull tested other const regs
-    v_if (dst_reg[0] == 7.0F)
+    v_if (sfpi::dst_reg[0] == 7.0F)
     {
-        dst_reg[5] = vConst0;
+        sfpi::dst_reg[5] = vConst0;
     }
-    v_elseif (dst_reg[0] == 8.0F)
+    v_elseif (sfpi::dst_reg[0] == 8.0F)
     {
-        dst_reg[5] = vConst0;
+        sfpi::dst_reg[5] = vConst0;
     }
-    v_elseif (dst_reg[0] == 9.0F)
+    v_elseif (sfpi::dst_reg[0] == 9.0F)
     {
-        dst_reg[5] = vConst0;
+        sfpi::dst_reg[5] = vConst0;
     }
-    v_elseif (dst_reg[0] == 10.0F)
+    v_elseif (sfpi::dst_reg[0] == 10.0F)
     {
-        dst_reg[5] = vConst0;
+        sfpi::dst_reg[5] = vConst0;
     }
-    v_elseif (dst_reg[0] == 11.0F)
+    v_elseif (sfpi::dst_reg[0] == 11.0F)
     {
-        dst_reg[5] = vConst0p8373 * vConstNeg1 + vConst1;
+        sfpi::dst_reg[5] = vConst0p8373 * vConstNeg1 + vConst1;
     }
     v_endif;
     // [7] = 0.0
@@ -579,40 +579,40 @@ sfpi_test_noinline void test5()
     // [10] = 0.0
     // [11] = .1627
 
-    vFloat a = dst_reg[0];
-    vFloat b = 20.0F;
+    sfpi::vFloat a = sfpi::dst_reg[0];
+    sfpi::vFloat b = 20.0F;
 
-    // Note: loading dst_reg[0] takes a reg and comparing against a float const
+    // Note: loading sfpi::dst_reg[0] takes a reg and comparing against a float const
     // takes a reg so can't store A, B and C across the condtionals
 
-    v_if (dst_reg[0] == 12.0F)
+    v_if (sfpi::dst_reg[0] == 12.0F)
     {
-        dst_reg[5] = a * b;
+        sfpi::dst_reg[5] = a * b;
     }
-    v_elseif (dst_reg[0] == 13.0F)
+    v_elseif (sfpi::dst_reg[0] == 13.0F)
     {
-        dst_reg[5] = a + b;
+        sfpi::dst_reg[5] = a + b;
     }
-    v_elseif (dst_reg[0] == 14.0F)
+    v_elseif (sfpi::dst_reg[0] == 14.0F)
     {
-        dst_reg[5] = a * b + 0.5F;
+        sfpi::dst_reg[5] = a * b + 0.5F;
     }
-    v_elseif (dst_reg[0] == 15.0F)
+    v_elseif (sfpi::dst_reg[0] == 15.0F)
     {
-        dst_reg[5] = a + b + 0.5F;
+        sfpi::dst_reg[5] = a + b + 0.5F;
     }
-    v_elseif (dst_reg[0] == 16.0F)
+    v_elseif (sfpi::dst_reg[0] == 16.0F)
     {
-        dst_reg[5] = a * b - 0.5F;
+        sfpi::dst_reg[5] = a * b - 0.5F;
     }
-    v_elseif (dst_reg[0] == 17.0F)
+    v_elseif (sfpi::dst_reg[0] == 17.0F)
     {
-        dst_reg[5] = a + b - 0.5F;
+        sfpi::dst_reg[5] = a + b - 0.5F;
     }
-    v_elseif (dst_reg[0] == 18.0F)
+    v_elseif (sfpi::dst_reg[0] == 18.0F)
     {
-        vFloat c   = -5.0F;
-        dst_reg[5] = a * b + c;
+        sfpi::vFloat c   = -5.0F;
+        sfpi::dst_reg[5] = a * b + c;
     }
     v_endif;
     // [12] = 240.0
@@ -623,35 +623,35 @@ sfpi_test_noinline void test5()
     // [17] = 36.5
     // [18] = 355.0
 
-    v_if (dst_reg[0] == 19.0F)
+    v_if (sfpi::dst_reg[0] == 19.0F)
     {
-        vFloat c   = -5.0F;
-        dst_reg[5] = a * b + c + 0.5F;
+        sfpi::vFloat c   = -5.0F;
+        sfpi::dst_reg[5] = a * b + c + 0.5F;
     }
-    v_elseif (dst_reg[0] == 20.0F)
+    v_elseif (sfpi::dst_reg[0] == 20.0F)
     {
-        vFloat c   = -5.0F;
-        dst_reg[5] = a * b + c - 0.5F;
+        sfpi::vFloat c   = -5.0F;
+        sfpi::dst_reg[5] = a * b + c - 0.5F;
     }
-    v_elseif (dst_reg[0] == 21.0F)
+    v_elseif (sfpi::dst_reg[0] == 21.0F)
     {
-        vFloat c = -5.0F;
-        vFloat d;
+        sfpi::vFloat c = -5.0F;
+        sfpi::vFloat d;
         d          = a * b + c - 0.5F;
-        dst_reg[5] = d;
+        sfpi::dst_reg[5] = d;
     }
-    v_elseif (dst_reg[0] == 22.0F)
+    v_elseif (sfpi::dst_reg[0] == 22.0F)
     {
-        vFloat c   = -5.0F;
-        dst_reg[5] = a * b - c;
+        sfpi::vFloat c   = -5.0F;
+        sfpi::dst_reg[5] = a * b - c;
     }
-    v_elseif (dst_reg[0] == 23.0F)
+    v_elseif (sfpi::dst_reg[0] == 23.0F)
     {
-        dst_reg[5] = a * b + vConst1;
+        sfpi::dst_reg[5] = a * b + vConst1;
     }
-    v_elseif (dst_reg[0] == 24.0F)
+    v_elseif (sfpi::dst_reg[0] == 24.0F)
     {
-        dst_reg[5] = vConst1 * b + vConst1;
+        sfpi::dst_reg[5] = vConst1 * b + vConst1;
     }
     v_endif;
     // [19] = 375.5
@@ -661,23 +661,23 @@ sfpi_test_noinline void test5()
     // [23] = 461.0
     // [24] = 21.0
 
-    v_if (dst_reg[0] == 25.0F)
+    v_if (sfpi::dst_reg[0] == 25.0F)
     {
-        vFloat c   = -5.0F;
-        dst_reg[5] = dst_reg[0] * b + c;
+        sfpi::vFloat c   = -5.0F;
+        sfpi::dst_reg[5] = sfpi::dst_reg[0] * b + c;
     }
-    v_elseif (dst_reg[0] == 26.0F)
+    v_elseif (sfpi::dst_reg[0] == 26.0F)
     {
-        vFloat c   = -5.0F;
-        dst_reg[5] = b * dst_reg[0] + c;
+        sfpi::vFloat c   = -5.0F;
+        sfpi::dst_reg[5] = b * sfpi::dst_reg[0] + c;
     }
-    v_elseif (dst_reg[0] == 27.0F)
+    v_elseif (sfpi::dst_reg[0] == 27.0F)
     {
-        dst_reg[5] = a * b + dst_reg[0];
+        sfpi::dst_reg[5] = a * b + sfpi::dst_reg[0];
     }
-    v_elseif (dst_reg[0] == 28.0F)
+    v_elseif (sfpi::dst_reg[0] == 28.0F)
     {
-        dst_reg[5] = a * b - dst_reg[0];
+        sfpi::dst_reg[5] = a * b - sfpi::dst_reg[0];
     }
     v_endif;
     // [25] = 495.0
@@ -685,17 +685,17 @@ sfpi_test_noinline void test5()
     // [27] = 567.0
     // [28] = 532.0
 
-    v_if (dst_reg[0] == 29.0F)
+    v_if (sfpi::dst_reg[0] == 29.0F)
     {
-        dst_reg[5] = a - b;
+        sfpi::dst_reg[5] = a - b;
     }
-    v_elseif (dst_reg[0] == 30.0F)
+    v_elseif (sfpi::dst_reg[0] == 30.0F)
     {
-        dst_reg[5] = a - b - 0.5F;
+        sfpi::dst_reg[5] = a - b - 0.5F;
     }
-    v_elseif (dst_reg[0] == 31.0F)
+    v_elseif (sfpi::dst_reg[0] == 31.0F)
     {
-        dst_reg[5] = dst_reg[0] - b + 0.5F;
+        sfpi::dst_reg[5] = sfpi::dst_reg[0] - b + 0.5F;
     }
     v_endif;
     // [29] = 9.0
@@ -712,24 +712,24 @@ sfpi_test_noinline void test6()
 
     // SFPIADD
 
-    dst_reg[6] = -dst_reg[0];
+    sfpi::dst_reg[6] = -sfpi::dst_reg[0];
 
-    v_if (dst_reg[0] < 3.0F)
+    v_if (sfpi::dst_reg[0] < 3.0F)
     {
-        v_if (dst_reg[0] >= 0.0F)
+        v_if (sfpi::dst_reg[0] >= 0.0F)
         {
-            dst_reg[6] = 256.0F;
+            sfpi::dst_reg[6] = 256.0F;
 
             vInt a;
-            v_if (dst_reg[0] == 0.0F)
+            v_if (sfpi::dst_reg[0] == 0.0F)
             {
                 a = 28;
             }
-            v_elseif (dst_reg[0] == 1.0F)
+            v_elseif (sfpi::dst_reg[0] == 1.0F)
             {
                 a = 29;
             }
-            v_elseif (dst_reg[0] == 2.0F)
+            v_elseif (sfpi::dst_reg[0] == 2.0F)
             {
                 a = 30;
             }
@@ -740,7 +740,7 @@ sfpi_test_noinline void test6()
             b = a - 29;
             v_if (b >= 0)
             {
-                dst_reg[6] = 1024.0F;
+                sfpi::dst_reg[6] = 1024.0F;
             }
             v_endif;
         }
@@ -748,22 +748,22 @@ sfpi_test_noinline void test6()
     }
     v_endif;
 
-    v_if (dst_reg[0] < 6.0F)
+    v_if (sfpi::dst_reg[0] < 6.0F)
     {
-        v_if (dst_reg[0] >= 3.0F)
+        v_if (sfpi::dst_reg[0] >= 3.0F)
         {
-            dst_reg[6] = 256.0F;
+            sfpi::dst_reg[6] = 256.0F;
 
             vInt a;
-            v_if (dst_reg[0] == 3.0F)
+            v_if (sfpi::dst_reg[0] == 3.0F)
             {
                 a = 28;
             }
-            v_elseif (dst_reg[0] == 4.0F)
+            v_elseif (sfpi::dst_reg[0] == 4.0F)
             {
                 a = 29;
             }
-            v_elseif (dst_reg[0] == 5.0F)
+            v_elseif (sfpi::dst_reg[0] == 5.0F)
             {
                 a = 30;
             }
@@ -774,7 +774,7 @@ sfpi_test_noinline void test6()
             b = a + b;
             v_if (b < 0)
             {
-                dst_reg[6] = 1024.0F;
+                sfpi::dst_reg[6] = 1024.0F;
             }
             v_endif;
         }
@@ -782,28 +782,28 @@ sfpi_test_noinline void test6()
     }
     v_endif;
 
-    v_if (dst_reg[0] < 9.0F)
+    v_if (sfpi::dst_reg[0] < 9.0F)
     {
-        v_if (dst_reg[0] >= 6.0F)
+        v_if (sfpi::dst_reg[0] >= 6.0F)
         {
-            dst_reg[6] = 16.0F;
+            sfpi::dst_reg[6] = 16.0F;
 
             vInt a = 3;
-            v_if (dst_reg[0] == 6.0F)
+            v_if (sfpi::dst_reg[0] == 6.0F)
             {
                 a = 28;
             }
-            v_elseif (dst_reg[0] == 7.0F)
+            v_elseif (sfpi::dst_reg[0] == 7.0F)
             {
                 a = 29;
             }
-            v_elseif (dst_reg[0] == 8.0F)
+            v_elseif (sfpi::dst_reg[0] == 8.0F)
             {
                 a = 30;
             }
             v_endif;
 
-            vFloat b = 128.0F;
+            sfpi::vFloat b = 128.0F;
             v_if (a >= 29)
             {
                 b = 256.0F;
@@ -820,34 +820,34 @@ sfpi_test_noinline void test6()
             }
             v_endif;
 
-            dst_reg[6] = b;
+            sfpi::dst_reg[6] = b;
         }
         v_endif;
     }
     v_endif;
 
-    v_if (dst_reg[0] < 12.0F)
+    v_if (sfpi::dst_reg[0] < 12.0F)
     {
-        v_if (dst_reg[0] >= 9.0F)
+        v_if (sfpi::dst_reg[0] >= 9.0F)
         {
-            dst_reg[6] = 16.0F;
+            sfpi::dst_reg[6] = 16.0F;
 
             vInt a = 3;
-            v_if (dst_reg[0] == 9.0F)
+            v_if (sfpi::dst_reg[0] == 9.0F)
             {
                 a = 28;
             }
-            v_elseif (dst_reg[0] == 10.0F)
+            v_elseif (sfpi::dst_reg[0] == 10.0F)
             {
                 a = 29;
             }
-            v_elseif (dst_reg[0] == 11.0F)
+            v_elseif (sfpi::dst_reg[0] == 11.0F)
             {
                 a = 30;
             }
             v_endif;
 
-            vFloat b = 128.0F;
+            sfpi::vFloat b = 128.0F;
             vInt c   = 29;
             v_if (a >= c)
             {
@@ -865,31 +865,31 @@ sfpi_test_noinline void test6()
             }
             v_endif;
 
-            dst_reg[6] = b;
+            sfpi::dst_reg[6] = b;
         }
         v_endif;
     }
     v_endif;
 
-    v_if (dst_reg[0] == 12.0F)
+    v_if (sfpi::dst_reg[0] == 12.0F)
     {
         vInt v = 25;
         set_expected_result(6, 4.0F, 25, v);
     }
-    v_elseif (dst_reg[0] == 13.0F)
+    v_elseif (sfpi::dst_reg[0] == 13.0F)
     {
         vInt a = 20;
         a      = a + 12;
         set_expected_result(6, 8.0F, 32, a);
     }
-    v_elseif (dst_reg[0] == 14.0F)
+    v_elseif (sfpi::dst_reg[0] == 14.0F)
     {
         vInt a = 18;
         vInt b = -6;
         a      = a + b;
         set_expected_result(6, 16.0F, 12, a);
     }
-    v_elseif (dst_reg[0] == 15.0F)
+    v_elseif (sfpi::dst_reg[0] == 15.0F)
     {
         vInt a = 14;
         vInt b = -5;
@@ -898,25 +898,25 @@ sfpi_test_noinline void test6()
     }
     v_endif;
 
-    v_if (dst_reg[0] == 16.0F)
+    v_if (sfpi::dst_reg[0] == 16.0F)
     {
         vInt v = 25;
         set_expected_result(6, 4.0F, 25, v);
     }
-    v_elseif (dst_reg[0] == 17.0F)
+    v_elseif (sfpi::dst_reg[0] == 17.0F)
     {
         vInt a = 20;
         a      = a - 12;
         set_expected_result(6, 8.0F, 8, a);
     }
-    v_elseif (dst_reg[0] == 18.0F)
+    v_elseif (sfpi::dst_reg[0] == 18.0F)
     {
         vInt a = 18;
         vInt b = 6;
         a      = a - b;
         set_expected_result(6, 16.0F, 12, a);
     }
-    v_elseif (dst_reg[0] == 19.0F)
+    v_elseif (sfpi::dst_reg[0] == 19.0F)
     {
         vInt a = 14;
         vInt b = 5;
@@ -925,25 +925,25 @@ sfpi_test_noinline void test6()
     }
     v_endif;
 
-    v_if (dst_reg[0] == 20.0F)
+    v_if (sfpi::dst_reg[0] == 20.0F)
     {
         vUInt v = 25;
         set_expected_result(6, 4.0F, 25, reinterpret<vInt>(v));
     }
-    v_elseif (dst_reg[0] == 21.0F)
+    v_elseif (sfpi::dst_reg[0] == 21.0F)
     {
         vUInt a = 20;
         a       = a - 12;
         set_expected_result(6, 8.0F, 8, reinterpret<vInt>(a));
     }
-    v_elseif (dst_reg[0] == 22.0F)
+    v_elseif (sfpi::dst_reg[0] == 22.0F)
     {
         vUInt a = 18;
         vUInt b = 6;
         a       = a - b;
         set_expected_result(6, 16.0F, 12, reinterpret<vInt>(a));
     }
-    v_elseif (dst_reg[0] == 23.0F)
+    v_elseif (sfpi::dst_reg[0] == 23.0F)
     {
         vUInt a = 14;
         vUInt b = 5;
@@ -952,14 +952,14 @@ sfpi_test_noinline void test6()
     }
     v_endif;
 
-    v_if (dst_reg[0] == 24.0F)
+    v_if (sfpi::dst_reg[0] == 24.0F)
     {
         vInt a = 10;
         vInt b = 20;
         a -= b;
         set_expected_result(6, 64.0F, -10, a);
     }
-    v_elseif (dst_reg[0] == 25.0F)
+    v_elseif (sfpi::dst_reg[0] == 25.0F)
     {
         vInt a = 10;
         vInt b = 20;
@@ -969,39 +969,39 @@ sfpi_test_noinline void test6()
     v_endif;
 
     // Pseudo-16 bit via hidden loadi
-    v_if (dst_reg[0] == 26.0F)
+    v_if (sfpi::dst_reg[0] == 26.0F)
     {
         vInt a = 10;
         a += 4096;
         set_expected_result(6, 256.0F, 4106, a);
     }
-    v_elseif (dst_reg[0] == 27.0F)
+    v_elseif (sfpi::dst_reg[0] == 27.0F)
     {
         vInt a = 4096;
         v_if (a >= 4096)
         {
-            dst_reg[6] = 512.0f;
+            sfpi::dst_reg[6] = 512.0f;
         }
         v_else
         {
-            dst_reg[6] = 0.0f;
+            sfpi::dst_reg[6] = 0.0f;
         }
         v_endif;
     }
     v_endif;
 
-    v_if (dst_reg[0] >= 28.0F)
+    v_if (sfpi::dst_reg[0] >= 28.0F)
     {
         vInt a = vConstTileId;
-        v_if (dst_reg[0] == 28.0F)
+        v_if (sfpi::dst_reg[0] == 28.0F)
         {
             set_expected_result(6, 256.0F, 56, a);
         }
-        v_elseif (dst_reg[0] == 29.0F)
+        v_elseif (sfpi::dst_reg[0] == 29.0F)
         {
             set_expected_result(6, 256.0F, 58, a);
         }
-        v_elseif (dst_reg[0] == 30.0F)
+        v_elseif (sfpi::dst_reg[0] == 30.0F)
         {
             set_expected_result(6, 256.0F, 60, a);
         }
@@ -1009,16 +1009,16 @@ sfpi_test_noinline void test6()
     }
     v_endif;
 
-    v_if (dst_reg[0] == 31.0F)
+    v_if (sfpi::dst_reg[0] == 31.0F)
     {
-        vFloat x = 3.0f;
+        sfpi::vFloat x = 3.0f;
         v_if (!!(x == 3.0f && x != 4.0f))
         {
-            dst_reg[6] = 16.0;
+            sfpi::dst_reg[6] = 16.0;
         }
         v_else
         {
-            dst_reg[6] = 32.0;
+            sfpi::dst_reg[6] = 32.0;
         }
         v_endif;
     }
@@ -1065,36 +1065,36 @@ sfpi_test_noinline void test7()
     // SFPEXMAN, SFPEXEXP, SFPSETEXP, SFPSETMAN
     // Plus a little more && ||
 
-    dst_reg[7] = -dst_reg[0];
-    v_if (dst_reg[0] == 1.0F)
+    sfpi::dst_reg[7] = -sfpi::dst_reg[0];
+    v_if (sfpi::dst_reg[0] == 1.0F)
     {
-        vFloat tmp = 124.05F;
+        sfpi::vFloat tmp = 124.05F;
         set_expected_result(7, 30.0F, 0xF8199A, exman8(tmp));
     }
-    v_elseif (dst_reg[0] == 2.0F)
+    v_elseif (sfpi::dst_reg[0] == 2.0F)
     {
-        vFloat tmp = 124.05F;
+        sfpi::vFloat tmp = 124.05F;
         set_expected_result(7, 32.0F, 0x78199A, exman9(tmp));
     }
-    v_elseif (dst_reg[0] == 3.0F)
+    v_elseif (sfpi::dst_reg[0] == 3.0F)
     {
-        vFloat tmp = 65536.0F * 256.0F;
+        sfpi::vFloat tmp = 65536.0F * 256.0F;
         set_expected_result(7, 33.0F, 0x18, exexp(tmp));
     }
-    v_elseif (dst_reg[0] == 4.0F)
+    v_elseif (sfpi::dst_reg[0] == 4.0F)
     {
-        vFloat tmp = 65536.0F * 256.0F;
+        sfpi::vFloat tmp = 65536.0F * 256.0F;
         set_expected_result(7, 34.0F, 0x97, exexp_nodebias(tmp));
     }
-    v_elseif (dst_reg[0] < 8.0F)
+    v_elseif (sfpi::dst_reg[0] < 8.0F)
     {
-        vFloat tmp;
-        v_if (dst_reg[0] == 5.0F)
+        sfpi::vFloat tmp;
+        v_if (sfpi::dst_reg[0] == 5.0F)
         {
             // Exp < 0 for 5.0
             tmp = 0.5F;
         }
-        v_elseif (dst_reg[0] < 8.0F)
+        v_elseif (sfpi::dst_reg[0] < 8.0F)
         {
             // Exp > 0 for 6.0, 7.0
             tmp = 512.0F;
@@ -1105,15 +1105,15 @@ sfpi_test_noinline void test7()
         v = exexp(tmp);
         v_if (v < 0)
         {
-            dst_reg[7] = 32.0F;
+            sfpi::dst_reg[7] = 32.0F;
         }
         v_else
         {
-            dst_reg[7] = 64.0F;
+            sfpi::dst_reg[7] = 64.0F;
         }
         v_endif;
 
-        v_if (dst_reg[0] == 7.0F)
+        v_if (sfpi::dst_reg[0] == 7.0F)
         {
             // Exponent is 9, save it
             set_expected_result(7, 35.0F, 9, v);
@@ -1128,46 +1128,46 @@ sfpi_test_noinline void test7()
         // [6] = 64.0
         // [7] = 35.0 (exponent(512) = 8)
     }
-    v_elseif (dst_reg[0] == 8.0F)
+    v_elseif (sfpi::dst_reg[0] == 8.0F)
     {
-        vFloat tmp = 1.0F;
-        vFloat v   = setexp(tmp, 137);
-        dst_reg[7] = v;
+        sfpi::vFloat tmp = 1.0F;
+        sfpi::vFloat v   = setexp(tmp, 137);
+        sfpi::dst_reg[7] = v;
     }
-    v_elseif (dst_reg[0] == 9.0F)
+    v_elseif (sfpi::dst_reg[0] == 9.0F)
     {
         vInt exp       = 0x007F;   // Exponent in low bits
-        vFloat sgn_man = -1664.0F; // 1024 + 512 + 128 or 1101
+        sfpi::vFloat sgn_man = -1664.0F; // 1024 + 512 + 128 or 1101
         sgn_man        = setexp(sgn_man, exp);
-        dst_reg[7]     = sgn_man;
+        sfpi::dst_reg[7]     = sgn_man;
     }
     v_endif;
 
     // [8] = 1024.0
     // [9] = -1.625
 
-    v_if (dst_reg[0] == 10.0F)
+    v_if (sfpi::dst_reg[0] == 10.0F)
     {
-        vFloat tmp = 1024.0F;
-        vFloat b   = setman(tmp, 0x75019a);
-        dst_reg[7] = b;
+        sfpi::vFloat tmp = 1024.0F;
+        sfpi::vFloat b   = setman(tmp, 0x75019a);
+        sfpi::dst_reg[7] = b;
     }
-    v_elseif (dst_reg[0] == 11.0F)
+    v_elseif (sfpi::dst_reg[0] == 11.0F)
     {
-        vFloat tmp  = 1024.0F;
+        sfpi::vFloat tmp  = 1024.0F;
         vInt man    = 0x75019a;
-        vFloat tmp2 = setman(tmp, man);
-        dst_reg[7]  = tmp2;
+        sfpi::vFloat tmp2 = setman(tmp, man);
+        sfpi::dst_reg[7]  = tmp2;
     }
     v_endif;
 
     // [10] = 1960.050049
     // [11] = 1960.050049
 
-    vFloat v = dst_reg[0];
+    sfpi::vFloat v = sfpi::dst_reg[0];
     v_if ((v >= 12.0f && v < 14.0f) || (v >= 15.0f && v < 17.0f))
     {
-        dst_reg[7] = -128.0f;
+        sfpi::dst_reg[7] = -128.0f;
     }
     v_endif;
     // [12] = -128.0
@@ -1178,7 +1178,7 @@ sfpi_test_noinline void test7()
 
     v_if (((v >= 17.0f && v < 18.0f) || (v >= 19.0f && v < 20.0f)) || ((v >= 21.0f && v < 22.0f) || (v >= 23.0f && v < 24.0f)))
     {
-        dst_reg[7] = -256.0f;
+        sfpi::dst_reg[7] = -256.0f;
     }
     v_endif;
     // [17] = -256.0
@@ -1194,7 +1194,7 @@ sfpi_test_noinline void test7()
     {
         v_if (!(v >= 25.0f && v < 26.0f) && !(v >= 27.0f && v < 28.0f))
         {
-            dst_reg[7] = -1024.0f;
+            sfpi::dst_reg[7] = -1024.0f;
         }
         v_endif;
     }
@@ -1209,7 +1209,7 @@ sfpi_test_noinline void test7()
     v_if (v >= 29.0f && v < 32.0f)
     {
         vInt t       = vConstTileId >> 1;
-        vFloat total = 16.0F;
+        sfpi::vFloat total = 16.0F;
 
         v_if (t <= 30)
         {
@@ -1242,7 +1242,7 @@ sfpi_test_noinline void test7()
         }
         v_endif;
 
-        dst_reg[7] = total;
+        sfpi::dst_reg[7] = total;
     }
     v_endif;
     // [29] = 1712.0
@@ -1258,29 +1258,29 @@ sfpi_test_noinline void test8()
     // Atypical usage of conditionals
     // More conditionals (short v compares)
 
-    dst_reg[8] = -dst_reg[0];
-    v_if (dst_reg[0] == 1.0F)
+    sfpi::dst_reg[8] = -sfpi::dst_reg[0];
+    v_if (sfpi::dst_reg[0] == 1.0F)
     {
         vUInt a = 0x05FF;
         vUInt b = 0x0AAA;
         b &= a;
         set_expected_result(8, 16.0F, 0x00AA, static_cast<vInt>(b));
     }
-    v_elseif (dst_reg[0] == 2.0F)
+    v_elseif (sfpi::dst_reg[0] == 2.0F)
     {
         vUInt a = 0x05FF;
         vUInt b = 0x0AAA;
         vUInt c = a & b;
         set_expected_result(8, 16.0F, 0x00AA, static_cast<vInt>(c));
     }
-    v_elseif (dst_reg[0] == 3.0F)
+    v_elseif (sfpi::dst_reg[0] == 3.0F)
     {
         vInt a = 0x05FF;
         vInt b = 0x0AAA;
         b &= a;
         set_expected_result(8, 16.0F, 0x00AA, b);
     }
-    v_elseif (dst_reg[0] == 4.0F)
+    v_elseif (sfpi::dst_reg[0] == 4.0F)
     {
         vInt a = 0x05FF;
         vInt b = 0x0AAA;
@@ -1289,28 +1289,28 @@ sfpi_test_noinline void test8()
     }
     v_endif;
 
-    v_if (dst_reg[0] == 5.0F)
+    v_if (sfpi::dst_reg[0] == 5.0F)
     {
         vUInt a = 0x0111;
         vUInt b = 0x0444;
         b |= a;
         set_expected_result(8, 20.0F, 0x0555, static_cast<vInt>(b));
     }
-    v_elseif (dst_reg[0] == 6.0F)
+    v_elseif (sfpi::dst_reg[0] == 6.0F)
     {
         vUInt a = 0x0111;
         vUInt b = 0x0444;
         vUInt c = b | a;
         set_expected_result(8, 20.0F, 0x0555, static_cast<vInt>(c));
     }
-    v_elseif (dst_reg[0] == 7.0F)
+    v_elseif (sfpi::dst_reg[0] == 7.0F)
     {
         vInt a = 0x0111;
         vInt b = 0x0444;
         b |= a;
         set_expected_result(8, 20.0F, 0x0555, b);
     }
-    v_elseif (dst_reg[0] == 8.0F)
+    v_elseif (sfpi::dst_reg[0] == 8.0F)
     {
         vInt a = 0x0111;
         vInt b = 0x0444;
@@ -1319,107 +1319,107 @@ sfpi_test_noinline void test8()
     }
     v_endif;
 
-    v_if (dst_reg[0] == 9.0F)
+    v_if (sfpi::dst_reg[0] == 9.0F)
     {
         vUInt a = 0x0AAA;
         a       = ~a;
         a &= 0x0FFF; // Tricky since ~ flips upper bits that immediates can't access
         set_expected_result(8, 22.0F, 0x0555, static_cast<vInt>(a));
     }
-    v_elseif (dst_reg[0] == 10.0F)
+    v_elseif (sfpi::dst_reg[0] == 10.0F)
     {
-        vFloat a   = 100.0F;
-        dst_reg[8] = sfpi::abs(a);
+        sfpi::vFloat a   = 100.0F;
+        sfpi::dst_reg[8] = sfpi::abs(a);
     }
-    v_elseif (dst_reg[0] == 11.0F)
+    v_elseif (sfpi::dst_reg[0] == 11.0F)
     {
-        vFloat a   = -100.0F;
-        dst_reg[8] = sfpi::abs(a);
+        sfpi::vFloat a   = -100.0F;
+        sfpi::dst_reg[8] = sfpi::abs(a);
     }
-    v_elseif (dst_reg[0] == 12.0F)
+    v_elseif (sfpi::dst_reg[0] == 12.0F)
     {
         vInt a = 100;
         set_expected_result(8, 24.0F, 100, sfpi::abs(a));
     }
-    v_elseif (dst_reg[0] == 13.0F)
+    v_elseif (sfpi::dst_reg[0] == 13.0F)
     {
         vInt a = -100;
         set_expected_result(8, 26.0F, 100, sfpi::abs(a));
     }
     v_endif;
 
-    v_if (test_interleaved_scalar_vector_cond(true, dst_reg[0], 14.0F, 15.0F))
+    v_if (test_interleaved_scalar_vector_cond(true, sfpi::dst_reg[0], 14.0F, 15.0F))
     {
-        dst_reg[8] = 32.0F;
+        sfpi::dst_reg[8] = 32.0F;
     }
-    v_elseif (test_interleaved_scalar_vector_cond(false, dst_reg[0], 14.0F, 15.0F))
+    v_elseif (test_interleaved_scalar_vector_cond(false, sfpi::dst_reg[0], 14.0F, 15.0F))
     {
-        dst_reg[8] = 16.0F;
+        sfpi::dst_reg[8] = 16.0F;
     }
     v_endif;
 
-    vFloat tmp = dst_reg[8];
+    sfpi::vFloat tmp = sfpi::dst_reg[8];
     v_block
     {
-        v_and(dst_reg[0] >= 16.0F);
+        v_and(sfpi::dst_reg[0] >= 16.0F);
 
         for (int x = 0; x < 4; x++)
         {
-            v_and(dst_reg[0] < 20.0F - x);
+            v_and(sfpi::dst_reg[0] < 20.0F - x);
             tmp += 16.0F;
         }
     }
     v_endblock;
-    dst_reg[8] = tmp;
+    sfpi::dst_reg[8] = tmp;
 
     // <= and > are compound statements in the compiler, <= uses a compc
     // and things get flipped around when joined by ||
-    v_if (dst_reg[0] >= 20.0f && dst_reg[0] < 23.0f)
+    v_if (sfpi::dst_reg[0] >= 20.0f && sfpi::dst_reg[0] < 23.0f)
     {
         vInt t    = vConstTileId >> 1;
         vInt low  = 20;
         vInt high = 21;
 
-        dst_reg[8] = 16.0f;
+        sfpi::dst_reg[8] = 16.0f;
 
         v_if (t <= high)
         {
-            dst_reg[8] = dst_reg[8] + 32.0F;
+            sfpi::dst_reg[8] = sfpi::dst_reg[8] + 32.0F;
         }
         v_endif;
         v_if (t > high)
         {
-            dst_reg[8] = dst_reg[8] + 64.0F;
+            sfpi::dst_reg[8] = sfpi::dst_reg[8] + 64.0F;
         }
         v_endif;
         v_if (!(t > high))
         {
-            dst_reg[8] = dst_reg[8] + 128.0F;
+            sfpi::dst_reg[8] = sfpi::dst_reg[8] + 128.0F;
         }
         v_endif;
         v_if (!(t <= high))
         {
-            dst_reg[8] = dst_reg[8] + 256.0F;
+            sfpi::dst_reg[8] = sfpi::dst_reg[8] + 256.0F;
         }
         v_endif;
         v_if (t <= low || t > high)
         {
-            dst_reg[8] = dst_reg[8] + 512.0F;
+            sfpi::dst_reg[8] = sfpi::dst_reg[8] + 512.0F;
         }
         v_endif;
         v_if (t > high || t <= low)
         {
-            dst_reg[8] = dst_reg[8] + 1024.0F;
+            sfpi::dst_reg[8] = sfpi::dst_reg[8] + 1024.0F;
         }
         v_endif;
     }
     v_endif;
 
     // Do the same tests as above, but for floats
-    v_if (dst_reg[0] >= 23.0f && dst_reg[0] < 26.0f)
+    v_if (sfpi::dst_reg[0] >= 23.0f && sfpi::dst_reg[0] < 26.0f)
     {
-        vFloat t     = dst_reg[0];
-        vFloat total = 16.0F;
+        sfpi::vFloat t     = sfpi::dst_reg[0];
+        sfpi::vFloat total = 16.0F;
 
         v_if (t <= 24.0f)
         {
@@ -1452,59 +1452,59 @@ sfpi_test_noinline void test8()
         }
         v_endif;
 
-        dst_reg[8] = total;
+        sfpi::dst_reg[8] = total;
     }
     v_endif;
 
     // More of the same, again for floats.  Reloads for reg pressure
-    v_if (dst_reg[0] >= 26.0f && dst_reg[0] < 29.0f)
+    v_if (sfpi::dst_reg[0] >= 26.0f && sfpi::dst_reg[0] < 29.0f)
     {
-        vFloat low  = 26.0f;
-        vFloat high = 27.0f;
+        sfpi::vFloat low  = 26.0f;
+        sfpi::vFloat high = 27.0f;
 
-        dst_reg[8] = 16.0f;
+        sfpi::dst_reg[8] = 16.0f;
 
-        vFloat t = dst_reg[0];
+        sfpi::vFloat t = sfpi::dst_reg[0];
         v_if (t <= high)
         {
-            dst_reg[8] = dst_reg[8] + 32.0F;
+            sfpi::dst_reg[8] = sfpi::dst_reg[8] + 32.0F;
         }
         v_endif;
-        t = dst_reg[0];
+        t = sfpi::dst_reg[0];
         v_if (t > high)
         {
-            dst_reg[8] = dst_reg[8] + 64.0F;
+            sfpi::dst_reg[8] = sfpi::dst_reg[8] + 64.0F;
         }
         v_endif;
-        t = dst_reg[0];
+        t = sfpi::dst_reg[0];
         v_if (!(t > high))
         {
-            dst_reg[8] = dst_reg[8] + 128.0F;
+            sfpi::dst_reg[8] = sfpi::dst_reg[8] + 128.0F;
         }
         v_endif;
-        t = dst_reg[0];
+        t = sfpi::dst_reg[0];
         v_if (!(t <= high))
         {
-            dst_reg[8] = dst_reg[8] + 256.0F;
+            sfpi::dst_reg[8] = sfpi::dst_reg[8] + 256.0F;
         }
         v_endif;
-        t = dst_reg[0];
+        t = sfpi::dst_reg[0];
         v_if (t <= low || t > high)
         {
-            dst_reg[8] = dst_reg[8] + 512.0F;
+            sfpi::dst_reg[8] = sfpi::dst_reg[8] + 512.0F;
         }
         v_endif;
-        t   = dst_reg[0];
+        t   = sfpi::dst_reg[0];
         low = 26.0f;
         v_if (t > high || t <= low)
         {
-            dst_reg[8] = dst_reg[8] + 1024.0F;
+            sfpi::dst_reg[8] = sfpi::dst_reg[8] + 1024.0F;
         }
         v_endif;
     }
     v_endif;
 
-    v_if (dst_reg[0] == 29.0F)
+    v_if (sfpi::dst_reg[0] == 29.0F)
     {
         vInt a = 0xA5A5;
         vInt b = 0xFF00;
@@ -1513,7 +1513,7 @@ sfpi_test_noinline void test8()
     }
     v_endif;
 
-    v_if (dst_reg[0] == 30.0F)
+    v_if (sfpi::dst_reg[0] == 30.0F)
     {
         vUInt a = 0xA5A5;
         vUInt b = 0xFF00;
@@ -1522,7 +1522,7 @@ sfpi_test_noinline void test8()
     }
     v_endif;
 
-    v_if (dst_reg[0] == 31.0F)
+    v_if (sfpi::dst_reg[0] == 31.0F)
     {
         vInt a = 0xA5A5;
         vInt b = 0xFF00;
@@ -1572,75 +1572,75 @@ sfpi_test_noinline void test9()
     // SFPMULI, SFPADDI, SFPDIVP2, SFPLZ
     // More conditional tests
 
-    dst_reg[9] = -dst_reg[0];
-    v_if (dst_reg[0] == 1.0F)
+    sfpi::dst_reg[9] = -sfpi::dst_reg[0];
+    v_if (sfpi::dst_reg[0] == 1.0F)
     {
-        vFloat a   = 20.0F;
-        dst_reg[9] = a * 30.0F;
+        sfpi::vFloat a   = 20.0F;
+        sfpi::dst_reg[9] = a * 30.0F;
     }
-    v_elseif (dst_reg[0] == 2.0F)
+    v_elseif (sfpi::dst_reg[0] == 2.0F)
     {
-        vFloat a = 20.0F;
+        sfpi::vFloat a = 20.0F;
         a *= 40.0F;
-        dst_reg[9] = a;
+        sfpi::dst_reg[9] = a;
     }
-    v_elseif (dst_reg[0] == 3.0F)
+    v_elseif (sfpi::dst_reg[0] == 3.0F)
     {
-        vFloat a   = 20.0F;
-        dst_reg[9] = a + 30.0F;
+        sfpi::vFloat a   = 20.0F;
+        sfpi::dst_reg[9] = a + 30.0F;
     }
-    v_elseif (dst_reg[0] == 4.0F)
+    v_elseif (sfpi::dst_reg[0] == 4.0F)
     {
-        vFloat a = 20.0F;
+        sfpi::vFloat a = 20.0F;
         a += 40.0F;
-        dst_reg[9] = a;
+        sfpi::dst_reg[9] = a;
     }
-    v_elseif (dst_reg[0] == 5.0F)
+    v_elseif (sfpi::dst_reg[0] == 5.0F)
     {
-        vFloat a   = 16.0F;
-        dst_reg[9] = addexp(a, 4);
+        sfpi::vFloat a   = 16.0F;
+        sfpi::dst_reg[9] = addexp(a, 4);
     }
-    v_elseif (dst_reg[0] == 6.0F)
+    v_elseif (sfpi::dst_reg[0] == 6.0F)
     {
-        vFloat a   = 256.0F;
-        dst_reg[9] = addexp(a, -4);
+        sfpi::vFloat a   = 256.0F;
+        sfpi::dst_reg[9] = addexp(a, -4);
     }
     v_endif;
 
-    v_if (dst_reg[0] == 7.0F)
+    v_if (sfpi::dst_reg[0] == 7.0F)
     {
         vInt a = 0;
         vInt b = lz(a);
         set_expected_result(9, 38.0F, 0x20, b);
     }
-    v_elseif (dst_reg[0] == 8.0F)
+    v_elseif (sfpi::dst_reg[0] == 8.0F)
     {
         vInt a = 0xFFFFFFFF;
         vInt b = lz(a);
         set_expected_result(9, 55.0F, 0x0, b);
     }
-    v_elseif (dst_reg[0] == 9.0F)
+    v_elseif (sfpi::dst_reg[0] == 9.0F)
     {
         vUInt a = 0xFFFFU;
         vInt b  = lz(a);
         set_expected_result(9, 30.0F, 0x10, b);
     }
-    v_elseif (dst_reg[0] < 13.0F)
+    v_elseif (sfpi::dst_reg[0] < 13.0F)
     {
-        vFloat a = dst_reg[0] - 11.0F;
+        sfpi::vFloat a = sfpi::dst_reg[0] - 11.0F;
         vUInt b;
 
         // Relies on if chain above...
-        v_if (dst_reg[0] >= 7.0F)
+        v_if (sfpi::dst_reg[0] >= 7.0F)
         {
             b = reinterpret<vUInt>(lz(a));
             v_if (b != 32)
             {
-                dst_reg[9] = 60.0F;
+                sfpi::dst_reg[9] = 60.0F;
             }
             v_else
             {
-                dst_reg[9] = 40.0F;
+                sfpi::dst_reg[9] = 40.0F;
             }
             v_endif;
         }
@@ -1648,62 +1648,62 @@ sfpi_test_noinline void test9()
     }
     v_endif;
 
-    v_if (dst_reg[0] == 13.0F)
+    v_if (sfpi::dst_reg[0] == 13.0F)
     {
-        vFloat x = 1.0F;
+        sfpi::vFloat x = 1.0F;
 
         x *= 2.0f;
         x *= -3.0f;
         x += 4.0f;
         x += -4.0f;
 
-        dst_reg[9] = x;
+        sfpi::dst_reg[9] = x;
     }
-    v_elseif (dst_reg[0] == 14.0F)
+    v_elseif (sfpi::dst_reg[0] == 14.0F)
     {
         // MULI/ADDI don't accept fp16a
         // Ensure this goes to MAD
 
-        vFloat x = 1.0F;
+        sfpi::vFloat x = 1.0F;
 
-        x *= s2vFloat16a(2.0);
-        x *= s2vFloat16a(-3.0);
-        x += s2vFloat16a(4.0);
-        x += s2vFloat16a(-4.0);
+        x *= s2sfpi::vFloat16a(2.0);
+        x *= s2sfpi::vFloat16a(-3.0);
+        x += s2sfpi::vFloat16a(4.0);
+        x += s2sfpi::vFloat16a(-4.0);
 
-        dst_reg[9] = x;
+        sfpi::dst_reg[9] = x;
     }
     v_endif;
 
     // Test more boolean expressions
-    v_if (dst_reg[0] >= 15.0F && dst_reg[0] < 19.0)
+    v_if (sfpi::dst_reg[0] >= 15.0F && sfpi::dst_reg[0] < 19.0)
     {
-        vFloat v = dst_reg[0];
+        sfpi::vFloat v = sfpi::dst_reg[0];
         v_if ((v <= 16.0f && v != 15.0f) || (v == 18.0f))
         {
-            dst_reg[9] = 32.0f;
+            sfpi::dst_reg[9] = 32.0f;
         }
         v_endif;
     }
     v_endif;
 
     // Same as above, but flip the order of the top level OR
-    v_if (dst_reg[0] >= 19.0F && dst_reg[0] < 23.0)
+    v_if (sfpi::dst_reg[0] >= 19.0F && sfpi::dst_reg[0] < 23.0)
     {
-        vFloat v = dst_reg[0];
+        sfpi::vFloat v = sfpi::dst_reg[0];
         v_if ((v == 22.0f) || (v <= 20.0f && v != 19.0f))
         {
-            dst_reg[9] = 32.0f;
+            sfpi::dst_reg[9] = 32.0f;
         }
         v_endif;
     }
     v_endif;
 
     v_if (
-        (dst_reg[0] == 23.0 || dst_reg[0] == 24.0 || dst_reg[0] == 25.0 || dst_reg[0] == 26.0 || dst_reg[0] == 27.0 || dst_reg[0] == 28.0) &&
-        (dst_reg[0] != 23.0 && dst_reg[0] != 25.0 && dst_reg[0] != 27.0f))
+        (sfpi::dst_reg[0] == 23.0 || sfpi::dst_reg[0] == 24.0 || sfpi::dst_reg[0] == 25.0 || sfpi::dst_reg[0] == 26.0 || sfpi::dst_reg[0] == 27.0 || sfpi::dst_reg[0] == 28.0) &&
+        (sfpi::dst_reg[0] != 23.0 && sfpi::dst_reg[0] != 25.0 && sfpi::dst_reg[0] != 27.0f))
     {
-        dst_reg[9] = 64.0f;
+        sfpi::dst_reg[9] = 64.0f;
     }
     v_endif;
 
@@ -1742,8 +1742,8 @@ sfpi_test_noinline void test9()
 sfpi_test_noinline void test10()
 {
     // SFPSHFT, SFTSETSGN
-    dst_reg[10] = -dst_reg[0];
-    v_if (dst_reg[0] == 1.0F)
+    sfpi::dst_reg[10] = -sfpi::dst_reg[0];
+    v_if (sfpi::dst_reg[0] == 1.0F)
     {
         vUInt a    = 0x015;
         vInt shift = 6;
@@ -1751,33 +1751,33 @@ sfpi_test_noinline void test10()
         // Could write better tests if we could return and test the int result
         set_expected_result(10, 20.0F, 0x0540, static_cast<vInt>(b));
     }
-    v_elseif (dst_reg[0] == 2.0F)
+    v_elseif (sfpi::dst_reg[0] == 2.0F)
     {
         vUInt a = 0x2AAA;
         vUInt b = shft(a, -4);
         set_expected_result(10, 22.0F, 0x02AA, static_cast<vInt>(b));
     }
-    v_elseif (dst_reg[0] == 3.0F)
+    v_elseif (sfpi::dst_reg[0] == 3.0F)
     {
         vUInt a    = 0xAAAAU;
         vInt shift = -6;
         vUInt b    = shft(a, shift);
         set_expected_result(10, 24.0F, 0x02AA, static_cast<vInt>(b));
     }
-    v_elseif (dst_reg[0] == 4.0F)
+    v_elseif (sfpi::dst_reg[0] == 4.0F)
     {
         vUInt a = 0x005A;
         vUInt b = shft(a, 4);
         set_expected_result(10, 26.0F, 0x05A0, static_cast<vInt>(b));
     }
-    v_elseif (dst_reg[0] == 5.0F)
+    v_elseif (sfpi::dst_reg[0] == 5.0F)
     {
         vInt a = 25;
         a      = a + 5;
         a += 7;
         set_expected_result(10, 28.0F, 0x25, a);
     }
-    v_elseif (dst_reg[0] == 6.0F)
+    v_elseif (sfpi::dst_reg[0] == 6.0F)
     {
         vInt a = 28;
         vInt b = 100;
@@ -1786,32 +1786,32 @@ sfpi_test_noinline void test10()
     }
     v_endif;
 
-    v_if (dst_reg[0] == 7.0F)
+    v_if (sfpi::dst_reg[0] == 7.0F)
     {
-        vFloat a    = dst_reg[0];
-        dst_reg[10] = setsgn(a, 1);
+        sfpi::vFloat a    = sfpi::dst_reg[0];
+        sfpi::dst_reg[10] = setsgn(a, 1);
     }
-    v_elseif (dst_reg[0] == 8.0F)
+    v_elseif (sfpi::dst_reg[0] == 8.0F)
     {
-        vFloat a = dst_reg[0];
-        vFloat b = -128.0;
-        vFloat r = setsgn(b, a);
+        sfpi::vFloat a = sfpi::dst_reg[0];
+        sfpi::vFloat b = -128.0;
+        sfpi::vFloat r = setsgn(b, a);
 
-        dst_reg[10] = r;
+        sfpi::dst_reg[10] = r;
     }
-    v_elseif (dst_reg[0] == 9.0F)
+    v_elseif (sfpi::dst_reg[0] == 9.0F)
     {
-        vFloat a    = -256.0F;
-        dst_reg[10] = setsgn(a, 0);
+        sfpi::vFloat a    = -256.0F;
+        sfpi::dst_reg[10] = setsgn(a, 0);
     }
-    v_elseif (dst_reg[0] == 10.0F)
+    v_elseif (sfpi::dst_reg[0] == 10.0F)
     {
-        vFloat a = dst_reg[0];
+        sfpi::vFloat a = sfpi::dst_reg[0];
         a += 20.0f;
-        vFloat b = -512.0F;
-        vFloat r = setsgn(a, b);
+        sfpi::vFloat b = -512.0F;
+        sfpi::vFloat r = setsgn(a, b);
 
-        dst_reg[10] = r;
+        sfpi::dst_reg[10] = r;
     }
     v_endif;
 
@@ -1831,60 +1831,60 @@ sfpi_test_noinline void test10()
 sfpi_test_noinline void test11()
 {
     // SFPLUT, SFPLOADL<n>
-    dst_reg[11] = -dst_reg[0];
+    sfpi::dst_reg[11] = -sfpi::dst_reg[0];
 
     vUInt l0a = 0xFF30; // Multiply by 0.0, add 0.125
     vUInt l1a = 0X3020; // Multiply by 0.125, add 0.25
-    v_if (dst_reg[0] == 1.0F)
+    v_if (sfpi::dst_reg[0] == 1.0F)
     {
         // Use L0
-        vFloat h    = -0.3F;
+        sfpi::vFloat h    = -0.3F;
         vUInt l2a   = 0xA010; // Mulitply by -0.25, add 0.5
         h           = lut_sign(h, l0a, l1a, l2a);
-        dst_reg[11] = h;
+        sfpi::dst_reg[11] = h;
     }
-    v_elseif (dst_reg[0] == 2.0F)
+    v_elseif (sfpi::dst_reg[0] == 2.0F)
     {
         // Use L0
-        vFloat h    = -0.3F;
+        sfpi::vFloat h    = -0.3F;
         vUInt l2a   = 0xA010; // Mulitply by -0.25, add 0.5
         h           = lut(h, l0a, l1a, l2a);
-        dst_reg[11] = h;
+        sfpi::dst_reg[11] = h;
     }
-    v_elseif (dst_reg[0] == 3.0F)
+    v_elseif (sfpi::dst_reg[0] == 3.0F)
     {
         // Use L0
-        vFloat h  = -0.3F;
+        sfpi::vFloat h  = -0.3F;
         vUInt l2a = 0xA010; // Mulitply by -0.25, add 0.5
         // Test used a bias on Grayskull, not supported on Wormhole
         h           = lut_sign(h, l0a, l1a, l2a);
-        dst_reg[11] = h;
+        sfpi::dst_reg[11] = h;
     }
-    v_elseif (dst_reg[0] == 4.0F)
+    v_elseif (sfpi::dst_reg[0] == 4.0F)
     {
         // Use L0
-        vFloat h  = -0.3F;
+        sfpi::vFloat h  = -0.3F;
         vUInt l2a = 0xA010; // Mulitply by -0.25, add 0.5
         // Test used a bias on Grayskull, not supported on Wormhole
         h           = lut(h, l0a, l1a, l2a);
-        dst_reg[11] = h;
+        sfpi::dst_reg[11] = h;
     }
-    v_elseif (dst_reg[0] == 5.0F)
+    v_elseif (sfpi::dst_reg[0] == 5.0F)
     {
         // Use L1
-        vFloat h  = 1.0F;
+        sfpi::vFloat h  = 1.0F;
         vUInt l2a = 0xA010; // Mulitply by -0.25, add 0.5
         // Test used a bias on Grayskull, not supported on Wormhole
         h           = lut(h, l0a, l1a, l2a);
-        dst_reg[11] = h;
+        sfpi::dst_reg[11] = h;
     }
-    v_elseif (dst_reg[0] == 6.0F)
+    v_elseif (sfpi::dst_reg[0] == 6.0F)
     {
         // Use L2
-        vFloat h    = 4.0F;
+        sfpi::vFloat h    = 4.0F;
         vUInt l2a   = 0xA010; // Mulitply by -0.25, add 0.5
         h           = lut_sign(h, l0a, l1a, l2a);
-        dst_reg[11] = h;
+        sfpi::dst_reg[11] = h;
     }
     v_endif;
 
@@ -1901,231 +1901,231 @@ sfpi_test_noinline void test11()
         l0b = l_reg[LRegs::LReg0];
         l1b = l_reg[LRegs::LReg1];
 
-        v_if (dst_reg[0] == 7.0F)
+        v_if (sfpi::dst_reg[0] == 7.0F)
         {
             // Use L0
-            vFloat h    = -0.3F;
+            sfpi::vFloat h    = -0.3F;
             vUInt l2b   = 0x9000;
             h           = lut_sign(h, l0b, l1b, l2b);
-            dst_reg[11] = h;
+            sfpi::dst_reg[11] = h;
         }
-        v_elseif (dst_reg[0] == 8.0F)
+        v_elseif (sfpi::dst_reg[0] == 8.0F)
         {
             // Use L0
-            vFloat h    = -0.3F;
+            sfpi::vFloat h    = -0.3F;
             vUInt l2b   = 0x9000;
             h           = lut(h, l0b, l1b, l2b);
-            dst_reg[11] = h;
+            sfpi::dst_reg[11] = h;
         }
-        v_elseif (dst_reg[0] == 9.0F)
+        v_elseif (sfpi::dst_reg[0] == 9.0F)
         {
             // Use L0
-            vFloat h  = -0.3F;
+            sfpi::vFloat h  = -0.3F;
             vUInt l2b = 0x9000;
             // Test used a bias on Grayskull, not supported on Wormhole
             h           = lut_sign(h, l0b, l1b, l2b);
-            dst_reg[11] = h;
+            sfpi::dst_reg[11] = h;
         }
-        v_elseif (dst_reg[0] == 10.0F)
+        v_elseif (sfpi::dst_reg[0] == 10.0F)
         {
             // Use L0
-            vFloat h  = -0.3F;
+            sfpi::vFloat h  = -0.3F;
             vUInt l2b = 0x9000;
             // Test used a bias on Grayskull, not supported on Wormhole
             h           = lut(h, l0b, l1b, l2b);
-            dst_reg[11] = h;
+            sfpi::dst_reg[11] = h;
         }
-        v_elseif (dst_reg[0] == 11.0F)
+        v_elseif (sfpi::dst_reg[0] == 11.0F)
         {
             // Use L1
-            vFloat h  = 1.0F;
+            sfpi::vFloat h  = 1.0F;
             vUInt l2b = 0x9000;
             // Test used a bias on Grayskull, not supported on Wormhole
             h           = lut(h, l0b, l1b, l2b);
-            dst_reg[11] = h;
+            sfpi::dst_reg[11] = h;
         }
-        v_elseif (dst_reg[0] == 12.0F)
+        v_elseif (sfpi::dst_reg[0] == 12.0F)
         {
             // Use L2
-            vFloat h    = 4.0F;
+            sfpi::vFloat h    = 4.0F;
             vUInt l2b   = 0x9000;
             h           = lut_sign(h, l0b, l1b, l2b);
-            dst_reg[11] = h;
+            sfpi::dst_reg[11] = h;
         }
         v_endif;
     }
 
     // lut2 3 entry 16 bit
     {
-        vUInt l0 = (s2vFloat16a(2.0f).get() << 16) | s2vFloat16a(3.0f).get();
-        vUInt l1 = (s2vFloat16a(4.0f).get() << 16) | s2vFloat16a(5.0f).get();
-        vUInt l2 = (s2vFloat16a(6.0f).get() << 16) | s2vFloat16a(7.0f).get();
-        v_if (dst_reg[0] == 13.0f)
+        vUInt l0 = (s2sfpi::vFloat16a(2.0f).get() << 16) | s2sfpi::vFloat16a(3.0f).get();
+        vUInt l1 = (s2sfpi::vFloat16a(4.0f).get() << 16) | s2sfpi::vFloat16a(5.0f).get();
+        vUInt l2 = (s2sfpi::vFloat16a(6.0f).get() << 16) | s2sfpi::vFloat16a(7.0f).get();
+        v_if (sfpi::dst_reg[0] == 13.0f)
         {
-            vFloat h    = -0.25f;
+            sfpi::vFloat h    = -0.25f;
             h           = lut2(h, l0, l1, l2);
-            dst_reg[11] = h; // .25 * 2 + 3 = -3.5 (sign retain)
+            sfpi::dst_reg[11] = h; // .25 * 2 + 3 = -3.5 (sign retain)
         }
-        v_elseif (dst_reg[0] == 14.0f)
+        v_elseif (sfpi::dst_reg[0] == 14.0f)
         {
-            vFloat h    = 1.25f;
+            sfpi::vFloat h    = 1.25f;
             h           = lut2(h, l0, l1, l2);
-            dst_reg[11] = h; // 1.25 * 4 + 5 = 10 (sign retain)
+            sfpi::dst_reg[11] = h; // 1.25 * 4 + 5 = 10 (sign retain)
         }
-        v_elseif (dst_reg[0] == 15.0f)
+        v_elseif (sfpi::dst_reg[0] == 15.0f)
         {
-            vFloat h    = -2.25f;
+            sfpi::vFloat h    = -2.25f;
             h           = lut2(h, l0, l1, l2);
-            dst_reg[11] = h; // 2.25 * 6 + 7 = 13.5 + 7 = -20.5 (sign retain)
+            sfpi::dst_reg[11] = h; // 2.25 * 6 + 7 = 13.5 + 7 = -20.5 (sign retain)
         }
-        v_elseif (dst_reg[0] == 16.0f)
+        v_elseif (sfpi::dst_reg[0] == 16.0f)
         {
-            vFloat h    = -0.25f;
+            sfpi::vFloat h    = -0.25f;
             h           = lut2_sign(h, l0, l1, l2);
-            dst_reg[11] = h; // .25 * 2 + 3 = 3.5 (sign update)
+            sfpi::dst_reg[11] = h; // .25 * 2 + 3 = 3.5 (sign update)
         }
         v_endif;
     }
 
     // lut2 3 entry 32 bit
     {
-        vFloat a0 = 2.0f;
-        vFloat a1 = 4.0f;
-        vFloat a2 = 6.0f;
-        vFloat b0 = 3.0f;
-        vFloat b1 = 5.0f;
-        vFloat b2 = 7.0f;
-        v_if (dst_reg[0] == 17.0f)
+        sfpi::vFloat a0 = 2.0f;
+        sfpi::vFloat a1 = 4.0f;
+        sfpi::vFloat a2 = 6.0f;
+        sfpi::vFloat b0 = 3.0f;
+        sfpi::vFloat b1 = 5.0f;
+        sfpi::vFloat b2 = 7.0f;
+        v_if (sfpi::dst_reg[0] == 17.0f)
         {
-            vFloat h    = -0.25f;
+            sfpi::vFloat h    = -0.25f;
             h           = lut2(h, a0, a1, a2, b0, b1, b2);
-            dst_reg[11] = h; // .25 * 2 + 3 = -3.5 (sign retain)
+            sfpi::dst_reg[11] = h; // .25 * 2 + 3 = -3.5 (sign retain)
         }
-        v_elseif (dst_reg[0] == 18.0f)
+        v_elseif (sfpi::dst_reg[0] == 18.0f)
         {
-            vFloat h    = 1.25f;
+            sfpi::vFloat h    = 1.25f;
             h           = lut2(h, a0, a1, a2, b0, b1, b2);
-            dst_reg[11] = h; // 1.25 * 4 + 5 = 10 (sign retain)
+            sfpi::dst_reg[11] = h; // 1.25 * 4 + 5 = 10 (sign retain)
         }
-        v_elseif (dst_reg[0] == 19.0f)
+        v_elseif (sfpi::dst_reg[0] == 19.0f)
         {
-            vFloat h    = -3.0f;
+            sfpi::vFloat h    = -3.0f;
             h           = lut2(h, a0, a1, a2, b0, b1, b2);
-            dst_reg[11] = h; // 3 * 6 + 7 = 18 + 7 = -25.0 (sign retain)
+            sfpi::dst_reg[11] = h; // 3 * 6 + 7 = 18 + 7 = -25.0 (sign retain)
         }
-        v_elseif (dst_reg[0] == 20.0f)
+        v_elseif (sfpi::dst_reg[0] == 20.0f)
         {
-            vFloat h    = -0.25f;
+            sfpi::vFloat h    = -0.25f;
             h           = lut2_sign(h, a0, a1, a2, b0, b1, b2);
-            dst_reg[11] = h; // .25 * 2 + 3 = 3.5 (sign update)
+            sfpi::dst_reg[11] = h; // .25 * 2 + 3 = 3.5 (sign update)
         }
         v_endif;
     }
 
     // lut2 6 entry 16 bit mode 1
     {
-        vUInt a01 = (s2vFloat16a(4.0f).get() << 16) | s2vFloat16a(2.0f).get();
-        vUInt a23 = (s2vFloat16a(8.0f).get() << 16) | s2vFloat16a(6.0f).get();
+        vUInt a01 = (s2sfpi::vFloat16a(4.0f).get() << 16) | s2sfpi::vFloat16a(2.0f).get();
+        vUInt a23 = (s2sfpi::vFloat16a(8.0f).get() << 16) | s2sfpi::vFloat16a(6.0f).get();
         ;
-        vUInt a34 = (s2vFloat16a(12.0f).get() << 16) | s2vFloat16a(10.0f).get();
-        vUInt b01 = (s2vFloat16a(5.0f).get() << 16) | s2vFloat16a(3.0f).get();
-        vUInt b23 = (s2vFloat16a(9.0f).get() << 16) | s2vFloat16a(7.0f).get();
-        vUInt b34 = (s2vFloat16a(13.0f).get() << 16) | s2vFloat16a(11.0f).get();
-        v_if (dst_reg[0] == 21.0f)
+        vUInt a34 = (s2sfpi::vFloat16a(12.0f).get() << 16) | s2sfpi::vFloat16a(10.0f).get();
+        vUInt b01 = (s2sfpi::vFloat16a(5.0f).get() << 16) | s2sfpi::vFloat16a(3.0f).get();
+        vUInt b23 = (s2sfpi::vFloat16a(9.0f).get() << 16) | s2sfpi::vFloat16a(7.0f).get();
+        vUInt b34 = (s2sfpi::vFloat16a(13.0f).get() << 16) | s2sfpi::vFloat16a(11.0f).get();
+        v_if (sfpi::dst_reg[0] == 21.0f)
         {
-            vFloat h    = -0.25f;
+            sfpi::vFloat h    = -0.25f;
             h           = lut2(h, a01, a23, a34, b01, b23, b34);
-            dst_reg[11] = h; // .25 * 2 + 3 = -3.5 (sign retain)
+            sfpi::dst_reg[11] = h; // .25 * 2 + 3 = -3.5 (sign retain)
         }
-        v_elseif (dst_reg[0] == 22.0f)
+        v_elseif (sfpi::dst_reg[0] == 22.0f)
         {
-            vFloat h    = 0.75f;
+            sfpi::vFloat h    = 0.75f;
             h           = lut2(h, a01, a23, a34, b01, b23, b34);
-            dst_reg[11] = h; // .75 * 4 + 5 = 8
+            sfpi::dst_reg[11] = h; // .75 * 4 + 5 = 8
         }
-        v_elseif (dst_reg[0] == 23.0f)
+        v_elseif (sfpi::dst_reg[0] == 23.0f)
         {
-            vFloat h    = -1.25f;
+            sfpi::vFloat h    = -1.25f;
             h           = lut2(h, a01, a23, a34, b01, b23, b34);
-            dst_reg[11] = h; // 1.25 * 6 + 7 = 7.5 + 7 = -14.5 (sign retain)
+            sfpi::dst_reg[11] = h; // 1.25 * 6 + 7 = 7.5 + 7 = -14.5 (sign retain)
         }
-        v_elseif (dst_reg[0] == 24.0f)
+        v_elseif (sfpi::dst_reg[0] == 24.0f)
         {
-            vFloat h    = -1.75f;
+            sfpi::vFloat h    = -1.75f;
             h           = lut2(h, a01, a23, a34, b01, b23, b34);
-            dst_reg[11] = h; // 1.75 * 8 + 9 = 14 + 9 = -23 (sign retain)
+            sfpi::dst_reg[11] = h; // 1.75 * 8 + 9 = 14 + 9 = -23 (sign retain)
         }
-        v_elseif (dst_reg[0] == 25.0f)
+        v_elseif (sfpi::dst_reg[0] == 25.0f)
         {
-            vFloat h    = 2.5f;
+            sfpi::vFloat h    = 2.5f;
             h           = lut2(h, a01, a23, a34, b01, b23, b34);
-            dst_reg[11] = h; // 2.5 * 10 + 11 = 25 + 11 = 36.0
+            sfpi::dst_reg[11] = h; // 2.5 * 10 + 11 = 25 + 11 = 36.0
         }
-        v_elseif (dst_reg[0] == 26.0f)
+        v_elseif (sfpi::dst_reg[0] == 26.0f)
         {
-            vFloat h    = 3.5f;
+            sfpi::vFloat h    = 3.5f;
             h           = lut2(h, a01, a23, a34, b01, b23, b34);
-            dst_reg[11] = h; // 3.5 * 12 + 13 = 42 + 13 = 55.0
+            sfpi::dst_reg[11] = h; // 3.5 * 12 + 13 = 42 + 13 = 55.0
         }
-        v_elseif (dst_reg[0] == 27.0f)
+        v_elseif (sfpi::dst_reg[0] == 27.0f)
         {
-            vFloat h    = -0.25f;
+            sfpi::vFloat h    = -0.25f;
             h           = lut2_sign(h, a01, a23, a34, b01, b23, b34);
-            dst_reg[11] = h; // .25 * 2 + 3 = 3.5 (sign update)
+            sfpi::dst_reg[11] = h; // .25 * 2 + 3 = 3.5 (sign update)
         }
         v_endif;
     }
 
     // lut2 6 entry 16 bit mode 2
     {
-        vUInt a01 = (s2vFloat16a(4.0f).get() << 16) | s2vFloat16a(2.0f).get();
-        vUInt a23 = (s2vFloat16a(8.0f).get() << 16) | s2vFloat16a(6.0f).get();
+        vUInt a01 = (s2sfpi::vFloat16a(4.0f).get() << 16) | s2sfpi::vFloat16a(2.0f).get();
+        vUInt a23 = (s2sfpi::vFloat16a(8.0f).get() << 16) | s2sfpi::vFloat16a(6.0f).get();
         ;
-        vUInt a34 = (s2vFloat16a(12.0f).get() << 16) | s2vFloat16a(10.0f).get();
-        vUInt b01 = (s2vFloat16a(5.0f).get() << 16) | s2vFloat16a(3.0f).get();
-        vUInt b23 = (s2vFloat16a(9.0f).get() << 16) | s2vFloat16a(7.0f).get();
-        vUInt b34 = (s2vFloat16a(13.0f).get() << 16) | s2vFloat16a(11.0f).get();
+        vUInt a34 = (s2sfpi::vFloat16a(12.0f).get() << 16) | s2sfpi::vFloat16a(10.0f).get();
+        vUInt b01 = (s2sfpi::vFloat16a(5.0f).get() << 16) | s2sfpi::vFloat16a(3.0f).get();
+        vUInt b23 = (s2sfpi::vFloat16a(9.0f).get() << 16) | s2sfpi::vFloat16a(7.0f).get();
+        vUInt b34 = (s2sfpi::vFloat16a(13.0f).get() << 16) | s2sfpi::vFloat16a(11.0f).get();
 
         // Can't fit all the tests into 32 elements, skipping a few that are
         // the most redundant to prior tests here
 #if 0
-        v_if(dst_reg[0] == 28.0f) {
-            vFloat h = -0.25f;
+        v_if(sfpi::dst_reg[0] == 28.0f) {
+            sfpi::vFloat h = -0.25f;
             h = lut2(h, a01, a23, a34, b01, b23, b34, 2);
-            dst_reg[11] = h; // .25 * 2 + 3 = -3.5 (sign retain)
-        } v_elseif(dst_reg[0] == 29.0f) {
-            vFloat h = 0.75f;
+            sfpi::dst_reg[11] = h; // .25 * 2 + 3 = -3.5 (sign retain)
+        } v_elseif(sfpi::dst_reg[0] == 29.0f) {
+            sfpi::vFloat h = 0.75f;
             h = lut2(h, a01, a23, a34, b01, b23, b34, 2);
-            dst_reg[11] = h; // .75 * 4 + 5 = 8
-        } v_elseif(dst_reg[0] == 30.0f) {
-            vFloat h = -1.25f;
+            sfpi::dst_reg[11] = h; // .75 * 4 + 5 = 8
+        } v_elseif(sfpi::dst_reg[0] == 30.0f) {
+            sfpi::vFloat h = -1.25f;
             h = lut2(h, a01, a23, a34, b01, b23, b34, 2);
-            dst_reg[11] = h; // 1.25 * 6 + 7 = 7.5 + 7 = -14.5 (sign retain)
+            sfpi::dst_reg[11] = h; // 1.25 * 6 + 7 = 7.5 + 7 = -14.5 (sign retain)
         }
 #endif
-        v_if (dst_reg[0] == 28.0f)
+        v_if (sfpi::dst_reg[0] == 28.0f)
         {
-            vFloat h    = -1.75f;
+            sfpi::vFloat h    = -1.75f;
             h           = lut2(h, a01, a23, a34, b01, b23, b34, 2);
-            dst_reg[11] = h; // 1.75 * 8 + 9 = 14 + 9 = -23 (sign retain)
+            sfpi::dst_reg[11] = h; // 1.75 * 8 + 9 = 14 + 9 = -23 (sign retain)
         }
-        v_elseif (dst_reg[0] == 29.0f)
+        v_elseif (sfpi::dst_reg[0] == 29.0f)
         {
-            vFloat h    = 3.5f;
+            sfpi::vFloat h    = 3.5f;
             h           = lut2(h, a01, a23, a34, b01, b23, b34, 2);
-            dst_reg[11] = h; // 3.5 * 10 + 11 = 35 + 11 = 46.0
+            sfpi::dst_reg[11] = h; // 3.5 * 10 + 11 = 35 + 11 = 46.0
         }
-        v_elseif (dst_reg[0] == 30.0f)
+        v_elseif (sfpi::dst_reg[0] == 30.0f)
         {
-            vFloat h    = 4.5f;
+            sfpi::vFloat h    = 4.5f;
             h           = lut2(h, a01, a23, a34, b01, b23, b34, 2);
-            dst_reg[11] = h; // 4.5 * 12 + 13 = 54 + 13 = 67.0
+            sfpi::dst_reg[11] = h; // 4.5 * 12 + 13 = 54 + 13 = 67.0
         }
-        v_elseif (dst_reg[0] == 31.0f)
+        v_elseif (sfpi::dst_reg[0] == 31.0f)
         {
-            vFloat h    = -0.25f;
+            sfpi::vFloat h    = -0.25f;
             h           = lut2_sign(h, a01, a23, a34, b01, b23, b34, 2);
-            dst_reg[11] = h; // .25 * 2 + 3 = 3.5 (sign update)
+            sfpi::dst_reg[11] = h; // .25 * 2 + 3 = 3.5 (sign update)
         }
         v_endif;
     }
@@ -2171,163 +2171,163 @@ sfpi_test_noinline void test12(int imm)
     // Test immediate forms of SFPLOAD, SFPLOADI, SFPSTORE, SFPIADD_I, SFPADDI
     // SFPMULI, SFPSHFT, SFPDIVP2, SFPSETEXP, SFPSETMAN, SFPSETSGN,
     // Tries to cover both positive and negative params (sign extension)
-    dst_reg[12] = -dst_reg[0];
+    sfpi::dst_reg[12] = -sfpi::dst_reg[0];
 
-    v_if (dst_reg[0] == 1.0F)
+    v_if (sfpi::dst_reg[0] == 1.0F)
     {
-        dst_reg[12] = static_cast<float>(imm); // SFPLOADI
+        sfpi::dst_reg[12] = static_cast<float>(imm); // SFPLOADI
     }
-    v_elseif (dst_reg[0] == 2.0F)
+    v_elseif (sfpi::dst_reg[0] == 2.0F)
     {
-        dst_reg[12] = static_cast<float>(-imm); // SFPLOADI
+        sfpi::dst_reg[12] = static_cast<float>(-imm); // SFPLOADI
     }
-    v_elseif (dst_reg[0] == 3.0F)
+    v_elseif (sfpi::dst_reg[0] == 3.0F)
     {
         vInt a = 5;
         a += imm; // SFPIADD_I
         set_expected_result(12, 25.0F, 40, a);
     }
-    v_elseif (dst_reg[0] == 4.0F)
+    v_elseif (sfpi::dst_reg[0] == 4.0F)
     {
         vInt a = 5;
         a -= imm; // SFPIADD_I
         set_expected_result(12, -25.0F, -30, a);
     }
-    v_elseif (dst_reg[0] == 5.0F)
+    v_elseif (sfpi::dst_reg[0] == 5.0F)
     {
-        vFloat a = 3.0F;
+        sfpi::vFloat a = 3.0F;
         a += static_cast<float>(imm); // SFPADDI
-        dst_reg[12] = a;
+        sfpi::dst_reg[12] = a;
     }
-    v_elseif (dst_reg[0] == 6.0F)
+    v_elseif (sfpi::dst_reg[0] == 6.0F)
     {
-        vFloat a = 3.0F;
+        sfpi::vFloat a = 3.0F;
         a += static_cast<float>(-imm); // SFPADDI
-        dst_reg[12] = a;
+        sfpi::dst_reg[12] = a;
     }
     v_endif;
 
-    v_if (dst_reg[0] == 7.0F)
+    v_if (sfpi::dst_reg[0] == 7.0F)
     {
         vUInt a = 0x4000;
         a >>= imm - 25;
         set_expected_result(12, 64.0F, 0x0010, reinterpret<vInt>(a));
     }
-    v_elseif (dst_reg[0] == 8.0F)
+    v_elseif (sfpi::dst_reg[0] == 8.0F)
     {
         vUInt a = 1;
         a <<= imm - 25;
         set_expected_result(12, 128.0F, 0x0400, reinterpret<vInt>(a));
     }
-    v_elseif (dst_reg[0] == 9.0F)
+    v_elseif (sfpi::dst_reg[0] == 9.0F)
     {
-        vFloat a    = 256.0F;
-        dst_reg[12] = addexp(a, imm - 31);
+        sfpi::vFloat a    = 256.0F;
+        sfpi::dst_reg[12] = addexp(a, imm - 31);
     }
-    v_elseif (dst_reg[0] == 10.0F)
+    v_elseif (sfpi::dst_reg[0] == 10.0F)
     {
-        vFloat a    = 256.0F;
-        dst_reg[12] = addexp(a, imm - 39);
+        sfpi::vFloat a    = 256.0F;
+        sfpi::dst_reg[12] = addexp(a, imm - 39);
     }
     v_endif;
 
-    v_if (dst_reg[0] == 11.0F)
+    v_if (sfpi::dst_reg[0] == 11.0F)
     {
-        vFloat a    = 128.0;
-        vFloat r    = setsgn(a, imm - 36);
-        dst_reg[12] = r;
+        sfpi::vFloat a    = 128.0;
+        sfpi::vFloat r    = setsgn(a, imm - 36);
+        sfpi::dst_reg[12] = r;
     }
-    v_elseif (dst_reg[0] == 12.0F)
+    v_elseif (sfpi::dst_reg[0] == 12.0F)
     {
-        vFloat tmp  = 1024.0F;
+        sfpi::vFloat tmp  = 1024.0F;
         int man     = 0x75019a + 35 - imm;
-        vFloat tmp2 = setman(tmp, man);
-        dst_reg[12] = tmp2;
+        sfpi::vFloat tmp2 = setman(tmp, man);
+        sfpi::dst_reg[12] = tmp2;
     }
-    v_elseif (dst_reg[0] == 13.0F)
+    v_elseif (sfpi::dst_reg[0] == 13.0F)
     {
         int exp        = 0x007F + 35 - imm; // Exponent in low bits
-        vFloat sgn_man = -1664.0F;          // 1024 + 512 + 128 or 1101
+        sfpi::vFloat sgn_man = -1664.0F;          // 1024 + 512 + 128 or 1101
         sgn_man        = setexp(sgn_man, exp);
-        dst_reg[12]    = sgn_man;
+        sfpi::dst_reg[12]    = sgn_man;
     }
     v_endif;
 
-    dst_reg[30 + 35 - imm]     = 30.0F; // SFPSTORE
-    dst_reg[30 + 35 - imm + 1] = vConstNeg1;
+    sfpi::dst_reg[30 + 35 - imm]     = 30.0F; // SFPSTORE
+    sfpi::dst_reg[30 + 35 - imm + 1] = vConstNeg1;
 
-    v_if (dst_reg[0] == 14.0F)
+    v_if (sfpi::dst_reg[0] == 14.0F)
     {
-        dst_reg[12] = dst_reg[30 + 35 - imm]; // SFPLOAD
+        sfpi::dst_reg[12] = sfpi::dst_reg[30 + 35 - imm]; // SFPLOAD
     }
     v_endif;
-    v_if (dst_reg[0] == 15.0F)
+    v_if (sfpi::dst_reg[0] == 15.0F)
     {
-        dst_reg[12] = dst_reg[30 + 35 - imm + 1]; // SFPLOAD
+        sfpi::dst_reg[12] = sfpi::dst_reg[30 + 35 - imm + 1]; // SFPLOAD
     }
     v_endif;
 
     // Test for store/load nops, imm store non-imm load
     // Need to use the semaphores to get TRISC to run ahead for non-imm loads
 
-    v_if (dst_reg[0] == 16.0F)
+    v_if (sfpi::dst_reg[0] == 16.0F)
     {
         // imm store, non-imm load
-        vFloat a = 120.0F;
+        sfpi::vFloat a = 120.0F;
 
         TTI_SEMINIT(1, 0, p_stall::SEMAPHORE_3);
         TTI_SEMWAIT(p_stall::STALL_MATH, p_stall::SEMAPHORE_3, p_stall::STALL_ON_ZERO);
 
-        dst_reg[12] = a;
+        sfpi::dst_reg[12] = a;
         __builtin_rvtt_sfpnop(); // XXXXXX remove me when compiler is fixed
-        a = dst_reg[imm - 23];
+        a = sfpi::dst_reg[imm - 23];
 
         semaphore_post(3);
 
-        dst_reg[12] = a + 1.0F;
+        sfpi::dst_reg[12] = a + 1.0F;
     }
     v_endif;
 
-    v_if (dst_reg[0] == 17.0F)
+    v_if (sfpi::dst_reg[0] == 17.0F)
     {
         // non-imm store, imm load
-        vFloat a          = 130.0F;
-        dst_reg[imm - 23] = a;
+        sfpi::vFloat a          = 130.0F;
+        sfpi::dst_reg[imm - 23] = a;
         __builtin_rvtt_sfpnop(); // XXXXXX remove me when compiler is fixed
-        a           = dst_reg[12];
-        dst_reg[12] = a + 1.0F;
+        a           = sfpi::dst_reg[12];
+        sfpi::dst_reg[12] = a + 1.0F;
     }
     v_endif;
 
-    v_if (dst_reg[0] == 18.0F)
+    v_if (sfpi::dst_reg[0] == 18.0F)
     {
         // non-imm store, non-imm load
-        vFloat a = 140.0F;
+        sfpi::vFloat a = 140.0F;
 
         TTI_SEMINIT(1, 0, p_stall::SEMAPHORE_3);
         TTI_SEMWAIT(p_stall::STALL_MATH, p_stall::SEMAPHORE_3, p_stall::STALL_ON_ZERO);
 
-        dst_reg[imm - 23] = a;
+        sfpi::dst_reg[imm - 23] = a;
         __builtin_rvtt_sfpnop(); // XXXXXX remove me when compiler is fixed
-        a = dst_reg[imm - 23];
+        a = sfpi::dst_reg[imm - 23];
 
         semaphore_post(3);
 
-        dst_reg[12] = a + 1.0F;
+        sfpi::dst_reg[12] = a + 1.0F;
     }
     v_endif;
 
-    v_if (dst_reg[0] == 19.0F)
+    v_if (sfpi::dst_reg[0] == 19.0F)
     {
-        vFloat a = 3.0F;
+        sfpi::vFloat a = 3.0F;
         a *= static_cast<float>(imm); // SFPADDI
-        dst_reg[12] = a;
+        sfpi::dst_reg[12] = a;
     }
-    v_elseif (dst_reg[0] == 20.0F)
+    v_elseif (sfpi::dst_reg[0] == 20.0F)
     {
-        vFloat a = 3.0F;
+        sfpi::vFloat a = 3.0F;
         a *= static_cast<float>(-imm); // SFPADDI
-        dst_reg[12] = a;
+        sfpi::dst_reg[12] = a;
     }
     v_endif;
 
@@ -2362,20 +2362,20 @@ sfpi_test_noinline void test13(int imm)
 {
     // Test variable liveness
 
-    dst_reg[13] = -dst_reg[0];
+    sfpi::dst_reg[13] = -sfpi::dst_reg[0];
 
     // ABS liveness across SETCC
     {
-        vFloat x = -20.0F;
-        vFloat y = -30.0F;
-        v_if (dst_reg[0] == 0.0F)
+        sfpi::vFloat x = -20.0F;
+        sfpi::vFloat y = -30.0F;
+        v_if (sfpi::dst_reg[0] == 0.0F)
         {
             y = sfpi::abs(x);
         }
         v_endif;
-        v_if (dst_reg[0] == 0.0F || dst_reg[0] == 1.0F)
+        v_if (sfpi::dst_reg[0] == 0.0F || sfpi::dst_reg[0] == 1.0F)
         {
-            dst_reg[13] = y;
+            sfpi::dst_reg[13] = y;
         }
         v_endif;
     }
@@ -2386,19 +2386,19 @@ sfpi_test_noinline void test13(int imm)
     {
         vInt a = 0xFAAA;
         vInt b = 0x07BB;
-        v_if (dst_reg[0] == 2.0F)
+        v_if (sfpi::dst_reg[0] == 2.0F)
         {
             b = ~a;
         }
         v_endif;
-        v_if (dst_reg[0] == 2.0F || dst_reg[0] == 3.0F)
+        v_if (sfpi::dst_reg[0] == 2.0F || sfpi::dst_reg[0] == 3.0F)
         {
-            v_if (dst_reg[0] == 2.0F)
+            v_if (sfpi::dst_reg[0] == 2.0F)
             {
                 set_expected_result(13, 40.0F, 0xFFFF0555, b);
             }
             v_endif;
-            v_if (dst_reg[0] == 3.0F)
+            v_if (sfpi::dst_reg[0] == 3.0F)
             {
                 set_expected_result(13, 50.0F, 0x07BB, b);
             }
@@ -2413,19 +2413,19 @@ sfpi_test_noinline void test13(int imm)
     {
         vInt a = 0x0080;
         vInt b = 0x07BB;
-        v_if (dst_reg[0] == 4.0F)
+        v_if (sfpi::dst_reg[0] == 4.0F)
         {
             b = lz(a);
         }
         v_endif;
-        v_if (dst_reg[0] == 4.0F || dst_reg[0] == 5.0F)
+        v_if (sfpi::dst_reg[0] == 4.0F || sfpi::dst_reg[0] == 5.0F)
         {
-            v_if (dst_reg[0] == 4.0F)
+            v_if (sfpi::dst_reg[0] == 4.0F)
             {
                 set_expected_result(13, 60.0F, 24, b);
             }
             v_endif;
-            v_if (dst_reg[0] == 5.0F)
+            v_if (sfpi::dst_reg[0] == 5.0F)
             {
                 set_expected_result(13, 70.0F, 0x07BB, b);
             }
@@ -2438,16 +2438,16 @@ sfpi_test_noinline void test13(int imm)
 
     // MAD liveness across SETCC
     {
-        vFloat a = 90.0F;
-        vFloat b = 110.0F;
-        v_if (dst_reg[0] == 6.0F)
+        sfpi::vFloat a = 90.0F;
+        sfpi::vFloat b = 110.0F;
+        v_if (sfpi::dst_reg[0] == 6.0F)
         {
             b = a * a + 10.0;
         }
         v_endif;
-        v_if (dst_reg[0] == 6.0F || dst_reg[0] == 7.0F)
+        v_if (sfpi::dst_reg[0] == 6.0F || sfpi::dst_reg[0] == 7.0F)
         {
-            dst_reg[13] = b;
+            sfpi::dst_reg[13] = b;
         }
         v_endif;
     }
@@ -2456,16 +2456,16 @@ sfpi_test_noinline void test13(int imm)
 
     // MOV liveness across SETCC
     {
-        vFloat a = 120.0F;
-        vFloat b = 130.0F;
-        v_if (dst_reg[0] == 8.0F)
+        sfpi::vFloat a = 120.0F;
+        sfpi::vFloat b = 130.0F;
+        v_if (sfpi::dst_reg[0] == 8.0F)
         {
             b = -a;
         }
         v_endif;
-        v_if (dst_reg[0] == 8.0F || dst_reg[0] == 9.0F)
+        v_if (sfpi::dst_reg[0] == 8.0F || sfpi::dst_reg[0] == 9.0F)
         {
-            dst_reg[13] = b;
+            sfpi::dst_reg[13] = b;
         }
         v_endif;
     }
@@ -2474,16 +2474,16 @@ sfpi_test_noinline void test13(int imm)
 
     // DIVP2 liveness across SETCC
     {
-        vFloat a = 140.0F;
-        vFloat b = 150.0F;
-        v_if (dst_reg[0] == 10.0F)
+        sfpi::vFloat a = 140.0F;
+        sfpi::vFloat b = 150.0F;
+        v_if (sfpi::dst_reg[0] == 10.0F)
         {
             b = addexp(a, 1);
         }
         v_endif;
-        v_if (dst_reg[0] == 10.0F || dst_reg[0] == 11.0F)
+        v_if (sfpi::dst_reg[0] == 10.0F || sfpi::dst_reg[0] == 11.0F)
         {
-            dst_reg[13] = b;
+            sfpi::dst_reg[13] = b;
         }
         v_endif;
     }
@@ -2492,17 +2492,17 @@ sfpi_test_noinline void test13(int imm)
 
     // EXEXP liveness across SETCC
     {
-        vFloat a = 160.0F;
+        sfpi::vFloat a = 160.0F;
         vInt b   = 128;
-        v_if (dst_reg[0] == 12.0F)
+        v_if (sfpi::dst_reg[0] == 12.0F)
         {
             b = exexp_nodebias(a);
         }
         v_endif;
-        v_if (dst_reg[0] == 12.0F || dst_reg[0] == 13.0F)
+        v_if (sfpi::dst_reg[0] == 12.0F || sfpi::dst_reg[0] == 13.0F)
         {
-            vFloat tmp  = 1.0F;
-            dst_reg[13] = setexp(tmp, b);
+            sfpi::vFloat tmp  = 1.0F;
+            sfpi::dst_reg[13] = setexp(tmp, b);
         }
         v_endif;
     }
@@ -2511,17 +2511,17 @@ sfpi_test_noinline void test13(int imm)
 
     // EXMAN liveness across SETCC
     {
-        vFloat a = 160.0F;
+        sfpi::vFloat a = 160.0F;
         vInt b   = 0x80000;
-        v_if (dst_reg[0] == 14.0F)
+        v_if (sfpi::dst_reg[0] == 14.0F)
         {
             b = exman8(a);
         }
         v_endif;
-        v_if (dst_reg[0] == 14.0F || dst_reg[0] == 15.0F)
+        v_if (sfpi::dst_reg[0] == 14.0F || sfpi::dst_reg[0] == 15.0F)
         {
-            vFloat tmp  = 128.0F;
-            dst_reg[13] = setman(tmp, b);
+            sfpi::vFloat tmp  = 128.0F;
+            sfpi::dst_reg[13] = setman(tmp, b);
         }
         v_endif;
     }
@@ -2530,16 +2530,16 @@ sfpi_test_noinline void test13(int imm)
 
     // SETEXP_I liveness across SETCC
     {
-        vFloat a = 170.0F;
-        vFloat b = 180.0F;
-        v_if (dst_reg[0] == 16.0F)
+        sfpi::vFloat a = 170.0F;
+        sfpi::vFloat b = 180.0F;
+        v_if (sfpi::dst_reg[0] == 16.0F)
         {
             b = setexp(a, 132);
         }
         v_endif;
-        v_if (dst_reg[0] == 16.0F || dst_reg[0] == 17.0F)
+        v_if (sfpi::dst_reg[0] == 16.0F || sfpi::dst_reg[0] == 17.0F)
         {
-            dst_reg[13] = b;
+            sfpi::dst_reg[13] = b;
         }
         v_endif;
     }
@@ -2548,16 +2548,16 @@ sfpi_test_noinline void test13(int imm)
 
     // SETMAN_I liveness across SETCC
     {
-        vFloat a = 190.0F;
-        vFloat b = 200.0F;
-        v_if (dst_reg[0] == 18.0F)
+        sfpi::vFloat a = 190.0F;
+        sfpi::vFloat b = 200.0F;
+        v_if (sfpi::dst_reg[0] == 18.0F)
         {
             b = setman(a, 0x75019a);
         }
         v_endif;
-        v_if (dst_reg[0] == 18.0F || dst_reg[0] == 19.0F)
+        v_if (sfpi::dst_reg[0] == 18.0F || sfpi::dst_reg[0] == 19.0F)
         {
-            dst_reg[13] = b;
+            sfpi::dst_reg[13] = b;
         }
         v_endif;
     }
@@ -2566,16 +2566,16 @@ sfpi_test_noinline void test13(int imm)
 
     // SETSGN_I liveness across SETCC
     {
-        vFloat a = 210.0F;
-        vFloat b = 220.0F;
-        v_if (dst_reg[0] == 20.0F)
+        sfpi::vFloat a = 210.0F;
+        sfpi::vFloat b = 220.0F;
+        v_if (sfpi::dst_reg[0] == 20.0F)
         {
             b = setsgn(a, 1);
         }
         v_endif;
-        v_if (dst_reg[0] == 20.0F || dst_reg[0] == 21.0F)
+        v_if (sfpi::dst_reg[0] == 20.0F || sfpi::dst_reg[0] == 21.0F)
         {
-            dst_reg[13] = b;
+            sfpi::dst_reg[13] = b;
         }
         v_endif;
     }
@@ -2584,16 +2584,16 @@ sfpi_test_noinline void test13(int imm)
 
     // nonimm_dst_src using DIVP2 liveness across SETCC
     {
-        vFloat a = 140.0F;
-        vFloat b = 150.0F;
-        v_if (dst_reg[0] == 22.0F)
+        sfpi::vFloat a = 140.0F;
+        sfpi::vFloat b = 150.0F;
+        v_if (sfpi::dst_reg[0] == 22.0F)
         {
             b = addexp(a, imm - 34);
         }
         v_endif;
-        v_if (dst_reg[0] == 22.0F || dst_reg[0] == 23.0F)
+        v_if (sfpi::dst_reg[0] == 22.0F || sfpi::dst_reg[0] == 23.0F)
         {
-            dst_reg[13] = b;
+            sfpi::dst_reg[13] = b;
         }
         v_endif;
     }
@@ -2602,15 +2602,15 @@ sfpi_test_noinline void test13(int imm)
 
     // nonimm_dst using LOADI liveness across SETCC
     {
-        vFloat b = 240.0F;
-        v_if (dst_reg[0] == 24.0F)
+        sfpi::vFloat b = 240.0F;
+        v_if (sfpi::dst_reg[0] == 24.0F)
         {
             b = static_cast<float>(-imm);
         }
         v_endif;
-        v_if (dst_reg[0] == 24.0F || dst_reg[0] == 25.0F)
+        v_if (sfpi::dst_reg[0] == 24.0F || sfpi::dst_reg[0] == 25.0F)
         {
-            dst_reg[13] = b;
+            sfpi::dst_reg[13] = b;
         }
         v_endif;
     }
@@ -2625,26 +2625,26 @@ sfpi_test_noinline void test14(int imm)
     // Test13 tests various builtins for liveness across a SETCC
     // Below test MOV liveness across COMPC, LZ, EXEXP, IADD
 
-    dst_reg[14] = -dst_reg[0];
+    sfpi::dst_reg[14] = -sfpi::dst_reg[0];
 
     // MOV liveness across COMPC
     {
-        vFloat a = 250.0F;
-        vFloat b = 260.0F;
-        v_if (dst_reg[0] != 0.0F)
+        sfpi::vFloat a = 250.0F;
+        sfpi::vFloat b = 260.0F;
+        v_if (sfpi::dst_reg[0] != 0.0F)
         {
             b = 160.0F;
         }
         v_else
         {
-            vFloat c = vConst0 * vConst0 + vConst0;
+            sfpi::vFloat c = vConst0 * vConst0 + vConst0;
             b        = -a;
             a        = c;
         }
         v_endif;
-        v_if (dst_reg[0] == 0.0F || dst_reg[0] == 1.0F)
+        v_if (sfpi::dst_reg[0] == 0.0F || sfpi::dst_reg[0] == 1.0F)
         {
-            dst_reg[14] = b;
+            sfpi::dst_reg[14] = b;
         }
         v_endif;
     }
@@ -2653,24 +2653,24 @@ sfpi_test_noinline void test14(int imm)
 
     // MOV liveness across LZ
     {
-        vFloat a = 250.0F;
-        vFloat b = 260.0F;
+        sfpi::vFloat a = 250.0F;
+        sfpi::vFloat b = 260.0F;
         vInt tmp;
 
-        v_if (dst_reg[0] == 2.0F)
+        v_if (sfpi::dst_reg[0] == 2.0F)
         {
             v_if ((tmp = lz(a)) != 0)
             {
-                vFloat c = vConst0 * vConst0 + vConst0;
+                sfpi::vFloat c = vConst0 * vConst0 + vConst0;
                 b        = -a;
                 a        = c;
             }
             v_endif;
         }
         v_endif;
-        v_if (dst_reg[0] == 2.0F || dst_reg[0] == 3.0F)
+        v_if (sfpi::dst_reg[0] == 2.0F || sfpi::dst_reg[0] == 3.0F)
         {
-            dst_reg[14] = b;
+            sfpi::dst_reg[14] = b;
         }
         v_endif;
     }
@@ -2679,24 +2679,24 @@ sfpi_test_noinline void test14(int imm)
 
     // MOV liveness across EXEXP
     {
-        vFloat a = 270.0F;
-        vFloat b = 280.0F;
+        sfpi::vFloat a = 270.0F;
+        sfpi::vFloat b = 280.0F;
         vInt tmp;
 
-        v_if (dst_reg[0] == 4.0F)
+        v_if (sfpi::dst_reg[0] == 4.0F)
         {
             v_if ((tmp = exexp(a)) >= 0)
             {
-                vFloat c = vConst0 * vConst0 + vConst0;
+                sfpi::vFloat c = vConst0 * vConst0 + vConst0;
                 b        = -a;
                 a        = c;
             }
             v_endif;
         }
         v_endif;
-        v_if (dst_reg[0] == 4.0F || dst_reg[0] == 5.0F)
+        v_if (sfpi::dst_reg[0] == 4.0F || sfpi::dst_reg[0] == 5.0F)
         {
-            dst_reg[14] = b;
+            sfpi::dst_reg[14] = b;
         }
         v_endif;
     }
@@ -2706,24 +2706,24 @@ sfpi_test_noinline void test14(int imm)
     // Below 2 tests are incidentally covered by tests 1..12
     // MOV liveness across IADD
     {
-        vFloat b = 300.0F;
+        sfpi::vFloat b = 300.0F;
         vInt tmp = 5;
 
-        v_if (dst_reg[0] == 6.0F)
+        v_if (sfpi::dst_reg[0] == 6.0F)
         {
-            vFloat a = 290.0F;
+            sfpi::vFloat a = 290.0F;
             v_if (tmp >= 2)
             {
-                vFloat c = vConst0 * vConst0 + vConst0;
+                sfpi::vFloat c = vConst0 * vConst0 + vConst0;
                 b        = -a;
                 a        = c;
             }
             v_endif;
         }
         v_endif;
-        v_if (dst_reg[0] == 6.0F || dst_reg[0] == 7.0F)
+        v_if (sfpi::dst_reg[0] == 6.0F || sfpi::dst_reg[0] == 7.0F)
         {
-            dst_reg[14] = b;
+            sfpi::dst_reg[14] = b;
         }
         v_endif;
     }
@@ -2734,19 +2734,19 @@ sfpi_test_noinline void test14(int imm)
     {
         vInt a = 10;
         vInt b = 20;
-        v_if (dst_reg[0] == 8.0F)
+        v_if (sfpi::dst_reg[0] == 8.0F)
         {
             b = a + 30;
         }
         v_endif;
-        v_if (dst_reg[0] == 8.0F || dst_reg[0] == 9.0F)
+        v_if (sfpi::dst_reg[0] == 8.0F || sfpi::dst_reg[0] == 9.0F)
         {
-            v_if (dst_reg[0] == 8.0F)
+            v_if (sfpi::dst_reg[0] == 8.0F)
             {
                 set_expected_result(14, -310.0F, 40, b);
             }
             v_endif;
-            v_if (dst_reg[0] == 9.0F)
+            v_if (sfpi::dst_reg[0] == 9.0F)
             {
                 set_expected_result(14, 320.0F, 20, b);
             }
@@ -2765,17 +2765,17 @@ sfpi_test_noinline void test14(int imm)
     // Case 2a
     // Assignment resulting in register rename
     {
-        vFloat a = -20.0f;
-        vFloat b = 30.0f;
-        v_if (dst_reg[0] == 10.0f)
+        sfpi::vFloat a = -20.0f;
+        sfpi::vFloat b = 30.0f;
+        v_if (sfpi::dst_reg[0] == 10.0f)
         {
             b = a;
         }
         v_endif;
 
-        v_if (dst_reg[0] == 10.0F || dst_reg[0] == 11.0F)
+        v_if (sfpi::dst_reg[0] == 10.0F || sfpi::dst_reg[0] == 11.0F)
         {
-            dst_reg[14] = b;
+            sfpi::dst_reg[14] = b;
         }
         v_endif;
     }
@@ -2787,23 +2787,23 @@ sfpi_test_noinline void test14(int imm)
     // This straddles case 2a and 3 - both values need to be preserved but the
     // compiler doesn't know that, solving case2a will solve this case as well
     {
-        vFloat a = -40.0f;
-        vFloat b = 50.0f;
-        v_if (dst_reg[0] == 12.0f)
+        sfpi::vFloat a = -40.0f;
+        sfpi::vFloat b = 50.0f;
+        v_if (sfpi::dst_reg[0] == 12.0f)
         {
             b = a;
         }
         v_endif;
 
-        v_if (dst_reg[0] == 100.0f)
+        v_if (sfpi::dst_reg[0] == 100.0f)
         { // always fail
-            dst_reg[14] = a;
+            sfpi::dst_reg[14] = a;
         }
         v_endif;
 
-        v_if (dst_reg[0] == 12.0F || dst_reg[0] == 13.0F)
+        v_if (sfpi::dst_reg[0] == 12.0F || sfpi::dst_reg[0] == 13.0F)
         {
-            dst_reg[14] = b;
+            sfpi::dst_reg[14] = b;
         }
         v_endif;
     }
@@ -2813,23 +2813,23 @@ sfpi_test_noinline void test14(int imm)
     // Case 3
     // Assignment requiring move (both a and b need to be preserved)
     {
-        vFloat a = -60.0f;
-        vFloat b = 70.0f;
-        v_if (dst_reg[0] == 14.0f)
+        sfpi::vFloat a = -60.0f;
+        sfpi::vFloat b = 70.0f;
+        v_if (sfpi::dst_reg[0] == 14.0f)
         {
             b = a;
         }
         v_endif;
 
-        v_if (dst_reg[0] == 100.0f)
+        v_if (sfpi::dst_reg[0] == 100.0f)
         { // always fail
-            dst_reg[14] = a + 1.0f;
+            sfpi::dst_reg[14] = a + 1.0f;
         }
         v_endif;
 
-        v_if (dst_reg[0] == 14.0F || dst_reg[0] == 15.0F)
+        v_if (sfpi::dst_reg[0] == 14.0F || sfpi::dst_reg[0] == 15.0F)
         {
-            dst_reg[14] = b + 1.0f;
+            sfpi::dst_reg[14] = b + 1.0f;
         }
         v_endif;
     }
@@ -2842,25 +2842,25 @@ sfpi_test_noinline void test14(int imm)
     {
         vInt a = 10;
         vInt b = 20;
-        v_if (dst_reg[0] == 16.0f)
+        v_if (sfpi::dst_reg[0] == 16.0f)
         {
             b = b - a;
         }
         v_endif;
 
-        v_if (dst_reg[0] == 100.0f)
+        v_if (sfpi::dst_reg[0] == 100.0f)
         { // always fail
-            dst_reg[14] = a;
+            sfpi::dst_reg[14] = a;
         }
         v_endif;
 
-        v_if (dst_reg[0] == 16.0F)
+        v_if (sfpi::dst_reg[0] == 16.0F)
         {
             set_expected_result(14, -80.0F, 10, b);
         }
         v_endif;
 
-        v_if (dst_reg[0] == 17.0F)
+        v_if (sfpi::dst_reg[0] == 17.0F)
         {
             set_expected_result(14, 90.0F, 20, b);
         }
@@ -2875,25 +2875,25 @@ sfpi_test_noinline void test14(int imm)
     {
         vInt a = 10;
         vInt b = 20;
-        v_if (dst_reg[0] == 16.0f)
+        v_if (sfpi::dst_reg[0] == 16.0f)
         {
             b = b - a;
         }
         v_endif;
 
-        v_if (dst_reg[0] == 100.0f)
+        v_if (sfpi::dst_reg[0] == 100.0f)
         { // always fail
-            dst_reg[14] = b;
+            sfpi::dst_reg[14] = b;
         }
         v_endif;
 
-        v_if (dst_reg[0] == 18.0F)
+        v_if (sfpi::dst_reg[0] == 18.0F)
         {
             set_expected_result(14, -90.0F, 10, a);
         }
         v_endif;
 
-        v_if (dst_reg[0] == 19.0F)
+        v_if (sfpi::dst_reg[0] == 19.0F)
         {
             set_expected_result(14, 100.0F, 10, a);
         }
@@ -2907,7 +2907,7 @@ sfpi_test_noinline void test14(int imm)
     // Confirm c is correct
     {
         // Out of regs doing this the typical way
-        vFloat condition = dst_reg[0] - 20.0F;
+        sfpi::vFloat condition = sfpi::dst_reg[0] - 20.0F;
         vInt a           = 10;
         vInt b           = 20;
         vInt c           = 30;
@@ -2918,20 +2918,20 @@ sfpi_test_noinline void test14(int imm)
         }
         v_endif;
 
-        v_if (vConst0p8373 == dst_reg[0])
+        v_if (vConst0p8373 == sfpi::dst_reg[0])
         { // always fail
-            dst_reg[14] = a;
-            dst_reg[14] = b;
+            sfpi::dst_reg[14] = a;
+            sfpi::dst_reg[14] = b;
         }
         v_endif;
 
-        v_if (dst_reg[0] == 20.0F)
+        v_if (sfpi::dst_reg[0] == 20.0F)
         {
             set_expected_result(14, -100.0F, -10, c);
         }
         v_endif;
 
-        v_if (dst_reg[0] == 21.0F)
+        v_if (sfpi::dst_reg[0] == 21.0F)
         {
             set_expected_result(14, 110.0F, 30, c);
         }
@@ -2945,7 +2945,7 @@ sfpi_test_noinline void test14(int imm)
     // Confirm a is correct
     {
         // Out of regs doing this the typical way
-        vFloat condition = dst_reg[0] - 22.0F;
+        sfpi::vFloat condition = sfpi::dst_reg[0] - 22.0F;
         vInt a           = 10;
         vInt b           = 20;
         vInt c           = 30;
@@ -2956,20 +2956,20 @@ sfpi_test_noinline void test14(int imm)
         }
         v_endif;
 
-        v_if (vConst0p8373 == dst_reg[0])
+        v_if (vConst0p8373 == sfpi::dst_reg[0])
         { // always fail
-            dst_reg[14] = a;
-            dst_reg[14] = c;
+            sfpi::dst_reg[14] = a;
+            sfpi::dst_reg[14] = c;
         }
         v_endif;
 
-        v_if (dst_reg[0] == 22.0F)
+        v_if (sfpi::dst_reg[0] == 22.0F)
         {
             set_expected_result(14, -110.0F, 10, a);
         }
         v_endif;
 
-        v_if (dst_reg[0] == 23.0F)
+        v_if (sfpi::dst_reg[0] == 23.0F)
         {
             set_expected_result(14, 120.0F, 10, a);
         }
@@ -2983,7 +2983,7 @@ sfpi_test_noinline void test14(int imm)
     // Confirm b is correct
     {
         // Out of regs doing this the typical way
-        vFloat condition = dst_reg[0] - 24.0F;
+        sfpi::vFloat condition = sfpi::dst_reg[0] - 24.0F;
         vInt a           = 10;
         vInt b           = 20;
         vInt c           = 30;
@@ -2994,20 +2994,20 @@ sfpi_test_noinline void test14(int imm)
         }
         v_endif;
 
-        v_if (vConst0p8373 == dst_reg[0])
+        v_if (vConst0p8373 == sfpi::dst_reg[0])
         { // always fail
-            dst_reg[14] = c;
-            dst_reg[14] = b;
+            sfpi::dst_reg[14] = c;
+            sfpi::dst_reg[14] = b;
         }
         v_endif;
 
-        v_if (dst_reg[0] == 24.0F)
+        v_if (sfpi::dst_reg[0] == 24.0F)
         {
             set_expected_result(14, -120.0F, 20, b);
         }
         v_endif;
 
-        v_if (dst_reg[0] == 25.0F)
+        v_if (sfpi::dst_reg[0] == 25.0F)
         {
             set_expected_result(14, 130.0F, 20, b);
         }
@@ -3021,9 +3021,9 @@ sfpi_test_noinline void test14(int imm)
     // stay live when assigned at the same CC level but in a different
     // cascade, ie, across generations?
     {
-        vFloat a;
-        vFloat b;
-        vFloat dr = dst_reg[0];
+        sfpi::vFloat a;
+        sfpi::vFloat b;
+        sfpi::vFloat dr = sfpi::dst_reg[0];
 
         v_if (dr == 26.0F || dr == 27.0F)
         {
@@ -3051,13 +3051,13 @@ sfpi_test_noinline void test14(int imm)
 
         v_if (dr == 26.0F || dr == 27.0F)
         {
-            dst_reg[14] = b;
+            sfpi::dst_reg[14] = b;
         }
         v_endif;
 
         v_if (dr == 500.0F)
         {
-            dst_reg[14] = a;
+            sfpi::dst_reg[14] = a;
         }
         v_endif;
     }
@@ -3070,8 +3070,8 @@ sfpi_test_noinline void test14(int imm)
     //    (30.0f - i) != static_cast<float>(30 - i)
     // and not just due to rounding (off by orders of magnitude)
     {
-        vFloat a = 200.0F;
-        vFloat b = 1.0F;
+        sfpi::vFloat a = 200.0F;
+        sfpi::vFloat b = 1.0F;
 
         // unroll forces the compiler into multiple basic blocks
 #if defined(__GNUC__) && !defined(__clang__)
@@ -3079,7 +3079,7 @@ sfpi_test_noinline void test14(int imm)
 #endif
         for (int i = 0; i < imm - 30; i++)
         { // 0..4
-            v_if (dst_reg[0] == 28.0F)
+            v_if (sfpi::dst_reg[0] == 28.0F)
             {
                 switch (i)
                 {
@@ -3096,7 +3096,7 @@ sfpi_test_noinline void test14(int imm)
                         b = b * 4.0F;
                 }
             }
-            v_elseif (dst_reg[0] >= static_cast<float>(30 - i))
+            v_elseif (sfpi::dst_reg[0] >= static_cast<float>(30 - i))
             {
                 if (i % 2 == 0)
                 {
@@ -3112,9 +3112,9 @@ sfpi_test_noinline void test14(int imm)
             a = a + a * b;
         }
 
-        v_if (dst_reg[0] == 28.0F || dst_reg[0] == 29.0F)
+        v_if (sfpi::dst_reg[0] == 28.0F || sfpi::dst_reg[0] == 29.0F)
         {
-            dst_reg[14] = a;
+            sfpi::dst_reg[14] = a;
         }
         v_endif;
     }
@@ -3130,7 +3130,7 @@ sfpi_test_noinline void test15()
 {
     // SFPTRANSP, SFPSHFT2
 
-    dst_reg[15] = -dst_reg[0];
+    sfpi::dst_reg[15] = -sfpi::dst_reg[0];
     {
         vUInt a = vConstTileId + 0x100;
         vUInt b = vConstTileId + 0x200;
@@ -3168,7 +3168,7 @@ sfpi_test_noinline void test15()
         // Reduce result (only care about first subbvec, rest along for the ride)
         vUInt final = reduce_bool4(result, cmpb, cmpc, cmpd, 1);
 
-        v_if (dst_reg[0] < 8.0F)
+        v_if (sfpi::dst_reg[0] < 8.0F)
         {
             set_expected_result(15, 8.0F, 1, final);
         }
@@ -3195,7 +3195,7 @@ sfpi_test_noinline void test15()
         subvec_transp(tmp1, dst, tmp2, tmp3);
 
         vUInt final = reduce_bool4(dst, tmp1, tmp2, tmp3, 0);
-        v_if (dst_reg[0] >= 8.0F && dst_reg[0] < 16.0F)
+        v_if (sfpi::dst_reg[0] >= 8.0F && sfpi::dst_reg[0] < 16.0F)
         {
             set_expected_result(15, 16.0F, 1, final);
         }
@@ -3222,7 +3222,7 @@ sfpi_test_noinline void test15()
         subvec_transp(tmp1, tmp2, dst, tmp3);
 
         vUInt final = reduce_bool4(tmp1, dst, tmp2, tmp3, 0);
-        v_if (dst_reg[0] >= 16.0F && dst_reg[0] < 24.0F)
+        v_if (sfpi::dst_reg[0] >= 16.0F && sfpi::dst_reg[0] < 24.0F)
         {
             set_expected_result(15, 24.0F, 1, final);
         }
@@ -3231,7 +3231,7 @@ sfpi_test_noinline void test15()
 #if 0
     // Decided not to implement these at this time.  These insns are only
     // interesting if/when we implement LOADMACRO
-    v_if (dst_reg[0] == 16.0F) {
+    v_if (sfpi::dst_reg[0] == 16.0F) {
         // Wrapper doesn't emit shft2 bit shift, test directly
         vUInt a = 0x005A;
 
@@ -3240,7 +3240,7 @@ sfpi_test_noinline void test15()
     }
     v_endif;
 
-    v_if (dst_reg[0] == 17.0F) {
+    v_if (sfpi::dst_reg[0] == 17.0F) {
         // Wrapper doesn't emit shft2 bit shift, test directly
         vUInt a = 0x005A;
         vUInt b = 4;
@@ -3258,17 +3258,17 @@ sfpi_test_noinline void test15()
 void test16()
 {
     // SFPSWAP, SFPCAST, SFPSTOCHRND
-    dst_reg[16] = -dst_reg[0];
+    sfpi::dst_reg[16] = -sfpi::dst_reg[0];
 
     // Tests are all 2 results per row, allowing 4 independent tests only 2 of
     // which are used
-    vFloat x = 2.0f;
-    vFloat y = 3.0f;
+    sfpi::vFloat x = 2.0f;
+    sfpi::vFloat y = 3.0f;
 
-    v_if (dst_reg[0] < 8.0F)
+    v_if (sfpi::dst_reg[0] < 8.0F)
     {
         vec_swap(x, y);
-        v_if (dst_reg[0] >= 4.0f)
+        v_if (sfpi::dst_reg[0] >= 4.0f)
         {
             vec_min_max(x, y);
         }
@@ -3276,11 +3276,11 @@ void test16()
 
         v_if (((vConstTileId >> 1) & 1) == 0)
         {
-            dst_reg[16] = x;
+            sfpi::dst_reg[16] = x;
         }
         v_else
         {
-            dst_reg[16] = y;
+            sfpi::dst_reg[16] = y;
         }
         v_endif;
     }
@@ -3295,65 +3295,65 @@ void test16()
     // [7] = 3.0
 
     // These are really crappy "touch" tests
-    v_if (dst_reg[0] == 8.0F)
+    v_if (sfpi::dst_reg[0] == 8.0F)
     {
-        dst_reg[16] = int32_to_float(0xABBAAB);
+        sfpi::dst_reg[16] = int32_to_float(0xABBAAB);
     }
     v_endif;
-    v_if (dst_reg[0] == 9.0F)
+    v_if (sfpi::dst_reg[0] == 9.0F)
     {
-        dst_reg[16] = int32_to_float(0xABBAAB, 0);
+        sfpi::dst_reg[16] = int32_to_float(0xABBAAB, 0);
     }
     v_endif;
 
-    v_if (dst_reg[0] == 10.0F)
+    v_if (sfpi::dst_reg[0] == 10.0F)
     {
-        dst_reg[16] = float_to_fp16a(1.32332);
+        sfpi::dst_reg[16] = float_to_fp16a(1.32332);
     }
     v_endif;
-    v_if (dst_reg[0] == 11.0F)
+    v_if (sfpi::dst_reg[0] == 11.0F)
     {
-        dst_reg[16] = float_to_fp16b(1.32332);
+        sfpi::dst_reg[16] = float_to_fp16b(1.32332);
     }
     v_endif;
-    v_if (dst_reg[0] == 12.0F)
+    v_if (sfpi::dst_reg[0] == 12.0F)
     {
         set_expected_result(16, 48.0f, 24, float_to_uint8(23.3));
     }
     v_endif;
-    v_if (dst_reg[0] == 13.0F)
+    v_if (sfpi::dst_reg[0] == 13.0F)
     {
         set_expected_result(16, 64.0f, 24, float_to_int8(23.3));
     }
     v_endif;
-    v_if (dst_reg[0] == 14.0F)
+    v_if (sfpi::dst_reg[0] == 14.0F)
     {
         vUInt descale = 8;
         set_expected_result(16, 80.0f, 0xeb, int32_to_uint8(0xea00, descale));
     }
     v_endif;
-    v_if (dst_reg[0] == 15.0F)
+    v_if (sfpi::dst_reg[0] == 15.0F)
     {
         set_expected_result(16, 96.0f, 0xf, int32_to_uint8(0xea0, 8));
     }
     v_endif;
-    v_if (dst_reg[0] == 16.0F)
+    v_if (sfpi::dst_reg[0] == 16.0F)
     {
         vUInt descale = 8;
         set_expected_result(16, 112.0f, 0xf, int32_to_int8(0xea0, descale));
     }
     v_endif;
-    v_if (dst_reg[0] == 17.0F)
+    v_if (sfpi::dst_reg[0] == 17.0F)
     {
         set_expected_result(16, 128.0f, 0xf, int32_to_int8(0xea0, 8));
     }
     v_endif;
-    v_if (dst_reg[0] == 18.0F)
+    v_if (sfpi::dst_reg[0] == 18.0F)
     {
         set_expected_result(16, 130.0f, 0x7eb1, float_to_int16(32432.0f));
     }
     v_endif;
-    v_if (dst_reg[0] == 19.0F)
+    v_if (sfpi::dst_reg[0] == 19.0F)
     {
         set_expected_result(16, 132.0f, 0x7eb1, float_to_uint16(32432.0f));
     }
@@ -3365,10 +3365,10 @@ void test16()
 void test17()
 {
     // more SFPSWAP
-    dst_reg[17] = -dst_reg[0];
+    sfpi::dst_reg[17] = -sfpi::dst_reg[0];
 
     // Test sign-magnitude for ints
-    v_if (dst_reg[0] == 2.0F)
+    v_if (sfpi::dst_reg[0] == 2.0F)
     {
         vUInt x = -1;
         vUInt y = -2;
@@ -3378,32 +3378,32 @@ void test17()
     v_endif;
     // [2] = 23.0f
 
-    v_if (dst_reg[0] == 3.0F)
+    v_if (sfpi::dst_reg[0] == 3.0F)
     {
-        vFloat x = -1.0F;
-        vFloat y = -2.0F;
+        sfpi::vFloat x = -1.0F;
+        sfpi::vFloat y = -2.0F;
         vec_min_max(x, y);
-        dst_reg[17] = x;
+        sfpi::dst_reg[17] = x;
     }
     v_endif;
     // [3] = -2.0
 
-    v_if (dst_reg[0] == 4.0F)
+    v_if (sfpi::dst_reg[0] == 4.0F)
     {
-        vFloat x = 1.0F;
-        vFloat y = 2.0F;
+        sfpi::vFloat x = 1.0F;
+        sfpi::vFloat y = 2.0F;
         vec_min_max(x, y);
-        dst_reg[17] = x;
+        sfpi::dst_reg[17] = x;
     }
     v_endif;
     // [4] = 1.0
 
-    v_if (dst_reg[0] == 5.0F || dst_reg[0] == 6.0F)
+    v_if (sfpi::dst_reg[0] == 5.0F || sfpi::dst_reg[0] == 6.0F)
     {
-        vFloat x = -1.0F;
-        vFloat y = 1.0F;
+        sfpi::vFloat x = -1.0F;
+        sfpi::vFloat y = 1.0F;
 
-        v_if (dst_reg[0] == 5.0F)
+        v_if (sfpi::dst_reg[0] == 5.0F)
         {
             set_expected_result(17, 20.0F, 2, lz_nosgn(x));
         }

--- a/tt_llk_blackhole/common/inc/cmath_common.h
+++ b/tt_llk_blackhole/common/inc/cmath_common.h
@@ -177,7 +177,7 @@ inline void set_dst_write_addr(uint32_t tile_index)
 
 // Programming a dst write addr offset that gets added to base
 //
-inline void clear_dst_reg_addr()
+inline void clear_sfpi::dst_reg_addr()
 {
     TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_D);
 }

--- a/tt_llk_blackhole/common/inc/cmath_common.h
+++ b/tt_llk_blackhole/common/inc/cmath_common.h
@@ -177,7 +177,7 @@ inline void set_dst_write_addr(uint32_t tile_index)
 
 // Programming a dst write addr offset that gets added to base
 //
-inline void clear_sfpi::dst_reg_addr()
+inline void clear_dst_reg_addr()
 {
     TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_D);
 }

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_abs.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_abs.h
@@ -6,8 +6,6 @@
 
 #include "sfpi.h"
 
-using namespace sfpi;
-
 namespace ckernel
 {
 namespace sfpu

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_abs.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_abs.h
@@ -19,9 +19,9 @@ inline void _calculate_abs_(const int iterations)
     // SFPU microcode
     for (int d = 0; d < iterations; d++)
     {
-        vFloat v   = dst_reg[0];
-        dst_reg[0] = sfpi::abs(v);
-        dst_reg++;
+        sfpi::vFloat v   = sfpi::dst_reg[0];
+        sfpi::dst_reg[0] = sfpi::abs(v);
+        sfpi::dst_reg++;
     }
 }
 

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_abs.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_abs.h
@@ -4,8 +4,6 @@
 
 #pragma once
 
-#include "ckernel.h"
-#include "ckernel_defs.h"
 #include "sfpi.h"
 
 using namespace sfpi;

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_add_int32.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_add_int32.h
@@ -58,7 +58,7 @@ inline void _add_int32_(const uint dst_offset)
             TTI_SFPSETSGN(0 /* imm */, 1 /*lreg_c*/, 0 /*ldest*/, 0 /*imod*/);
         }
         TTI_SFPSTORE(0, INSTR_MOD_LOAD_STORE, ADDR_MOD_7, 0);
-        dst_reg++;
+        sfpi::dst_reg++;
     }
 }
 

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_add_int32.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_add_int32.h
@@ -4,11 +4,9 @@
 
 #pragma once
 
-#include "ckernel.h"
-#include "ckernel_defs.h"
 #include "sfpi.h"
-
-using namespace sfpi;
+#include "ckernel_ops.h"
+#include "ckernel_addrmod.h"
 
 namespace ckernel
 {

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_add_int32.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_add_int32.h
@@ -4,9 +4,9 @@
 
 #pragma once
 
-#include "sfpi.h"
-#include "ckernel_ops.h"
 #include "ckernel_addrmod.h"
+#include "ckernel_ops.h"
+#include "sfpi.h"
 
 namespace ckernel
 {

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_binary.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_binary.h
@@ -4,13 +4,9 @@
 
 #pragma once
 
-#include "ckernel.h"
-#include "ckernel_defs.h"
-#include "ckernel_sfpu_exp.h"
-#include "noc_nonblocking_api.h"
 #include "sfpi.h"
-
-using namespace sfpi;
+#include "ckernel_sfpu_exp.h"
+#include "ckernel_sfpu_recip.h"
 
 namespace ckernel
 {

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_binary.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_binary.h
@@ -67,7 +67,7 @@ sfpi_inline sfpi::vFloat _calculate_sfpu_binary_power_(sfpi::vFloat base, sfpi::
     sfpi::vFloat val = pow * log_result;
 
     // Force sign to 0 (make number positive)
-    sfpi::vFloat result = _sfpu_exp_(setsgn(val, 0));
+    sfpi::vFloat result = _sfpu_exp_(sfpi::setsgn(val, 0));
 
     v_if (val < 0)
     {
@@ -84,7 +84,7 @@ sfpi_inline sfpi::vFloat _calculate_sfpu_binary_power_(sfpi::vFloat base, sfpi::
             // if pow is odd integer, set result to negative
             v_if (pow_int & 0x1)
             {
-                result = setsgn(result, 1);
+                result = sfpi::setsgn(result, 1);
             }
             v_endif;
         }
@@ -133,7 +133,7 @@ inline void _calculate_sfpu_binary_(const uint dst_offset)
                 v_else
                 {
                     result = std::numeric_limits<float>::infinity();
-                    result = setsgn(result, in0);
+                    result = sfpi::setsgn(result, in0);
                 }
                 v_endif;
             }

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_binary.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_binary.h
@@ -4,9 +4,9 @@
 
 #pragma once
 
-#include "sfpi.h"
 #include "ckernel_sfpu_exp.h"
 #include "ckernel_sfpu_recip.h"
+#include "sfpi.h"
 
 namespace ckernel
 {
@@ -28,29 +28,29 @@ sfpi_inline sfpi::vFloat _calculate_sfpu_binary_power_(sfpi::vFloat base, sfpi::
     sfpi::vFloat original_base = base;
 
     // Check for integer power
-    vInt pow_int       = float_to_int16(pow, 0); // int16 should be plenty, since large powers will approach 0/Inf
-    sfpi::vFloat pow_rounded = int32_to_float(pow_int, 0);
+    sfpi::vInt pow_int       = sfpi::float_to_int16(pow, 0); // int16 should be plenty, since large powers will approach 0/Inf
+    sfpi::vFloat pow_rounded = sfpi::int32_to_float(pow_int, 0);
     v_if (pow_rounded == pow)
     {
         // if pow is integer, set base to positive
-        base = setsgn(base, 0);
+        base = sfpi::setsgn(base, 0);
     }
     v_endif;
 
     // Normalize base to calculation range
-    sfpi::vFloat x = setexp(base, 127); // set exp to exp bias (put base in range of 1-2)
+    sfpi::vFloat x = sfpi::setexp(base, 127); // set exp to exp bias (put base in range of 1-2)
 
     // 3rd order polynomial approx - determined using rminimax over [1,2]
     sfpi::vFloat series_result = x * (x * (x * 0x2.44734p-4f - 0xd.e712ap-4f) + 0x2.4f5388p+0f) - 0x1.952992p+0f;
 
     // Convert exponent to float
-    vInt exp = exexp(base);
+    sfpi::vInt exp = sfpi::exexp(base);
     v_if (exp < 0)
     {
-        exp = setsgn(~exp + 1, 1);
+        exp = sfpi::setsgn(~exp + 1, 1);
     }
     v_endif;
-    sfpi::vFloat expf = int32_to_float(exp, 0);
+    sfpi::vFloat expf = sfpi::int32_to_float(exp, 0);
 
     // De-normalize to original range
     sfpi::vFloat vConstLn2  = 0.692871f;
@@ -106,9 +106,9 @@ inline void _calculate_sfpu_binary_(const uint dst_offset)
     for (int d = 0; d < ITERATIONS; d++)
     {
         constexpr uint dst_tile_size = 32;
-        sfpi::vFloat in0                   = sfpi::dst_reg[0];
-        sfpi::vFloat in1                   = sfpi::dst_reg[dst_offset * dst_tile_size];
-        sfpi::vFloat result                = 0.0f;
+        sfpi::vFloat in0             = sfpi::dst_reg[0];
+        sfpi::vFloat in1             = sfpi::dst_reg[dst_offset * dst_tile_size];
+        sfpi::vFloat result          = 0.0f;
 
         if constexpr (BINOP == BinaryOp::ADD)
         {
@@ -139,11 +139,11 @@ inline void _calculate_sfpu_binary_(const uint dst_offset)
             }
             v_elseif (in0 == in1)
             {
-                result = vConst1;
+                result = sfpi::vConst1;
             }
             v_else
             {
-                result = in0 * setsgn(_sfpu_reciprocal_<4>(in1), in1);
+                result = in0 * sfpi::setsgn(_sfpu_reciprocal_<4>(in1), in1);
             }
             v_endif;
         }

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_binary.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_binary.h
@@ -23,13 +23,13 @@ enum class BinaryOp : uint8_t
     POW  = 5
 };
 
-sfpi_inline vFloat _calculate_sfpu_binary_power_(vFloat base, vFloat pow)
+sfpi_inline sfpi::vFloat _calculate_sfpu_binary_power_(sfpi::vFloat base, sfpi::vFloat pow)
 {
-    vFloat original_base = base;
+    sfpi::vFloat original_base = base;
 
     // Check for integer power
     vInt pow_int       = float_to_int16(pow, 0); // int16 should be plenty, since large powers will approach 0/Inf
-    vFloat pow_rounded = int32_to_float(pow_int, 0);
+    sfpi::vFloat pow_rounded = int32_to_float(pow_int, 0);
     v_if (pow_rounded == pow)
     {
         // if pow is integer, set base to positive
@@ -38,10 +38,10 @@ sfpi_inline vFloat _calculate_sfpu_binary_power_(vFloat base, vFloat pow)
     v_endif;
 
     // Normalize base to calculation range
-    vFloat x = setexp(base, 127); // set exp to exp bias (put base in range of 1-2)
+    sfpi::vFloat x = setexp(base, 127); // set exp to exp bias (put base in range of 1-2)
 
     // 3rd order polynomial approx - determined using rminimax over [1,2]
-    vFloat series_result = x * (x * (x * 0x2.44734p-4f - 0xd.e712ap-4f) + 0x2.4f5388p+0f) - 0x1.952992p+0f;
+    sfpi::vFloat series_result = x * (x * (x * 0x2.44734p-4f - 0xd.e712ap-4f) + 0x2.4f5388p+0f) - 0x1.952992p+0f;
 
     // Convert exponent to float
     vInt exp = exexp(base);
@@ -50,11 +50,11 @@ sfpi_inline vFloat _calculate_sfpu_binary_power_(vFloat base, vFloat pow)
         exp = setsgn(~exp + 1, 1);
     }
     v_endif;
-    vFloat expf = int32_to_float(exp, 0);
+    sfpi::vFloat expf = int32_to_float(exp, 0);
 
     // De-normalize to original range
-    vFloat vConstLn2  = 0.692871f;
-    vFloat log_result = expf * vConstLn2 + series_result; // exp correction: ln(1+x) + exp*ln(2)
+    sfpi::vFloat vConstLn2  = 0.692871f;
+    sfpi::vFloat log_result = expf * vConstLn2 + series_result; // exp correction: ln(1+x) + exp*ln(2)
 
     // Base case when input is 0. ln(0) = -inf
     v_if (base == 0.0f)
@@ -64,10 +64,10 @@ sfpi_inline vFloat _calculate_sfpu_binary_power_(vFloat base, vFloat pow)
     v_endif;
 
     // Take exp(pow * log(base)) to produce base^pow
-    vFloat val = pow * log_result;
+    sfpi::vFloat val = pow * log_result;
 
     // Force sign to 0 (make number positive)
-    vFloat result = _sfpu_exp_(setsgn(val, 0));
+    sfpi::vFloat result = _sfpu_exp_(setsgn(val, 0));
 
     v_if (val < 0)
     {
@@ -106,9 +106,9 @@ inline void _calculate_sfpu_binary_(const uint dst_offset)
     for (int d = 0; d < ITERATIONS; d++)
     {
         constexpr uint dst_tile_size = 32;
-        vFloat in0                   = dst_reg[0];
-        vFloat in1                   = dst_reg[dst_offset * dst_tile_size];
-        vFloat result                = 0.0f;
+        sfpi::vFloat in0                   = sfpi::dst_reg[0];
+        sfpi::vFloat in1                   = sfpi::dst_reg[dst_offset * dst_tile_size];
+        sfpi::vFloat result                = 0.0f;
 
         if constexpr (BINOP == BinaryOp::ADD)
         {
@@ -156,8 +156,8 @@ inline void _calculate_sfpu_binary_(const uint dst_offset)
             result = _calculate_sfpu_binary_power_(in0, in1);
         }
 
-        dst_reg[0] = result;
-        dst_reg++;
+        sfpi::dst_reg[0] = result;
+        sfpi::dst_reg++;
     }
 }
 

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_binary_bitwise.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_binary_bitwise.h
@@ -45,7 +45,7 @@ inline void _calculate_sfpu_binary_bitwise_(const uint dst_offset)
         }
 
         TTI_SFPSTORE(0, 12, ADDR_MOD_7, 0);
-        dst_reg++;
+        sfpi::dst_reg++;
     }
 }
 

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_binary_bitwise.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_binary_bitwise.h
@@ -4,14 +4,9 @@
 
 #pragma once
 
-#include <limits.h>
-
-#include "ckernel.h"
-#include "ckernel_defs.h"
-#include "noc_nonblocking_api.h"
 #include "sfpi.h"
-
-using namespace sfpi;
+#include "ckernel_ops.h"
+#include "ckernel_addrmod.h"
 
 namespace ckernel
 {

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_binary_bitwise.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_binary_bitwise.h
@@ -4,9 +4,9 @@
 
 #pragma once
 
-#include "sfpi.h"
-#include "ckernel_ops.h"
 #include "ckernel_addrmod.h"
+#include "ckernel_ops.h"
+#include "sfpi.h"
 
 namespace ckernel
 {

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_cast_fp32_to_fp16a.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_cast_fp32_to_fp16a.h
@@ -19,12 +19,12 @@ inline void _cast_fp32_to_fp16a_(const int iterations)
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
     {
-        // vFloat val = dst_reg[0];
-        // dst_reg[0] = float_to_fp16a(val, 0);
+        // sfpi::vFloat val = sfpi::dst_reg[0];
+        // sfpi::dst_reg[0] = float_to_fp16a(val, 0);
         TTI_SFPLOAD(0, 0, ADDR_MOD_7, 0);
         TTI_SFP_STOCH_RND(0, 0, 0, 0, 0, 8);
         TTI_SFPSTORE(0, 1, ADDR_MOD_7, 0);
-        dst_reg++;
+        sfpi::dst_reg++;
     }
 }
 

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_cast_fp32_to_fp16a.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_cast_fp32_to_fp16a.h
@@ -4,11 +4,9 @@
 
 #pragma once
 
-#include "ckernel.h"
-#include "ckernel_defs.h"
 #include "sfpi.h"
-
-using namespace sfpi;
+#include "ckernel_ops.h"
+#include "ckernel_addrmod.h"
 
 namespace ckernel
 {

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_cast_fp32_to_fp16a.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_cast_fp32_to_fp16a.h
@@ -4,9 +4,9 @@
 
 #pragma once
 
-#include "sfpi.h"
-#include "ckernel_ops.h"
 #include "ckernel_addrmod.h"
+#include "ckernel_ops.h"
+#include "sfpi.h"
 
 namespace ckernel
 {

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_clamp.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_clamp.h
@@ -4,11 +4,8 @@
 
 #pragma once
 
-#include "ckernel.h"
-#include "ckernel_defs.h"
 #include "sfpi.h"
-
-using namespace sfpi;
+#include "sfpi_fp16.h"
 
 namespace ckernel
 {

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_clamp.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_clamp.h
@@ -20,11 +20,11 @@ inline void _calculate_clamp_(const int iterations, uint param0, uint param1, ui
     // param1 = max
 
     // uint format = (param0 >> 16)&0x1;
-    s2sfpi::vFloat16::Format format = s2sfpi::vFloat16::fp16a;
+    sfpi::s2vFloat16::Format format = sfpi::s2vFloat16::fp16a;
 
     // SFPU microcode
-    sfpi::vFloat min = s2sfpi::vFloat16(param0, format);
-    sfpi::vFloat max = s2sfpi::vFloat16(param1, format);
+    sfpi::vFloat min = sfpi::s2vFloat16(param0, format);
+    sfpi::vFloat max = sfpi::s2vFloat16(param1, format);
 #pragma GCC unroll 0
     for (int d = 0; d < iterations; d++)
     {
@@ -32,15 +32,15 @@ inline void _calculate_clamp_(const int iterations, uint param0, uint param1, ui
 
         v_if (val < min)
         {
-            val = s2sfpi::vFloat16(param0, format);
+            val = sfpi::s2vFloat16(param0, format);
         }
         v_elseif (val >= max)
         {
-            val = s2sfpi::vFloat16(param1, format);
+            val = sfpi::s2vFloat16(param1, format);
         }
         v_endif;
 
-        sfpi::dst_reg[0] = val + s2sfpi::vFloat16b(param2); // 12 bits
+        sfpi::dst_reg[0] = val + sfpi::s2vFloat16b(param2); // 12 bits
 
         sfpi::dst_reg++;
     }

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_clamp.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_clamp.h
@@ -20,29 +20,29 @@ inline void _calculate_clamp_(const int iterations, uint param0, uint param1, ui
     // param1 = max
 
     // uint format = (param0 >> 16)&0x1;
-    s2vFloat16::Format format = s2vFloat16::fp16a;
+    s2sfpi::vFloat16::Format format = s2sfpi::vFloat16::fp16a;
 
     // SFPU microcode
-    vFloat min = s2vFloat16(param0, format);
-    vFloat max = s2vFloat16(param1, format);
+    sfpi::vFloat min = s2sfpi::vFloat16(param0, format);
+    sfpi::vFloat max = s2sfpi::vFloat16(param1, format);
 #pragma GCC unroll 0
     for (int d = 0; d < iterations; d++)
     {
-        vFloat val = dst_reg[0];
+        sfpi::vFloat val = sfpi::dst_reg[0];
 
         v_if (val < min)
         {
-            val = s2vFloat16(param0, format);
+            val = s2sfpi::vFloat16(param0, format);
         }
         v_elseif (val >= max)
         {
-            val = s2vFloat16(param1, format);
+            val = s2sfpi::vFloat16(param1, format);
         }
         v_endif;
 
-        dst_reg[0] = val + s2vFloat16b(param2); // 12 bits
+        sfpi::dst_reg[0] = val + s2sfpi::vFloat16b(param2); // 12 bits
 
-        dst_reg++;
+        sfpi::dst_reg++;
     }
 }
 

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_comp.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_comp.h
@@ -4,8 +4,8 @@
 
 #pragma once
 
-#include "sfpi.h"
 #include "ckernel_sfpu_is_fp16_zero.h"
+#include "sfpi.h"
 
 namespace ckernel
 {
@@ -73,7 +73,7 @@ inline void _calculate_comp_(const int iterations, uint exponent_size_8)
             // Result will be either 0x0000(0.0) or 0x3F80(1.0)
             if constexpr (is_less_than_equal_zero)
             {
-                result = reinterpret<sfpi::vFloat>(reinterpret<vUInt>(flag1) | reinterpret<vUInt>(flag2));
+                result = sfpi::reinterpret<sfpi::vFloat>(sfpi::reinterpret<sfpi::vUInt>(flag1) | sfpi::reinterpret<sfpi::vUInt>(flag2));
             }
             else
             {
@@ -83,7 +83,7 @@ inline void _calculate_comp_(const int iterations, uint exponent_size_8)
                 // Do a bitwise And (flag1 & flag2) to get > condition.
                 // flag2 >= 0 AND flag1 != 0 => DST is Greater than zero
                 // Result will be either 0x0000(0.0) or 0x3F80(1.0)
-                result = reinterpret<sfpi::vFloat>(reinterpret<vUInt>(flag1) & reinterpret<vUInt>(flag2));
+                result = sfpi::reinterpret<sfpi::vFloat>(sfpi::reinterpret<sfpi::vUInt>(flag1) & sfpi::reinterpret<sfpi::vUInt>(flag2));
             }
         }
         else

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_comp.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_comp.h
@@ -12,7 +12,7 @@ namespace ckernel
 namespace sfpu
 {
 
-sfpi_inline void _calculate_comp_init_flag_(bool check, vFloat& flag1, vFloat& flag2, float init)
+sfpi_inline void _calculate_comp_init_flag_(bool check, sfpi::vFloat& flag1, sfpi::vFloat& flag2, float init)
 {
     flag1 = init;
     if (check)
@@ -35,8 +35,8 @@ inline void _calculate_comp_(const int iterations, uint exponent_size_8)
 
     for (int d = 0; d < iterations; d++)
     {
-        vFloat v = dst_reg[0];
-        vFloat flag1, flag2;
+        sfpi::vFloat v = sfpi::dst_reg[0];
+        sfpi::vFloat flag1, flag2;
         if constexpr (check_zero)
         {
             v_if (_sfpu_is_fp16_zero_(v, exponent_size_8))
@@ -62,7 +62,7 @@ inline void _calculate_comp_(const int iterations, uint exponent_size_8)
             v_endif;
         }
 
-        vFloat result;
+        sfpi::vFloat result;
         if constexpr (second_check)
         {
             // less_than_equal_zero
@@ -73,7 +73,7 @@ inline void _calculate_comp_(const int iterations, uint exponent_size_8)
             // Result will be either 0x0000(0.0) or 0x3F80(1.0)
             if constexpr (is_less_than_equal_zero)
             {
-                result = reinterpret<vFloat>(reinterpret<vUInt>(flag1) | reinterpret<vUInt>(flag2));
+                result = reinterpret<sfpi::vFloat>(reinterpret<vUInt>(flag1) | reinterpret<vUInt>(flag2));
             }
             else
             {
@@ -83,7 +83,7 @@ inline void _calculate_comp_(const int iterations, uint exponent_size_8)
                 // Do a bitwise And (flag1 & flag2) to get > condition.
                 // flag2 >= 0 AND flag1 != 0 => DST is Greater than zero
                 // Result will be either 0x0000(0.0) or 0x3F80(1.0)
-                result = reinterpret<vFloat>(reinterpret<vUInt>(flag1) & reinterpret<vUInt>(flag2));
+                result = reinterpret<sfpi::vFloat>(reinterpret<vUInt>(flag1) & reinterpret<vUInt>(flag2));
             }
         }
         else
@@ -91,9 +91,9 @@ inline void _calculate_comp_(const int iterations, uint exponent_size_8)
             result = flag1;
         }
 
-        dst_reg[0] = result;
+        sfpi::dst_reg[0] = result;
 
-        dst_reg++;
+        sfpi::dst_reg++;
     }
 }
 

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_comp.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_comp.h
@@ -4,12 +4,8 @@
 
 #pragma once
 
-#include "ckernel.h"
-#include "ckernel_defs.h"
-#include "ckernel_sfpu_is_fp16_zero.h"
 #include "sfpi.h"
-
-using namespace sfpi;
+#include "ckernel_sfpu_is_fp16_zero.h"
 
 namespace ckernel
 {

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_cumsum.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_cumsum.h
@@ -4,12 +4,9 @@
 
 #pragma once
 
-#include "ckernel.h"
-#include "ckernel_defs.h"
-#include "noc_nonblocking_api.h"
 #include "sfpi.h"
-
-using namespace sfpi;
+#include "ckernel_ops.h"
+#include "ckernel_addrmod.h"
 
 namespace ckernel
 {

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_cumsum.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_cumsum.h
@@ -4,9 +4,9 @@
 
 #pragma once
 
-#include "sfpi.h"
-#include "ckernel_ops.h"
 #include "ckernel_addrmod.h"
+#include "ckernel_ops.h"
+#include "sfpi.h"
 
 namespace ckernel
 {

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_dropout.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_dropout.h
@@ -4,11 +4,10 @@
 
 #pragma once
 
-#include "ckernel.h"
-#include "ckernel_ops.h"
 #include "sfpi.h"
-
-using namespace sfpi;
+#include "ckernel_ops.h"
+#include "noc_nonblocking_api.h"
+#include "sfpi_fp16.h"
 
 namespace ckernel
 {

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_dropout.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_dropout.h
@@ -21,18 +21,10 @@ inline void _calculate_dropout_(const int iterations, uint probability, uint sca
 {
     // SFPU microcode
 
-<<<<<<< HEAD
     TT_SFPLOADI(p_sfpu::LREG1, 10, scale & 0xFFFF);
     TT_SFPLOADI(p_sfpu::LREG1, 8, scale >> 16);
     TT_SFPLOADI(p_sfpu::LREG2, 10, probability & 0xFFFF);
     TT_SFPLOADI(p_sfpu::LREG2, 8, probability >> 16);
-=======
-    FWLOG1("calculate_dropout() -- prob:%x", prob);
-    FWLOG1("calculate_dropout() -- scale:%x", scale);
-
-    sfpi::vUInt rand = sfpi::l_reg[sfpi::LRegs::LReg3];
-
->>>>>>> 7f32186... fix: remove more namespaces
 #pragma GCC unroll 0
     for (int d = 0; d < iterations; d++)
     {

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_dropout.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_dropout.h
@@ -44,7 +44,7 @@ inline void _calculate_dropout_(const int iterations, uint probability, uint sca
         TTI_SFPMOV(0, 9, p_sfpu::LREG3, 8);
         TTI_SFPSETSGN(0, p_sfpu::LREG3, p_sfpu::LREG3, 1);
 
-	////////////////////////
+        ////////////////////////
         // Drop samples
         // v_if (rand < probability)
         //   dst_reg[0] = vConst0;

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_dropout.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_dropout.h
@@ -54,7 +54,7 @@ inline void _calculate_dropout_(const int iterations, uint probability, uint sca
         TTI_SFPENCC(0, 0, 0, 0);
         TTI_SFPSTORE(0, 0, 3, 0);
 
-        dst_reg++;
+        sfpi::dst_reg++;
     }
 }
 

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_dropout.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_dropout.h
@@ -4,9 +4,9 @@
 
 #pragma once
 
-#include "sfpi.h"
 #include "ckernel_ops.h"
 #include "noc_nonblocking_api.h"
+#include "sfpi.h"
 #include "sfpi_fp16.h"
 
 namespace ckernel
@@ -21,10 +21,18 @@ inline void _calculate_dropout_(const int iterations, uint probability, uint sca
 {
     // SFPU microcode
 
+<<<<<<< HEAD
     TT_SFPLOADI(p_sfpu::LREG1, 10, scale & 0xFFFF);
     TT_SFPLOADI(p_sfpu::LREG1, 8, scale >> 16);
     TT_SFPLOADI(p_sfpu::LREG2, 10, probability & 0xFFFF);
     TT_SFPLOADI(p_sfpu::LREG2, 8, probability >> 16);
+=======
+    FWLOG1("calculate_dropout() -- prob:%x", prob);
+    FWLOG1("calculate_dropout() -- scale:%x", scale);
+
+    sfpi::vUInt rand = sfpi::l_reg[sfpi::LRegs::LReg3];
+
+>>>>>>> 7f32186... fix: remove more namespaces
 #pragma GCC unroll 0
     for (int d = 0; d < iterations; d++)
     {
@@ -44,7 +52,7 @@ inline void _calculate_dropout_(const int iterations, uint probability, uint sca
         TTI_SFPMOV(0, 9, p_sfpu::LREG3, 8);
         TTI_SFPSETSGN(0, p_sfpu::LREG3, p_sfpu::LREG3, 1);
 
-        ////////////////////////
+	////////////////////////
         // Drop samples
         // v_if (rand < probability)
         //   dst_reg[0] = vConst0;

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_exp.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_exp.h
@@ -26,7 +26,7 @@ sfpi_inline sfpi::vFloat _sfpu_exp_(sfpi::vFloat val)
     v_endif;
 
     // Run series in Horner form
-    sfpi::vFloat tmp = val * vConst0p8373 + s2sfpi::vFloat16b(0.863281);
+    sfpi::vFloat tmp = val * vConst0p8373 + sfpi::s2vFloat16b(0.863281);
     val        = val * tmp + vConst1;
 
     v_if (exp >= 0)
@@ -187,7 +187,7 @@ void _calculate_exponential_(const int iterations, uint16_t exp_base_scale_facto
             sfpi::vFloat val = sfpi::dst_reg[0];
             if constexpr (SCALE_EN)
             {
-                val = val * s2sfpi::vFloat16a(exp_base_scale_factor);
+                val = val * sfpi::s2vFloat16a(exp_base_scale_factor);
             }
             if constexpr (APPROXIMATION_MODE)
             {
@@ -356,8 +356,8 @@ inline void _init_exponential_()
     else if constexpr (APPROXIMATION_MODE)
     {
         vConstFloatPrgm0 = 1.442695f; // ln2_recip
-        vConstFloatPrgm1 = s2sfpi::vFloat16b(p_exp::C23_73);
-        vConstFloatPrgm2 = s2sfpi::vFloat16b(p_exp::ADJ_EXP);
+        vConstFloatPrgm1 = sfpi::s2vFloat16b(p_exp::C23_73);
+        vConstFloatPrgm2 = sfpi::s2vFloat16b(p_exp::ADJ_EXP);
     }
     else
     {

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_exp.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_exp.h
@@ -4,12 +4,11 @@
 
 #pragma once
 
-#include "ckernel.h"
-#include "ckernel_defs.h"
-#include "ckernel_sfpu_recip.h"
 #include "sfpi.h"
-
-using namespace sfpi;
+#include "sfpi_fp16.h"
+#include "ckernel_sfpu_recip.h"
+#include "ckernel_ops.h"
+#include "ckernel_addrmod.h"
 
 namespace ckernel
 {

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_exp.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_exp.h
@@ -213,14 +213,14 @@ void _calculate_exponential_(const int iterations, uint16_t exp_base_scale_facto
 
                     // SHL to move integer bits to exponent
                     val_short <<= 10 - p_exp::FRAC_BITS;
-                    sfpi::dst_reg[0] = reinterpret<sfpi::vFloat>(val_short);
+                    sfpi::dst_reg[0] = sfpi::reinterpret<sfpi::vFloat>(val_short);
                 }
                 v_endif;
             }
             else
             {
                 // Force sign to 0 (make number positive)
-                sfpi::vFloat result = _sfpu_exp_(setsgn(val, 0));
+                sfpi::vFloat result = _sfpu_exp_(sfpi::setsgn(val, 0));
 
                 v_if (val < 0)
                 {

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_exp.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_exp.h
@@ -4,11 +4,11 @@
 
 #pragma once
 
+#include "ckernel_addrmod.h"
+#include "ckernel_ops.h"
+#include "ckernel_sfpu_recip.h"
 #include "sfpi.h"
 #include "sfpi_fp16.h"
-#include "ckernel_sfpu_recip.h"
-#include "ckernel_ops.h"
-#include "ckernel_addrmod.h"
 
 namespace ckernel
 {
@@ -18,7 +18,7 @@ namespace sfpu
 sfpi_inline sfpi::vFloat _sfpu_exp_(sfpi::vFloat val)
 {
     // If exponent is > -1 extract it and replace with -1
-    vInt exp = exexp(val);
+    sfpi::vInt exp = exexp(val);
     v_if (exp >= 0)
     {
         val = setexp(val, 126);
@@ -26,8 +26,8 @@ sfpi_inline sfpi::vFloat _sfpu_exp_(sfpi::vFloat val)
     v_endif;
 
     // Run series in Horner form
-    sfpi::vFloat tmp = val * vConst0p8373 + sfpi::s2vFloat16b(0.863281);
-    val        = val * tmp + vConst1;
+    sfpi::vFloat tmp = val * sfpi::vConst0p8373 + sfpi::s2vFloat16b(0.863281);
+    val              = val * tmp + sfpi::vConst1;
 
     v_if (exp >= 0)
     {
@@ -56,23 +56,23 @@ sfpi_inline sfpi::vFloat _calculate_exponential_body_(sfpi::vFloat in)
         constexpr uint SP_BIAS  = 127 << FRAC_BITS;
 
         // * by 1/ln2 and add convert to 7.3 FxP format
-        sfpi::vFloat vConstLn2Recip = vConstFloatPrgm0;
+        sfpi::vFloat vConstLn2Recip = sfpi::vConstFloatPrgm0;
         sfpi::vFloat conv           = in * vConstLn2Recip;
 
         // Clear exp bits
-        vInt c23_73 = p_exp::C23_73;
-        vInt tmp    = reinterpret<vInt>(conv) - c23_73;
+        sfpi::vInt c23_73 = p_exp::C23_73;
+        sfpi::vInt tmp    = sfpi::reinterpret<sfpi::vInt>(conv) - c23_73;
 
         // Add bias
         tmp += SP_BIAS;
 
         // SHL to move integer bits to exponent
-        out = reinterpret<sfpi::vFloat>(tmp << (10 - FRAC_BITS));
+        out = sfpi::reinterpret<sfpi::vFloat>(tmp << (10 - FRAC_BITS));
     }
     else
     {
         // Force sign to 0 (make number positive)
-        out = _sfpu_exp_(setsgn(in, 0));
+        out = _sfpu_exp_(sfpi::setsgn(in, 0));
 
         v_if (in < 0)
         {
@@ -203,13 +203,13 @@ void _calculate_exponential_(const int iterations, uint16_t exp_base_scale_facto
                 v_else
                 {
                     // * by 1/ln2 and add convert to 7.3 FxP format
-                    sfpi::vFloat vConstLn2Recip = vConstFloatPrgm0;
-                    sfpi::vFloat c23_73         = vConstFloatPrgm1;
-                    vInt adj_exp          = vConstIntPrgm2;
-                    val                   = val * vConstLn2Recip + c23_73;
+                    sfpi::vFloat vConstLn2Recip = sfpi::vConstFloatPrgm0;
+                    sfpi::vFloat c23_73         = sfpi::vConstFloatPrgm1;
+                    sfpi::vInt adj_exp          = sfpi::vConstIntPrgm2;
+                    val                         = val * vConstLn2Recip + c23_73;
 
                     // Remove Exponent of 7 and bias the Mantissa to 127.
-                    vInt val_short = adj_exp + reinterpret<vInt>(val);
+                    sfpi::vInt val_short = adj_exp + sfpi::reinterpret<sfpi::vInt>(val);
 
                     // SHL to move integer bits to exponent
                     val_short <<= 10 - p_exp::FRAC_BITS;
@@ -355,15 +355,15 @@ inline void _init_exponential_()
     }
     else if constexpr (APPROXIMATION_MODE)
     {
-        vConstFloatPrgm0 = 1.442695f; // ln2_recip
-        vConstFloatPrgm1 = sfpi::s2vFloat16b(p_exp::C23_73);
-        vConstFloatPrgm2 = sfpi::s2vFloat16b(p_exp::ADJ_EXP);
+        sfpi::vConstFloatPrgm0 = 1.442695f; // ln2_recip
+        sfpi::vConstFloatPrgm1 = sfpi::s2vFloat16b(p_exp::C23_73);
+        sfpi::vConstFloatPrgm2 = sfpi::s2vFloat16b(p_exp::ADJ_EXP);
     }
     else
     {
-        vConstFloatPrgm0 = 1.442695f; // ln2_recip
-        vConstFloatPrgm1 = 2.0f;
-        vConstFloatPrgm2 = 0.863281f;
+        sfpi::vConstFloatPrgm0 = 1.442695f; // ln2_recip
+        sfpi::vConstFloatPrgm1 = 2.0f;
+        sfpi::vConstFloatPrgm2 = 0.863281f;
     }
 }
 

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_gelu.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_gelu.h
@@ -4,13 +4,10 @@
 
 #pragma once
 
-#include "ckernel.h"
-#include "ckernel_defs.h"
+#include "sfpi.h"
+#include "sfpi_fp16.h"
 #include "ckernel_sfpu_exp.h"
 #include "ckernel_sfpu_load_config.h"
-#include "sfpi.h"
-
-using namespace sfpi;
 
 namespace ckernel
 {

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_gelu.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_gelu.h
@@ -29,8 +29,8 @@ inline sfpi::vFloat _calculate_gelu_core_(sfpi::vFloat in)
     else
     {
         // f = (0.044715*x^3 + x)
-        result = (in * in) * (in * s2sfpi::vFloat16b(0.044715f)) + in;
-        result *= s2sfpi::vFloat16b(0.79788f);
+        result = (in * in) * (in * sfpi::s2vFloat16b(0.044715f)) + in;
+        result *= sfpi::s2vFloat16b(0.79788f);
     }
 
     return result;
@@ -138,7 +138,7 @@ inline void _calculate_gelu_derivative_(const int iterations)
             sfpi::vFloat exp = _calculate_exponential_body_<false>(neg_half_sq_in);
 
             // exp = exp * 1/sqrt(2*pi)
-            sfpi::vFloat partial = exp * in * s2sfpi::vFloat16b(0.3989423F);
+            sfpi::vFloat partial = exp * in * sfpi::s2vFloat16b(0.3989423F);
 
             sfpi::vFloat result = _calculate_gelu_core_<true>(in);
 

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_gelu.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_gelu.h
@@ -4,10 +4,10 @@
 
 #pragma once
 
-#include "sfpi.h"
-#include "sfpi_fp16.h"
 #include "ckernel_sfpu_exp.h"
 #include "ckernel_sfpu_load_config.h"
+#include "sfpi.h"
+#include "sfpi_fp16.h"
 
 namespace ckernel
 {
@@ -39,12 +39,12 @@ inline sfpi::vFloat _calculate_gelu_core_(sfpi::vFloat in)
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void _calculate_gelu_(const int iterations)
 {
-    vUInt l0 = l_reg[LRegs::LReg0];
-    vUInt l1 = l_reg[LRegs::LReg1];
-    vUInt l2 = l_reg[LRegs::LReg2];
-    vUInt l4 = l_reg[LRegs::LReg4];
-    vUInt l5 = l_reg[LRegs::LReg5];
-    vUInt l6 = l_reg[LRegs::LReg6];
+    sfpi::vUInt l0 = sfpi::l_reg[sfpi::LRegs::LReg0];
+    sfpi::vUInt l1 = sfpi::l_reg[sfpi::LRegs::LReg1];
+    sfpi::vUInt l2 = sfpi::l_reg[sfpi::LRegs::LReg2];
+    sfpi::vUInt l4 = sfpi::l_reg[sfpi::LRegs::LReg4];
+    sfpi::vUInt l5 = sfpi::l_reg[sfpi::LRegs::LReg5];
+    sfpi::vUInt l6 = sfpi::l_reg[sfpi::LRegs::LReg6];
 
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
@@ -59,10 +59,10 @@ inline void _calculate_gelu_(const int iterations)
         // sfpi::dst_reg[0] = result;
 
         sfpi::vFloat in      = sfpi::dst_reg[0];
-        sfpi::vFloat half    = vConstFloatPrgm0;
+        sfpi::vFloat half    = sfpi::vConstFloatPrgm0;
         sfpi::vFloat half_in = in * half;
         sfpi::vFloat result  = lut2_sign(in, l0, l1, l2, l4, l5, l6);
-        result         = half_in + result;
+        result               = half_in + result;
 
         sfpi::dst_reg[0] = result;
 
@@ -76,12 +76,12 @@ inline void _calculate_gelu_(const int iterations)
         // TTI_SFPSTORE(3, 0, 3/*store_addr_mod3*/, 0);   // and INCRWC by 4 using mode 3
     }
 
-    l_reg[LRegs::LReg0] = l0;
-    l_reg[LRegs::LReg1] = l1;
-    l_reg[LRegs::LReg2] = l2;
-    l_reg[LRegs::LReg4] = l4;
-    l_reg[LRegs::LReg5] = l5;
-    l_reg[LRegs::LReg6] = l6;
+    sfpi::l_reg[sfpi::LRegs::LReg0] = l0;
+    sfpi::l_reg[sfpi::LRegs::LReg1] = l1;
+    sfpi::l_reg[sfpi::LRegs::LReg2] = l2;
+    sfpi::l_reg[sfpi::LRegs::LReg4] = l4;
+    sfpi::l_reg[sfpi::LRegs::LReg5] = l5;
+    sfpi::l_reg[sfpi::LRegs::LReg6] = l6;
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
@@ -91,19 +91,19 @@ inline void _calculate_gelu_derivative_(const int iterations)
     {
         constexpr int lut_mode = 1; // SFPLUTFP32_MOD0_FP16_6ENTRY_TABLE1
 
-        vUInt l0 = l_reg[LRegs::LReg0];
-        vUInt l1 = l_reg[LRegs::LReg1];
-        vUInt l2 = l_reg[LRegs::LReg2];
-        vUInt l4 = l_reg[LRegs::LReg4];
-        vUInt l5 = l_reg[LRegs::LReg5];
-        vUInt l6 = l_reg[LRegs::LReg6];
+        sfpi::vUInt l0 = sfpi::l_reg[sfpi::LRegs::LReg0];
+        sfpi::vUInt l1 = sfpi::l_reg[sfpi::LRegs::LReg1];
+        sfpi::vUInt l2 = sfpi::l_reg[sfpi::LRegs::LReg2];
+        sfpi::vUInt l4 = sfpi::l_reg[sfpi::LRegs::LReg4];
+        sfpi::vUInt l5 = sfpi::l_reg[sfpi::LRegs::LReg5];
+        sfpi::vUInt l6 = sfpi::l_reg[sfpi::LRegs::LReg6];
 
 // SFPU microcode:
 #pragma GCC unroll 0
         for (int d = 0; d < iterations; d++)
         {
             sfpi::vFloat val = sfpi::dst_reg[0];
-            val        = lut2(val, l0, l1, l2, l4, l5, l6, lut_mode);
+            val              = lut2(val, l0, l1, l2, l4, l5, l6, lut_mode);
             v_if (val < 0.0F)
             {
                 val = val + 1.0f;
@@ -113,19 +113,19 @@ inline void _calculate_gelu_derivative_(const int iterations)
             sfpi::dst_reg++;
         }
 
-        l_reg[LRegs::LReg0] = l0;
-        l_reg[LRegs::LReg1] = l1;
-        l_reg[LRegs::LReg2] = l2;
-        l_reg[LRegs::LReg4] = l4;
-        l_reg[LRegs::LReg5] = l5;
-        l_reg[LRegs::LReg6] = l6;
+        sfpi::l_reg[sfpi::LRegs::LReg0] = l0;
+        sfpi::l_reg[sfpi::LRegs::LReg1] = l1;
+        sfpi::l_reg[sfpi::LRegs::LReg2] = l2;
+        sfpi::l_reg[sfpi::LRegs::LReg4] = l4;
+        sfpi::l_reg[sfpi::LRegs::LReg5] = l5;
+        sfpi::l_reg[sfpi::LRegs::LReg6] = l6;
     }
     else
     {
         constexpr uint imm2 = 0xFF10;
 
-        vUInt l0 = l_reg[LRegs::LReg0];
-        vUInt l1 = l_reg[LRegs::LReg1];
+        sfpi::vUInt l0 = sfpi::l_reg[sfpi::LRegs::LReg0];
+        sfpi::vUInt l1 = sfpi::l_reg[sfpi::LRegs::LReg1];
 
 // SFPU microcode:
 #pragma GCC unroll 0
@@ -148,15 +148,15 @@ inline void _calculate_gelu_derivative_(const int iterations)
             sfpi::dst_reg++;
         }
 
-        l_reg[LRegs::LReg0] = l0;
-        l_reg[LRegs::LReg1] = l1;
+        sfpi::l_reg[sfpi::LRegs::LReg0] = l0;
+        sfpi::l_reg[sfpi::LRegs::LReg1] = l1;
     }
 }
 
 template <bool APPROXIMATION_MODE>
 inline void _init_gelu_()
 {
-    vConstFloatPrgm0 = 0.5f;
+    sfpi::vConstFloatPrgm0 = 0.5f;
 
     // // >= 3.0f
     // lreg2_hi=0.50;//3800
@@ -189,9 +189,9 @@ inline void _init_gelu_()
 template <bool APPROXIMATION_MODE>
 inline void _init_gelu_derivative_()
 {
-    vConstFloatPrgm0 = 1.442695f; // ln2_recip
-    vConstFloatPrgm1 = 2.0f;
-    vConstFloatPrgm2 = 0.863281f;
+    sfpi::vConstFloatPrgm0 = 1.442695f; // ln2_recip
+    sfpi::vConstFloatPrgm1 = 2.0f;
+    sfpi::vConstFloatPrgm2 = 0.863281f;
 
     uint imm0;
     uint imm1;

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_gelu.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_gelu.h
@@ -15,13 +15,13 @@ namespace sfpu
 {
 
 template <bool APPROXIMATION_MODE>
-inline vFloat _calculate_gelu_core_(vFloat in)
+inline sfpi::vFloat _calculate_gelu_core_(sfpi::vFloat in)
 {
     // SFPU microcode:
     // result = (APPROX_MODE == 1)
     //   ? (1 + erf(x/sqrt(2)))
     //   : (1 + tanh( sqrt(2/pi) * (x + 0.044715*x^3) )
-    vFloat result;
+    sfpi::vFloat result;
     if constexpr (APPROXIMATION_MODE)
     {
         result = in;
@@ -29,8 +29,8 @@ inline vFloat _calculate_gelu_core_(vFloat in)
     else
     {
         // f = (0.044715*x^3 + x)
-        result = (in * in) * (in * s2vFloat16b(0.044715f)) + in;
-        result *= s2vFloat16b(0.79788f);
+        result = (in * in) * (in * s2sfpi::vFloat16b(0.044715f)) + in;
+        result *= s2sfpi::vFloat16b(0.79788f);
     }
 
     return result;
@@ -49,26 +49,26 @@ inline void _calculate_gelu_(const int iterations)
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
     {
-        // vFloat in = dst_reg[0];
-        // vFloat result = calculate_gelu_core<APPROXIMATION_MODE>(in);
+        // sfpi::vFloat in = sfpi::dst_reg[0];
+        // sfpi::vFloat result = calculate_gelu_core<APPROXIMATION_MODE>(in);
 
-        // vFloat half_in = in * half;
+        // sfpi::vFloat half_in = in * half;
         // result = lut(result, l0, l1, l2);
         // result = half_in * result + half_in;
 
-        // dst_reg[0] = result;
+        // sfpi::dst_reg[0] = result;
 
-        vFloat in      = dst_reg[0];
-        vFloat half    = vConstFloatPrgm0;
-        vFloat half_in = in * half;
-        vFloat result  = lut2_sign(in, l0, l1, l2, l4, l5, l6);
+        sfpi::vFloat in      = sfpi::dst_reg[0];
+        sfpi::vFloat half    = vConstFloatPrgm0;
+        sfpi::vFloat half_in = in * half;
+        sfpi::vFloat result  = lut2_sign(in, l0, l1, l2, l4, l5, l6);
         result         = half_in + result;
 
-        dst_reg[0] = result;
+        sfpi::dst_reg[0] = result;
 
-        dst_reg++;
+        sfpi::dst_reg++;
 
-        // dst_reg++;
+        // sfpi::dst_reg++;
         // TTI_SFPLOAD(3, 0, 1/*load addr mode*/,0);    // load from dest
         ////TTI_SFPMUL(3,11,9,7,0);           // lreg7 = 0.5*lreg3
         // TTI_SFPLUTFP32(7, 2);                // lreg7= LUT(3)
@@ -102,15 +102,15 @@ inline void _calculate_gelu_derivative_(const int iterations)
 #pragma GCC unroll 0
         for (int d = 0; d < iterations; d++)
         {
-            vFloat val = dst_reg[0];
+            sfpi::vFloat val = sfpi::dst_reg[0];
             val        = lut2(val, l0, l1, l2, l4, l5, l6, lut_mode);
             v_if (val < 0.0F)
             {
                 val = val + 1.0f;
             }
             v_endif;
-            dst_reg[0] = val;
-            dst_reg++;
+            sfpi::dst_reg[0] = val;
+            sfpi::dst_reg++;
         }
 
         l_reg[LRegs::LReg0] = l0;
@@ -131,21 +131,21 @@ inline void _calculate_gelu_derivative_(const int iterations)
 #pragma GCC unroll 0
         for (int d = 0; d < iterations; d++)
         {
-            vFloat in             = dst_reg[0];
-            vFloat neg_half_sq_in = in * in * -0.5f;
+            sfpi::vFloat in             = sfpi::dst_reg[0];
+            sfpi::vFloat neg_half_sq_in = in * in * -0.5f;
 
             // exp = e^(val)
-            vFloat exp = _calculate_exponential_body_<false>(neg_half_sq_in);
+            sfpi::vFloat exp = _calculate_exponential_body_<false>(neg_half_sq_in);
 
             // exp = exp * 1/sqrt(2*pi)
-            vFloat partial = exp * in * s2vFloat16b(0.3989423F);
+            sfpi::vFloat partial = exp * in * s2sfpi::vFloat16b(0.3989423F);
 
-            vFloat result = _calculate_gelu_core_<true>(in);
+            sfpi::vFloat result = _calculate_gelu_core_<true>(in);
 
             result = lut(result, l0, l1, imm2);
 
-            dst_reg[0] = partial + result + 0.5f;
-            dst_reg++;
+            sfpi::dst_reg[0] = partial + result + 0.5f;
+            sfpi::dst_reg++;
         }
 
         l_reg[LRegs::LReg0] = l0;

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_hardtanh.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_hardtanh.h
@@ -20,14 +20,14 @@ inline void _calculate_hardtanh_(const int iterations, uint param0, uint param1,
     // param1 = -(pos_threshold - neg_threshold)
     // param2 = -(pos_threshold)
 
-    vFloat p0 = s2vFloat16(param0);
-    vFloat p1 = s2vFloat16(param1);
-    vFloat p2 = s2vFloat16(param2);
+    sfpi::vFloat p0 = s2sfpi::vFloat16(param0);
+    sfpi::vFloat p1 = s2sfpi::vFloat16(param1);
+    sfpi::vFloat p2 = s2sfpi::vFloat16(param2);
 // SFPU microcode
 #pragma GCC unroll 0
     for (int d = 0; d < iterations; d++)
     {
-        vFloat val = dst_reg[0];
+        sfpi::vFloat val = sfpi::dst_reg[0];
 
         val += p0; // 12 bits
         v_if (val < 0.0f)
@@ -45,9 +45,9 @@ inline void _calculate_hardtanh_(const int iterations, uint param0, uint param1,
 
         val += p2; // 12 bits
 
-        dst_reg[0] = val;
+        sfpi::dst_reg[0] = val;
 
-        dst_reg++;
+        sfpi::dst_reg++;
     }
 }
 

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_hardtanh.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_hardtanh.h
@@ -4,11 +4,8 @@
 
 #pragma once
 
-#include "ckernel.h"
-#include "ckernel_defs.h"
 #include "sfpi.h"
-
-using namespace sfpi;
+#include "sfpi_fp16.h"
 
 namespace ckernel
 {

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_hardtanh.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_hardtanh.h
@@ -20,9 +20,9 @@ inline void _calculate_hardtanh_(const int iterations, uint param0, uint param1,
     // param1 = -(pos_threshold - neg_threshold)
     // param2 = -(pos_threshold)
 
-    sfpi::vFloat p0 = s2sfpi::vFloat16(param0);
-    sfpi::vFloat p1 = s2sfpi::vFloat16(param1);
-    sfpi::vFloat p2 = s2sfpi::vFloat16(param2);
+    sfpi::vFloat p0 = sfpi::s2vFloat16(param0);
+    sfpi::vFloat p1 = sfpi::s2vFloat16(param1);
+    sfpi::vFloat p2 = sfpi::s2vFloat16(param2);
 // SFPU microcode
 #pragma GCC unroll 0
     for (int d = 0; d < iterations; d++)

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_is_fp16_zero.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_is_fp16_zero.h
@@ -11,7 +11,7 @@ namespace ckernel
 namespace sfpu
 {
 
-sfpi_inline vInt _sfpu_is_fp16_zero_(const vFloat& v, uint exponent_size_8)
+sfpi_inline vInt _sfpu_is_fp16_zero_(const sfpi::vFloat& v, uint exponent_size_8)
 {
     if (exponent_size_8)
     {

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_is_fp16_zero.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_is_fp16_zero.h
@@ -4,11 +4,7 @@
 
 #pragma once
 
-#include "ckernel.h"
-#include "ckernel_defs.h"
 #include "sfpi.h"
-
-using namespace sfpi;
 
 namespace ckernel
 {

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_is_fp16_zero.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_is_fp16_zero.h
@@ -11,7 +11,7 @@ namespace ckernel
 namespace sfpu
 {
 
-sfpi_inline vInt _sfpu_is_fp16_zero_(const sfpi::vFloat& v, uint exponent_size_8)
+sfpi_inline sfpi::vInt _sfpu_is_fp16_zero_(const sfpi::vFloat& v, uint exponent_size_8)
 {
     if (exponent_size_8)
     {
@@ -23,8 +23,8 @@ sfpi_inline vInt _sfpu_is_fp16_zero_(const sfpi::vFloat& v, uint exponent_size_8
         // fp16a
         // if math data format is fp16, SFPU will convert 5 bit exp to 8 bit exp
         // in grayskull, this unconditionally adds bias value to exp (even for zero)
-        vInt tmp = 0x3800; // loads {0, 8'd112, 10'b0}
-        tmp += reinterpret<vInt>(v);
+        sfpi::vInt tmp = 0x3800; // loads {0, 8'd112, 10'b0}
+        tmp += sfpi::reinterpret<sfpi::vInt>(v);
 
         return tmp == 0;
     }

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_load_config.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_load_config.h
@@ -4,11 +4,8 @@
 
 #pragma once
 
-#include "ckernel.h"
-#include "ckernel_defs.h"
 #include "sfpi.h"
-
-using namespace sfpi;
+#include "ckernel_ops.h"
 
 namespace ckernel
 {

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_load_config.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_load_config.h
@@ -4,8 +4,8 @@
 
 #pragma once
 
-#include "sfpi.h"
 #include "ckernel_ops.h"
+#include "sfpi.h"
 
 namespace ckernel
 {

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_log.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_log.h
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
- 
+
 #include "sfpi.h"
 #include "sfpi_fp16.h"
 

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_log.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_log.h
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
-
+ 
 #include "sfpi.h"
 #include "sfpi_fp16.h"
 
@@ -34,28 +34,28 @@ sfpi_inline void _calculate_log_body_(const uint log_base_scale_factor)
     // D' = -A + B - C + D
     // A':0.1058, B':-0.7116, C':2.0871, D':-1.4753
     ////////////////////////////
-    sfpi::vFloat a = vConstFloatPrgm1;
-    sfpi::vFloat b = vConstFloatPrgm2;
+    sfpi::vFloat a = sfpi::vConstFloatPrgm1;
+    sfpi::vFloat b = sfpi::vConstFloatPrgm2;
     // XXXXX try variants of the below: B'=.7122, C'=2.0869
     sfpi::vFloat series_result = x * (x * (x * a + b) + 2.0871) + -1.4753f;
 
     ////////////////////////////
     // Convert exponent to float
     ////////////////////////////
-    vInt exp = exexp(in);
+    sfpi::vInt exp = sfpi::exexp(in);
     v_if (exp < 0)
     {
-        exp = setsgn(~exp + 1, 1);
+        exp = sfpi::setsgn(~exp + 1, 1);
     }
     v_endif;
 
     sfpi::vFloat expf      = int32_to_float(exp, 0);
-    sfpi::vFloat vConstLn2 = vConstFloatPrgm0;
+    sfpi::vFloat vConstLn2 = sfpi::vConstFloatPrgm0;
     sfpi::vFloat result    = expf * vConstLn2 + series_result; // exp correction: ln(1+x) + exp*ln(2)
 
     if constexpr (HAS_BASE_SCALING)
     {
-        result *= s2sfpi::vFloat16a(log_base_scale_factor);
+        result *= sfpi::s2vFloat16a(log_base_scale_factor);
     }
 
     ////////////////////////////
@@ -84,11 +84,11 @@ inline void _calculate_log_(const int iterations, uint log_base_scale_factor)
 template <bool APPROXIMATION_MODE>
 inline void _init_log_()
 {
-    vConstFloatPrgm0 = 0.692871f; // ln2
+    sfpi::vConstFloatPrgm0 = 0.692871f; // ln2
 
     // XXXXX could do these to higher precision
-    vConstFloatPrgm1 = 0.1058f;
-    vConstFloatPrgm2 = -0.7166f;
+    sfpi::vConstFloatPrgm1 = 0.1058f;
+    sfpi::vConstFloatPrgm2 = -0.7166f;
 }
 
 } // namespace sfpu

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_log.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_log.h
@@ -4,11 +4,8 @@
 
 #pragma once
 
-#include "ckernel.h"
-#include "ckernel_defs.h"
 #include "sfpi.h"
-
-using namespace sfpi;
+#include "sfpi_fp16.h"
 
 namespace ckernel
 {

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_log.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_log.h
@@ -18,8 +18,8 @@ sfpi_inline void _calculate_log_body_(const uint log_base_scale_factor)
     ////////////////////////////
     // Load From dest + "normalize to calculation range"
     ////////////////////////////
-    vFloat in = dst_reg[0];
-    vFloat x  = setexp(in, 127); // set exp to exp bias (put in range of 1-2)
+    sfpi::vFloat in = sfpi::dst_reg[0];
+    sfpi::vFloat x  = setexp(in, 127); // set exp to exp bias (put in range of 1-2)
 
     // XXXXXX ask Namal? if we can derive the coefficients below to higher precision
     ////////////////////////////
@@ -34,10 +34,10 @@ sfpi_inline void _calculate_log_body_(const uint log_base_scale_factor)
     // D' = -A + B - C + D
     // A':0.1058, B':-0.7116, C':2.0871, D':-1.4753
     ////////////////////////////
-    vFloat a = vConstFloatPrgm1;
-    vFloat b = vConstFloatPrgm2;
+    sfpi::vFloat a = vConstFloatPrgm1;
+    sfpi::vFloat b = vConstFloatPrgm2;
     // XXXXX try variants of the below: B'=.7122, C'=2.0869
-    vFloat series_result = x * (x * (x * a + b) + 2.0871) + -1.4753f;
+    sfpi::vFloat series_result = x * (x * (x * a + b) + 2.0871) + -1.4753f;
 
     ////////////////////////////
     // Convert exponent to float
@@ -49,13 +49,13 @@ sfpi_inline void _calculate_log_body_(const uint log_base_scale_factor)
     }
     v_endif;
 
-    vFloat expf      = int32_to_float(exp, 0);
-    vFloat vConstLn2 = vConstFloatPrgm0;
-    vFloat result    = expf * vConstLn2 + series_result; // exp correction: ln(1+x) + exp*ln(2)
+    sfpi::vFloat expf      = int32_to_float(exp, 0);
+    sfpi::vFloat vConstLn2 = vConstFloatPrgm0;
+    sfpi::vFloat result    = expf * vConstLn2 + series_result; // exp correction: ln(1+x) + exp*ln(2)
 
     if constexpr (HAS_BASE_SCALING)
     {
-        result *= s2vFloat16a(log_base_scale_factor);
+        result *= s2sfpi::vFloat16a(log_base_scale_factor);
     }
 
     ////////////////////////////
@@ -67,7 +67,7 @@ sfpi_inline void _calculate_log_body_(const uint log_base_scale_factor)
     }
     v_endif;
 
-    dst_reg[0] = result;
+    sfpi::dst_reg[0] = result;
 }
 
 template <bool APPROXIMATION_MODE, bool HAS_BASE_SCALING, int ITERATIONS>
@@ -77,7 +77,7 @@ inline void _calculate_log_(const int iterations, uint log_base_scale_factor)
     for (int d = 0; d < iterations; d++)
     {
         _calculate_log_body_<HAS_BASE_SCALING>(log_base_scale_factor);
-        dst_reg++;
+        sfpi::dst_reg++;
     }
 }
 

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_max.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_max.h
@@ -16,15 +16,15 @@ inline void _calculate_max_(const int iterations)
 {
     for (int d = 0; d < iterations; d++)
     {
-        vFloat a = dst_reg[0];
-        vFloat b = dst_reg[32];
+        sfpi::vFloat a = sfpi::dst_reg[0];
+        sfpi::vFloat b = sfpi::dst_reg[32];
         v_if (a < b)
         {
-            dst_reg[0] = b;
+            sfpi::dst_reg[0] = b;
         }
         v_endif;
 
-        dst_reg++;
+        sfpi::dst_reg++;
     }
 }
 

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_max.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_max.h
@@ -4,11 +4,7 @@
 
 #pragma once
 
-#include "ckernel.h"
-#include "ckernel_defs.h"
 #include "sfpi.h"
-
-using namespace sfpi;
 
 namespace ckernel
 {

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_max_int32.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_max_int32.h
@@ -4,11 +4,8 @@
 
 #pragma once
 
-#include "ckernel.h"
-#include "ckernel_defs.h"
-#include "sfpi.h"
-
-using namespace sfpi;
+#include "ckernel_ops.h"
+#include "ckernel_addrmod.h"
 
 namespace ckernel
 {

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_max_int32.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_max_int32.h
@@ -4,8 +4,8 @@
 
 #pragma once
 
-#include "ckernel_ops.h"
 #include "ckernel_addrmod.h"
+#include "ckernel_ops.h"
 
 namespace ckernel
 {

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_max_int32.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_max_int32.h
@@ -43,7 +43,7 @@ inline void _calculate_max_int32_(const int iterations)
         TTI_SFPSTORE(0, INSTR_MOD_LOAD_STORE, ADDR_MOD_7, 0);
 
         TTI_SFPENCC(0x003, 0, 0, 10);
-        dst_reg++;
+        sfpi::dst_reg++;
     }
 }
 

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_power.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_power.h
@@ -16,16 +16,16 @@ inline void _calculate_power_(const int iterations, uint exponent)
 {
     for (int d = 0; d < iterations; d++)
     {
-        vFloat in     = dst_reg[0];
-        vFloat result = in * in;
+        sfpi::vFloat in     = sfpi::dst_reg[0];
+        sfpi::vFloat result = in * in;
         for (uint i = 2; i < exponent; i++)
         {
             result *= in;
         }
 
-        dst_reg[0] = result;
+        sfpi::dst_reg[0] = result;
 
-        dst_reg++;
+        sfpi::dst_reg++;
     }
 }
 

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_power.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_power.h
@@ -4,11 +4,7 @@
 
 #pragma once
 
-#include "ckernel.h"
-#include "ckernel_defs.h"
 #include "sfpi.h"
-
-using namespace sfpi;
 
 namespace ckernel
 {

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_quant.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_quant.h
@@ -42,7 +42,7 @@ inline void _quant_int32_(const uint dst_offset)
             TTI_SFPSETSGN(0, 4, 0, 0);
         }
         TTI_SFPSTORE(0, InstrModLoadStore::INT32_2S_COMP, ADDR_MOD_7, 0);
-        dst_reg++;
+        sfpi::dst_reg++;
     }
 }
 
@@ -82,7 +82,7 @@ inline void _requant_int32_(const uint dst_offset)
             TTI_SFPSETSGN(0, 4, 0, 0);
         }
         TTI_SFPSTORE(0, InstrModLoadStore::INT32_2S_COMP, ADDR_MOD_7, 0);
-        dst_reg++;
+        sfpi::dst_reg++;
     }
 }
 
@@ -116,7 +116,7 @@ inline void _dequant_int32_(const uint dst_offset)
         TTI_NOP;
         // LREG_0 -> dest as fp32
         TTI_SFPSTORE(0, 3, ADDR_MOD_7, 0);
-        dst_reg++;
+        sfpi::dst_reg++;
     }
 }
 

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_quant.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_quant.h
@@ -4,12 +4,10 @@
 
 #pragma once
 
-#include "ckernel.h"
-#include "ckernel_defs.h"
-#include "ckernel_sfpu_load_config.h"
 #include "sfpi.h"
-
-using namespace sfpi;
+#include "ckernel_ops.h"
+#include "ckernel_sfpu_load_config.h"
+#include "ckernel_addrmod.h"
 
 namespace ckernel
 {

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_quant.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_quant.h
@@ -4,10 +4,10 @@
 
 #pragma once
 
-#include "sfpi.h"
+#include "ckernel_addrmod.h"
 #include "ckernel_ops.h"
 #include "ckernel_sfpu_load_config.h"
-#include "ckernel_addrmod.h"
+#include "sfpi.h"
 
 namespace ckernel
 {

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_recip.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_recip.h
@@ -19,8 +19,8 @@ sfpi_inline sfpi::vFloat _sfpu_reciprocal_(const sfpi::vFloat in)
 
     val = setexp(val, 126); // Set exponent to 126 to make the number in 0.5-1
     // Use 1.44 as first guess at x, ideal value would be 1.33, but we happen to have 1.44 available, so use that to avoid a load
-    sfpi::vFloat vConstLn2Recip = vConstFloatPrgm0;
-    sfpi::vFloat two            = vConstFloatPrgm1;
+    sfpi::vFloat vConstLn2Recip = sfpi::vConstFloatPrgm0;
+    sfpi::vFloat two            = sfpi::vConstFloatPrgm1;
     sfpi::vFloat result         = vConstLn2Recip * (val * vConstLn2Recip + two);
 
     for (int s_iter = 0; s_iter < (max_iter - 1); s_iter++)
@@ -28,8 +28,8 @@ sfpi_inline sfpi::vFloat _sfpu_reciprocal_(const sfpi::vFloat in)
         result = result * (val * result + two);
     }
 
-    vInt orig_exp = exexp(in);
-    vInt new_exp  = exexp(result);
+    sfpi::vInt orig_exp = exexp(in);
+    sfpi::vInt new_exp  = exexp(result);
 
     // "Subtract" exponents, and re-bias.
     // Execute: -1 - exp, then exp += 127
@@ -81,8 +81,8 @@ inline void _calculate_reciprocal_(const int iterations)
 template <bool APPROXIMATION_MODE>
 inline void _init_reciprocal_()
 {
-    vConstFloatPrgm0 = 1.442695f; // ln2_recip
-    vConstFloatPrgm1 = 2.0f;
+    sfpi::vConstFloatPrgm0 = 1.442695f; // ln2_recip
+    sfpi::vConstFloatPrgm1 = 2.0f;
 }
 
 } // namespace sfpu

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_recip.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_recip.h
@@ -12,16 +12,16 @@ namespace sfpu
 {
 
 template <int max_iter = 3>
-sfpi_inline vFloat _sfpu_reciprocal_(const vFloat in)
+sfpi_inline sfpi::vFloat _sfpu_reciprocal_(const sfpi::vFloat in)
 {
     // Force sign to 1 (make number negative)
-    vFloat val = setsgn(in, 1);
+    sfpi::vFloat val = setsgn(in, 1);
 
     val = setexp(val, 126); // Set exponent to 126 to make the number in 0.5-1
     // Use 1.44 as first guess at x, ideal value would be 1.33, but we happen to have 1.44 available, so use that to avoid a load
-    vFloat vConstLn2Recip = vConstFloatPrgm0;
-    vFloat two            = vConstFloatPrgm1;
-    vFloat result         = vConstLn2Recip * (val * vConstLn2Recip + two);
+    sfpi::vFloat vConstLn2Recip = vConstFloatPrgm0;
+    sfpi::vFloat two            = vConstFloatPrgm1;
+    sfpi::vFloat result         = vConstLn2Recip * (val * vConstLn2Recip + two);
 
     for (int s_iter = 0; s_iter < (max_iter - 1); s_iter++)
     {
@@ -55,8 +55,8 @@ inline void _calculate_reciprocal_(const int iterations)
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
     {
-        vFloat in  = dst_reg[0];
-        vFloat out = _sfpu_reciprocal_<APPROXIMATION_MODE ? 2 : 3>(in);
+        sfpi::vFloat in  = sfpi::dst_reg[0];
+        sfpi::vFloat out = _sfpu_reciprocal_<APPROXIMATION_MODE ? 2 : 3>(in);
 
         v_if (in < 0.0F)
         {
@@ -67,14 +67,14 @@ inline void _calculate_reciprocal_(const int iterations)
 
         if constexpr (APPROXIMATION_MODE)
         {
-            dst_reg[0] = out;
+            sfpi::dst_reg[0] = out;
         }
         else
         {
-            dst_reg[0] = reinterpret<vFloat>(float_to_fp16b(out, 0));
+            sfpi::dst_reg[0] = reinterpret<sfpi::vFloat>(float_to_fp16b(out, 0));
         }
 
-        dst_reg++;
+        sfpi::dst_reg++;
     }
 }
 

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_recip.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_recip.h
@@ -15,7 +15,7 @@ template <int max_iter = 3>
 sfpi_inline sfpi::vFloat _sfpu_reciprocal_(const sfpi::vFloat in)
 {
     // Force sign to 1 (make number negative)
-    sfpi::vFloat val = setsgn(in, 1);
+    sfpi::vFloat val = sfpi::setsgn(in, 1);
 
     val = setexp(val, 126); // Set exponent to 126 to make the number in 0.5-1
     // Use 1.44 as first guess at x, ideal value would be 1.33, but we happen to have 1.44 available, so use that to avoid a load
@@ -71,7 +71,7 @@ inline void _calculate_reciprocal_(const int iterations)
         }
         else
         {
-            sfpi::dst_reg[0] = reinterpret<sfpi::vFloat>(float_to_fp16b(out, 0));
+            sfpi::dst_reg[0] = sfpi::reinterpret<sfpi::vFloat>(float_to_fp16b(out, 0));
         }
 
         sfpi::dst_reg++;

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_recip.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_recip.h
@@ -4,11 +4,7 @@
 
 #pragma once
 
-#include "ckernel.h"
-#include "ckernel_defs.h"
 #include "sfpi.h"
-
-using namespace sfpi;
 
 namespace ckernel
 {

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_relu.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_relu.h
@@ -4,12 +4,9 @@
 
 #pragma once
 
-#include "ckernel.h"
-#include "ckernel_defs.h"
-#include "ckernel_sfpu_converter.h"
 #include "sfpi.h"
-
-using namespace sfpi;
+#include "sfpi_fp16.h"
+#include "ckernel_sfpu_converter.h"
 
 namespace ckernel
 {

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_relu.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_relu.h
@@ -4,9 +4,9 @@
 
 #pragma once
 
+#include "ckernel_sfpu_converter.h"
 #include "sfpi.h"
 #include "sfpi_fp16.h"
-#include "ckernel_sfpu_converter.h"
 
 namespace ckernel
 {

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_relu.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_relu.h
@@ -16,12 +16,12 @@ namespace sfpu
 template <bool APPROXIMATION_MODE>
 inline void _calculate_lrelu_(const int iterations, uint slope)
 {
-    vFloat s = Converter::to_float(slope);
+    sfpi::vFloat s = Converter::to_float(slope);
 
 #pragma GCC unroll 0
     for (int d = 0; d < iterations; d++)
     {
-        vFloat v = dst_reg[0];
+        sfpi::vFloat v = sfpi::dst_reg[0];
 
         v_if (v < 0.0f)
         {
@@ -29,19 +29,19 @@ inline void _calculate_lrelu_(const int iterations, uint slope)
         }
         v_endif;
 
-        dst_reg[0] = v;
+        sfpi::dst_reg[0] = v;
 
-        dst_reg++;
+        sfpi::dst_reg++;
     }
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void _relu_max_(const int iterations, uint uint_threshold)
 {
-    vFloat threshold = s2vFloat16(uint_threshold, s2vFloat16::fp16a);
+    sfpi::vFloat threshold = s2sfpi::vFloat16(uint_threshold, s2sfpi::vFloat16::fp16a);
     for (int d = 0; d < iterations; d++)
     {
-        vFloat a = dst_reg[0];
+        sfpi::vFloat a = sfpi::dst_reg[0];
         v_if (a > threshold)
         {
             a = threshold;
@@ -52,25 +52,25 @@ inline void _relu_max_(const int iterations, uint uint_threshold)
             a = 0.0f;
         }
         v_endif;
-        dst_reg[0] = a;
-        dst_reg++;
+        sfpi::dst_reg[0] = a;
+        sfpi::dst_reg++;
     }
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void _relu_min_(const int iterations, uint uint_threshold)
 {
-    vFloat threshold = s2vFloat16(uint_threshold, s2vFloat16::fp16a);
+    sfpi::vFloat threshold = s2sfpi::vFloat16(uint_threshold, s2sfpi::vFloat16::fp16a);
     for (int d = 0; d < iterations; d++)
     {
-        vFloat a = dst_reg[0];
+        sfpi::vFloat a = sfpi::dst_reg[0];
         v_if (a < threshold)
         {
             a = 0.0f;
         }
         v_endif;
-        dst_reg[0] = a;
-        dst_reg++;
+        sfpi::dst_reg[0] = a;
+        sfpi::dst_reg++;
     }
 }
 

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_relu.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_relu.h
@@ -38,7 +38,7 @@ inline void _calculate_lrelu_(const int iterations, uint slope)
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void _relu_max_(const int iterations, uint uint_threshold)
 {
-    sfpi::vFloat threshold = s2sfpi::vFloat16(uint_threshold, s2sfpi::vFloat16::fp16a);
+    sfpi::vFloat threshold = sfpi::s2vFloat16(uint_threshold, sfpi::s2vFloat16::fp16a);
     for (int d = 0; d < iterations; d++)
     {
         sfpi::vFloat a = sfpi::dst_reg[0];
@@ -60,7 +60,7 @@ inline void _relu_max_(const int iterations, uint uint_threshold)
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void _relu_min_(const int iterations, uint uint_threshold)
 {
-    sfpi::vFloat threshold = s2sfpi::vFloat16(uint_threshold, s2sfpi::vFloat16::fp16a);
+    sfpi::vFloat threshold = sfpi::s2vFloat16(uint_threshold, sfpi::s2vFloat16::fp16a);
     for (int d = 0; d < iterations; d++)
     {
         sfpi::vFloat a = sfpi::dst_reg[0];

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_shift.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_shift.h
@@ -4,12 +4,9 @@
 
 #pragma once
 
-#include "ckernel.h"
-#include "ckernel_defs.h"
-#include "noc_nonblocking_api.h"
 #include "sfpi.h"
-
-using namespace sfpi;
+#include "ckernel_ops.h"
+#include "ckernel_addrmod.h"
 
 namespace ckernel
 {

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_shift.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_shift.h
@@ -33,7 +33,7 @@ inline void _calculate_binary_left_shift_(const uint dst_offset)
         TTI_SFPSHFT(0, 1, 0, 0);
         // store result
         TTI_SFPSTORE(0, 12, ADDR_MOD_7, 0);
-        dst_reg++;
+        sfpi::dst_reg++;
     }
 }
 
@@ -61,7 +61,7 @@ inline void _calculate_binary_right_shift_(const uint dst_offset)
         TTI_SFPENCC(0, 0, 0, 0);
         // store result
         TTI_SFPSTORE(0, 12, ADDR_MOD_7, 0);
-        dst_reg++;
+        sfpi::dst_reg++;
     }
 }
 

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_shift.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_shift.h
@@ -4,9 +4,9 @@
 
 #pragma once
 
-#include "sfpi.h"
-#include "ckernel_ops.h"
 #include "ckernel_addrmod.h"
+#include "ckernel_ops.h"
+#include "sfpi.h"
 
 namespace ckernel
 {

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_sigmoid.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_sigmoid.h
@@ -4,8 +4,8 @@
 
 #pragma once
 
-#include "sfpi.h"
 #include "ckernel_sfpu_load_config.h"
+#include "sfpi.h"
 
 namespace ckernel
 {
@@ -16,12 +16,12 @@ template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void _calculate_sigmoid_(const int iterations)
 {
     constexpr int lut_mode = 0; // SFPLUTFP32_MOD0_FP16_6ENTRY_TABLE1
-    vUInt l0               = l_reg[LRegs::LReg0];
-    vUInt l1               = l_reg[LRegs::LReg1];
-    vUInt l2               = l_reg[LRegs::LReg2];
-    vUInt l4               = l_reg[LRegs::LReg4];
-    vUInt l5               = l_reg[LRegs::LReg5];
-    vUInt l6               = l_reg[LRegs::LReg6];
+    sfpi::vUInt l0         = sfpi::l_reg[sfpi::LRegs::LReg0];
+    sfpi::vUInt l1         = sfpi::l_reg[sfpi::LRegs::LReg1];
+    sfpi::vUInt l2         = sfpi::l_reg[sfpi::LRegs::LReg2];
+    sfpi::vUInt l4         = sfpi::l_reg[sfpi::LRegs::LReg4];
+    sfpi::vUInt l5         = sfpi::l_reg[sfpi::LRegs::LReg5];
+    sfpi::vUInt l6         = sfpi::l_reg[sfpi::LRegs::LReg6];
 
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
@@ -33,12 +33,12 @@ inline void _calculate_sigmoid_(const int iterations)
         sfpi::dst_reg++;
     }
 
-    l_reg[LRegs::LReg0] = l0;
-    l_reg[LRegs::LReg1] = l1;
-    l_reg[LRegs::LReg2] = l2;
-    l_reg[LRegs::LReg4] = l4;
-    l_reg[LRegs::LReg5] = l5;
-    l_reg[LRegs::LReg6] = l6;
+    sfpi::l_reg[sfpi::LRegs::LReg0] = l0;
+    sfpi::l_reg[sfpi::LRegs::LReg1] = l1;
+    sfpi::l_reg[sfpi::LRegs::LReg2] = l2;
+    sfpi::l_reg[sfpi::LRegs::LReg4] = l4;
+    sfpi::l_reg[sfpi::LRegs::LReg5] = l5;
+    sfpi::l_reg[sfpi::LRegs::LReg6] = l6;
 }
 
 template <bool APPROXIMATION_MODE>

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_sigmoid.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_sigmoid.h
@@ -4,12 +4,8 @@
 
 #pragma once
 
-#include "ckernel.h"
-#include "ckernel_defs.h"
-#include "ckernel_sfpu_load_config.h"
 #include "sfpi.h"
-
-using namespace sfpi;
+#include "ckernel_sfpu_load_config.h"
 
 namespace ckernel
 {

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_sigmoid.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_sigmoid.h
@@ -26,11 +26,11 @@ inline void _calculate_sigmoid_(const int iterations)
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
     {
-        vFloat val = dst_reg[0];
+        sfpi::vFloat val = sfpi::dst_reg[0];
 
-        dst_reg[0] = lut2(val, l0, l1, l2, l4, l5, l6, lut_mode) + 0.5f;
+        sfpi::dst_reg[0] = lut2(val, l0, l1, l2, l4, l5, l6, lut_mode) + 0.5f;
 
-        dst_reg++;
+        sfpi::dst_reg++;
     }
 
     l_reg[LRegs::LReg0] = l0;

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_sign.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_sign.h
@@ -20,11 +20,11 @@ inline void _calculate_sign_(const int iterations, uint exponent_size_8)
 #pragma GCC unroll 0
     for (int d = 0; d < iterations; d++)
     {
-        vFloat v   = dst_reg[0];
-        dst_reg[0] = vConst1;
+        sfpi::vFloat v   = sfpi::dst_reg[0];
+        sfpi::dst_reg[0] = vConst1;
         v_if (v < 0.0F)
         {
-            dst_reg[0] = vConstNeg1;
+            sfpi::dst_reg[0] = vConstNeg1;
         }
         v_endif;
 
@@ -32,11 +32,11 @@ inline void _calculate_sign_(const int iterations, uint exponent_size_8)
         // param0 != 0 is Float16 format and exp bias needs to be removed for zero check.
         v_if (_sfpu_is_fp16_zero_(v, exponent_size_8))
         {
-            dst_reg[0] = vConst0;
+            sfpi::dst_reg[0] = vConst0;
         }
         v_endif;
 
-        dst_reg++;
+        sfpi::dst_reg++;
     }
 }
 

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_sign.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_sign.h
@@ -4,12 +4,8 @@
 
 #pragma once
 
-#include "ckernel.h"
-#include "ckernel_defs.h"
-#include "ckernel_sfpu_is_fp16_zero.h"
 #include "sfpi.h"
-
-using namespace sfpi;
+#include "ckernel_sfpu_is_fp16_zero.h"
 
 namespace ckernel
 {

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_sign.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_sign.h
@@ -4,8 +4,8 @@
 
 #pragma once
 
-#include "sfpi.h"
 #include "ckernel_sfpu_is_fp16_zero.h"
+#include "sfpi.h"
 
 namespace ckernel
 {
@@ -21,10 +21,10 @@ inline void _calculate_sign_(const int iterations, uint exponent_size_8)
     for (int d = 0; d < iterations; d++)
     {
         sfpi::vFloat v   = sfpi::dst_reg[0];
-        sfpi::dst_reg[0] = vConst1;
+        sfpi::dst_reg[0] = sfpi::vConst1;
         v_if (v < 0.0F)
         {
-            sfpi::dst_reg[0] = vConstNeg1;
+            sfpi::dst_reg[0] = sfpi::vConstNeg1;
         }
         v_endif;
 
@@ -32,7 +32,7 @@ inline void _calculate_sign_(const int iterations, uint exponent_size_8)
         // param0 != 0 is Float16 format and exp bias needs to be removed for zero check.
         v_if (_sfpu_is_fp16_zero_(v, exponent_size_8))
         {
-            sfpi::dst_reg[0] = vConst0;
+            sfpi::dst_reg[0] = sfpi::vConst0;
         }
         v_endif;
 

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_sqrt.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_sqrt.h
@@ -22,15 +22,15 @@ inline void _calculate_sqrt_(const int iterations)
 
         if constexpr (APPROXIMATION_MODE)
         {
-            vUInt magic = vConstIntPrgm0;
+            sfpi::vUInt magic = sfpi::vConstIntPrgm0;
 
             // sqrt initial approximation
             //  adjust bias
-            vUInt val_s = magic + reinterpret<vUInt>(val);
+            sfpi::vUInt val_s = magic + sfpi::reinterpret<sfpi::vUInt>(val);
 
             // approximation of square root
             val_s >>= 1;
-            sfpi::dst_reg[0] = reinterpret<sfpi::vFloat>(val_s);
+            sfpi::dst_reg[0] = sfpi::reinterpret<sfpi::vFloat>(val_s);
         }
         else
         {
@@ -39,8 +39,8 @@ inline void _calculate_sqrt_(const int iterations)
             // u.i = SQRT_MAGIC_F - (u.i >> 1);
             v_if (val != 0.0f)
             {
-                vUInt magic   = vConstIntPrgm0;
-                sfpi::vFloat approx = reinterpret<sfpi::vFloat>(magic - (reinterpret<vUInt>(val) >> 1));
+                sfpi::vUInt magic   = sfpi::vConstIntPrgm0;
+                sfpi::vFloat approx = sfpi::reinterpret<sfpi::vFloat>(magic - (sfpi::reinterpret<sfpi::vUInt>(val) >> 1));
 
                 // Reciproot iterations
                 for (int r = 0; r < RECIPROCAL_ITERATIONS; r++)
@@ -63,11 +63,11 @@ inline void _init_sqrt_()
 {
     if (APPROXIMATION_MODE)
     {
-        vConstFloatPrgm0 = s2sfpi::vFloat16b(127 << 7);
+        sfpi::vConstFloatPrgm0 = sfpi::s2vFloat16b(127 << 7);
     }
     else
     {
-        vConstFloatPrgm0 = s2sfpi::vFloat16b(0x5f37);
+        sfpi::vConstFloatPrgm0 = sfpi::s2vFloat16b(0x5f37);
     }
 }
 

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_sqrt.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_sqrt.h
@@ -4,11 +4,8 @@
 
 #pragma once
 
-#include "ckernel.h"
-#include "ckernel_defs.h"
 #include "sfpi.h"
-
-using namespace sfpi;
+#include "sfpi_fp16.h"
 
 namespace ckernel
 {

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_sqrt.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_sqrt.h
@@ -18,7 +18,7 @@ inline void _calculate_sqrt_(const int iterations)
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
     {
-        vFloat val = dst_reg[0];
+        sfpi::vFloat val = sfpi::dst_reg[0];
 
         if constexpr (APPROXIMATION_MODE)
         {
@@ -30,7 +30,7 @@ inline void _calculate_sqrt_(const int iterations)
 
             // approximation of square root
             val_s >>= 1;
-            dst_reg[0] = reinterpret<vFloat>(val_s);
+            sfpi::dst_reg[0] = reinterpret<sfpi::vFloat>(val_s);
         }
         else
         {
@@ -40,7 +40,7 @@ inline void _calculate_sqrt_(const int iterations)
             v_if (val != 0.0f)
             {
                 vUInt magic   = vConstIntPrgm0;
-                vFloat approx = reinterpret<vFloat>(magic - (reinterpret<vUInt>(val) >> 1));
+                sfpi::vFloat approx = reinterpret<sfpi::vFloat>(magic - (reinterpret<vUInt>(val) >> 1));
 
                 // Reciproot iterations
                 for (int r = 0; r < RECIPROCAL_ITERATIONS; r++)
@@ -49,12 +49,12 @@ inline void _calculate_sqrt_(const int iterations)
                     approx = ((approx * approx) * (val * -0.5f) + 1.5f) * approx;
                 }
 
-                dst_reg[0] = approx * val;
+                sfpi::dst_reg[0] = approx * val;
             }
             v_endif;
         }
 
-        dst_reg++;
+        sfpi::dst_reg++;
     }
 }
 
@@ -63,11 +63,11 @@ inline void _init_sqrt_()
 {
     if (APPROXIMATION_MODE)
     {
-        vConstFloatPrgm0 = s2vFloat16b(127 << 7);
+        vConstFloatPrgm0 = s2sfpi::vFloat16b(127 << 7);
     }
     else
     {
-        vConstFloatPrgm0 = s2vFloat16b(0x5f37);
+        vConstFloatPrgm0 = s2sfpi::vFloat16b(0x5f37);
     }
 }
 

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_square.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_square.h
@@ -17,12 +17,12 @@ inline void _calculate_square_(const int iterations)
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
     {
-        vFloat in     = dst_reg[0];
-        vFloat result = in * in;
+        sfpi::vFloat in     = sfpi::dst_reg[0];
+        sfpi::vFloat result = in * in;
 
-        dst_reg[0] = result;
+        sfpi::dst_reg[0] = result;
 
-        dst_reg++;
+        sfpi::dst_reg++;
     }
 }
 

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_square.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_square.h
@@ -4,11 +4,7 @@
 
 #pragma once
 
-#include "ckernel.h"
-#include "ckernel_defs.h"
 #include "sfpi.h"
-
-using namespace sfpi;
 
 namespace ckernel
 {

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_sub_int32.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_sub_int32.h
@@ -4,11 +4,9 @@
 
 #pragma once
 
-#include "ckernel.h"
-#include "ckernel_defs.h"
 #include "sfpi.h"
-
-using namespace sfpi;
+#include "ckernel_ops.h"
+#include "ckernel_addrmod.h"
 
 namespace ckernel
 {

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_sub_int32.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_sub_int32.h
@@ -59,7 +59,7 @@ inline void _sub_int32_(const uint dst_offset)
             TTI_SFPSETSGN(0 /* imm */, 1 /*lreg_c*/, 0 /*ldest*/, 0 /*imod*/);
         }
         TTI_SFPSTORE(0, INSTR_MOD_LOAD_STORE, ADDR_MOD_7, 0);
-        dst_reg++;
+        sfpi::dst_reg++;
     }
 }
 

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_sub_int32.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_sub_int32.h
@@ -4,9 +4,9 @@
 
 #pragma once
 
-#include "sfpi.h"
-#include "ckernel_ops.h"
 #include "ckernel_addrmod.h"
+#include "ckernel_ops.h"
+#include "sfpi.h"
 
 namespace ckernel
 {

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_tanh.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_tanh.h
@@ -4,12 +4,8 @@
 
 #pragma once
 
-#include "ckernel.h"
-#include "ckernel_defs.h"
-#include "ckernel_sfpu_load_config.h"
 #include "sfpi.h"
-
-using namespace sfpi;
+#include "ckernel_sfpu_load_config.h"
 
 namespace ckernel
 {

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_tanh.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_tanh.h
@@ -23,11 +23,11 @@ inline void _calculate_tanh_(const int iterations)
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
     {
-        vFloat val = dst_reg[0];
+        sfpi::vFloat val = sfpi::dst_reg[0];
         val        = lut(val, l0, l1, l2);
-        dst_reg[0] = val;
+        sfpi::dst_reg[0] = val;
 
-        dst_reg++;
+        sfpi::dst_reg++;
     }
 
     l_reg[LRegs::LReg0] = l0;

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_tanh.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_tanh.h
@@ -4,8 +4,8 @@
 
 #pragma once
 
-#include "sfpi.h"
 #include "ckernel_sfpu_load_config.h"
+#include "sfpi.h"
 
 namespace ckernel
 {
@@ -16,23 +16,23 @@ template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void _calculate_tanh_(const int iterations)
 {
     // SFPU microcode
-    vUInt l0 = l_reg[LRegs::LReg0];
-    vUInt l1 = l_reg[LRegs::LReg1];
-    vUInt l2 = l_reg[LRegs::LReg2];
+    sfpi::vUInt l0 = sfpi::l_reg[sfpi::LRegs::LReg0];
+    sfpi::vUInt l1 = sfpi::l_reg[sfpi::LRegs::LReg1];
+    sfpi::vUInt l2 = sfpi::l_reg[sfpi::LRegs::LReg2];
 
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
     {
         sfpi::vFloat val = sfpi::dst_reg[0];
-        val        = lut(val, l0, l1, l2);
+        val              = lut(val, l0, l1, l2);
         sfpi::dst_reg[0] = val;
 
         sfpi::dst_reg++;
     }
 
-    l_reg[LRegs::LReg0] = l0;
-    l_reg[LRegs::LReg1] = l1;
-    l_reg[LRegs::LReg2] = l2;
+    sfpi::l_reg[sfpi::LRegs::LReg0] = l0;
+    sfpi::l_reg[sfpi::LRegs::LReg1] = l1;
+    sfpi::l_reg[sfpi::LRegs::LReg2] = l2;
 }
 
 template <bool APPROXIMATION_MODE>

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_tanh_derivative.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_tanh_derivative.h
@@ -4,11 +4,7 @@
 
 #pragma once
 
-#include "ckernel.h"
-#include "ckernel_defs.h"
 #include "sfpi.h"
-
-using namespace sfpi;
 
 namespace ckernel
 {

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_tanh_derivative.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_tanh_derivative.h
@@ -14,9 +14,9 @@ namespace sfpu
 template <bool APPROXIMATION_MODE, int WITH_PRECOMPUTED_TANH, int ITERATIONS>
 inline void _calculate_tanh_derivative_(const int iterations)
 {
-    vUInt l0 = l_reg[LRegs::LReg0];
-    vUInt l1 = l_reg[LRegs::LReg1];
-    vUInt l2 = l_reg[LRegs::LReg2];
+    sfpi::vUInt l0 = sfpi::l_reg[sfpi::LRegs::LReg0];
+    sfpi::vUInt l1 = sfpi::l_reg[sfpi::LRegs::LReg1];
+    sfpi::vUInt l2 = sfpi::l_reg[sfpi::LRegs::LReg2];
 
     // tanh'(x) = 1 - (tanh(x))^2
     for (int d = 0; d < iterations; d++)
@@ -28,15 +28,15 @@ inline void _calculate_tanh_derivative_(const int iterations)
             val = lut(val, l0, l1, l2);
         }
 
-        val        = val * (-val) + vConst1;
+        val              = val * (-val) + sfpi::vConst1;
         sfpi::dst_reg[0] = val;
 
         sfpi::dst_reg++;
     }
 
-    l_reg[LRegs::LReg0] = l0;
-    l_reg[LRegs::LReg1] = l1;
-    l_reg[LRegs::LReg2] = l2;
+    sfpi::l_reg[sfpi::LRegs::LReg0] = l0;
+    sfpi::l_reg[sfpi::LRegs::LReg1] = l1;
+    sfpi::l_reg[sfpi::LRegs::LReg2] = l2;
 }
 
 } // namespace sfpu

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_tanh_derivative.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_tanh_derivative.h
@@ -21,7 +21,7 @@ inline void _calculate_tanh_derivative_(const int iterations)
     // tanh'(x) = 1 - (tanh(x))^2
     for (int d = 0; d < iterations; d++)
     {
-        vFloat val = dst_reg[0];
+        sfpi::vFloat val = sfpi::dst_reg[0];
 
         if constexpr (!WITH_PRECOMPUTED_TANH)
         {
@@ -29,9 +29,9 @@ inline void _calculate_tanh_derivative_(const int iterations)
         }
 
         val        = val * (-val) + vConst1;
-        dst_reg[0] = val;
+        sfpi::dst_reg[0] = val;
 
-        dst_reg++;
+        sfpi::dst_reg++;
     }
 
     l_reg[LRegs::LReg0] = l0;

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_topk.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_topk.h
@@ -4,12 +4,12 @@
 
 #pragma once
 
-#include "ckernel.h"
-#include "ckernel_defs.h"
-#include "ckernel_sfpu_load_config.h"
 #include "sfpi.h"
-
-using namespace sfpi;
+#include "ckernel.h"
+#include "ckernel_ops.h"
+#include "ckernel_addrmod.h"
+#include "ckernel_instr_params.h"
+#include "ckernel_sfpu_load_config.h"
 
 namespace ckernel
 {

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_topk.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_topk.h
@@ -4,12 +4,12 @@
 
 #pragma once
 
-#include "sfpi.h"
 #include "ckernel.h"
-#include "ckernel_ops.h"
 #include "ckernel_addrmod.h"
 #include "ckernel_instr_params.h"
+#include "ckernel_ops.h"
 #include "ckernel_sfpu_load_config.h"
+#include "sfpi.h"
 
 namespace ckernel
 {

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_trigonometry.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_trigonometry.h
@@ -79,10 +79,10 @@ inline void _calculate_sine_(const int iterations)
     for (int d = 0; d < iterations; d++)
     {
         sfpi::vFloat v             = sfpi::dst_reg[0];
-        v                    = 0.318309886183791f * v; // *1/pi to get number of pi rads.
-        vInt whole_v         = float_to_int16(v, 0);
-        sfpi::vFloat whole_v_float = int32_to_float(whole_v, 0);
-        v                    = v - whole_v_float;
+        v                          = 0.318309886183791f * v; // *1/pi to get number of pi rads.
+        sfpi::vInt whole_v         = sfpi::float_to_int16(v, 0);
+        sfpi::vFloat whole_v_float = sfpi::int32_to_float(whole_v, 0);
+        v                          = v - whole_v_float;
         v *= 3.141592653589793f; // fractional * pi to get it in [-pi:pi]
         v       = _sfpu_sine_maclaurin_series_<APPROXIMATION_MODE>(v);
         whole_v = whole_v & 0x1;
@@ -104,10 +104,10 @@ inline void _calculate_cosine_(const int iterations)
     for (int d = 0; d < iterations; d++)
     {
         sfpi::vFloat v             = sfpi::dst_reg[0];
-        v                    = 0.318309886183791f * v; // *1/pi to get number of pi rads.
-        vInt whole_v         = float_to_int16(v, 0);
-        sfpi::vFloat whole_v_float = int32_to_float(whole_v, 0);
-        v                    = v - whole_v_float;
+        v                          = 0.318309886183791f * v; // *1/pi to get number of pi rads.
+        sfpi::vInt whole_v         = sfpi::float_to_int16(v, 0);
+        sfpi::vFloat whole_v_float = sfpi::int32_to_float(whole_v, 0);
+        v                          = v - whole_v_float;
         v *= 3.141592653589793f; // fractional * pi to get it in [-pi:pi]
         v       = _sfpu_cosine_maclaurin_series_<APPROXIMATION_MODE>(v);
         whole_v = whole_v & 0x1;

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_trigonometry.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_trigonometry.h
@@ -12,13 +12,13 @@ namespace sfpu
 {
 
 template <bool APPROXIMATION_MODE>
-sfpi_inline vFloat _sfpu_sine_maclaurin_series_(vFloat val)
+sfpi_inline sfpi::vFloat _sfpu_sine_maclaurin_series_(sfpi::vFloat val)
 {
     // Good for [-pi:pi]
     // Mclauren series = x - x^3/3! + x^5/5! - x^7/7! + x^9/9! - x^11/11!
-    vFloat tmp = val;
+    sfpi::vFloat tmp = val;
     // x
-    vFloat output = tmp;
+    sfpi::vFloat output = tmp;
     // x^3/3!
     tmp = tmp * val * val;
     output += -0.166666666 * tmp;
@@ -43,14 +43,14 @@ sfpi_inline vFloat _sfpu_sine_maclaurin_series_(vFloat val)
 }
 
 template <bool APPROXIMATION_MODE>
-sfpi_inline vFloat _sfpu_cosine_maclaurin_series_(vFloat val)
+sfpi_inline sfpi::vFloat _sfpu_cosine_maclaurin_series_(sfpi::vFloat val)
 {
     // Good for [-pi:pi]
     // Mclauren series = 1 - x^2/2! + x^4/4! - x^6/6! + x^8/8! - x^10/10! + x^12/12!
     // 1
-    vFloat output = 1.0f;
+    sfpi::vFloat output = 1.0f;
     // x^2/2!
-    vFloat tmp = val * val;
+    sfpi::vFloat tmp = val * val;
     output += -0.5 * tmp;
     // x^4/4!
     tmp = tmp * val * val;
@@ -78,10 +78,10 @@ inline void _calculate_sine_(const int iterations)
     // SFPU microcode
     for (int d = 0; d < iterations; d++)
     {
-        vFloat v             = dst_reg[0];
+        sfpi::vFloat v             = sfpi::dst_reg[0];
         v                    = 0.318309886183791f * v; // *1/pi to get number of pi rads.
         vInt whole_v         = float_to_int16(v, 0);
-        vFloat whole_v_float = int32_to_float(whole_v, 0);
+        sfpi::vFloat whole_v_float = int32_to_float(whole_v, 0);
         v                    = v - whole_v_float;
         v *= 3.141592653589793f; // fractional * pi to get it in [-pi:pi]
         v       = _sfpu_sine_maclaurin_series_<APPROXIMATION_MODE>(v);
@@ -92,8 +92,8 @@ inline void _calculate_sine_(const int iterations)
             v *= -1;
         }
         v_endif;
-        dst_reg[0] = v;
-        dst_reg++;
+        sfpi::dst_reg[0] = v;
+        sfpi::dst_reg++;
     }
 }
 
@@ -103,10 +103,10 @@ inline void _calculate_cosine_(const int iterations)
     // SFPU microcode
     for (int d = 0; d < iterations; d++)
     {
-        vFloat v             = dst_reg[0];
+        sfpi::vFloat v             = sfpi::dst_reg[0];
         v                    = 0.318309886183791f * v; // *1/pi to get number of pi rads.
         vInt whole_v         = float_to_int16(v, 0);
-        vFloat whole_v_float = int32_to_float(whole_v, 0);
+        sfpi::vFloat whole_v_float = int32_to_float(whole_v, 0);
         v                    = v - whole_v_float;
         v *= 3.141592653589793f; // fractional * pi to get it in [-pi:pi]
         v       = _sfpu_cosine_maclaurin_series_<APPROXIMATION_MODE>(v);
@@ -117,8 +117,8 @@ inline void _calculate_cosine_(const int iterations)
             v *= -1;
         }
         v_endif;
-        dst_reg[0] = v;
-        dst_reg++;
+        sfpi::dst_reg[0] = v;
+        sfpi::dst_reg++;
     }
 }
 

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_trigonometry.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_trigonometry.h
@@ -4,11 +4,7 @@
 
 #pragma once
 
-#include "ckernel.h"
-#include "ckernel_defs.h"
 #include "sfpi.h"
-
-using namespace sfpi;
 
 namespace ckernel
 {

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_typecast.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_typecast.h
@@ -5,13 +5,9 @@
 #pragma once
 
 #include <limits>
-
-#include "ckernel.h"
-#include "ckernel_defs.h"
-#include "noc_nonblocking_api.h"
 #include "sfpi.h"
-
-using namespace sfpi;
+#include "ckernel_ops.h"
+#include "ckernel_addrmod.h"
 
 namespace ckernel
 {

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_typecast.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_typecast.h
@@ -5,9 +5,10 @@
 #pragma once
 
 #include <limits>
-#include "sfpi.h"
-#include "ckernel_ops.h"
+
 #include "ckernel_addrmod.h"
+#include "ckernel_ops.h"
+#include "sfpi.h"
 
 namespace ckernel
 {
@@ -77,7 +78,7 @@ inline void _calculate_typecast_fp16b_to_int32_()
         sfpi::vFloat in = sfpi::dst_reg[0];
 
         // extract exponent
-        vInt exp = exexp(in);
+        sfpi::vInt exp = exexp(in);
 
         v_if (exp < 0)
         {
@@ -86,7 +87,7 @@ inline void _calculate_typecast_fp16b_to_int32_()
         v_elseif (exp > 30)
         {
             // set to int32 max value in case of overflow
-            vInt tmp = std::numeric_limits<int32_t>::max();
+            sfpi::vInt tmp = std::numeric_limits<int32_t>::max();
             // check sign
             v_if (in < 0)
             {
@@ -98,10 +99,10 @@ inline void _calculate_typecast_fp16b_to_int32_()
         v_else
         {
             // extract mantissa
-            vInt man = exman8(in);
+            sfpi::vInt man = exman8(in);
             // shift the mantissa by (23-exponent) to the right
-            vInt shift = exp - 23;
-            man        = shft(reinterpret<vUInt>(man), shift);
+            sfpi::vInt shift = exp - 23;
+            man              = sfpi::shft(sfpi::reinterpret<sfpi::vUInt>(man), shift);
             // check sign
             v_if (in < 0)
             {
@@ -181,7 +182,7 @@ inline void _calculate_typecast_fp16b_to_uint32_()
         v_else
         {
             // extract exponent
-            vInt exp = exexp(in);
+            sfpi::vInt exp = exexp(in);
 
             v_if (exp < 0)
             {
@@ -190,26 +191,26 @@ inline void _calculate_typecast_fp16b_to_uint32_()
             v_elseif (exp > 31)
             {
                 // set to uint32 max value in case of overflow
-                vInt tmp   = std::numeric_limits<int32_t>::max();
-                sfpi::dst_reg[0] = setsgn(reinterpret<sfpi::vFloat>(tmp), 1);
+                sfpi::vInt tmp   = std::numeric_limits<int32_t>::max();
+                sfpi::dst_reg[0] = sfpi::setsgn(sfpi::reinterpret<sfpi::vFloat>(tmp), 1);
             }
             v_elseif (exp == 31)
             {
                 // extract mantissa without hidden bit
-                vInt man = exman9(in);
+                sfpi::vInt man = exman9(in);
                 // shift the mantissa by (23-exponent) to the right
-                vInt shift = exp - 23;
-                man        = shft(reinterpret<vUInt>(man), shift);
+                sfpi::vInt shift = exp - 23;
+                man              = sfpi::shft(sfpi::reinterpret<sfpi::vUInt>(man), shift);
                 // add hidden bit back (due to bug when shifting a 1 into MSB)
-                sfpi::dst_reg[0] = setsgn(reinterpret<sfpi::vFloat>(man), 1);
+                sfpi::dst_reg[0] = sfpi::setsgn(sfpi::reinterpret<sfpi::vFloat>(man), 1);
             }
             v_else
             {
                 // extract mantissa
-                vInt man = exman8(in);
+                sfpi::vInt man = exman8(in);
                 // shift the mantissa by (23-exponent) to the right
-                vInt shift = exp - 23;
-                man        = shft(reinterpret<vUInt>(man), shift);
+                sfpi::vInt shift = exp - 23;
+                man              = sfpi::shft(sfpi::reinterpret<sfpi::vUInt>(man), shift);
                 sfpi::dst_reg[0] = man;
             }
             v_endif

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_typecast.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_typecast.h
@@ -26,7 +26,7 @@ inline void _calculate_typecast_fp16b_to_uint16_()
         TTI_SFPENCC(0, 0, 0, 0);
         TTI_SFP_STOCH_RND(0, 0, 2, 0, 1, 14);
         TTI_SFPSTORE(1, 6, ADDR_MOD_7, 0);
-        dst_reg++;
+        sfpi::dst_reg++;
     }
 }
 
@@ -40,7 +40,7 @@ inline void _calculate_typecast_uint16_to_fp16b_()
         TTI_SFPCAST(0, 1, 0);
         TTI_SFP_STOCH_RND(0, 0, 3, 1, 2, 1);
         TTI_SFPSTORE(2, 2, ADDR_MOD_7, 0);
-        dst_reg++;
+        sfpi::dst_reg++;
     }
 }
 
@@ -64,7 +64,7 @@ inline void _calculate_typecast_int32_to_fp16b_()
         TTI_SFPCAST(0, 1, 0);
         TTI_SFP_STOCH_RND(0, 0, 3, 1, 2, 1);
         TTI_SFPSTORE(2, 2, ADDR_MOD_7, 0);
-        dst_reg++;
+        sfpi::dst_reg++;
     }
 }
 
@@ -74,14 +74,14 @@ inline void _calculate_typecast_fp16b_to_int32_()
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++)
     {
-        vFloat in = dst_reg[0];
+        sfpi::vFloat in = sfpi::dst_reg[0];
 
         // extract exponent
         vInt exp = exexp(in);
 
         v_if (exp < 0)
         {
-            dst_reg[0] = 0;
+            sfpi::dst_reg[0] = 0;
         }
         v_elseif (exp > 30)
         {
@@ -93,7 +93,7 @@ inline void _calculate_typecast_fp16b_to_int32_()
                 // 2's complement conversion
                 tmp = (~tmp) + 1;
             }
-            v_endif dst_reg[0] = tmp;
+            v_endif sfpi::dst_reg[0] = tmp;
         }
         v_else
         {
@@ -108,11 +108,11 @@ inline void _calculate_typecast_fp16b_to_int32_()
                 // 2's complement conversion
                 man = (~man) + 1;
             }
-            v_endif dst_reg[0] = man;
+            v_endif sfpi::dst_reg[0] = man;
         }
         v_endif
 
-            dst_reg++;
+            sfpi::dst_reg++;
     }
 }
 
@@ -125,7 +125,7 @@ inline void _calculate_typecast_fp32_to_fp16b_()
         TTI_SFPLOAD(0, 0, ADDR_MOD_7, 0);
         TTI_SFP_STOCH_RND(0, 0, 2, 0, 1, 1);
         TTI_SFPSTORE(1, 0, ADDR_MOD_7, 0);
-        dst_reg++;
+        sfpi::dst_reg++;
     }
 }
 
@@ -138,7 +138,7 @@ inline void _calculate_typecast_uint16_to_fp32_()
         TTI_SFPLOAD(0, 6, ADDR_MOD_7, 0);
         TTI_SFPCAST(0, 1, 0);
         TTI_SFPSTORE(1, 3, ADDR_MOD_7, 0);
-        dst_reg++;
+        sfpi::dst_reg++;
     }
 }
 
@@ -161,7 +161,7 @@ inline void _calculate_typecast_int32_to_fp32_()
         TTI_SFPSETSGN(0, 2, 0, 0);
         TTI_SFPCAST(0, 1, 0);
         TTI_SFPSTORE(1, 3, ADDR_MOD_7, 0);
-        dst_reg++;
+        sfpi::dst_reg++;
     }
 }
 
@@ -171,12 +171,12 @@ inline void _calculate_typecast_fp16b_to_uint32_()
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++)
     {
-        vFloat in = dst_reg[0];
+        sfpi::vFloat in = sfpi::dst_reg[0];
 
         // check sign
         v_if (in <= 0)
         {
-            dst_reg[0] = 0;
+            sfpi::dst_reg[0] = 0;
         }
         v_else
         {
@@ -185,13 +185,13 @@ inline void _calculate_typecast_fp16b_to_uint32_()
 
             v_if (exp < 0)
             {
-                dst_reg[0] = 0;
+                sfpi::dst_reg[0] = 0;
             }
             v_elseif (exp > 31)
             {
                 // set to uint32 max value in case of overflow
                 vInt tmp   = std::numeric_limits<int32_t>::max();
-                dst_reg[0] = setsgn(reinterpret<vFloat>(tmp), 1);
+                sfpi::dst_reg[0] = setsgn(reinterpret<sfpi::vFloat>(tmp), 1);
             }
             v_elseif (exp == 31)
             {
@@ -201,7 +201,7 @@ inline void _calculate_typecast_fp16b_to_uint32_()
                 vInt shift = exp - 23;
                 man        = shft(reinterpret<vUInt>(man), shift);
                 // add hidden bit back (due to bug when shifting a 1 into MSB)
-                dst_reg[0] = setsgn(reinterpret<vFloat>(man), 1);
+                sfpi::dst_reg[0] = setsgn(reinterpret<sfpi::vFloat>(man), 1);
             }
             v_else
             {
@@ -210,13 +210,13 @@ inline void _calculate_typecast_fp16b_to_uint32_()
                 // shift the mantissa by (23-exponent) to the right
                 vInt shift = exp - 23;
                 man        = shft(reinterpret<vUInt>(man), shift);
-                dst_reg[0] = man;
+                sfpi::dst_reg[0] = man;
             }
             v_endif
         }
         v_endif
 
-            dst_reg++;
+            sfpi::dst_reg++;
     }
 }
 
@@ -234,7 +234,7 @@ inline void _calculate_typecast_uint32_to_fp16b_()
         TTI_SFPADDI(0x4f00, 3, 0); // 2^31
         TTI_SFPENCC(0, 0, 0, 0);
         TTI_SFPSTORE(3, 2, ADDR_MOD_7, 0);
-        dst_reg++;
+        sfpi::dst_reg++;
     }
 }
 
@@ -251,7 +251,7 @@ inline void _calculate_typecast_uint32_to_fp32_()
         TTI_SFPADDI(0x4f00, 2, 0); // 2^31
         TTI_SFPENCC(0, 0, 0, 0);
         TTI_SFPSTORE(2, 3, ADDR_MOD_7, 0);
-        dst_reg++;
+        sfpi::dst_reg++;
     }
 }
 
@@ -263,7 +263,7 @@ inline void _calculate_typecast_uint16_to_uint32_()
     {
         TTI_SFPLOAD(0, 9, ADDR_MOD_7, 0);
         TTI_SFPSTORE(0, 12, ADDR_MOD_7, 0);
-        dst_reg++;
+        sfpi::dst_reg++;
     }
 }
 

--- a/tt_llk_wormhole_b0/common/inc/ckernel_sfpi.h
+++ b/tt_llk_wormhole_b0/common/inc/ckernel_sfpi.h
@@ -1632,7 +1632,7 @@ sfpi_test_noinline void test9()
         // Relies on if chain above...
         v_if (sfpi::dst_reg[0] >= 7.0F)
         {
-            b = reinterpret<vUInt>(lz(a));
+            b = sfpi::reinterpret<vUInt>(lz(a));
             v_if (b != 32)
             {
                 sfpi::dst_reg[9] = 60.0F;
@@ -1789,27 +1789,27 @@ sfpi_test_noinline void test10()
     v_if (sfpi::dst_reg[0] == 7.0F)
     {
         sfpi::vFloat a    = sfpi::dst_reg[0];
-        sfpi::dst_reg[10] = setsgn(a, 1);
+        sfpi::dst_reg[10] = sfpi::setsgn(a, 1);
     }
     v_elseif (sfpi::dst_reg[0] == 8.0F)
     {
         sfpi::vFloat a = sfpi::dst_reg[0];
         sfpi::vFloat b = -128.0;
-        sfpi::vFloat r = setsgn(b, a);
+        sfpi::vFloat r = sfpi::setsgn(b, a);
 
         sfpi::dst_reg[10] = r;
     }
     v_elseif (sfpi::dst_reg[0] == 9.0F)
     {
         sfpi::vFloat a    = -256.0F;
-        sfpi::dst_reg[10] = setsgn(a, 0);
+        sfpi::dst_reg[10] = sfpi::setsgn(a, 0);
     }
     v_elseif (sfpi::dst_reg[0] == 10.0F)
     {
         sfpi::vFloat a = sfpi::dst_reg[0];
         a += 20.0f;
         sfpi::vFloat b = -512.0F;
-        sfpi::vFloat r = setsgn(a, b);
+        sfpi::vFloat r = sfpi::setsgn(a, b);
 
         sfpi::dst_reg[10] = r;
     }
@@ -2234,7 +2234,7 @@ sfpi_test_noinline void test12(int imm)
     v_if (sfpi::dst_reg[0] == 11.0F)
     {
         sfpi::vFloat a    = 128.0;
-        sfpi::vFloat r    = setsgn(a, imm - 36);
+        sfpi::vFloat r    = sfpi::setsgn(a, imm - 36);
         sfpi::dst_reg[12] = r;
     }
     v_elseif (sfpi::dst_reg[0] == 12.0F)
@@ -2570,7 +2570,7 @@ sfpi_test_noinline void test13(int imm)
         sfpi::vFloat b = 220.0F;
         v_if (sfpi::dst_reg[0] == 20.0F)
         {
-            b = setsgn(a, 1);
+            b = sfpi::setsgn(a, 1);
         }
         v_endif;
         v_if (sfpi::dst_reg[0] == 20.0F || sfpi::dst_reg[0] == 21.0F)

--- a/tt_llk_wormhole_b0/common/inc/ckernel_sfpi.h
+++ b/tt_llk_wormhole_b0/common/inc/ckernel_sfpi.h
@@ -25,31 +25,31 @@ namespace sfpi_test
 
 sfpi_inline void copy_result_to_dreg0(int addr)
 {
-    dst_reg[0] = dst_reg[addr];
+    sfpi::dst_reg[0] = sfpi::dst_reg[addr];
 }
 
 // Test infrastructure is set up to test float values, not ints
 // Viewing the ints as floats leads to a mess (eg, denorms)
 // Instead, compare in the kernel to the expected result and write a sentinal
-// value for "pass" and the vInt v value for "fail"
+// value for "pass" and the sfpi::vInt v value for "fail"
 // Assumes this code is called in an "inner" if
-sfpi_inline void set_expected_result(int addr, float sentinel, int expected, vInt v)
+sfpi_inline void set_expected_result(int addr, float sentinel, int expected, sfpi::vInt v)
 {
     // Poor man's equals
     // Careful, the register is 19 bits and the immediate is sign extended 12
     // bits so comparing bit patterns w/ the MSB set won't work
     v_if (v >= expected && v < expected + 1)
     {
-        dst_reg[addr] = sentinel;
+        sfpi::dst_reg[addr] = sentinel;
     }
     v_else
     {
-        dst_reg[addr] = v;
+        sfpi::dst_reg[addr] = v;
     }
     v_endif;
 }
 
-sfpi_inline vInt test_interleaved_scalar_vector_cond(bool scalar_bool, vFloat vec, float a, float b)
+sfpi_inline sfpi::vInt test_interleaved_scalar_vector_cond(bool scalar_bool, sfpi::vFloat vec, float a, float b)
 {
     if (scalar_bool)
     {
@@ -91,13 +91,13 @@ sfpi_inline vType reduce_bool4(vType a, vType b, vType c, vType d, int reference
 sfpi_test_noinline void test1()
 {
     // Test SFPLOADI, SFPSTORE
-    dst_reg[0] = 1.3f;
+    sfpi::dst_reg[0] = 1.3f;
 }
 
 sfpi_test_noinline void test2()
 {
     // Test SFPLOAD, SFPMOV
-    dst_reg[2] = -dst_reg[0];
+    sfpi::dst_reg[2] = -sfpi::dst_reg[0];
 
     // Out: ramp down from 0 to -63
     copy_result_to_dreg0(2);
@@ -107,190 +107,190 @@ sfpi_test_noinline void test3()
 {
     // Test SFPENCC, SFPSETCC, SFPCOMPC, LOADI, MAD (in conditionals)
     // Note: WH complains about the integer tests storing into float formated
-    // dst_reg w/ exponent of 0, so some tests use SFPOR to pass the result
+    // sfpi::dst_reg w/ exponent of 0, so some tests use SFPOR to pass the result
     // through violating the spirit of testing one thing at a time
 
-    v_if (dst_reg[0] == 0.0F)
+    v_if (sfpi::dst_reg[0] == 0.0F)
     {
         // 1 load
-        dst_reg[3] = 10.0F;
+        sfpi::dst_reg[3] = 10.0F;
     }
     v_else
     {
         // 1 load
-        dst_reg[3] = 20.0F;
+        sfpi::dst_reg[3] = 20.0F;
     }
     v_endif;
 
-    v_if (dst_reg[0] == 2.0F)
+    v_if (sfpi::dst_reg[0] == 2.0F)
     {
         // 1 load
-        vFloat a   = 30.0F;
-        dst_reg[3] = a;
+        sfpi::vFloat a   = 30.0F;
+        sfpi::dst_reg[3] = a;
     }
     v_endif;
 
-    v_if (dst_reg[0] == 3.0F)
+    v_if (sfpi::dst_reg[0] == 3.0F)
     {
         // 2 loads
-        dst_reg[3] = 1.005f;
+        sfpi::dst_reg[3] = 1.005f;
     }
     v_endif;
 
-    v_if (dst_reg[0] == 4.0F)
+    v_if (sfpi::dst_reg[0] == 4.0F)
     {
         // 2 loads
-        vFloat a   = 1.005f;
-        dst_reg[3] = a;
+        sfpi::vFloat a   = 1.005f;
+        sfpi::dst_reg[3] = a;
     }
     v_endif;
 
-    v_if (dst_reg[0] == 5.0F)
+    v_if (sfpi::dst_reg[0] == 5.0F)
     {
         // This will be a short w/ 1 load
-        vInt a = 0x3F80;
+        sfpi::vInt a = 0x3F80;
         a |= 0x3f800000;
-        dst_reg[3] = a;
+        sfpi::dst_reg[3] = a;
     }
     v_endif;
 
-    v_if (dst_reg[0] == 6.0F)
+    v_if (sfpi::dst_reg[0] == 6.0F)
     {
         // This will be an int w/ 2 loads
-        vInt a     = 0x3F80A3D7; // 1.005
-        dst_reg[3] = a;
+        sfpi::vInt a     = 0x3F80A3D7; // 1.005
+        sfpi::dst_reg[3] = a;
     }
     v_endif;
 
-    v_if (dst_reg[0] == 7.0F)
+    v_if (sfpi::dst_reg[0] == 7.0F)
     {
         // This will be an int w/ 1 load (not sign extended)
-        vInt a     = 0x8F80;
-        dst_reg[3] = a | 0x3f800000;
+        sfpi::vInt a     = 0x8F80;
+        sfpi::dst_reg[3] = a | 0x3f800000;
     }
     v_endif;
 
-    v_if (dst_reg[0] == 8.0F)
+    v_if (sfpi::dst_reg[0] == 8.0F)
     {
         // This will be a ushort w/ 1 load (not sign extended)
         vUInt a    = 0x8F80U;
-        dst_reg[3] = a | 0x3f800000;
+        sfpi::dst_reg[3] = a | 0x3f800000;
     }
     v_endif;
 
-    v_if (dst_reg[0] == 9.0F)
+    v_if (sfpi::dst_reg[0] == 9.0F)
     {
         // This will be an int w/ 2 loads
-        dst_reg[3] = 0x3F80A3D7; // 1.005
+        sfpi::dst_reg[3] = 0x3F80A3D7; // 1.005
     }
     v_endif;
 
-    v_if (dst_reg[0] == 10.0F)
+    v_if (sfpi::dst_reg[0] == 10.0F)
     {
         vUInt a    = static_cast<unsigned short>(0x3f80);
-        dst_reg[3] = a | 0x3f800000;
+        sfpi::dst_reg[3] = a | 0x3f800000;
     }
     v_endif;
 
-    v_if (dst_reg[0] == 11.0F)
+    v_if (sfpi::dst_reg[0] == 11.0F)
     {
         // This will be a short w/ 1 load (sign extended)
-        dst_reg[3] = static_cast<short>(0x8f80);
+        sfpi::dst_reg[3] = static_cast<short>(0x8f80);
     }
     v_endif;
 
-    v_if (dst_reg[0] == 12.0F)
+    v_if (sfpi::dst_reg[0] == 12.0F)
     {
         vUInt a    = 0x3F80A3D7;
-        dst_reg[3] = a;
+        sfpi::dst_reg[3] = a;
     }
     v_endif;
 
-    v_if (dst_reg[0] == 13.0F)
+    v_if (sfpi::dst_reg[0] == 13.0F)
     {
-        dst_reg[3] = s2vFloat16b(0.005f);
+        sfpi::dst_reg[3] = s2vFloat16b(0.005f);
     }
     v_endif;
 
-    v_if (dst_reg[0] == 14.0F)
+    v_if (sfpi::dst_reg[0] == 14.0F)
     {
-        dst_reg[3] = s2vFloat16a(0x3c05);
+        sfpi::dst_reg[3] = s2vFloat16a(0x3c05);
     }
     v_endif;
 
-    v_if (dst_reg[0] == 15.0F)
+    v_if (sfpi::dst_reg[0] == 15.0F)
     {
-        dst_reg[3] = 25.0; // double
+        sfpi::dst_reg[3] = 25.0; // double
     }
     v_endif;
 
-    v_if (dst_reg[0] == 16.0F)
+    v_if (sfpi::dst_reg[0] == 16.0F)
     {
-        vFloat a   = 28.0; // double
-        dst_reg[3] = a;
+        sfpi::vFloat a   = 28.0; // double
+        sfpi::dst_reg[3] = a;
     }
     v_endif;
 
-    v_if (dst_reg[0] == 17.0F)
+    v_if (sfpi::dst_reg[0] == 17.0F)
     {
-        dst_reg[3] = vConst0p8373;
+        sfpi::dst_reg[3] = vConst0p8373;
     }
     v_endif;
 
     // Below are from the limits test.  Test the compiler's ability to use
     // fp16a, fp16b or fp32 as needed
 
-    v_if (dst_reg[0] == 18.0F)
+    v_if (sfpi::dst_reg[0] == 18.0F)
     {
-        dst_reg[3] = 1.9921875f; // 0x3fff0000
+        sfpi::dst_reg[3] = 1.9921875f; // 0x3fff0000
     }
     v_endif;
 
-    v_if (dst_reg[0] == 19.0F)
+    v_if (sfpi::dst_reg[0] == 19.0F)
     {
-        dst_reg[3] = 1.99609375f; // 0x3fff8000
+        sfpi::dst_reg[3] = 1.99609375f; // 0x3fff8000
     }
     v_endif;
 
-    v_if (dst_reg[0] == 20.0F)
+    v_if (sfpi::dst_reg[0] == 20.0F)
     {
         // This is fp16b w/ large exp, with pass_offset != 0 the mantissa will overflow, use fp32
-        dst_reg[3] = 130560.0f; // 0x47ff0000
+        sfpi::dst_reg[3] = 130560.0f; // 0x47ff0000
     }
     v_endif;
 
-    v_if (dst_reg[0] == 21.0F)
+    v_if (sfpi::dst_reg[0] == 21.0F)
     {
         // This is fp16b w/ large exp, with pass_offset != 0 the mantissa will overflow, use fp32
-        dst_reg[3] = 130592.0f; // 0x47ff1000
+        sfpi::dst_reg[3] = 130592.0f; // 0x47ff1000
     }
     v_endif;
 
-    v_if (dst_reg[0] == 22.0F)
+    v_if (sfpi::dst_reg[0] == 22.0F)
     {
         // This is fp16a w/ largest exp, with pass_offset != 0 the exponent will overflow, use fp32
-        dst_reg[3] = 65408.0f; // 0x477f8000
+        sfpi::dst_reg[3] = 65408.0f; // 0x477f8000
     }
     v_endif;
 
-    v_if (dst_reg[0] == 23.0F)
+    v_if (sfpi::dst_reg[0] == 23.0F)
     {
         // This is fp16a w/ largest exp, with pass_offset != 0 the exponent will overflow, use fp32
-        dst_reg[3] = 130816.0f; // 0x47ff8000
+        sfpi::dst_reg[3] = 130816.0f; // 0x47ff8000
     }
     v_endif;
 
-    v_if (dst_reg[0] == 24.0F)
+    v_if (sfpi::dst_reg[0] == 24.0F)
     {
         // This is fp16a w/ smallest exp, with pass offset != 0 the exponent will underflow, use fp32
-        dst_reg[3] = 0.000121831894f; // 0x38ff8000
+        sfpi::dst_reg[3] = 0.000121831894f; // 0x38ff8000
     }
     v_endif;
 
-    v_if (dst_reg[0] == 25.0F)
+    v_if (sfpi::dst_reg[0] == 25.0F)
     {
         // This is fp16a w/ smallest exp, with pass offset != 0 the exponent will underflow, use fp32
-        dst_reg[3] = 0.000060915947f; // 0x387f8000
+        sfpi::dst_reg[3] = 0.000060915947f; // 0x387f8000
     }
     v_endif;
 
@@ -323,13 +323,13 @@ sfpi_test_noinline void test4()
     // Test vector loads
     // Operators &&, ||, !
 
-    vFloat v = dst_reg[0];
+    sfpi::vFloat v = sfpi::dst_reg[0];
 
-    dst_reg[4] = v;
+    sfpi::dst_reg[4] = v;
 
     v_if (v < 2.0F)
     {
-        dst_reg[4] = 64.0F;
+        sfpi::dst_reg[4] = 64.0F;
     }
     v_endif;
     // [0,1] = 64.0
@@ -340,17 +340,17 @@ sfpi_test_noinline void test4()
         {
             v_if (v >= 3.0F)
             {
-                dst_reg[4] = 65.0F;
+                sfpi::dst_reg[4] = 65.0F;
             }
             v_else
             {
-                dst_reg[4] = 66.0F;
+                sfpi::dst_reg[4] = 66.0F;
             }
             v_endif;
 
             v_if (v == 5.0F)
             {
-                dst_reg[4] = 67.0F;
+                sfpi::dst_reg[4] = 67.0F;
             }
             v_endif;
         }
@@ -367,25 +367,25 @@ sfpi_test_noinline void test4()
         {
             v_if (v == 6.0F)
             {
-                dst_reg[4] = 68.0F;
+                sfpi::dst_reg[4] = 68.0F;
             }
             v_elseif (v != 8.0F)
             {
-                dst_reg[4] = 69.0F;
+                sfpi::dst_reg[4] = 69.0F;
             }
             v_else
             {
-                dst_reg[4] = 70.0F;
+                sfpi::dst_reg[4] = 70.0F;
             }
             v_endif;
         }
         v_elseif (v == 9.0F)
         {
-            dst_reg[4] = 71.0F;
+            sfpi::dst_reg[4] = 71.0F;
         }
         v_elseif (v == 10.0F)
         {
-            dst_reg[4] = 72.0F;
+            sfpi::dst_reg[4] = 72.0F;
         }
 
         v_endif;
@@ -396,11 +396,11 @@ sfpi_test_noinline void test4()
     {
         v_if (v < 18.0F && v >= 12.0F && v != 15.0F)
         {
-            dst_reg[4] = 120.0F;
+            sfpi::dst_reg[4] = 120.0F;
         }
         v_else
         {
-            dst_reg[4] = -dst_reg[0];
+            sfpi::dst_reg[4] = -sfpi::dst_reg[0];
         }
         v_endif;
     }
@@ -410,11 +410,11 @@ sfpi_test_noinline void test4()
     {
         v_if (v == 19.0F || v == 21.0F)
         {
-            dst_reg[4] = 160.0F;
+            sfpi::dst_reg[4] = 160.0F;
         }
         v_else
         {
-            dst_reg[4] = 180.0F;
+            sfpi::dst_reg[4] = 180.0F;
         }
         v_endif;
     }
@@ -423,29 +423,29 @@ sfpi_test_noinline void test4()
     // Test ! on OP
     v_if (!(v != 23.0F))
     {
-        dst_reg[4] = 200.0F;
+        sfpi::dst_reg[4] = 200.0F;
     }
     v_endif;
 
     v_if (!(v >= 25.0F) && !(v < 24.0F))
     {
-        dst_reg[4] = 220.0F;
+        sfpi::dst_reg[4] = 220.0F;
     }
     v_endif;
 
     // Test ! on Boolean
     v_if (!((v < 25.0F) || (v >= 26.0F)))
     {
-        dst_reg[4] = 240.0F;
+        sfpi::dst_reg[4] = 240.0F;
     }
     v_endif;
 
     v_if ((v >= 26.0F) && (v < 29.0F))
     {
-        dst_reg[4] = 260.0F;
+        sfpi::dst_reg[4] = 260.0F;
         v_if (!((v >= 27.0F) && (v < 28.0F)))
         {
-            dst_reg[4] = 270.0F;
+            sfpi::dst_reg[4] = 270.0F;
         }
         v_endif;
     }
@@ -454,8 +454,8 @@ sfpi_test_noinline void test4()
     // Test || after && to be sure PUSHC works properly
     v_if ((v >= 28.0F) && (v == 29.0F || v == 30.0F || v == 31.0F))
     {
-        vFloat x = 30.0F;
-        vFloat y = 280.0F;
+        sfpi::vFloat x = 30.0F;
+        sfpi::vFloat y = 280.0F;
         v_if (v < x)
         {
             y += 10.0F;
@@ -471,7 +471,7 @@ sfpi_test_noinline void test4()
             y += 40.0F;
         }
         v_endif;
-        dst_reg[4] = y;
+        sfpi::dst_reg[4] = y;
     }
     v_endif;
 
@@ -508,39 +508,39 @@ sfpi_test_noinline void test4()
 sfpi_test_noinline void test5()
 {
     // Test SFPMAD, SFPMOV, vConsts
-    dst_reg[5] = -dst_reg[0];
+    sfpi::dst_reg[5] = -sfpi::dst_reg[0];
 
     vConstFloatPrgm0 = .5F;
     vConstFloatPrgm1 = 1.5F;
     vConstIntPrgm2   = 0xBFC00000; // -1.5F
 
-    v_if (dst_reg[0] == 0.0F)
+    v_if (sfpi::dst_reg[0] == 0.0F)
     {
-        dst_reg[5] = vConst0 * vConst0 + vConst0p8373;
+        sfpi::dst_reg[5] = vConst0 * vConst0 + vConst0p8373;
     }
-    v_elseif (dst_reg[0] == 1.0F)
+    v_elseif (sfpi::dst_reg[0] == 1.0F)
     {
-        dst_reg[5] = vConst0 * vConst0 + vConst0;
+        sfpi::dst_reg[5] = vConst0 * vConst0 + vConst0;
     }
-    v_elseif (dst_reg[0] == 2.0F)
+    v_elseif (sfpi::dst_reg[0] == 2.0F)
     {
-        dst_reg[5] = vConst0 * vConst0 + vConstNeg1;
+        sfpi::dst_reg[5] = vConst0 * vConst0 + vConstNeg1;
     }
-    v_elseif (dst_reg[0] == 3.0F)
+    v_elseif (sfpi::dst_reg[0] == 3.0F)
     {
-        dst_reg[5] = vConst0 * vConst0 + vConstFloatPrgm0;
+        sfpi::dst_reg[5] = vConst0 * vConst0 + vConstFloatPrgm0;
     }
-    v_elseif (dst_reg[0] == 4.0F)
+    v_elseif (sfpi::dst_reg[0] == 4.0F)
     {
-        dst_reg[5] = vConst0 * vConst0 + vConstFloatPrgm1;
+        sfpi::dst_reg[5] = vConst0 * vConst0 + vConstFloatPrgm1;
     }
-    v_elseif (dst_reg[0] == 5.0F)
+    v_elseif (sfpi::dst_reg[0] == 5.0F)
     {
-        dst_reg[5] = vConst0 * vConst0 + vConstFloatPrgm2;
+        sfpi::dst_reg[5] = vConst0 * vConst0 + vConstFloatPrgm2;
     }
-    v_elseif (dst_reg[0] == 6.0F)
+    v_elseif (sfpi::dst_reg[0] == 6.0F)
     {
-        dst_reg[5] = vConst0 * vConst0 + vConst1;
+        sfpi::dst_reg[5] = vConst0 * vConst0 + vConst1;
     }
     v_endif;
     // [0] = 0.8373
@@ -552,25 +552,25 @@ sfpi_test_noinline void test5()
     // [6] = 1.0
 
     // Fill holes in the tests; grayskull tested other const regs
-    v_if (dst_reg[0] == 7.0F)
+    v_if (sfpi::dst_reg[0] == 7.0F)
     {
-        dst_reg[5] = vConst0;
+        sfpi::dst_reg[5] = vConst0;
     }
-    v_elseif (dst_reg[0] == 8.0F)
+    v_elseif (sfpi::dst_reg[0] == 8.0F)
     {
-        dst_reg[5] = vConst0;
+        sfpi::dst_reg[5] = vConst0;
     }
-    v_elseif (dst_reg[0] == 9.0F)
+    v_elseif (sfpi::dst_reg[0] == 9.0F)
     {
-        dst_reg[5] = vConst0;
+        sfpi::dst_reg[5] = vConst0;
     }
-    v_elseif (dst_reg[0] == 10.0F)
+    v_elseif (sfpi::dst_reg[0] == 10.0F)
     {
-        dst_reg[5] = vConst0;
+        sfpi::dst_reg[5] = vConst0;
     }
-    v_elseif (dst_reg[0] == 11.0F)
+    v_elseif (sfpi::dst_reg[0] == 11.0F)
     {
-        dst_reg[5] = vConst0p8373 * vConstNeg1 + vConst1;
+        sfpi::dst_reg[5] = vConst0p8373 * vConstNeg1 + vConst1;
     }
     v_endif;
     // [7] = 0.0
@@ -579,40 +579,40 @@ sfpi_test_noinline void test5()
     // [10] = 0.0
     // [11] = .1627
 
-    vFloat a = dst_reg[0];
-    vFloat b = 20.0F;
+    sfpi::vFloat a = sfpi::dst_reg[0];
+    sfpi::vFloat b = 20.0F;
 
-    // Note: loading dst_reg[0] takes a reg and comparing against a float const
+    // Note: loading sfpi::dst_reg[0] takes a reg and comparing against a float const
     // takes a reg so can't store A, B and C across the condtionals
 
-    v_if (dst_reg[0] == 12.0F)
+    v_if (sfpi::dst_reg[0] == 12.0F)
     {
-        dst_reg[5] = a * b;
+        sfpi::dst_reg[5] = a * b;
     }
-    v_elseif (dst_reg[0] == 13.0F)
+    v_elseif (sfpi::dst_reg[0] == 13.0F)
     {
-        dst_reg[5] = a + b;
+        sfpi::dst_reg[5] = a + b;
     }
-    v_elseif (dst_reg[0] == 14.0F)
+    v_elseif (sfpi::dst_reg[0] == 14.0F)
     {
-        dst_reg[5] = a * b + 0.5F;
+        sfpi::dst_reg[5] = a * b + 0.5F;
     }
-    v_elseif (dst_reg[0] == 15.0F)
+    v_elseif (sfpi::dst_reg[0] == 15.0F)
     {
-        dst_reg[5] = a + b + 0.5F;
+        sfpi::dst_reg[5] = a + b + 0.5F;
     }
-    v_elseif (dst_reg[0] == 16.0F)
+    v_elseif (sfpi::dst_reg[0] == 16.0F)
     {
-        dst_reg[5] = a * b - 0.5F;
+        sfpi::dst_reg[5] = a * b - 0.5F;
     }
-    v_elseif (dst_reg[0] == 17.0F)
+    v_elseif (sfpi::dst_reg[0] == 17.0F)
     {
-        dst_reg[5] = a + b - 0.5F;
+        sfpi::dst_reg[5] = a + b - 0.5F;
     }
-    v_elseif (dst_reg[0] == 18.0F)
+    v_elseif (sfpi::dst_reg[0] == 18.0F)
     {
-        vFloat c   = -5.0F;
-        dst_reg[5] = a * b + c;
+        sfpi::vFloat c   = -5.0F;
+        sfpi::dst_reg[5] = a * b + c;
     }
     v_endif;
     // [12] = 240.0
@@ -623,35 +623,35 @@ sfpi_test_noinline void test5()
     // [17] = 36.5
     // [18] = 355.0
 
-    v_if (dst_reg[0] == 19.0F)
+    v_if (sfpi::dst_reg[0] == 19.0F)
     {
-        vFloat c   = -5.0F;
-        dst_reg[5] = a * b + c + 0.5F;
+        sfpi::vFloat c   = -5.0F;
+        sfpi::dst_reg[5] = a * b + c + 0.5F;
     }
-    v_elseif (dst_reg[0] == 20.0F)
+    v_elseif (sfpi::dst_reg[0] == 20.0F)
     {
-        vFloat c   = -5.0F;
-        dst_reg[5] = a * b + c - 0.5F;
+        sfpi::vFloat c   = -5.0F;
+        sfpi::dst_reg[5] = a * b + c - 0.5F;
     }
-    v_elseif (dst_reg[0] == 21.0F)
+    v_elseif (sfpi::dst_reg[0] == 21.0F)
     {
-        vFloat c = -5.0F;
-        vFloat d;
+        sfpi::vFloat c = -5.0F;
+        sfpi::vFloat d;
         d          = a * b + c - 0.5F;
-        dst_reg[5] = d;
+        sfpi::dst_reg[5] = d;
     }
-    v_elseif (dst_reg[0] == 22.0F)
+    v_elseif (sfpi::dst_reg[0] == 22.0F)
     {
-        vFloat c   = -5.0F;
-        dst_reg[5] = a * b - c;
+        sfpi::vFloat c   = -5.0F;
+        sfpi::dst_reg[5] = a * b - c;
     }
-    v_elseif (dst_reg[0] == 23.0F)
+    v_elseif (sfpi::dst_reg[0] == 23.0F)
     {
-        dst_reg[5] = a * b + vConst1;
+        sfpi::dst_reg[5] = a * b + vConst1;
     }
-    v_elseif (dst_reg[0] == 24.0F)
+    v_elseif (sfpi::dst_reg[0] == 24.0F)
     {
-        dst_reg[5] = vConst1 * b + vConst1;
+        sfpi::dst_reg[5] = vConst1 * b + vConst1;
     }
     v_endif;
     // [19] = 375.5
@@ -661,23 +661,23 @@ sfpi_test_noinline void test5()
     // [23] = 461.0
     // [24] = 21.0
 
-    v_if (dst_reg[0] == 25.0F)
+    v_if (sfpi::dst_reg[0] == 25.0F)
     {
-        vFloat c   = -5.0F;
-        dst_reg[5] = dst_reg[0] * b + c;
+        sfpi::vFloat c   = -5.0F;
+        sfpi::dst_reg[5] = sfpi::dst_reg[0] * b + c;
     }
-    v_elseif (dst_reg[0] == 26.0F)
+    v_elseif (sfpi::dst_reg[0] == 26.0F)
     {
-        vFloat c   = -5.0F;
-        dst_reg[5] = b * dst_reg[0] + c;
+        sfpi::vFloat c   = -5.0F;
+        sfpi::dst_reg[5] = b * sfpi::dst_reg[0] + c;
     }
-    v_elseif (dst_reg[0] == 27.0F)
+    v_elseif (sfpi::dst_reg[0] == 27.0F)
     {
-        dst_reg[5] = a * b + dst_reg[0];
+        sfpi::dst_reg[5] = a * b + sfpi::dst_reg[0];
     }
-    v_elseif (dst_reg[0] == 28.0F)
+    v_elseif (sfpi::dst_reg[0] == 28.0F)
     {
-        dst_reg[5] = a * b - dst_reg[0];
+        sfpi::dst_reg[5] = a * b - sfpi::dst_reg[0];
     }
     v_endif;
     // [25] = 495.0
@@ -685,17 +685,17 @@ sfpi_test_noinline void test5()
     // [27] = 567.0
     // [28] = 532.0
 
-    v_if (dst_reg[0] == 29.0F)
+    v_if (sfpi::dst_reg[0] == 29.0F)
     {
-        dst_reg[5] = a - b;
+        sfpi::dst_reg[5] = a - b;
     }
-    v_elseif (dst_reg[0] == 30.0F)
+    v_elseif (sfpi::dst_reg[0] == 30.0F)
     {
-        dst_reg[5] = a - b - 0.5F;
+        sfpi::dst_reg[5] = a - b - 0.5F;
     }
-    v_elseif (dst_reg[0] == 31.0F)
+    v_elseif (sfpi::dst_reg[0] == 31.0F)
     {
-        dst_reg[5] = dst_reg[0] - b + 0.5F;
+        sfpi::dst_reg[5] = sfpi::dst_reg[0] - b + 0.5F;
     }
     v_endif;
     // [29] = 9.0
@@ -712,35 +712,35 @@ sfpi_test_noinline void test6()
 
     // SFPIADD
 
-    dst_reg[6] = -dst_reg[0];
+    sfpi::dst_reg[6] = -sfpi::dst_reg[0];
 
-    v_if (dst_reg[0] < 3.0F)
+    v_if (sfpi::dst_reg[0] < 3.0F)
     {
-        v_if (dst_reg[0] >= 0.0F)
+        v_if (sfpi::dst_reg[0] >= 0.0F)
         {
-            dst_reg[6] = 256.0F;
+            sfpi::dst_reg[6] = 256.0F;
 
-            vInt a;
-            v_if (dst_reg[0] == 0.0F)
+            sfpi::vInt a;
+            v_if (sfpi::dst_reg[0] == 0.0F)
             {
                 a = 28;
             }
-            v_elseif (dst_reg[0] == 1.0F)
+            v_elseif (sfpi::dst_reg[0] == 1.0F)
             {
                 a = 29;
             }
-            v_elseif (dst_reg[0] == 2.0F)
+            v_elseif (sfpi::dst_reg[0] == 2.0F)
             {
                 a = 30;
             }
             v_endif;
 
-            vInt b;
+            sfpi::vInt b;
             // IADD imm
             b = a - 29;
             v_if (b >= 0)
             {
-                dst_reg[6] = 1024.0F;
+                sfpi::dst_reg[6] = 1024.0F;
             }
             v_endif;
         }
@@ -748,33 +748,33 @@ sfpi_test_noinline void test6()
     }
     v_endif;
 
-    v_if (dst_reg[0] < 6.0F)
+    v_if (sfpi::dst_reg[0] < 6.0F)
     {
-        v_if (dst_reg[0] >= 3.0F)
+        v_if (sfpi::dst_reg[0] >= 3.0F)
         {
-            dst_reg[6] = 256.0F;
+            sfpi::dst_reg[6] = 256.0F;
 
-            vInt a;
-            v_if (dst_reg[0] == 3.0F)
+            sfpi::vInt a;
+            v_if (sfpi::dst_reg[0] == 3.0F)
             {
                 a = 28;
             }
-            v_elseif (dst_reg[0] == 4.0F)
+            v_elseif (sfpi::dst_reg[0] == 4.0F)
             {
                 a = 29;
             }
-            v_elseif (dst_reg[0] == 5.0F)
+            v_elseif (sfpi::dst_reg[0] == 5.0F)
             {
                 a = 30;
             }
             v_endif;
 
-            vInt b = -29;
+            sfpi::vInt b = -29;
             // IADD reg
             b = a + b;
             v_if (b < 0)
             {
-                dst_reg[6] = 1024.0F;
+                sfpi::dst_reg[6] = 1024.0F;
             }
             v_endif;
         }
@@ -782,28 +782,28 @@ sfpi_test_noinline void test6()
     }
     v_endif;
 
-    v_if (dst_reg[0] < 9.0F)
+    v_if (sfpi::dst_reg[0] < 9.0F)
     {
-        v_if (dst_reg[0] >= 6.0F)
+        v_if (sfpi::dst_reg[0] >= 6.0F)
         {
-            dst_reg[6] = 16.0F;
+            sfpi::dst_reg[6] = 16.0F;
 
-            vInt a = 3;
-            v_if (dst_reg[0] == 6.0F)
+            sfpi::vInt a = 3;
+            v_if (sfpi::dst_reg[0] == 6.0F)
             {
                 a = 28;
             }
-            v_elseif (dst_reg[0] == 7.0F)
+            v_elseif (sfpi::dst_reg[0] == 7.0F)
             {
                 a = 29;
             }
-            v_elseif (dst_reg[0] == 8.0F)
+            v_elseif (sfpi::dst_reg[0] == 8.0F)
             {
                 a = 30;
             }
             v_endif;
 
-            vFloat b = 128.0F;
+            sfpi::vFloat b = 128.0F;
             v_if (a >= 29)
             {
                 b = 256.0F;
@@ -820,35 +820,35 @@ sfpi_test_noinline void test6()
             }
             v_endif;
 
-            dst_reg[6] = b;
+            sfpi::dst_reg[6] = b;
         }
         v_endif;
     }
     v_endif;
 
-    v_if (dst_reg[0] < 12.0F)
+    v_if (sfpi::dst_reg[0] < 12.0F)
     {
-        v_if (dst_reg[0] >= 9.0F)
+        v_if (sfpi::dst_reg[0] >= 9.0F)
         {
-            dst_reg[6] = 16.0F;
+            sfpi::dst_reg[6] = 16.0F;
 
-            vInt a = 3;
-            v_if (dst_reg[0] == 9.0F)
+            sfpi::vInt a = 3;
+            v_if (sfpi::dst_reg[0] == 9.0F)
             {
                 a = 28;
             }
-            v_elseif (dst_reg[0] == 10.0F)
+            v_elseif (sfpi::dst_reg[0] == 10.0F)
             {
                 a = 29;
             }
-            v_elseif (dst_reg[0] == 11.0F)
+            v_elseif (sfpi::dst_reg[0] == 11.0F)
             {
                 a = 30;
             }
             v_endif;
 
-            vFloat b = 128.0F;
-            vInt c   = 29;
+            sfpi::vFloat b = 128.0F;
+            sfpi::vInt c   = 29;
             v_if (a >= c)
             {
                 b = 256.0F;
@@ -865,143 +865,143 @@ sfpi_test_noinline void test6()
             }
             v_endif;
 
-            dst_reg[6] = b;
+            sfpi::dst_reg[6] = b;
         }
         v_endif;
     }
     v_endif;
 
-    v_if (dst_reg[0] == 12.0F)
+    v_if (sfpi::dst_reg[0] == 12.0F)
     {
-        vInt v = 25;
+        sfpi::vInt v = 25;
         set_expected_result(6, 4.0F, 25, v);
     }
-    v_elseif (dst_reg[0] == 13.0F)
+    v_elseif (sfpi::dst_reg[0] == 13.0F)
     {
-        vInt a = 20;
+        sfpi::vInt a = 20;
         a      = a + 12;
         set_expected_result(6, 8.0F, 32, a);
     }
-    v_elseif (dst_reg[0] == 14.0F)
+    v_elseif (sfpi::dst_reg[0] == 14.0F)
     {
-        vInt a = 18;
-        vInt b = -6;
+        sfpi::vInt a = 18;
+        sfpi::vInt b = -6;
         a      = a + b;
         set_expected_result(6, 16.0F, 12, a);
     }
-    v_elseif (dst_reg[0] == 15.0F)
+    v_elseif (sfpi::dst_reg[0] == 15.0F)
     {
-        vInt a = 14;
-        vInt b = -5;
+        sfpi::vInt a = 14;
+        sfpi::vInt b = -5;
         a      = b + a;
         set_expected_result(6, 32.0F, 9, a);
     }
     v_endif;
 
-    v_if (dst_reg[0] == 16.0F)
+    v_if (sfpi::dst_reg[0] == 16.0F)
     {
-        vInt v = 25;
+        sfpi::vInt v = 25;
         set_expected_result(6, 4.0F, 25, v);
     }
-    v_elseif (dst_reg[0] == 17.0F)
+    v_elseif (sfpi::dst_reg[0] == 17.0F)
     {
-        vInt a = 20;
+        sfpi::vInt a = 20;
         a      = a - 12;
         set_expected_result(6, 8.0F, 8, a);
     }
-    v_elseif (dst_reg[0] == 18.0F)
+    v_elseif (sfpi::dst_reg[0] == 18.0F)
     {
-        vInt a = 18;
-        vInt b = 6;
+        sfpi::vInt a = 18;
+        sfpi::vInt b = 6;
         a      = a - b;
         set_expected_result(6, 16.0F, 12, a);
     }
-    v_elseif (dst_reg[0] == 19.0F)
+    v_elseif (sfpi::dst_reg[0] == 19.0F)
     {
-        vInt a = 14;
-        vInt b = 5;
+        sfpi::vInt a = 14;
+        sfpi::vInt b = 5;
         a      = b - a;
         set_expected_result(6, 32.0F, -9, a);
     }
     v_endif;
 
-    v_if (dst_reg[0] == 20.0F)
+    v_if (sfpi::dst_reg[0] == 20.0F)
     {
         vUInt v = 25;
-        set_expected_result(6, 4.0F, 25, reinterpret<vInt>(v));
+        set_expected_result(6, 4.0F, 25, reinterpret<sfpi::vInt>(v));
     }
-    v_elseif (dst_reg[0] == 21.0F)
+    v_elseif (sfpi::dst_reg[0] == 21.0F)
     {
         vUInt a = 20;
         a       = a - 12;
-        set_expected_result(6, 8.0F, 8, reinterpret<vInt>(a));
+        set_expected_result(6, 8.0F, 8, reinterpret<sfpi::vInt>(a));
     }
-    v_elseif (dst_reg[0] == 22.0F)
+    v_elseif (sfpi::dst_reg[0] == 22.0F)
     {
         vUInt a = 18;
         vUInt b = 6;
         a       = a - b;
-        set_expected_result(6, 16.0F, 12, reinterpret<vInt>(a));
+        set_expected_result(6, 16.0F, 12, reinterpret<sfpi::vInt>(a));
     }
-    v_elseif (dst_reg[0] == 23.0F)
+    v_elseif (sfpi::dst_reg[0] == 23.0F)
     {
         vUInt a = 14;
         vUInt b = 5;
         a       = b - a;
-        set_expected_result(6, 32.0F, -9, reinterpret<vInt>(a));
+        set_expected_result(6, 32.0F, -9, reinterpret<sfpi::vInt>(a));
     }
     v_endif;
 
-    v_if (dst_reg[0] == 24.0F)
+    v_if (sfpi::dst_reg[0] == 24.0F)
     {
-        vInt a = 10;
-        vInt b = 20;
+        sfpi::vInt a = 10;
+        sfpi::vInt b = 20;
         a -= b;
         set_expected_result(6, 64.0F, -10, a);
     }
-    v_elseif (dst_reg[0] == 25.0F)
+    v_elseif (sfpi::dst_reg[0] == 25.0F)
     {
-        vInt a = 10;
-        vInt b = 20;
+        sfpi::vInt a = 10;
+        sfpi::vInt b = 20;
         a += b;
         set_expected_result(6, 128.0F, 30, a);
     }
     v_endif;
 
     // Pseudo-16 bit via hidden loadi
-    v_if (dst_reg[0] == 26.0F)
+    v_if (sfpi::dst_reg[0] == 26.0F)
     {
-        vInt a = 10;
+        sfpi::vInt a = 10;
         a += 4096;
         set_expected_result(6, 256.0F, 4106, a);
     }
-    v_elseif (dst_reg[0] == 27.0F)
+    v_elseif (sfpi::dst_reg[0] == 27.0F)
     {
-        vInt a = 4096;
+        sfpi::vInt a = 4096;
         v_if (a >= 4096)
         {
-            dst_reg[6] = 512.0f;
+            sfpi::dst_reg[6] = 512.0f;
         }
         v_else
         {
-            dst_reg[6] = 0.0f;
+            sfpi::dst_reg[6] = 0.0f;
         }
         v_endif;
     }
     v_endif;
 
-    v_if (dst_reg[0] >= 28.0F)
+    v_if (sfpi::dst_reg[0] >= 28.0F)
     {
-        vInt a = vConstTileId;
-        v_if (dst_reg[0] == 28.0F)
+        sfpi::vInt a = vConstTileId;
+        v_if (sfpi::dst_reg[0] == 28.0F)
         {
             set_expected_result(6, 256.0F, 56, a);
         }
-        v_elseif (dst_reg[0] == 29.0F)
+        v_elseif (sfpi::dst_reg[0] == 29.0F)
         {
             set_expected_result(6, 256.0F, 58, a);
         }
-        v_elseif (dst_reg[0] == 30.0F)
+        v_elseif (sfpi::dst_reg[0] == 30.0F)
         {
             set_expected_result(6, 256.0F, 60, a);
         }
@@ -1009,16 +1009,16 @@ sfpi_test_noinline void test6()
     }
     v_endif;
 
-    v_if (dst_reg[0] == 31.0F)
+    v_if (sfpi::dst_reg[0] == 31.0F)
     {
-        vFloat x = 3.0f;
+        sfpi::vFloat x = 3.0f;
         v_if (!!(x == 3.0f && x != 4.0f))
         {
-            dst_reg[6] = 16.0;
+            sfpi::dst_reg[6] = 16.0;
         }
         v_else
         {
-            dst_reg[6] = 32.0;
+            sfpi::dst_reg[6] = 32.0;
         }
         v_endif;
     }
@@ -1065,55 +1065,55 @@ sfpi_test_noinline void test7()
     // SFPEXMAN, SFPEXEXP, SFPSETEXP, SFPSETMAN
     // Plus a little more && ||
 
-    dst_reg[7] = -dst_reg[0];
-    v_if (dst_reg[0] == 1.0F)
+    sfpi::dst_reg[7] = -sfpi::dst_reg[0];
+    v_if (sfpi::dst_reg[0] == 1.0F)
     {
-        vFloat tmp = 124.05F;
+        sfpi::vFloat tmp = 124.05F;
         set_expected_result(7, 30.0F, 0xF8199A, exman8(tmp));
     }
-    v_elseif (dst_reg[0] == 2.0F)
+    v_elseif (sfpi::dst_reg[0] == 2.0F)
     {
-        vFloat tmp = 124.05F;
+        sfpi::vFloat tmp = 124.05F;
         set_expected_result(7, 32.0F, 0x78199A, exman9(tmp));
     }
-    v_elseif (dst_reg[0] == 3.0F)
+    v_elseif (sfpi::dst_reg[0] == 3.0F)
     {
-        vFloat tmp = 65536.0F * 256.0F;
+        sfpi::vFloat tmp = 65536.0F * 256.0F;
         set_expected_result(7, 33.0F, 0x18, exexp(tmp));
     }
-    v_elseif (dst_reg[0] == 4.0F)
+    v_elseif (sfpi::dst_reg[0] == 4.0F)
     {
-        vFloat tmp = 65536.0F * 256.0F;
+        sfpi::vFloat tmp = 65536.0F * 256.0F;
         set_expected_result(7, 34.0F, 0x97, exexp_nodebias(tmp));
     }
-    v_elseif (dst_reg[0] < 8.0F)
+    v_elseif (sfpi::dst_reg[0] < 8.0F)
     {
-        vFloat tmp;
-        v_if (dst_reg[0] == 5.0F)
+        sfpi::vFloat tmp;
+        v_if (sfpi::dst_reg[0] == 5.0F)
         {
             // Exp < 0 for 5.0
             tmp = 0.5F;
         }
-        v_elseif (dst_reg[0] < 8.0F)
+        v_elseif (sfpi::dst_reg[0] < 8.0F)
         {
             // Exp > 0 for 6.0, 7.0
             tmp = 512.0F;
         }
         v_endif;
 
-        vInt v;
+        sfpi::vInt v;
         v = exexp(tmp);
         v_if (v < 0)
         {
-            dst_reg[7] = 32.0F;
+            sfpi::dst_reg[7] = 32.0F;
         }
         v_else
         {
-            dst_reg[7] = 64.0F;
+            sfpi::dst_reg[7] = 64.0F;
         }
         v_endif;
 
-        v_if (dst_reg[0] == 7.0F)
+        v_if (sfpi::dst_reg[0] == 7.0F)
         {
             // Exponent is 9, save it
             set_expected_result(7, 35.0F, 9, v);
@@ -1128,46 +1128,46 @@ sfpi_test_noinline void test7()
         // [6] = 64.0
         // [7] = 35.0 (exponent(512) = 8)
     }
-    v_elseif (dst_reg[0] == 8.0F)
+    v_elseif (sfpi::dst_reg[0] == 8.0F)
     {
-        vFloat tmp = 1.0F;
-        vFloat v   = setexp(tmp, 137);
-        dst_reg[7] = v;
+        sfpi::vFloat tmp = 1.0F;
+        sfpi::vFloat v   = setexp(tmp, 137);
+        sfpi::dst_reg[7] = v;
     }
-    v_elseif (dst_reg[0] == 9.0F)
+    v_elseif (sfpi::dst_reg[0] == 9.0F)
     {
-        vInt exp       = 0x007F;   // Exponent in low bits
-        vFloat sgn_man = -1664.0F; // 1024 + 512 + 128 or 1101
+        sfpi::vInt exp       = 0x007F;   // Exponent in low bits
+        sfpi::vFloat sgn_man = -1664.0F; // 1024 + 512 + 128 or 1101
         sgn_man        = setexp(sgn_man, exp);
-        dst_reg[7]     = sgn_man;
+        sfpi::dst_reg[7]     = sgn_man;
     }
     v_endif;
 
     // [8] = 1024.0
     // [9] = -1.625
 
-    v_if (dst_reg[0] == 10.0F)
+    v_if (sfpi::dst_reg[0] == 10.0F)
     {
-        vFloat tmp = 1024.0F;
-        vFloat b   = setman(tmp, 0x75019a);
-        dst_reg[7] = b;
+        sfpi::vFloat tmp = 1024.0F;
+        sfpi::vFloat b   = setman(tmp, 0x75019a);
+        sfpi::dst_reg[7] = b;
     }
-    v_elseif (dst_reg[0] == 11.0F)
+    v_elseif (sfpi::dst_reg[0] == 11.0F)
     {
-        vFloat tmp  = 1024.0F;
-        vInt man    = 0x75019a;
-        vFloat tmp2 = setman(tmp, man);
-        dst_reg[7]  = tmp2;
+        sfpi::vFloat tmp  = 1024.0F;
+        sfpi::vInt man    = 0x75019a;
+        sfpi::vFloat tmp2 = setman(tmp, man);
+        sfpi::dst_reg[7]  = tmp2;
     }
     v_endif;
 
     // [10] = 1960.050049
     // [11] = 1960.050049
 
-    vFloat v = dst_reg[0];
+    sfpi::vFloat v = sfpi::dst_reg[0];
     v_if ((v >= 12.0f && v < 14.0f) || (v >= 15.0f && v < 17.0f))
     {
-        dst_reg[7] = -128.0f;
+        sfpi::dst_reg[7] = -128.0f;
     }
     v_endif;
     // [12] = -128.0
@@ -1178,7 +1178,7 @@ sfpi_test_noinline void test7()
 
     v_if (((v >= 17.0f && v < 18.0f) || (v >= 19.0f && v < 20.0f)) || ((v >= 21.0f && v < 22.0f) || (v >= 23.0f && v < 24.0f)))
     {
-        dst_reg[7] = -256.0f;
+        sfpi::dst_reg[7] = -256.0f;
     }
     v_endif;
     // [17] = -256.0
@@ -1194,7 +1194,7 @@ sfpi_test_noinline void test7()
     {
         v_if (!(v >= 25.0f && v < 26.0f) && !(v >= 27.0f && v < 28.0f))
         {
-            dst_reg[7] = -1024.0f;
+            sfpi::dst_reg[7] = -1024.0f;
         }
         v_endif;
     }
@@ -1208,8 +1208,8 @@ sfpi_test_noinline void test7()
     // and things get flipped around when joined by ||
     v_if (v >= 29.0f && v < 32.0f)
     {
-        vInt t       = vConstTileId >> 1;
-        vFloat total = 16.0F;
+        sfpi::vInt t       = vConstTileId >> 1;
+        sfpi::vFloat total = 16.0F;
 
         v_if (t <= 30)
         {
@@ -1242,7 +1242,7 @@ sfpi_test_noinline void test7()
         }
         v_endif;
 
-        dst_reg[7] = total;
+        sfpi::dst_reg[7] = total;
     }
     v_endif;
     // [29] = 1712.0
@@ -1258,168 +1258,168 @@ sfpi_test_noinline void test8()
     // Atypical usage of conditionals
     // More conditionals (short v compares)
 
-    dst_reg[8] = -dst_reg[0];
-    v_if (dst_reg[0] == 1.0F)
+    sfpi::dst_reg[8] = -sfpi::dst_reg[0];
+    v_if (sfpi::dst_reg[0] == 1.0F)
     {
         vUInt a = 0x05FF;
         vUInt b = 0x0AAA;
         b &= a;
-        set_expected_result(8, 16.0F, 0x00AA, static_cast<vInt>(b));
+        set_expected_result(8, 16.0F, 0x00AA, static_cast<sfpi::vInt>(b));
     }
-    v_elseif (dst_reg[0] == 2.0F)
+    v_elseif (sfpi::dst_reg[0] == 2.0F)
     {
         vUInt a = 0x05FF;
         vUInt b = 0x0AAA;
         vUInt c = a & b;
-        set_expected_result(8, 16.0F, 0x00AA, static_cast<vInt>(c));
+        set_expected_result(8, 16.0F, 0x00AA, static_cast<sfpi::vInt>(c));
     }
-    v_elseif (dst_reg[0] == 3.0F)
+    v_elseif (sfpi::dst_reg[0] == 3.0F)
     {
-        vInt a = 0x05FF;
-        vInt b = 0x0AAA;
+        sfpi::vInt a = 0x05FF;
+        sfpi::vInt b = 0x0AAA;
         b &= a;
         set_expected_result(8, 16.0F, 0x00AA, b);
     }
-    v_elseif (dst_reg[0] == 4.0F)
+    v_elseif (sfpi::dst_reg[0] == 4.0F)
     {
-        vInt a = 0x05FF;
-        vInt b = 0x0AAA;
-        vInt c = a & b;
+        sfpi::vInt a = 0x05FF;
+        sfpi::vInt b = 0x0AAA;
+        sfpi::vInt c = a & b;
         set_expected_result(8, 16.0F, 0x00AA, c);
     }
     v_endif;
 
-    v_if (dst_reg[0] == 5.0F)
+    v_if (sfpi::dst_reg[0] == 5.0F)
     {
         vUInt a = 0x0111;
         vUInt b = 0x0444;
         b |= a;
-        set_expected_result(8, 20.0F, 0x0555, static_cast<vInt>(b));
+        set_expected_result(8, 20.0F, 0x0555, static_cast<sfpi::vInt>(b));
     }
-    v_elseif (dst_reg[0] == 6.0F)
+    v_elseif (sfpi::dst_reg[0] == 6.0F)
     {
         vUInt a = 0x0111;
         vUInt b = 0x0444;
         vUInt c = b | a;
-        set_expected_result(8, 20.0F, 0x0555, static_cast<vInt>(c));
+        set_expected_result(8, 20.0F, 0x0555, static_cast<sfpi::vInt>(c));
     }
-    v_elseif (dst_reg[0] == 7.0F)
+    v_elseif (sfpi::dst_reg[0] == 7.0F)
     {
-        vInt a = 0x0111;
-        vInt b = 0x0444;
+        sfpi::vInt a = 0x0111;
+        sfpi::vInt b = 0x0444;
         b |= a;
         set_expected_result(8, 20.0F, 0x0555, b);
     }
-    v_elseif (dst_reg[0] == 8.0F)
+    v_elseif (sfpi::dst_reg[0] == 8.0F)
     {
-        vInt a = 0x0111;
-        vInt b = 0x0444;
-        vInt c = b | a;
+        sfpi::vInt a = 0x0111;
+        sfpi::vInt b = 0x0444;
+        sfpi::vInt c = b | a;
         set_expected_result(8, 20.0F, 0x0555, c);
     }
     v_endif;
 
-    v_if (dst_reg[0] == 9.0F)
+    v_if (sfpi::dst_reg[0] == 9.0F)
     {
         vUInt a = 0x0AAA;
         a       = ~a;
         a &= 0x0FFF; // Tricky since ~ flips upper bits that immediates can't access
-        set_expected_result(8, 22.0F, 0x0555, static_cast<vInt>(a));
+        set_expected_result(8, 22.0F, 0x0555, static_cast<sfpi::vInt>(a));
     }
-    v_elseif (dst_reg[0] == 10.0F)
+    v_elseif (sfpi::dst_reg[0] == 10.0F)
     {
-        vFloat a   = 100.0F;
-        dst_reg[8] = sfpi::abs(a);
+        sfpi::vFloat a   = 100.0F;
+        sfpi::dst_reg[8] = sfpi::abs(a);
     }
-    v_elseif (dst_reg[0] == 11.0F)
+    v_elseif (sfpi::dst_reg[0] == 11.0F)
     {
-        vFloat a   = -100.0F;
-        dst_reg[8] = sfpi::abs(a);
+        sfpi::vFloat a   = -100.0F;
+        sfpi::dst_reg[8] = sfpi::abs(a);
     }
-    v_elseif (dst_reg[0] == 12.0F)
+    v_elseif (sfpi::dst_reg[0] == 12.0F)
     {
-        vInt a = 100;
+        sfpi::vInt a = 100;
         set_expected_result(8, 24.0F, 100, sfpi::abs(a));
     }
-    v_elseif (dst_reg[0] == 13.0F)
+    v_elseif (sfpi::dst_reg[0] == 13.0F)
     {
-        vInt a = -100;
+        sfpi::vInt a = -100;
         set_expected_result(8, 26.0F, 100, sfpi::abs(a));
     }
     v_endif;
 
-    v_if (test_interleaved_scalar_vector_cond(true, dst_reg[0], 14.0F, 15.0F))
+    v_if (test_interleaved_scalar_vector_cond(true, sfpi::dst_reg[0], 14.0F, 15.0F))
     {
-        dst_reg[8] = 32.0F;
+        sfpi::dst_reg[8] = 32.0F;
     }
-    v_elseif (test_interleaved_scalar_vector_cond(false, dst_reg[0], 14.0F, 15.0F))
+    v_elseif (test_interleaved_scalar_vector_cond(false, sfpi::dst_reg[0], 14.0F, 15.0F))
     {
-        dst_reg[8] = 16.0F;
+        sfpi::dst_reg[8] = 16.0F;
     }
     v_endif;
 
-    vFloat tmp = dst_reg[8];
+    sfpi::vFloat tmp = sfpi::dst_reg[8];
     v_block
     {
-        v_and(dst_reg[0] >= 16.0F);
+        v_and(sfpi::dst_reg[0] >= 16.0F);
 
         for (int x = 0; x < 4; x++)
         {
-            v_and(dst_reg[0] < 20.0F - x);
+            v_and(sfpi::dst_reg[0] < 20.0F - x);
             tmp += 16.0F;
         }
     }
     v_endblock;
-    dst_reg[8] = tmp;
+    sfpi::dst_reg[8] = tmp;
 
     // <= and > are compound statements in the compiler, <= uses a compc
     // and things get flipped around when joined by ||
-    v_if (dst_reg[0] >= 20.0f && dst_reg[0] < 23.0f)
+    v_if (sfpi::dst_reg[0] >= 20.0f && sfpi::dst_reg[0] < 23.0f)
     {
-        vInt t    = vConstTileId >> 1;
-        vInt low  = 20;
-        vInt high = 21;
+        sfpi::vInt t    = vConstTileId >> 1;
+        sfpi::vInt low  = 20;
+        sfpi::vInt high = 21;
 
-        dst_reg[8] = 16.0f;
+        sfpi::dst_reg[8] = 16.0f;
 
         v_if (t <= high)
         {
-            dst_reg[8] = dst_reg[8] + 32.0F;
+            sfpi::dst_reg[8] = sfpi::dst_reg[8] + 32.0F;
         }
         v_endif;
         v_if (t > high)
         {
-            dst_reg[8] = dst_reg[8] + 64.0F;
+            sfpi::dst_reg[8] = sfpi::dst_reg[8] + 64.0F;
         }
         v_endif;
         v_if (!(t > high))
         {
-            dst_reg[8] = dst_reg[8] + 128.0F;
+            sfpi::dst_reg[8] = sfpi::dst_reg[8] + 128.0F;
         }
         v_endif;
         v_if (!(t <= high))
         {
-            dst_reg[8] = dst_reg[8] + 256.0F;
+            sfpi::dst_reg[8] = sfpi::dst_reg[8] + 256.0F;
         }
         v_endif;
         v_if (t <= low || t > high)
         {
-            dst_reg[8] = dst_reg[8] + 512.0F;
+            sfpi::dst_reg[8] = sfpi::dst_reg[8] + 512.0F;
         }
         v_endif;
         v_if (t > high || t <= low)
         {
-            dst_reg[8] = dst_reg[8] + 1024.0F;
+            sfpi::dst_reg[8] = sfpi::dst_reg[8] + 1024.0F;
         }
         v_endif;
     }
     v_endif;
 
     // Do the same tests as above, but for floats
-    v_if (dst_reg[0] >= 23.0f && dst_reg[0] < 26.0f)
+    v_if (sfpi::dst_reg[0] >= 23.0f && sfpi::dst_reg[0] < 26.0f)
     {
-        vFloat t     = dst_reg[0];
-        vFloat total = 16.0F;
+        sfpi::vFloat t     = sfpi::dst_reg[0];
+        sfpi::vFloat total = 16.0F;
 
         v_if (t <= 24.0f)
         {
@@ -1452,68 +1452,68 @@ sfpi_test_noinline void test8()
         }
         v_endif;
 
-        dst_reg[8] = total;
+        sfpi::dst_reg[8] = total;
     }
     v_endif;
 
     // More of the same, again for floats.  Reloads for reg pressure
-    v_if (dst_reg[0] >= 26.0f && dst_reg[0] < 29.0f)
+    v_if (sfpi::dst_reg[0] >= 26.0f && sfpi::dst_reg[0] < 29.0f)
     {
-        vFloat low  = 26.0f;
-        vFloat high = 27.0f;
+        sfpi::vFloat low  = 26.0f;
+        sfpi::vFloat high = 27.0f;
 
-        dst_reg[8] = 16.0f;
+        sfpi::dst_reg[8] = 16.0f;
 
-        vFloat t = dst_reg[0];
+        sfpi::vFloat t = sfpi::dst_reg[0];
         v_if (t <= high)
         {
-            dst_reg[8] = dst_reg[8] + 32.0F;
+            sfpi::dst_reg[8] = sfpi::dst_reg[8] + 32.0F;
         }
         v_endif;
-        t = dst_reg[0];
+        t = sfpi::dst_reg[0];
         v_if (t > high)
         {
-            dst_reg[8] = dst_reg[8] + 64.0F;
+            sfpi::dst_reg[8] = sfpi::dst_reg[8] + 64.0F;
         }
         v_endif;
-        t = dst_reg[0];
+        t = sfpi::dst_reg[0];
         v_if (!(t > high))
         {
-            dst_reg[8] = dst_reg[8] + 128.0F;
+            sfpi::dst_reg[8] = sfpi::dst_reg[8] + 128.0F;
         }
         v_endif;
-        t = dst_reg[0];
+        t = sfpi::dst_reg[0];
         v_if (!(t <= high))
         {
-            dst_reg[8] = dst_reg[8] + 256.0F;
+            sfpi::dst_reg[8] = sfpi::dst_reg[8] + 256.0F;
         }
         v_endif;
-        t = dst_reg[0];
+        t = sfpi::dst_reg[0];
         v_if (t <= low || t > high)
         {
-            dst_reg[8] = dst_reg[8] + 512.0F;
+            sfpi::dst_reg[8] = sfpi::dst_reg[8] + 512.0F;
         }
         v_endif;
-        t   = dst_reg[0];
+        t   = sfpi::dst_reg[0];
         low = 26.0f;
         v_if (t > high || t <= low)
         {
-            dst_reg[8] = dst_reg[8] + 1024.0F;
+            sfpi::dst_reg[8] = sfpi::dst_reg[8] + 1024.0F;
         }
         v_endif;
     }
     v_endif;
 
-    v_if (dst_reg[0] == 29.0F)
+    v_if (sfpi::dst_reg[0] == 29.0F)
     {
-        vInt a = 0xA5A5;
-        vInt b = 0xFF00;
-        vInt c = a ^ b;
+        sfpi::vInt a = 0xA5A5;
+        sfpi::vInt b = 0xFF00;
+        sfpi::vInt c = a ^ b;
         set_expected_result(8, 32.0F, 0x5AA5, c);
     }
     v_endif;
 
-    v_if (dst_reg[0] == 30.0F)
+    v_if (sfpi::dst_reg[0] == 30.0F)
     {
         vUInt a = 0xA5A5;
         vUInt b = 0xFF00;
@@ -1522,10 +1522,10 @@ sfpi_test_noinline void test8()
     }
     v_endif;
 
-    v_if (dst_reg[0] == 31.0F)
+    v_if (sfpi::dst_reg[0] == 31.0F)
     {
-        vInt a = 0xA5A5;
-        vInt b = 0xFF00;
+        sfpi::vInt a = 0xA5A5;
+        sfpi::vInt b = 0xFF00;
         b ^= a;
         set_expected_result(8, 32.0F, 0x5AA5, b);
     }
@@ -1572,75 +1572,75 @@ sfpi_test_noinline void test9()
     // SFPMULI, SFPADDI, SFPDIVP2, SFPLZ
     // More conditional tests
 
-    dst_reg[9] = -dst_reg[0];
-    v_if (dst_reg[0] == 1.0F)
+    sfpi::dst_reg[9] = -sfpi::dst_reg[0];
+    v_if (sfpi::dst_reg[0] == 1.0F)
     {
-        vFloat a   = 20.0F;
-        dst_reg[9] = a * 30.0F;
+        sfpi::vFloat a   = 20.0F;
+        sfpi::dst_reg[9] = a * 30.0F;
     }
-    v_elseif (dst_reg[0] == 2.0F)
+    v_elseif (sfpi::dst_reg[0] == 2.0F)
     {
-        vFloat a = 20.0F;
+        sfpi::vFloat a = 20.0F;
         a *= 40.0F;
-        dst_reg[9] = a;
+        sfpi::dst_reg[9] = a;
     }
-    v_elseif (dst_reg[0] == 3.0F)
+    v_elseif (sfpi::dst_reg[0] == 3.0F)
     {
-        vFloat a   = 20.0F;
-        dst_reg[9] = a + 30.0F;
+        sfpi::vFloat a   = 20.0F;
+        sfpi::dst_reg[9] = a + 30.0F;
     }
-    v_elseif (dst_reg[0] == 4.0F)
+    v_elseif (sfpi::dst_reg[0] == 4.0F)
     {
-        vFloat a = 20.0F;
+        sfpi::vFloat a = 20.0F;
         a += 40.0F;
-        dst_reg[9] = a;
+        sfpi::dst_reg[9] = a;
     }
-    v_elseif (dst_reg[0] == 5.0F)
+    v_elseif (sfpi::dst_reg[0] == 5.0F)
     {
-        vFloat a   = 16.0F;
-        dst_reg[9] = addexp(a, 4);
+        sfpi::vFloat a   = 16.0F;
+        sfpi::dst_reg[9] = addexp(a, 4);
     }
-    v_elseif (dst_reg[0] == 6.0F)
+    v_elseif (sfpi::dst_reg[0] == 6.0F)
     {
-        vFloat a   = 256.0F;
-        dst_reg[9] = addexp(a, -4);
+        sfpi::vFloat a   = 256.0F;
+        sfpi::dst_reg[9] = addexp(a, -4);
     }
     v_endif;
 
-    v_if (dst_reg[0] == 7.0F)
+    v_if (sfpi::dst_reg[0] == 7.0F)
     {
-        vInt a = 0;
-        vInt b = lz(a);
+        sfpi::vInt a = 0;
+        sfpi::vInt b = lz(a);
         set_expected_result(9, 38.0F, 0x20, b);
     }
-    v_elseif (dst_reg[0] == 8.0F)
+    v_elseif (sfpi::dst_reg[0] == 8.0F)
     {
-        vInt a = 0xFFFFFFFF;
-        vInt b = lz(a);
+        sfpi::vInt a = 0xFFFFFFFF;
+        sfpi::vInt b = lz(a);
         set_expected_result(9, 55.0F, 0x0, b);
     }
-    v_elseif (dst_reg[0] == 9.0F)
+    v_elseif (sfpi::dst_reg[0] == 9.0F)
     {
         vUInt a = 0xFFFFU;
-        vInt b  = lz(a);
+        sfpi::vInt b  = lz(a);
         set_expected_result(9, 30.0F, 0x10, b);
     }
-    v_elseif (dst_reg[0] < 13.0F)
+    v_elseif (sfpi::dst_reg[0] < 13.0F)
     {
-        vFloat a = dst_reg[0] - 11.0F;
+        sfpi::vFloat a = sfpi::dst_reg[0] - 11.0F;
         vUInt b;
 
         // Relies on if chain above...
-        v_if (dst_reg[0] >= 7.0F)
+        v_if (sfpi::dst_reg[0] >= 7.0F)
         {
             b = reinterpret<vUInt>(lz(a));
             v_if (b != 32)
             {
-                dst_reg[9] = 60.0F;
+                sfpi::dst_reg[9] = 60.0F;
             }
             v_else
             {
-                dst_reg[9] = 40.0F;
+                sfpi::dst_reg[9] = 40.0F;
             }
             v_endif;
         }
@@ -1648,62 +1648,62 @@ sfpi_test_noinline void test9()
     }
     v_endif;
 
-    v_if (dst_reg[0] == 13.0F)
+    v_if (sfpi::dst_reg[0] == 13.0F)
     {
-        vFloat x = 1.0F;
+        sfpi::vFloat x = 1.0F;
 
         x *= 2.0f;
         x *= -3.0f;
         x += 4.0f;
         x += -4.0f;
 
-        dst_reg[9] = x;
+        sfpi::dst_reg[9] = x;
     }
-    v_elseif (dst_reg[0] == 14.0F)
+    v_elseif (sfpi::dst_reg[0] == 14.0F)
     {
         // MULI/ADDI don't accept fp16a
         // Ensure this goes to MAD
 
-        vFloat x = 1.0F;
+        sfpi::vFloat x = 1.0F;
 
         x *= s2vFloat16a(2.0);
         x *= s2vFloat16a(-3.0);
         x += s2vFloat16a(4.0);
         x += s2vFloat16a(-4.0);
 
-        dst_reg[9] = x;
+        sfpi::dst_reg[9] = x;
     }
     v_endif;
 
     // Test more boolean expressions
-    v_if (dst_reg[0] >= 15.0F && dst_reg[0] < 19.0)
+    v_if (sfpi::dst_reg[0] >= 15.0F && sfpi::dst_reg[0] < 19.0)
     {
-        vFloat v = dst_reg[0];
+        sfpi::vFloat v = sfpi::dst_reg[0];
         v_if ((v <= 16.0f && v != 15.0f) || (v == 18.0f))
         {
-            dst_reg[9] = 32.0f;
+            sfpi::dst_reg[9] = 32.0f;
         }
         v_endif;
     }
     v_endif;
 
     // Same as above, but flip the order of the top level OR
-    v_if (dst_reg[0] >= 19.0F && dst_reg[0] < 23.0)
+    v_if (sfpi::dst_reg[0] >= 19.0F && sfpi::dst_reg[0] < 23.0)
     {
-        vFloat v = dst_reg[0];
+        sfpi::vFloat v = sfpi::dst_reg[0];
         v_if ((v == 22.0f) || (v <= 20.0f && v != 19.0f))
         {
-            dst_reg[9] = 32.0f;
+            sfpi::dst_reg[9] = 32.0f;
         }
         v_endif;
     }
     v_endif;
 
     v_if (
-        (dst_reg[0] == 23.0 || dst_reg[0] == 24.0 || dst_reg[0] == 25.0 || dst_reg[0] == 26.0 || dst_reg[0] == 27.0 || dst_reg[0] == 28.0) &&
-        (dst_reg[0] != 23.0 && dst_reg[0] != 25.0 && dst_reg[0] != 27.0f))
+        (sfpi::dst_reg[0] == 23.0 || sfpi::dst_reg[0] == 24.0 || sfpi::dst_reg[0] == 25.0 || sfpi::dst_reg[0] == 26.0 || sfpi::dst_reg[0] == 27.0 || sfpi::dst_reg[0] == 28.0) &&
+        (sfpi::dst_reg[0] != 23.0 && sfpi::dst_reg[0] != 25.0 && sfpi::dst_reg[0] != 27.0f))
     {
-        dst_reg[9] = 64.0f;
+        sfpi::dst_reg[9] = 64.0f;
     }
     v_endif;
 
@@ -1742,76 +1742,76 @@ sfpi_test_noinline void test9()
 sfpi_test_noinline void test10()
 {
     // SFPSHFT, SFTSETSGN
-    dst_reg[10] = -dst_reg[0];
-    v_if (dst_reg[0] == 1.0F)
+    sfpi::dst_reg[10] = -sfpi::dst_reg[0];
+    v_if (sfpi::dst_reg[0] == 1.0F)
     {
         vUInt a    = 0x015;
-        vInt shift = 6;
+        sfpi::vInt shift = 6;
         vUInt b    = shft(a, shift);
         // Could write better tests if we could return and test the int result
-        set_expected_result(10, 20.0F, 0x0540, static_cast<vInt>(b));
+        set_expected_result(10, 20.0F, 0x0540, static_cast<sfpi::vInt>(b));
     }
-    v_elseif (dst_reg[0] == 2.0F)
+    v_elseif (sfpi::dst_reg[0] == 2.0F)
     {
         vUInt a = 0x2AAA;
         vUInt b = shft(a, -4);
-        set_expected_result(10, 22.0F, 0x02AA, static_cast<vInt>(b));
+        set_expected_result(10, 22.0F, 0x02AA, static_cast<sfpi::vInt>(b));
     }
-    v_elseif (dst_reg[0] == 3.0F)
+    v_elseif (sfpi::dst_reg[0] == 3.0F)
     {
         vUInt a    = 0xAAAAU;
-        vInt shift = -6;
+        sfpi::vInt shift = -6;
         vUInt b    = shft(a, shift);
-        set_expected_result(10, 24.0F, 0x02AA, static_cast<vInt>(b));
+        set_expected_result(10, 24.0F, 0x02AA, static_cast<sfpi::vInt>(b));
     }
-    v_elseif (dst_reg[0] == 4.0F)
+    v_elseif (sfpi::dst_reg[0] == 4.0F)
     {
         vUInt a = 0x005A;
         vUInt b = shft(a, 4);
-        set_expected_result(10, 26.0F, 0x05A0, static_cast<vInt>(b));
+        set_expected_result(10, 26.0F, 0x05A0, static_cast<sfpi::vInt>(b));
     }
-    v_elseif (dst_reg[0] == 5.0F)
+    v_elseif (sfpi::dst_reg[0] == 5.0F)
     {
-        vInt a = 25;
+        sfpi::vInt a = 25;
         a      = a + 5;
         a += 7;
         set_expected_result(10, 28.0F, 0x25, a);
     }
-    v_elseif (dst_reg[0] == 6.0F)
+    v_elseif (sfpi::dst_reg[0] == 6.0F)
     {
-        vInt a = 28;
-        vInt b = 100;
+        sfpi::vInt a = 28;
+        sfpi::vInt b = 100;
         a += b;
         set_expected_result(10, 30.0F, 0x80, a);
     }
     v_endif;
 
-    v_if (dst_reg[0] == 7.0F)
+    v_if (sfpi::dst_reg[0] == 7.0F)
     {
-        vFloat a    = dst_reg[0];
-        dst_reg[10] = setsgn(a, 1);
+        sfpi::vFloat a    = sfpi::dst_reg[0];
+        sfpi::dst_reg[10] = setsgn(a, 1);
     }
-    v_elseif (dst_reg[0] == 8.0F)
+    v_elseif (sfpi::dst_reg[0] == 8.0F)
     {
-        vFloat a = dst_reg[0];
-        vFloat b = -128.0;
-        vFloat r = setsgn(b, a);
+        sfpi::vFloat a = sfpi::dst_reg[0];
+        sfpi::vFloat b = -128.0;
+        sfpi::vFloat r = setsgn(b, a);
 
-        dst_reg[10] = r;
+        sfpi::dst_reg[10] = r;
     }
-    v_elseif (dst_reg[0] == 9.0F)
+    v_elseif (sfpi::dst_reg[0] == 9.0F)
     {
-        vFloat a    = -256.0F;
-        dst_reg[10] = setsgn(a, 0);
+        sfpi::vFloat a    = -256.0F;
+        sfpi::dst_reg[10] = setsgn(a, 0);
     }
-    v_elseif (dst_reg[0] == 10.0F)
+    v_elseif (sfpi::dst_reg[0] == 10.0F)
     {
-        vFloat a = dst_reg[0];
+        sfpi::vFloat a = sfpi::dst_reg[0];
         a += 20.0f;
-        vFloat b = -512.0F;
-        vFloat r = setsgn(a, b);
+        sfpi::vFloat b = -512.0F;
+        sfpi::vFloat r = setsgn(a, b);
 
-        dst_reg[10] = r;
+        sfpi::dst_reg[10] = r;
     }
     v_endif;
 
@@ -1831,60 +1831,60 @@ sfpi_test_noinline void test10()
 sfpi_test_noinline void test11()
 {
     // SFPLUT, SFPLOADL<n>
-    dst_reg[11] = -dst_reg[0];
+    sfpi::dst_reg[11] = -sfpi::dst_reg[0];
 
     vUInt l0a = 0xFF30; // Multiply by 0.0, add 0.125
     vUInt l1a = 0X3020; // Multiply by 0.125, add 0.25
-    v_if (dst_reg[0] == 1.0F)
+    v_if (sfpi::dst_reg[0] == 1.0F)
     {
         // Use L0
-        vFloat h    = -0.3F;
+        sfpi::vFloat h    = -0.3F;
         vUInt l2a   = 0xA010; // Mulitply by -0.25, add 0.5
         h           = lut_sign(h, l0a, l1a, l2a);
-        dst_reg[11] = h;
+        sfpi::dst_reg[11] = h;
     }
-    v_elseif (dst_reg[0] == 2.0F)
+    v_elseif (sfpi::dst_reg[0] == 2.0F)
     {
         // Use L0
-        vFloat h    = -0.3F;
+        sfpi::vFloat h    = -0.3F;
         vUInt l2a   = 0xA010; // Mulitply by -0.25, add 0.5
         h           = lut(h, l0a, l1a, l2a);
-        dst_reg[11] = h;
+        sfpi::dst_reg[11] = h;
     }
-    v_elseif (dst_reg[0] == 3.0F)
+    v_elseif (sfpi::dst_reg[0] == 3.0F)
     {
         // Use L0
-        vFloat h  = -0.3F;
+        sfpi::vFloat h  = -0.3F;
         vUInt l2a = 0xA010; // Mulitply by -0.25, add 0.5
         // Test used a bias on Grayskull, not supported on Wormhole
         h           = lut_sign(h, l0a, l1a, l2a);
-        dst_reg[11] = h;
+        sfpi::dst_reg[11] = h;
     }
-    v_elseif (dst_reg[0] == 4.0F)
+    v_elseif (sfpi::dst_reg[0] == 4.0F)
     {
         // Use L0
-        vFloat h  = -0.3F;
+        sfpi::vFloat h  = -0.3F;
         vUInt l2a = 0xA010; // Mulitply by -0.25, add 0.5
         // Test used a bias on Grayskull, not supported on Wormhole
         h           = lut(h, l0a, l1a, l2a);
-        dst_reg[11] = h;
+        sfpi::dst_reg[11] = h;
     }
-    v_elseif (dst_reg[0] == 5.0F)
+    v_elseif (sfpi::dst_reg[0] == 5.0F)
     {
         // Use L1
-        vFloat h  = 1.0F;
+        sfpi::vFloat h  = 1.0F;
         vUInt l2a = 0xA010; // Mulitply by -0.25, add 0.5
         // Test used a bias on Grayskull, not supported on Wormhole
         h           = lut(h, l0a, l1a, l2a);
-        dst_reg[11] = h;
+        sfpi::dst_reg[11] = h;
     }
-    v_elseif (dst_reg[0] == 6.0F)
+    v_elseif (sfpi::dst_reg[0] == 6.0F)
     {
         // Use L2
-        vFloat h    = 4.0F;
+        sfpi::vFloat h    = 4.0F;
         vUInt l2a   = 0xA010; // Mulitply by -0.25, add 0.5
         h           = lut_sign(h, l0a, l1a, l2a);
-        dst_reg[11] = h;
+        sfpi::dst_reg[11] = h;
     }
     v_endif;
 
@@ -1901,56 +1901,56 @@ sfpi_test_noinline void test11()
         l0b = l_reg[LRegs::LReg0];
         l1b = l_reg[LRegs::LReg1];
 
-        v_if (dst_reg[0] == 7.0F)
+        v_if (sfpi::dst_reg[0] == 7.0F)
         {
             // Use L0
-            vFloat h    = -0.3F;
+            sfpi::vFloat h    = -0.3F;
             vUInt l2b   = 0x9000;
             h           = lut_sign(h, l0b, l1b, l2b);
-            dst_reg[11] = h;
+            sfpi::dst_reg[11] = h;
         }
-        v_elseif (dst_reg[0] == 8.0F)
+        v_elseif (sfpi::dst_reg[0] == 8.0F)
         {
             // Use L0
-            vFloat h    = -0.3F;
+            sfpi::vFloat h    = -0.3F;
             vUInt l2b   = 0x9000;
             h           = lut(h, l0b, l1b, l2b);
-            dst_reg[11] = h;
+            sfpi::dst_reg[11] = h;
         }
-        v_elseif (dst_reg[0] == 9.0F)
+        v_elseif (sfpi::dst_reg[0] == 9.0F)
         {
             // Use L0
-            vFloat h  = -0.3F;
+            sfpi::vFloat h  = -0.3F;
             vUInt l2b = 0x9000;
             // Test used a bias on Grayskull, not supported on Wormhole
             h           = lut_sign(h, l0b, l1b, l2b);
-            dst_reg[11] = h;
+            sfpi::dst_reg[11] = h;
         }
-        v_elseif (dst_reg[0] == 10.0F)
+        v_elseif (sfpi::dst_reg[0] == 10.0F)
         {
             // Use L0
-            vFloat h  = -0.3F;
+            sfpi::vFloat h  = -0.3F;
             vUInt l2b = 0x9000;
             // Test used a bias on Grayskull, not supported on Wormhole
             h           = lut(h, l0b, l1b, l2b);
-            dst_reg[11] = h;
+            sfpi::dst_reg[11] = h;
         }
-        v_elseif (dst_reg[0] == 11.0F)
+        v_elseif (sfpi::dst_reg[0] == 11.0F)
         {
             // Use L1
-            vFloat h  = 1.0F;
+            sfpi::vFloat h  = 1.0F;
             vUInt l2b = 0x9000;
             // Test used a bias on Grayskull, not supported on Wormhole
             h           = lut(h, l0b, l1b, l2b);
-            dst_reg[11] = h;
+            sfpi::dst_reg[11] = h;
         }
-        v_elseif (dst_reg[0] == 12.0F)
+        v_elseif (sfpi::dst_reg[0] == 12.0F)
         {
             // Use L2
-            vFloat h    = 4.0F;
+            sfpi::vFloat h    = 4.0F;
             vUInt l2b   = 0x9000;
             h           = lut_sign(h, l0b, l1b, l2b);
-            dst_reg[11] = h;
+            sfpi::dst_reg[11] = h;
         }
         v_endif;
     }
@@ -1960,64 +1960,64 @@ sfpi_test_noinline void test11()
         vUInt l0 = (s2vFloat16a(2.0f).get() << 16) | s2vFloat16a(3.0f).get();
         vUInt l1 = (s2vFloat16a(4.0f).get() << 16) | s2vFloat16a(5.0f).get();
         vUInt l2 = (s2vFloat16a(6.0f).get() << 16) | s2vFloat16a(7.0f).get();
-        v_if (dst_reg[0] == 13.0f)
+        v_if (sfpi::dst_reg[0] == 13.0f)
         {
-            vFloat h    = -0.25f;
+            sfpi::vFloat h    = -0.25f;
             h           = lut2(h, l0, l1, l2);
-            dst_reg[11] = h; // .25 * 2 + 3 = -3.5 (sign retain)
+            sfpi::dst_reg[11] = h; // .25 * 2 + 3 = -3.5 (sign retain)
         }
-        v_elseif (dst_reg[0] == 14.0f)
+        v_elseif (sfpi::dst_reg[0] == 14.0f)
         {
-            vFloat h    = 1.25f;
+            sfpi::vFloat h    = 1.25f;
             h           = lut2(h, l0, l1, l2);
-            dst_reg[11] = h; // 1.25 * 4 + 5 = 10 (sign retain)
+            sfpi::dst_reg[11] = h; // 1.25 * 4 + 5 = 10 (sign retain)
         }
-        v_elseif (dst_reg[0] == 15.0f)
+        v_elseif (sfpi::dst_reg[0] == 15.0f)
         {
-            vFloat h    = -2.25f;
+            sfpi::vFloat h    = -2.25f;
             h           = lut2(h, l0, l1, l2);
-            dst_reg[11] = h; // 2.25 * 6 + 7 = 13.5 + 7 = -20.5 (sign retain)
+            sfpi::dst_reg[11] = h; // 2.25 * 6 + 7 = 13.5 + 7 = -20.5 (sign retain)
         }
-        v_elseif (dst_reg[0] == 16.0f)
+        v_elseif (sfpi::dst_reg[0] == 16.0f)
         {
-            vFloat h    = -0.25f;
+            sfpi::vFloat h    = -0.25f;
             h           = lut2_sign(h, l0, l1, l2);
-            dst_reg[11] = h; // .25 * 2 + 3 = 3.5 (sign update)
+            sfpi::dst_reg[11] = h; // .25 * 2 + 3 = 3.5 (sign update)
         }
         v_endif;
     }
 
     // lut2 3 entry 32 bit
     {
-        vFloat a0 = 2.0f;
-        vFloat a1 = 4.0f;
-        vFloat a2 = 6.0f;
-        vFloat b0 = 3.0f;
-        vFloat b1 = 5.0f;
-        vFloat b2 = 7.0f;
-        v_if (dst_reg[0] == 17.0f)
+        sfpi::vFloat a0 = 2.0f;
+        sfpi::vFloat a1 = 4.0f;
+        sfpi::vFloat a2 = 6.0f;
+        sfpi::vFloat b0 = 3.0f;
+        sfpi::vFloat b1 = 5.0f;
+        sfpi::vFloat b2 = 7.0f;
+        v_if (sfpi::dst_reg[0] == 17.0f)
         {
-            vFloat h    = -0.25f;
+            sfpi::vFloat h    = -0.25f;
             h           = lut2(h, a0, a1, a2, b0, b1, b2);
-            dst_reg[11] = h; // .25 * 2 + 3 = -3.5 (sign retain)
+            sfpi::dst_reg[11] = h; // .25 * 2 + 3 = -3.5 (sign retain)
         }
-        v_elseif (dst_reg[0] == 18.0f)
+        v_elseif (sfpi::dst_reg[0] == 18.0f)
         {
-            vFloat h    = 1.25f;
+            sfpi::vFloat h    = 1.25f;
             h           = lut2(h, a0, a1, a2, b0, b1, b2);
-            dst_reg[11] = h; // 1.25 * 4 + 5 = 10 (sign retain)
+            sfpi::dst_reg[11] = h; // 1.25 * 4 + 5 = 10 (sign retain)
         }
-        v_elseif (dst_reg[0] == 19.0f)
+        v_elseif (sfpi::dst_reg[0] == 19.0f)
         {
-            vFloat h    = -3.0f;
+            sfpi::vFloat h    = -3.0f;
             h           = lut2(h, a0, a1, a2, b0, b1, b2);
-            dst_reg[11] = h; // 3 * 6 + 7 = 18 + 7 = -25.0 (sign retain)
+            sfpi::dst_reg[11] = h; // 3 * 6 + 7 = 18 + 7 = -25.0 (sign retain)
         }
-        v_elseif (dst_reg[0] == 20.0f)
+        v_elseif (sfpi::dst_reg[0] == 20.0f)
         {
-            vFloat h    = -0.25f;
+            sfpi::vFloat h    = -0.25f;
             h           = lut2_sign(h, a0, a1, a2, b0, b1, b2);
-            dst_reg[11] = h; // .25 * 2 + 3 = 3.5 (sign update)
+            sfpi::dst_reg[11] = h; // .25 * 2 + 3 = 3.5 (sign update)
         }
         v_endif;
     }
@@ -2031,47 +2031,47 @@ sfpi_test_noinline void test11()
         vUInt b01 = (s2vFloat16a(5.0f).get() << 16) | s2vFloat16a(3.0f).get();
         vUInt b23 = (s2vFloat16a(9.0f).get() << 16) | s2vFloat16a(7.0f).get();
         vUInt b34 = (s2vFloat16a(13.0f).get() << 16) | s2vFloat16a(11.0f).get();
-        v_if (dst_reg[0] == 21.0f)
+        v_if (sfpi::dst_reg[0] == 21.0f)
         {
-            vFloat h    = -0.25f;
+            sfpi::vFloat h    = -0.25f;
             h           = lut2(h, a01, a23, a34, b01, b23, b34);
-            dst_reg[11] = h; // .25 * 2 + 3 = -3.5 (sign retain)
+            sfpi::dst_reg[11] = h; // .25 * 2 + 3 = -3.5 (sign retain)
         }
-        v_elseif (dst_reg[0] == 22.0f)
+        v_elseif (sfpi::dst_reg[0] == 22.0f)
         {
-            vFloat h    = 0.75f;
+            sfpi::vFloat h    = 0.75f;
             h           = lut2(h, a01, a23, a34, b01, b23, b34);
-            dst_reg[11] = h; // .75 * 4 + 5 = 8
+            sfpi::dst_reg[11] = h; // .75 * 4 + 5 = 8
         }
-        v_elseif (dst_reg[0] == 23.0f)
+        v_elseif (sfpi::dst_reg[0] == 23.0f)
         {
-            vFloat h    = -1.25f;
+            sfpi::vFloat h    = -1.25f;
             h           = lut2(h, a01, a23, a34, b01, b23, b34);
-            dst_reg[11] = h; // 1.25 * 6 + 7 = 7.5 + 7 = -14.5 (sign retain)
+            sfpi::dst_reg[11] = h; // 1.25 * 6 + 7 = 7.5 + 7 = -14.5 (sign retain)
         }
-        v_elseif (dst_reg[0] == 24.0f)
+        v_elseif (sfpi::dst_reg[0] == 24.0f)
         {
-            vFloat h    = -1.75f;
+            sfpi::vFloat h    = -1.75f;
             h           = lut2(h, a01, a23, a34, b01, b23, b34);
-            dst_reg[11] = h; // 1.75 * 8 + 9 = 14 + 9 = -23 (sign retain)
+            sfpi::dst_reg[11] = h; // 1.75 * 8 + 9 = 14 + 9 = -23 (sign retain)
         }
-        v_elseif (dst_reg[0] == 25.0f)
+        v_elseif (sfpi::dst_reg[0] == 25.0f)
         {
-            vFloat h    = 2.5f;
+            sfpi::vFloat h    = 2.5f;
             h           = lut2(h, a01, a23, a34, b01, b23, b34);
-            dst_reg[11] = h; // 2.5 * 10 + 11 = 25 + 11 = 36.0
+            sfpi::dst_reg[11] = h; // 2.5 * 10 + 11 = 25 + 11 = 36.0
         }
-        v_elseif (dst_reg[0] == 26.0f)
+        v_elseif (sfpi::dst_reg[0] == 26.0f)
         {
-            vFloat h    = 3.5f;
+            sfpi::vFloat h    = 3.5f;
             h           = lut2(h, a01, a23, a34, b01, b23, b34);
-            dst_reg[11] = h; // 3.5 * 12 + 13 = 42 + 13 = 55.0
+            sfpi::dst_reg[11] = h; // 3.5 * 12 + 13 = 42 + 13 = 55.0
         }
-        v_elseif (dst_reg[0] == 27.0f)
+        v_elseif (sfpi::dst_reg[0] == 27.0f)
         {
-            vFloat h    = -0.25f;
+            sfpi::vFloat h    = -0.25f;
             h           = lut2_sign(h, a01, a23, a34, b01, b23, b34);
-            dst_reg[11] = h; // .25 * 2 + 3 = 3.5 (sign update)
+            sfpi::dst_reg[11] = h; // .25 * 2 + 3 = 3.5 (sign update)
         }
         v_endif;
     }
@@ -2089,43 +2089,43 @@ sfpi_test_noinline void test11()
         // Can't fit all the tests into 32 elements, skipping a few that are
         // the most redundant to prior tests here
 #if 0
-        v_if(dst_reg[0] == 28.0f) {
-            vFloat h = -0.25f;
+        v_if(sfpi::dst_reg[0] == 28.0f) {
+            sfpi::vFloat h = -0.25f;
             h = lut2(h, a01, a23, a34, b01, b23, b34, 2);
-            dst_reg[11] = h; // .25 * 2 + 3 = -3.5 (sign retain)
-        } v_elseif(dst_reg[0] == 29.0f) {
-            vFloat h = 0.75f;
+            sfpi::dst_reg[11] = h; // .25 * 2 + 3 = -3.5 (sign retain)
+        } v_elseif(sfpi::dst_reg[0] == 29.0f) {
+            sfpi::vFloat h = 0.75f;
             h = lut2(h, a01, a23, a34, b01, b23, b34, 2);
-            dst_reg[11] = h; // .75 * 4 + 5 = 8
-        } v_elseif(dst_reg[0] == 30.0f) {
-            vFloat h = -1.25f;
+            sfpi::dst_reg[11] = h; // .75 * 4 + 5 = 8
+        } v_elseif(sfpi::dst_reg[0] == 30.0f) {
+            sfpi::vFloat h = -1.25f;
             h = lut2(h, a01, a23, a34, b01, b23, b34, 2);
-            dst_reg[11] = h; // 1.25 * 6 + 7 = 7.5 + 7 = -14.5 (sign retain)
+            sfpi::dst_reg[11] = h; // 1.25 * 6 + 7 = 7.5 + 7 = -14.5 (sign retain)
         }
 #endif
-        v_if (dst_reg[0] == 28.0f)
+        v_if (sfpi::dst_reg[0] == 28.0f)
         {
-            vFloat h    = -1.75f;
+            sfpi::vFloat h    = -1.75f;
             h           = lut2(h, a01, a23, a34, b01, b23, b34, 2);
-            dst_reg[11] = h; // 1.75 * 8 + 9 = 14 + 9 = -23 (sign retain)
+            sfpi::dst_reg[11] = h; // 1.75 * 8 + 9 = 14 + 9 = -23 (sign retain)
         }
-        v_elseif (dst_reg[0] == 29.0f)
+        v_elseif (sfpi::dst_reg[0] == 29.0f)
         {
-            vFloat h    = 3.5f;
+            sfpi::vFloat h    = 3.5f;
             h           = lut2(h, a01, a23, a34, b01, b23, b34, 2);
-            dst_reg[11] = h; // 3.5 * 10 + 11 = 35 + 11 = 46.0
+            sfpi::dst_reg[11] = h; // 3.5 * 10 + 11 = 35 + 11 = 46.0
         }
-        v_elseif (dst_reg[0] == 30.0f)
+        v_elseif (sfpi::dst_reg[0] == 30.0f)
         {
-            vFloat h    = 4.5f;
+            sfpi::vFloat h    = 4.5f;
             h           = lut2(h, a01, a23, a34, b01, b23, b34, 2);
-            dst_reg[11] = h; // 4.5 * 12 + 13 = 54 + 13 = 67.0
+            sfpi::dst_reg[11] = h; // 4.5 * 12 + 13 = 54 + 13 = 67.0
         }
-        v_elseif (dst_reg[0] == 31.0f)
+        v_elseif (sfpi::dst_reg[0] == 31.0f)
         {
-            vFloat h    = -0.25f;
+            sfpi::vFloat h    = -0.25f;
             h           = lut2_sign(h, a01, a23, a34, b01, b23, b34, 2);
-            dst_reg[11] = h; // .25 * 2 + 3 = 3.5 (sign update)
+            sfpi::dst_reg[11] = h; // .25 * 2 + 3 = 3.5 (sign update)
         }
         v_endif;
     }
@@ -2171,163 +2171,163 @@ sfpi_test_noinline void test12(int imm)
     // Test immediate forms of SFPLOAD, SFPLOADI, SFPSTORE, SFPIADD_I, SFPADDI
     // SFPMULI, SFPSHFT, SFPDIVP2, SFPSETEXP, SFPSETMAN, SFPSETSGN,
     // Tries to cover both positive and negative params (sign extension)
-    dst_reg[12] = -dst_reg[0];
+    sfpi::dst_reg[12] = -sfpi::dst_reg[0];
 
-    v_if (dst_reg[0] == 1.0F)
+    v_if (sfpi::dst_reg[0] == 1.0F)
     {
-        dst_reg[12] = static_cast<float>(imm); // SFPLOADI
+        sfpi::dst_reg[12] = static_cast<float>(imm); // SFPLOADI
     }
-    v_elseif (dst_reg[0] == 2.0F)
+    v_elseif (sfpi::dst_reg[0] == 2.0F)
     {
-        dst_reg[12] = static_cast<float>(-imm); // SFPLOADI
+        sfpi::dst_reg[12] = static_cast<float>(-imm); // SFPLOADI
     }
-    v_elseif (dst_reg[0] == 3.0F)
+    v_elseif (sfpi::dst_reg[0] == 3.0F)
     {
-        vInt a = 5;
+        sfpi::vInt a = 5;
         a += imm; // SFPIADD_I
         set_expected_result(12, 25.0F, 40, a);
     }
-    v_elseif (dst_reg[0] == 4.0F)
+    v_elseif (sfpi::dst_reg[0] == 4.0F)
     {
-        vInt a = 5;
+        sfpi::vInt a = 5;
         a -= imm; // SFPIADD_I
         set_expected_result(12, -25.0F, -30, a);
     }
-    v_elseif (dst_reg[0] == 5.0F)
+    v_elseif (sfpi::dst_reg[0] == 5.0F)
     {
-        vFloat a = 3.0F;
+        sfpi::vFloat a = 3.0F;
         a += static_cast<float>(imm); // SFPADDI
-        dst_reg[12] = a;
+        sfpi::dst_reg[12] = a;
     }
-    v_elseif (dst_reg[0] == 6.0F)
+    v_elseif (sfpi::dst_reg[0] == 6.0F)
     {
-        vFloat a = 3.0F;
+        sfpi::vFloat a = 3.0F;
         a += static_cast<float>(-imm); // SFPADDI
-        dst_reg[12] = a;
+        sfpi::dst_reg[12] = a;
     }
     v_endif;
 
-    v_if (dst_reg[0] == 7.0F)
+    v_if (sfpi::dst_reg[0] == 7.0F)
     {
         vUInt a = 0x4000;
         a >>= imm - 25;
-        set_expected_result(12, 64.0F, 0x0010, reinterpret<vInt>(a));
+        set_expected_result(12, 64.0F, 0x0010, reinterpret<sfpi::vInt>(a));
     }
-    v_elseif (dst_reg[0] == 8.0F)
+    v_elseif (sfpi::dst_reg[0] == 8.0F)
     {
         vUInt a = 1;
         a <<= imm - 25;
-        set_expected_result(12, 128.0F, 0x0400, reinterpret<vInt>(a));
+        set_expected_result(12, 128.0F, 0x0400, reinterpret<sfpi::vInt>(a));
     }
-    v_elseif (dst_reg[0] == 9.0F)
+    v_elseif (sfpi::dst_reg[0] == 9.0F)
     {
-        vFloat a    = 256.0F;
-        dst_reg[12] = addexp(a, imm - 31);
+        sfpi::vFloat a    = 256.0F;
+        sfpi::dst_reg[12] = addexp(a, imm - 31);
     }
-    v_elseif (dst_reg[0] == 10.0F)
+    v_elseif (sfpi::dst_reg[0] == 10.0F)
     {
-        vFloat a    = 256.0F;
-        dst_reg[12] = addexp(a, imm - 39);
+        sfpi::vFloat a    = 256.0F;
+        sfpi::dst_reg[12] = addexp(a, imm - 39);
     }
     v_endif;
 
-    v_if (dst_reg[0] == 11.0F)
+    v_if (sfpi::dst_reg[0] == 11.0F)
     {
-        vFloat a    = 128.0;
-        vFloat r    = setsgn(a, imm - 36);
-        dst_reg[12] = r;
+        sfpi::vFloat a    = 128.0;
+        sfpi::vFloat r    = setsgn(a, imm - 36);
+        sfpi::dst_reg[12] = r;
     }
-    v_elseif (dst_reg[0] == 12.0F)
+    v_elseif (sfpi::dst_reg[0] == 12.0F)
     {
-        vFloat tmp  = 1024.0F;
+        sfpi::vFloat tmp  = 1024.0F;
         int man     = 0x75019a + 35 - imm;
-        vFloat tmp2 = setman(tmp, man);
-        dst_reg[12] = tmp2;
+        sfpi::vFloat tmp2 = setman(tmp, man);
+        sfpi::dst_reg[12] = tmp2;
     }
-    v_elseif (dst_reg[0] == 13.0F)
+    v_elseif (sfpi::dst_reg[0] == 13.0F)
     {
         int exp        = 0x007F + 35 - imm; // Exponent in low bits
-        vFloat sgn_man = -1664.0F;          // 1024 + 512 + 128 or 1101
+        sfpi::vFloat sgn_man = -1664.0F;          // 1024 + 512 + 128 or 1101
         sgn_man        = setexp(sgn_man, exp);
-        dst_reg[12]    = sgn_man;
+        sfpi::dst_reg[12]    = sgn_man;
     }
     v_endif;
 
-    dst_reg[30 + 35 - imm]     = 30.0F; // SFPSTORE
-    dst_reg[30 + 35 - imm + 1] = vConstNeg1;
+    sfpi::dst_reg[30 + 35 - imm]     = 30.0F; // SFPSTORE
+    sfpi::dst_reg[30 + 35 - imm + 1] = vConstNeg1;
 
-    v_if (dst_reg[0] == 14.0F)
+    v_if (sfpi::dst_reg[0] == 14.0F)
     {
-        dst_reg[12] = dst_reg[30 + 35 - imm]; // SFPLOAD
+        sfpi::dst_reg[12] = sfpi::dst_reg[30 + 35 - imm]; // SFPLOAD
     }
     v_endif;
-    v_if (dst_reg[0] == 15.0F)
+    v_if (sfpi::dst_reg[0] == 15.0F)
     {
-        dst_reg[12] = dst_reg[30 + 35 - imm + 1]; // SFPLOAD
+        sfpi::dst_reg[12] = sfpi::dst_reg[30 + 35 - imm + 1]; // SFPLOAD
     }
     v_endif;
 
     // Test for store/load nops, imm store non-imm load
     // Need to use the semaphores to get TRISC to run ahead for non-imm loads
 
-    v_if (dst_reg[0] == 16.0F)
+    v_if (sfpi::dst_reg[0] == 16.0F)
     {
         // imm store, non-imm load
-        vFloat a = 120.0F;
+        sfpi::vFloat a = 120.0F;
 
         TTI_SEMINIT(1, 0, p_stall::SEMAPHORE_3);
         TTI_SEMWAIT(p_stall::STALL_MATH, p_stall::SEMAPHORE_3, p_stall::STALL_ON_ZERO);
 
-        dst_reg[12] = a;
+        sfpi::dst_reg[12] = a;
         __builtin_rvtt_sfpnop(); // XXXXXX remove me when compiler is fixed
-        a = dst_reg[imm - 23];
+        a = sfpi::dst_reg[imm - 23];
 
         semaphore_post(3);
 
-        dst_reg[12] = a + 1.0F;
+        sfpi::dst_reg[12] = a + 1.0F;
     }
     v_endif;
 
-    v_if (dst_reg[0] == 17.0F)
+    v_if (sfpi::dst_reg[0] == 17.0F)
     {
         // non-imm store, imm load
-        vFloat a          = 130.0F;
-        dst_reg[imm - 23] = a;
+        sfpi::vFloat a          = 130.0F;
+        sfpi::dst_reg[imm - 23] = a;
         __builtin_rvtt_sfpnop(); // XXXXXX remove me when compiler is fixed
-        a           = dst_reg[12];
-        dst_reg[12] = a + 1.0F;
+        a           = sfpi::dst_reg[12];
+        sfpi::dst_reg[12] = a + 1.0F;
     }
     v_endif;
 
-    v_if (dst_reg[0] == 18.0F)
+    v_if (sfpi::dst_reg[0] == 18.0F)
     {
         // non-imm store, non-imm load
-        vFloat a = 140.0F;
+        sfpi::vFloat a = 140.0F;
 
         TTI_SEMINIT(1, 0, p_stall::SEMAPHORE_3);
         TTI_SEMWAIT(p_stall::STALL_MATH, p_stall::SEMAPHORE_3, p_stall::STALL_ON_ZERO);
 
-        dst_reg[imm - 23] = a;
+        sfpi::dst_reg[imm - 23] = a;
         __builtin_rvtt_sfpnop(); // XXXXXX remove me when compiler is fixed
-        a = dst_reg[imm - 23];
+        a = sfpi::dst_reg[imm - 23];
 
         semaphore_post(3);
 
-        dst_reg[12] = a + 1.0F;
+        sfpi::dst_reg[12] = a + 1.0F;
     }
     v_endif;
 
-    v_if (dst_reg[0] == 19.0F)
+    v_if (sfpi::dst_reg[0] == 19.0F)
     {
-        vFloat a = 3.0F;
+        sfpi::vFloat a = 3.0F;
         a *= static_cast<float>(imm); // SFPADDI
-        dst_reg[12] = a;
+        sfpi::dst_reg[12] = a;
     }
-    v_elseif (dst_reg[0] == 20.0F)
+    v_elseif (sfpi::dst_reg[0] == 20.0F)
     {
-        vFloat a = 3.0F;
+        sfpi::vFloat a = 3.0F;
         a *= static_cast<float>(-imm); // SFPADDI
-        dst_reg[12] = a;
+        sfpi::dst_reg[12] = a;
     }
     v_endif;
 
@@ -2362,20 +2362,20 @@ sfpi_test_noinline void test13(int imm)
 {
     // Test variable liveness
 
-    dst_reg[13] = -dst_reg[0];
+    sfpi::dst_reg[13] = -sfpi::dst_reg[0];
 
     // ABS liveness across SETCC
     {
-        vFloat x = -20.0F;
-        vFloat y = -30.0F;
-        v_if (dst_reg[0] == 0.0F)
+        sfpi::vFloat x = -20.0F;
+        sfpi::vFloat y = -30.0F;
+        v_if (sfpi::dst_reg[0] == 0.0F)
         {
             y = sfpi::abs(x);
         }
         v_endif;
-        v_if (dst_reg[0] == 0.0F || dst_reg[0] == 1.0F)
+        v_if (sfpi::dst_reg[0] == 0.0F || sfpi::dst_reg[0] == 1.0F)
         {
-            dst_reg[13] = y;
+            sfpi::dst_reg[13] = y;
         }
         v_endif;
     }
@@ -2384,21 +2384,21 @@ sfpi_test_noinline void test13(int imm)
 
     // NOT liveness across SETCC
     {
-        vInt a = 0xFAAA;
-        vInt b = 0x07BB;
-        v_if (dst_reg[0] == 2.0F)
+        sfpi::vInt a = 0xFAAA;
+        sfpi::vInt b = 0x07BB;
+        v_if (sfpi::dst_reg[0] == 2.0F)
         {
             b = ~a;
         }
         v_endif;
-        v_if (dst_reg[0] == 2.0F || dst_reg[0] == 3.0F)
+        v_if (sfpi::dst_reg[0] == 2.0F || sfpi::dst_reg[0] == 3.0F)
         {
-            v_if (dst_reg[0] == 2.0F)
+            v_if (sfpi::dst_reg[0] == 2.0F)
             {
                 set_expected_result(13, 40.0F, 0xFFFF0555, b);
             }
             v_endif;
-            v_if (dst_reg[0] == 3.0F)
+            v_if (sfpi::dst_reg[0] == 3.0F)
             {
                 set_expected_result(13, 50.0F, 0x07BB, b);
             }
@@ -2411,21 +2411,21 @@ sfpi_test_noinline void test13(int imm)
 
     // LZ liveness across SETCC
     {
-        vInt a = 0x0080;
-        vInt b = 0x07BB;
-        v_if (dst_reg[0] == 4.0F)
+        sfpi::vInt a = 0x0080;
+        sfpi::vInt b = 0x07BB;
+        v_if (sfpi::dst_reg[0] == 4.0F)
         {
             b = lz(a);
         }
         v_endif;
-        v_if (dst_reg[0] == 4.0F || dst_reg[0] == 5.0F)
+        v_if (sfpi::dst_reg[0] == 4.0F || sfpi::dst_reg[0] == 5.0F)
         {
-            v_if (dst_reg[0] == 4.0F)
+            v_if (sfpi::dst_reg[0] == 4.0F)
             {
                 set_expected_result(13, 60.0F, 24, b);
             }
             v_endif;
-            v_if (dst_reg[0] == 5.0F)
+            v_if (sfpi::dst_reg[0] == 5.0F)
             {
                 set_expected_result(13, 70.0F, 0x07BB, b);
             }
@@ -2438,16 +2438,16 @@ sfpi_test_noinline void test13(int imm)
 
     // MAD liveness across SETCC
     {
-        vFloat a = 90.0F;
-        vFloat b = 110.0F;
-        v_if (dst_reg[0] == 6.0F)
+        sfpi::vFloat a = 90.0F;
+        sfpi::vFloat b = 110.0F;
+        v_if (sfpi::dst_reg[0] == 6.0F)
         {
             b = a * a + 10.0;
         }
         v_endif;
-        v_if (dst_reg[0] == 6.0F || dst_reg[0] == 7.0F)
+        v_if (sfpi::dst_reg[0] == 6.0F || sfpi::dst_reg[0] == 7.0F)
         {
-            dst_reg[13] = b;
+            sfpi::dst_reg[13] = b;
         }
         v_endif;
     }
@@ -2456,16 +2456,16 @@ sfpi_test_noinline void test13(int imm)
 
     // MOV liveness across SETCC
     {
-        vFloat a = 120.0F;
-        vFloat b = 130.0F;
-        v_if (dst_reg[0] == 8.0F)
+        sfpi::vFloat a = 120.0F;
+        sfpi::vFloat b = 130.0F;
+        v_if (sfpi::dst_reg[0] == 8.0F)
         {
             b = -a;
         }
         v_endif;
-        v_if (dst_reg[0] == 8.0F || dst_reg[0] == 9.0F)
+        v_if (sfpi::dst_reg[0] == 8.0F || sfpi::dst_reg[0] == 9.0F)
         {
-            dst_reg[13] = b;
+            sfpi::dst_reg[13] = b;
         }
         v_endif;
     }
@@ -2474,16 +2474,16 @@ sfpi_test_noinline void test13(int imm)
 
     // DIVP2 liveness across SETCC
     {
-        vFloat a = 140.0F;
-        vFloat b = 150.0F;
-        v_if (dst_reg[0] == 10.0F)
+        sfpi::vFloat a = 140.0F;
+        sfpi::vFloat b = 150.0F;
+        v_if (sfpi::dst_reg[0] == 10.0F)
         {
             b = addexp(a, 1);
         }
         v_endif;
-        v_if (dst_reg[0] == 10.0F || dst_reg[0] == 11.0F)
+        v_if (sfpi::dst_reg[0] == 10.0F || sfpi::dst_reg[0] == 11.0F)
         {
-            dst_reg[13] = b;
+            sfpi::dst_reg[13] = b;
         }
         v_endif;
     }
@@ -2492,17 +2492,17 @@ sfpi_test_noinline void test13(int imm)
 
     // EXEXP liveness across SETCC
     {
-        vFloat a = 160.0F;
-        vInt b   = 128;
-        v_if (dst_reg[0] == 12.0F)
+        sfpi::vFloat a = 160.0F;
+        sfpi::vInt b   = 128;
+        v_if (sfpi::dst_reg[0] == 12.0F)
         {
             b = exexp_nodebias(a);
         }
         v_endif;
-        v_if (dst_reg[0] == 12.0F || dst_reg[0] == 13.0F)
+        v_if (sfpi::dst_reg[0] == 12.0F || sfpi::dst_reg[0] == 13.0F)
         {
-            vFloat tmp  = 1.0F;
-            dst_reg[13] = setexp(tmp, b);
+            sfpi::vFloat tmp  = 1.0F;
+            sfpi::dst_reg[13] = setexp(tmp, b);
         }
         v_endif;
     }
@@ -2511,17 +2511,17 @@ sfpi_test_noinline void test13(int imm)
 
     // EXMAN liveness across SETCC
     {
-        vFloat a = 160.0F;
-        vInt b   = 0x80000;
-        v_if (dst_reg[0] == 14.0F)
+        sfpi::vFloat a = 160.0F;
+        sfpi::vInt b   = 0x80000;
+        v_if (sfpi::dst_reg[0] == 14.0F)
         {
             b = exman8(a);
         }
         v_endif;
-        v_if (dst_reg[0] == 14.0F || dst_reg[0] == 15.0F)
+        v_if (sfpi::dst_reg[0] == 14.0F || sfpi::dst_reg[0] == 15.0F)
         {
-            vFloat tmp  = 128.0F;
-            dst_reg[13] = setman(tmp, b);
+            sfpi::vFloat tmp  = 128.0F;
+            sfpi::dst_reg[13] = setman(tmp, b);
         }
         v_endif;
     }
@@ -2530,16 +2530,16 @@ sfpi_test_noinline void test13(int imm)
 
     // SETEXP_I liveness across SETCC
     {
-        vFloat a = 170.0F;
-        vFloat b = 180.0F;
-        v_if (dst_reg[0] == 16.0F)
+        sfpi::vFloat a = 170.0F;
+        sfpi::vFloat b = 180.0F;
+        v_if (sfpi::dst_reg[0] == 16.0F)
         {
             b = setexp(a, 132);
         }
         v_endif;
-        v_if (dst_reg[0] == 16.0F || dst_reg[0] == 17.0F)
+        v_if (sfpi::dst_reg[0] == 16.0F || sfpi::dst_reg[0] == 17.0F)
         {
-            dst_reg[13] = b;
+            sfpi::dst_reg[13] = b;
         }
         v_endif;
     }
@@ -2548,16 +2548,16 @@ sfpi_test_noinline void test13(int imm)
 
     // SETMAN_I liveness across SETCC
     {
-        vFloat a = 190.0F;
-        vFloat b = 200.0F;
-        v_if (dst_reg[0] == 18.0F)
+        sfpi::vFloat a = 190.0F;
+        sfpi::vFloat b = 200.0F;
+        v_if (sfpi::dst_reg[0] == 18.0F)
         {
             b = setman(a, 0x75019a);
         }
         v_endif;
-        v_if (dst_reg[0] == 18.0F || dst_reg[0] == 19.0F)
+        v_if (sfpi::dst_reg[0] == 18.0F || sfpi::dst_reg[0] == 19.0F)
         {
-            dst_reg[13] = b;
+            sfpi::dst_reg[13] = b;
         }
         v_endif;
     }
@@ -2566,16 +2566,16 @@ sfpi_test_noinline void test13(int imm)
 
     // SETSGN_I liveness across SETCC
     {
-        vFloat a = 210.0F;
-        vFloat b = 220.0F;
-        v_if (dst_reg[0] == 20.0F)
+        sfpi::vFloat a = 210.0F;
+        sfpi::vFloat b = 220.0F;
+        v_if (sfpi::dst_reg[0] == 20.0F)
         {
             b = setsgn(a, 1);
         }
         v_endif;
-        v_if (dst_reg[0] == 20.0F || dst_reg[0] == 21.0F)
+        v_if (sfpi::dst_reg[0] == 20.0F || sfpi::dst_reg[0] == 21.0F)
         {
-            dst_reg[13] = b;
+            sfpi::dst_reg[13] = b;
         }
         v_endif;
     }
@@ -2584,16 +2584,16 @@ sfpi_test_noinline void test13(int imm)
 
     // nonimm_dst_src using DIVP2 liveness across SETCC
     {
-        vFloat a = 140.0F;
-        vFloat b = 150.0F;
-        v_if (dst_reg[0] == 22.0F)
+        sfpi::vFloat a = 140.0F;
+        sfpi::vFloat b = 150.0F;
+        v_if (sfpi::dst_reg[0] == 22.0F)
         {
             b = addexp(a, imm - 34);
         }
         v_endif;
-        v_if (dst_reg[0] == 22.0F || dst_reg[0] == 23.0F)
+        v_if (sfpi::dst_reg[0] == 22.0F || sfpi::dst_reg[0] == 23.0F)
         {
-            dst_reg[13] = b;
+            sfpi::dst_reg[13] = b;
         }
         v_endif;
     }
@@ -2602,15 +2602,15 @@ sfpi_test_noinline void test13(int imm)
 
     // nonimm_dst using LOADI liveness across SETCC
     {
-        vFloat b = 240.0F;
-        v_if (dst_reg[0] == 24.0F)
+        sfpi::vFloat b = 240.0F;
+        v_if (sfpi::dst_reg[0] == 24.0F)
         {
             b = static_cast<float>(-imm);
         }
         v_endif;
-        v_if (dst_reg[0] == 24.0F || dst_reg[0] == 25.0F)
+        v_if (sfpi::dst_reg[0] == 24.0F || sfpi::dst_reg[0] == 25.0F)
         {
-            dst_reg[13] = b;
+            sfpi::dst_reg[13] = b;
         }
         v_endif;
     }
@@ -2625,26 +2625,26 @@ sfpi_test_noinline void test14(int imm)
     // Test13 tests various builtins for liveness across a SETCC
     // Below test MOV liveness across COMPC, LZ, EXEXP, IADD
 
-    dst_reg[14] = -dst_reg[0];
+    sfpi::dst_reg[14] = -sfpi::dst_reg[0];
 
     // MOV liveness across COMPC
     {
-        vFloat a = 250.0F;
-        vFloat b = 260.0F;
-        v_if (dst_reg[0] != 0.0F)
+        sfpi::vFloat a = 250.0F;
+        sfpi::vFloat b = 260.0F;
+        v_if (sfpi::dst_reg[0] != 0.0F)
         {
             b = 160.0F;
         }
         v_else
         {
-            vFloat c = vConst0 * vConst0 + vConst0;
+            sfpi::vFloat c = vConst0 * vConst0 + vConst0;
             b        = -a;
             a        = c;
         }
         v_endif;
-        v_if (dst_reg[0] == 0.0F || dst_reg[0] == 1.0F)
+        v_if (sfpi::dst_reg[0] == 0.0F || sfpi::dst_reg[0] == 1.0F)
         {
-            dst_reg[14] = b;
+            sfpi::dst_reg[14] = b;
         }
         v_endif;
     }
@@ -2653,24 +2653,24 @@ sfpi_test_noinline void test14(int imm)
 
     // MOV liveness across LZ
     {
-        vFloat a = 250.0F;
-        vFloat b = 260.0F;
-        vInt tmp;
+        sfpi::vFloat a = 250.0F;
+        sfpi::vFloat b = 260.0F;
+        sfpi::vInt tmp;
 
-        v_if (dst_reg[0] == 2.0F)
+        v_if (sfpi::dst_reg[0] == 2.0F)
         {
             v_if ((tmp = lz(a)) != 0)
             {
-                vFloat c = vConst0 * vConst0 + vConst0;
+                sfpi::vFloat c = vConst0 * vConst0 + vConst0;
                 b        = -a;
                 a        = c;
             }
             v_endif;
         }
         v_endif;
-        v_if (dst_reg[0] == 2.0F || dst_reg[0] == 3.0F)
+        v_if (sfpi::dst_reg[0] == 2.0F || sfpi::dst_reg[0] == 3.0F)
         {
-            dst_reg[14] = b;
+            sfpi::dst_reg[14] = b;
         }
         v_endif;
     }
@@ -2679,24 +2679,24 @@ sfpi_test_noinline void test14(int imm)
 
     // MOV liveness across EXEXP
     {
-        vFloat a = 270.0F;
-        vFloat b = 280.0F;
-        vInt tmp;
+        sfpi::vFloat a = 270.0F;
+        sfpi::vFloat b = 280.0F;
+        sfpi::vInt tmp;
 
-        v_if (dst_reg[0] == 4.0F)
+        v_if (sfpi::dst_reg[0] == 4.0F)
         {
             v_if ((tmp = exexp(a)) >= 0)
             {
-                vFloat c = vConst0 * vConst0 + vConst0;
+                sfpi::vFloat c = vConst0 * vConst0 + vConst0;
                 b        = -a;
                 a        = c;
             }
             v_endif;
         }
         v_endif;
-        v_if (dst_reg[0] == 4.0F || dst_reg[0] == 5.0F)
+        v_if (sfpi::dst_reg[0] == 4.0F || sfpi::dst_reg[0] == 5.0F)
         {
-            dst_reg[14] = b;
+            sfpi::dst_reg[14] = b;
         }
         v_endif;
     }
@@ -2706,24 +2706,24 @@ sfpi_test_noinline void test14(int imm)
     // Below 2 tests are incidentally covered by tests 1..12
     // MOV liveness across IADD
     {
-        vFloat b = 300.0F;
-        vInt tmp = 5;
+        sfpi::vFloat b = 300.0F;
+        sfpi::vInt tmp = 5;
 
-        v_if (dst_reg[0] == 6.0F)
+        v_if (sfpi::dst_reg[0] == 6.0F)
         {
-            vFloat a = 290.0F;
+            sfpi::vFloat a = 290.0F;
             v_if (tmp >= 2)
             {
-                vFloat c = vConst0 * vConst0 + vConst0;
+                sfpi::vFloat c = vConst0 * vConst0 + vConst0;
                 b        = -a;
                 a        = c;
             }
             v_endif;
         }
         v_endif;
-        v_if (dst_reg[0] == 6.0F || dst_reg[0] == 7.0F)
+        v_if (sfpi::dst_reg[0] == 6.0F || sfpi::dst_reg[0] == 7.0F)
         {
-            dst_reg[14] = b;
+            sfpi::dst_reg[14] = b;
         }
         v_endif;
     }
@@ -2732,21 +2732,21 @@ sfpi_test_noinline void test14(int imm)
 
     // IADD_I liveness
     {
-        vInt a = 10;
-        vInt b = 20;
-        v_if (dst_reg[0] == 8.0F)
+        sfpi::vInt a = 10;
+        sfpi::vInt b = 20;
+        v_if (sfpi::dst_reg[0] == 8.0F)
         {
             b = a + 30;
         }
         v_endif;
-        v_if (dst_reg[0] == 8.0F || dst_reg[0] == 9.0F)
+        v_if (sfpi::dst_reg[0] == 8.0F || sfpi::dst_reg[0] == 9.0F)
         {
-            v_if (dst_reg[0] == 8.0F)
+            v_if (sfpi::dst_reg[0] == 8.0F)
             {
                 set_expected_result(14, -310.0F, 40, b);
             }
             v_endif;
-            v_if (dst_reg[0] == 9.0F)
+            v_if (sfpi::dst_reg[0] == 9.0F)
             {
                 set_expected_result(14, 320.0F, 20, b);
             }
@@ -2765,17 +2765,17 @@ sfpi_test_noinline void test14(int imm)
     // Case 2a
     // Assignment resulting in register rename
     {
-        vFloat a = -20.0f;
-        vFloat b = 30.0f;
-        v_if (dst_reg[0] == 10.0f)
+        sfpi::vFloat a = -20.0f;
+        sfpi::vFloat b = 30.0f;
+        v_if (sfpi::dst_reg[0] == 10.0f)
         {
             b = a;
         }
         v_endif;
 
-        v_if (dst_reg[0] == 10.0F || dst_reg[0] == 11.0F)
+        v_if (sfpi::dst_reg[0] == 10.0F || sfpi::dst_reg[0] == 11.0F)
         {
-            dst_reg[14] = b;
+            sfpi::dst_reg[14] = b;
         }
         v_endif;
     }
@@ -2787,23 +2787,23 @@ sfpi_test_noinline void test14(int imm)
     // This straddles case 2a and 3 - both values need to be preserved but the
     // compiler doesn't know that, solving case2a will solve this case as well
     {
-        vFloat a = -40.0f;
-        vFloat b = 50.0f;
-        v_if (dst_reg[0] == 12.0f)
+        sfpi::vFloat a = -40.0f;
+        sfpi::vFloat b = 50.0f;
+        v_if (sfpi::dst_reg[0] == 12.0f)
         {
             b = a;
         }
         v_endif;
 
-        v_if (dst_reg[0] == 100.0f)
+        v_if (sfpi::dst_reg[0] == 100.0f)
         { // always fail
-            dst_reg[14] = a;
+            sfpi::dst_reg[14] = a;
         }
         v_endif;
 
-        v_if (dst_reg[0] == 12.0F || dst_reg[0] == 13.0F)
+        v_if (sfpi::dst_reg[0] == 12.0F || sfpi::dst_reg[0] == 13.0F)
         {
-            dst_reg[14] = b;
+            sfpi::dst_reg[14] = b;
         }
         v_endif;
     }
@@ -2813,23 +2813,23 @@ sfpi_test_noinline void test14(int imm)
     // Case 3
     // Assignment requiring move (both a and b need to be preserved)
     {
-        vFloat a = -60.0f;
-        vFloat b = 70.0f;
-        v_if (dst_reg[0] == 14.0f)
+        sfpi::vFloat a = -60.0f;
+        sfpi::vFloat b = 70.0f;
+        v_if (sfpi::dst_reg[0] == 14.0f)
         {
             b = a;
         }
         v_endif;
 
-        v_if (dst_reg[0] == 100.0f)
+        v_if (sfpi::dst_reg[0] == 100.0f)
         { // always fail
-            dst_reg[14] = a + 1.0f;
+            sfpi::dst_reg[14] = a + 1.0f;
         }
         v_endif;
 
-        v_if (dst_reg[0] == 14.0F || dst_reg[0] == 15.0F)
+        v_if (sfpi::dst_reg[0] == 14.0F || sfpi::dst_reg[0] == 15.0F)
         {
-            dst_reg[14] = b + 1.0f;
+            sfpi::dst_reg[14] = b + 1.0f;
         }
         v_endif;
     }
@@ -2840,27 +2840,27 @@ sfpi_test_noinline void test14(int imm)
     // Destination as source, 2 arguments in the wrong order
     // Confirm b is correct
     {
-        vInt a = 10;
-        vInt b = 20;
-        v_if (dst_reg[0] == 16.0f)
+        sfpi::vInt a = 10;
+        sfpi::vInt b = 20;
+        v_if (sfpi::dst_reg[0] == 16.0f)
         {
             b = b - a;
         }
         v_endif;
 
-        v_if (dst_reg[0] == 100.0f)
+        v_if (sfpi::dst_reg[0] == 100.0f)
         { // always fail
-            dst_reg[14] = a;
+            sfpi::dst_reg[14] = a;
         }
         v_endif;
 
-        v_if (dst_reg[0] == 16.0F)
+        v_if (sfpi::dst_reg[0] == 16.0F)
         {
             set_expected_result(14, -80.0F, 10, b);
         }
         v_endif;
 
-        v_if (dst_reg[0] == 17.0F)
+        v_if (sfpi::dst_reg[0] == 17.0F)
         {
             set_expected_result(14, 90.0F, 20, b);
         }
@@ -2873,27 +2873,27 @@ sfpi_test_noinline void test14(int imm)
     // Destination as source, 2 arguments in the wrong order
     // Confirm a is correct
     {
-        vInt a = 10;
-        vInt b = 20;
-        v_if (dst_reg[0] == 16.0f)
+        sfpi::vInt a = 10;
+        sfpi::vInt b = 20;
+        v_if (sfpi::dst_reg[0] == 16.0f)
         {
             b = b - a;
         }
         v_endif;
 
-        v_if (dst_reg[0] == 100.0f)
+        v_if (sfpi::dst_reg[0] == 100.0f)
         { // always fail
-            dst_reg[14] = b;
+            sfpi::dst_reg[14] = b;
         }
         v_endif;
 
-        v_if (dst_reg[0] == 18.0F)
+        v_if (sfpi::dst_reg[0] == 18.0F)
         {
             set_expected_result(14, -90.0F, 10, a);
         }
         v_endif;
 
-        v_if (dst_reg[0] == 19.0F)
+        v_if (sfpi::dst_reg[0] == 19.0F)
         {
             set_expected_result(14, 100.0F, 10, a);
         }
@@ -2907,10 +2907,10 @@ sfpi_test_noinline void test14(int imm)
     // Confirm c is correct
     {
         // Out of regs doing this the typical way
-        vFloat condition = dst_reg[0] - 20.0F;
-        vInt a           = 10;
-        vInt b           = 20;
-        vInt c           = 30;
+        sfpi::vFloat condition = sfpi::dst_reg[0] - 20.0F;
+        sfpi::vInt a           = 10;
+        sfpi::vInt b           = 20;
+        sfpi::vInt c           = 30;
 
         v_if (condition == 0.0F)
         {
@@ -2918,20 +2918,20 @@ sfpi_test_noinline void test14(int imm)
         }
         v_endif;
 
-        v_if (vConst0p8373 == dst_reg[0])
+        v_if (vConst0p8373 == sfpi::dst_reg[0])
         { // always fail
-            dst_reg[14] = a;
-            dst_reg[14] = b;
+            sfpi::dst_reg[14] = a;
+            sfpi::dst_reg[14] = b;
         }
         v_endif;
 
-        v_if (dst_reg[0] == 20.0F)
+        v_if (sfpi::dst_reg[0] == 20.0F)
         {
             set_expected_result(14, -100.0F, -10, c);
         }
         v_endif;
 
-        v_if (dst_reg[0] == 21.0F)
+        v_if (sfpi::dst_reg[0] == 21.0F)
         {
             set_expected_result(14, 110.0F, 30, c);
         }
@@ -2945,10 +2945,10 @@ sfpi_test_noinline void test14(int imm)
     // Confirm a is correct
     {
         // Out of regs doing this the typical way
-        vFloat condition = dst_reg[0] - 22.0F;
-        vInt a           = 10;
-        vInt b           = 20;
-        vInt c           = 30;
+        sfpi::vFloat condition = sfpi::dst_reg[0] - 22.0F;
+        sfpi::vInt a           = 10;
+        sfpi::vInt b           = 20;
+        sfpi::vInt c           = 30;
 
         v_if (condition == 0.0F)
         {
@@ -2956,20 +2956,20 @@ sfpi_test_noinline void test14(int imm)
         }
         v_endif;
 
-        v_if (vConst0p8373 == dst_reg[0])
+        v_if (vConst0p8373 == sfpi::dst_reg[0])
         { // always fail
-            dst_reg[14] = a;
-            dst_reg[14] = c;
+            sfpi::dst_reg[14] = a;
+            sfpi::dst_reg[14] = c;
         }
         v_endif;
 
-        v_if (dst_reg[0] == 22.0F)
+        v_if (sfpi::dst_reg[0] == 22.0F)
         {
             set_expected_result(14, -110.0F, 10, a);
         }
         v_endif;
 
-        v_if (dst_reg[0] == 23.0F)
+        v_if (sfpi::dst_reg[0] == 23.0F)
         {
             set_expected_result(14, 120.0F, 10, a);
         }
@@ -2983,10 +2983,10 @@ sfpi_test_noinline void test14(int imm)
     // Confirm b is correct
     {
         // Out of regs doing this the typical way
-        vFloat condition = dst_reg[0] - 24.0F;
-        vInt a           = 10;
-        vInt b           = 20;
-        vInt c           = 30;
+        sfpi::vFloat condition = sfpi::dst_reg[0] - 24.0F;
+        sfpi::vInt a           = 10;
+        sfpi::vInt b           = 20;
+        sfpi::vInt c           = 30;
 
         v_if (condition == 0.0F)
         {
@@ -2994,20 +2994,20 @@ sfpi_test_noinline void test14(int imm)
         }
         v_endif;
 
-        v_if (vConst0p8373 == dst_reg[0])
+        v_if (vConst0p8373 == sfpi::dst_reg[0])
         { // always fail
-            dst_reg[14] = c;
-            dst_reg[14] = b;
+            sfpi::dst_reg[14] = c;
+            sfpi::dst_reg[14] = b;
         }
         v_endif;
 
-        v_if (dst_reg[0] == 24.0F)
+        v_if (sfpi::dst_reg[0] == 24.0F)
         {
             set_expected_result(14, -120.0F, 20, b);
         }
         v_endif;
 
-        v_if (dst_reg[0] == 25.0F)
+        v_if (sfpi::dst_reg[0] == 25.0F)
         {
             set_expected_result(14, 130.0F, 20, b);
         }
@@ -3021,9 +3021,9 @@ sfpi_test_noinline void test14(int imm)
     // stay live when assigned at the same CC level but in a different
     // cascade, ie, across generations?
     {
-        vFloat a;
-        vFloat b;
-        vFloat dr = dst_reg[0];
+        sfpi::vFloat a;
+        sfpi::vFloat b;
+        sfpi::vFloat dr = sfpi::dst_reg[0];
 
         v_if (dr == 26.0F || dr == 27.0F)
         {
@@ -3051,13 +3051,13 @@ sfpi_test_noinline void test14(int imm)
 
         v_if (dr == 26.0F || dr == 27.0F)
         {
-            dst_reg[14] = b;
+            sfpi::dst_reg[14] = b;
         }
         v_endif;
 
         v_if (dr == 500.0F)
         {
-            dst_reg[14] = a;
+            sfpi::dst_reg[14] = a;
         }
         v_endif;
     }
@@ -3070,8 +3070,8 @@ sfpi_test_noinline void test14(int imm)
     //    (30.0f - i) != static_cast<float>(30 - i)
     // and not just due to rounding (off by orders of magnitude)
     {
-        vFloat a = 200.0F;
-        vFloat b = 1.0F;
+        sfpi::vFloat a = 200.0F;
+        sfpi::vFloat b = 1.0F;
 
         // unroll forces the compiler into multiple basic blocks
 #if defined(__GNUC__) && !defined(__clang__)
@@ -3079,7 +3079,7 @@ sfpi_test_noinline void test14(int imm)
 #endif
         for (int i = 0; i < imm - 30; i++)
         { // 0..4
-            v_if (dst_reg[0] == 28.0F)
+            v_if (sfpi::dst_reg[0] == 28.0F)
             {
                 switch (i)
                 {
@@ -3096,7 +3096,7 @@ sfpi_test_noinline void test14(int imm)
                         b = b * 4.0F;
                 }
             }
-            v_elseif (dst_reg[0] >= static_cast<float>(30 - i))
+            v_elseif (sfpi::dst_reg[0] >= static_cast<float>(30 - i))
             {
                 if (i % 2 == 0)
                 {
@@ -3112,9 +3112,9 @@ sfpi_test_noinline void test14(int imm)
             a = a + a * b;
         }
 
-        v_if (dst_reg[0] == 28.0F || dst_reg[0] == 29.0F)
+        v_if (sfpi::dst_reg[0] == 28.0F || sfpi::dst_reg[0] == 29.0F)
         {
-            dst_reg[14] = a;
+            sfpi::dst_reg[14] = a;
         }
         v_endif;
     }
@@ -3130,7 +3130,7 @@ sfpi_test_noinline void test15()
 {
     // SFPTRANSP, SFPSHFT2
 
-    dst_reg[15] = -dst_reg[0];
+    sfpi::dst_reg[15] = -sfpi::dst_reg[0];
     {
         vUInt a = vConstTileId + 0x100;
         vUInt b = vConstTileId + 0x200;
@@ -3168,7 +3168,7 @@ sfpi_test_noinline void test15()
         // Reduce result (only care about first subbvec, rest along for the ride)
         vUInt final = reduce_bool4(result, cmpb, cmpc, cmpd, 1);
 
-        v_if (dst_reg[0] < 8.0F)
+        v_if (sfpi::dst_reg[0] < 8.0F)
         {
             set_expected_result(15, 8.0F, 1, final);
         }
@@ -3195,7 +3195,7 @@ sfpi_test_noinline void test15()
         subvec_transp(tmp1, dst, tmp2, tmp3);
 
         vUInt final = reduce_bool4(dst, tmp1, tmp2, tmp3, 0);
-        v_if (dst_reg[0] >= 8.0F && dst_reg[0] < 16.0F)
+        v_if (sfpi::dst_reg[0] >= 8.0F && sfpi::dst_reg[0] < 16.0F)
         {
             set_expected_result(15, 16.0F, 1, final);
         }
@@ -3222,7 +3222,7 @@ sfpi_test_noinline void test15()
         subvec_transp(tmp1, tmp2, dst, tmp3);
 
         vUInt final = reduce_bool4(tmp1, dst, tmp2, tmp3, 0);
-        v_if (dst_reg[0] >= 16.0F && dst_reg[0] < 24.0F)
+        v_if (sfpi::dst_reg[0] >= 16.0F && sfpi::dst_reg[0] < 24.0F)
         {
             set_expected_result(15, 24.0F, 1, final);
         }
@@ -3231,7 +3231,7 @@ sfpi_test_noinline void test15()
 #if 0
     // Decided not to implement these at this time.  These insns are only
     // interesting if/when we implement LOADMACRO
-    v_if (dst_reg[0] == 16.0F) {
+    v_if (sfpi::dst_reg[0] == 16.0F) {
         // Wrapper doesn't emit shft2 bit shift, test directly
         vUInt a = 0x005A;
 
@@ -3240,7 +3240,7 @@ sfpi_test_noinline void test15()
     }
     v_endif;
 
-    v_if (dst_reg[0] == 17.0F) {
+    v_if (sfpi::dst_reg[0] == 17.0F) {
         // Wrapper doesn't emit shft2 bit shift, test directly
         vUInt a = 0x005A;
         vUInt b = 4;
@@ -3258,17 +3258,17 @@ sfpi_test_noinline void test15()
 void test16()
 {
     // SFPSWAP, SFPCAST, SFPSTOCHRND
-    dst_reg[16] = -dst_reg[0];
+    sfpi::dst_reg[16] = -sfpi::dst_reg[0];
 
     // Tests are all 2 results per row, allowing 4 independent tests only 2 of
     // which are used
-    vFloat x = 2.0f;
-    vFloat y = 3.0f;
+    sfpi::vFloat x = 2.0f;
+    sfpi::vFloat y = 3.0f;
 
-    v_if (dst_reg[0] < 8.0F)
+    v_if (sfpi::dst_reg[0] < 8.0F)
     {
         vec_swap(x, y);
-        v_if (dst_reg[0] >= 4.0f)
+        v_if (sfpi::dst_reg[0] >= 4.0f)
         {
             vec_min_max(x, y);
         }
@@ -3276,11 +3276,11 @@ void test16()
 
         v_if (((vConstTileId >> 1) & 1) == 0)
         {
-            dst_reg[16] = x;
+            sfpi::dst_reg[16] = x;
         }
         v_else
         {
-            dst_reg[16] = y;
+            sfpi::dst_reg[16] = y;
         }
         v_endif;
     }
@@ -3295,65 +3295,65 @@ void test16()
     // [7] = 3.0
 
     // These are really crappy "touch" tests
-    v_if (dst_reg[0] == 8.0F)
+    v_if (sfpi::dst_reg[0] == 8.0F)
     {
-        dst_reg[16] = int32_to_float(0xABBAAB);
+        sfpi::dst_reg[16] = int32_to_float(0xABBAAB);
     }
     v_endif;
-    v_if (dst_reg[0] == 9.0F)
+    v_if (sfpi::dst_reg[0] == 9.0F)
     {
-        dst_reg[16] = int32_to_float(0xABBAAB, 0);
+        sfpi::dst_reg[16] = int32_to_float(0xABBAAB, 0);
     }
     v_endif;
 
-    v_if (dst_reg[0] == 10.0F)
+    v_if (sfpi::dst_reg[0] == 10.0F)
     {
-        dst_reg[16] = float_to_fp16a(1.32332);
+        sfpi::dst_reg[16] = float_to_fp16a(1.32332);
     }
     v_endif;
-    v_if (dst_reg[0] == 11.0F)
+    v_if (sfpi::dst_reg[0] == 11.0F)
     {
-        dst_reg[16] = float_to_fp16b(1.32332);
+        sfpi::dst_reg[16] = float_to_fp16b(1.32332);
     }
     v_endif;
-    v_if (dst_reg[0] == 12.0F)
+    v_if (sfpi::dst_reg[0] == 12.0F)
     {
         set_expected_result(16, 48.0f, 24, float_to_uint8(23.3));
     }
     v_endif;
-    v_if (dst_reg[0] == 13.0F)
+    v_if (sfpi::dst_reg[0] == 13.0F)
     {
         set_expected_result(16, 64.0f, 24, float_to_int8(23.3));
     }
     v_endif;
-    v_if (dst_reg[0] == 14.0F)
+    v_if (sfpi::dst_reg[0] == 14.0F)
     {
         vUInt descale = 8;
         set_expected_result(16, 80.0f, 0xeb, int32_to_uint8(0xea00, descale));
     }
     v_endif;
-    v_if (dst_reg[0] == 15.0F)
+    v_if (sfpi::dst_reg[0] == 15.0F)
     {
         set_expected_result(16, 96.0f, 0xf, int32_to_uint8(0xea0, 8));
     }
     v_endif;
-    v_if (dst_reg[0] == 16.0F)
+    v_if (sfpi::dst_reg[0] == 16.0F)
     {
         vUInt descale = 8;
         set_expected_result(16, 112.0f, 0xf, int32_to_int8(0xea0, descale));
     }
     v_endif;
-    v_if (dst_reg[0] == 17.0F)
+    v_if (sfpi::dst_reg[0] == 17.0F)
     {
         set_expected_result(16, 128.0f, 0xf, int32_to_int8(0xea0, 8));
     }
     v_endif;
-    v_if (dst_reg[0] == 18.0F)
+    v_if (sfpi::dst_reg[0] == 18.0F)
     {
         set_expected_result(16, 130.0f, 0x7eb1, float_to_int16(32432.0f));
     }
     v_endif;
-    v_if (dst_reg[0] == 19.0F)
+    v_if (sfpi::dst_reg[0] == 19.0F)
     {
         set_expected_result(16, 132.0f, 0x7eb1, float_to_uint16(32432.0f));
     }
@@ -3365,10 +3365,10 @@ void test16()
 void test17()
 {
     // more SFPSWAP
-    dst_reg[17] = -dst_reg[0];
+    sfpi::dst_reg[17] = -sfpi::dst_reg[0];
 
     // Test sign-magnitude for ints
-    v_if (dst_reg[0] == 2.0F)
+    v_if (sfpi::dst_reg[0] == 2.0F)
     {
         vUInt x = -1;
         vUInt y = -2;
@@ -3378,32 +3378,32 @@ void test17()
     v_endif;
     // [2] = 23.0f
 
-    v_if (dst_reg[0] == 3.0F)
+    v_if (sfpi::dst_reg[0] == 3.0F)
     {
-        vFloat x = -1.0F;
-        vFloat y = -2.0F;
+        sfpi::vFloat x = -1.0F;
+        sfpi::vFloat y = -2.0F;
         vec_min_max(x, y);
-        dst_reg[17] = x;
+        sfpi::dst_reg[17] = x;
     }
     v_endif;
     // [3] = -2.0
 
-    v_if (dst_reg[0] == 4.0F)
+    v_if (sfpi::dst_reg[0] == 4.0F)
     {
-        vFloat x = 1.0F;
-        vFloat y = 2.0F;
+        sfpi::vFloat x = 1.0F;
+        sfpi::vFloat y = 2.0F;
         vec_min_max(x, y);
-        dst_reg[17] = x;
+        sfpi::dst_reg[17] = x;
     }
     v_endif;
     // [4] = 1.0
 
-    v_if (dst_reg[0] == 5.0F || dst_reg[0] == 6.0F)
+    v_if (sfpi::dst_reg[0] == 5.0F || sfpi::dst_reg[0] == 6.0F)
     {
-        vFloat x = -1.0F;
-        vFloat y = 1.0F;
+        sfpi::vFloat x = -1.0F;
+        sfpi::vFloat y = 1.0F;
 
-        v_if (dst_reg[0] == 5.0F)
+        v_if (sfpi::dst_reg[0] == 5.0F)
         {
             set_expected_result(17, 20.0F, 2, lz_nosgn(x));
         }

--- a/tt_llk_wormhole_b0/common/inc/ckernel_sfpi.h
+++ b/tt_llk_wormhole_b0/common/inc/ckernel_sfpi.h
@@ -18,7 +18,6 @@
 #endif
 
 using namespace ckernel;
-using namespace sfpi;
 
 namespace sfpi_test
 {
@@ -173,7 +172,7 @@ sfpi_test_noinline void test3()
     v_if (sfpi::dst_reg[0] == 8.0F)
     {
         // This will be a ushort w/ 1 load (not sign extended)
-        vUInt a    = 0x8F80U;
+        vUInt a          = 0x8F80U;
         sfpi::dst_reg[3] = a | 0x3f800000;
     }
     v_endif;
@@ -187,7 +186,7 @@ sfpi_test_noinline void test3()
 
     v_if (sfpi::dst_reg[0] == 10.0F)
     {
-        vUInt a    = static_cast<unsigned short>(0x3f80);
+        vUInt a          = static_cast<unsigned short>(0x3f80);
         sfpi::dst_reg[3] = a | 0x3f800000;
     }
     v_endif;
@@ -201,7 +200,7 @@ sfpi_test_noinline void test3()
 
     v_if (sfpi::dst_reg[0] == 12.0F)
     {
-        vUInt a    = 0x3F80A3D7;
+        vUInt a          = 0x3F80A3D7;
         sfpi::dst_reg[3] = a;
     }
     v_endif;
@@ -637,7 +636,7 @@ sfpi_test_noinline void test5()
     {
         sfpi::vFloat c = -5.0F;
         sfpi::vFloat d;
-        d          = a * b + c - 0.5F;
+        d                = a * b + c - 0.5F;
         sfpi::dst_reg[5] = d;
     }
     v_elseif (sfpi::dst_reg[0] == 22.0F)
@@ -879,21 +878,21 @@ sfpi_test_noinline void test6()
     v_elseif (sfpi::dst_reg[0] == 13.0F)
     {
         sfpi::vInt a = 20;
-        a      = a + 12;
+        a            = a + 12;
         set_expected_result(6, 8.0F, 32, a);
     }
     v_elseif (sfpi::dst_reg[0] == 14.0F)
     {
         sfpi::vInt a = 18;
         sfpi::vInt b = -6;
-        a      = a + b;
+        a            = a + b;
         set_expected_result(6, 16.0F, 12, a);
     }
     v_elseif (sfpi::dst_reg[0] == 15.0F)
     {
         sfpi::vInt a = 14;
         sfpi::vInt b = -5;
-        a      = b + a;
+        a            = b + a;
         set_expected_result(6, 32.0F, 9, a);
     }
     v_endif;
@@ -906,21 +905,21 @@ sfpi_test_noinline void test6()
     v_elseif (sfpi::dst_reg[0] == 17.0F)
     {
         sfpi::vInt a = 20;
-        a      = a - 12;
+        a            = a - 12;
         set_expected_result(6, 8.0F, 8, a);
     }
     v_elseif (sfpi::dst_reg[0] == 18.0F)
     {
         sfpi::vInt a = 18;
         sfpi::vInt b = 6;
-        a      = a - b;
+        a            = a - b;
         set_expected_result(6, 16.0F, 12, a);
     }
     v_elseif (sfpi::dst_reg[0] == 19.0F)
     {
         sfpi::vInt a = 14;
         sfpi::vInt b = 5;
-        a      = b - a;
+        a            = b - a;
         set_expected_result(6, 32.0F, -9, a);
     }
     v_endif;
@@ -1138,7 +1137,7 @@ sfpi_test_noinline void test7()
     {
         sfpi::vInt exp       = 0x007F;   // Exponent in low bits
         sfpi::vFloat sgn_man = -1664.0F; // 1024 + 512 + 128 or 1101
-        sgn_man        = setexp(sgn_man, exp);
+        sgn_man              = setexp(sgn_man, exp);
         sfpi::dst_reg[7]     = sgn_man;
     }
     v_endif;
@@ -1621,8 +1620,8 @@ sfpi_test_noinline void test9()
     }
     v_elseif (sfpi::dst_reg[0] == 9.0F)
     {
-        vUInt a = 0xFFFFU;
-        sfpi::vInt b  = lz(a);
+        vUInt a      = 0xFFFFU;
+        sfpi::vInt b = lz(a);
         set_expected_result(9, 30.0F, 0x10, b);
     }
     v_elseif (sfpi::dst_reg[0] < 13.0F)
@@ -1700,7 +1699,8 @@ sfpi_test_noinline void test9()
     v_endif;
 
     v_if (
-        (sfpi::dst_reg[0] == 23.0 || sfpi::dst_reg[0] == 24.0 || sfpi::dst_reg[0] == 25.0 || sfpi::dst_reg[0] == 26.0 || sfpi::dst_reg[0] == 27.0 || sfpi::dst_reg[0] == 28.0) &&
+        (sfpi::dst_reg[0] == 23.0 || sfpi::dst_reg[0] == 24.0 || sfpi::dst_reg[0] == 25.0 || sfpi::dst_reg[0] == 26.0 || sfpi::dst_reg[0] == 27.0 ||
+         sfpi::dst_reg[0] == 28.0) &&
         (sfpi::dst_reg[0] != 23.0 && sfpi::dst_reg[0] != 25.0 && sfpi::dst_reg[0] != 27.0f))
     {
         sfpi::dst_reg[9] = 64.0f;
@@ -1745,9 +1745,9 @@ sfpi_test_noinline void test10()
     sfpi::dst_reg[10] = -sfpi::dst_reg[0];
     v_if (sfpi::dst_reg[0] == 1.0F)
     {
-        vUInt a    = 0x015;
+        vUInt a          = 0x015;
         sfpi::vInt shift = 6;
-        vUInt b    = shft(a, shift);
+        vUInt b          = shft(a, shift);
         // Could write better tests if we could return and test the int result
         set_expected_result(10, 20.0F, 0x0540, static_cast<sfpi::vInt>(b));
     }
@@ -1759,9 +1759,9 @@ sfpi_test_noinline void test10()
     }
     v_elseif (sfpi::dst_reg[0] == 3.0F)
     {
-        vUInt a    = 0xAAAAU;
+        vUInt a          = 0xAAAAU;
         sfpi::vInt shift = -6;
-        vUInt b    = shft(a, shift);
+        vUInt b          = shft(a, shift);
         set_expected_result(10, 24.0F, 0x02AA, static_cast<sfpi::vInt>(b));
     }
     v_elseif (sfpi::dst_reg[0] == 4.0F)
@@ -1773,7 +1773,7 @@ sfpi_test_noinline void test10()
     v_elseif (sfpi::dst_reg[0] == 5.0F)
     {
         sfpi::vInt a = 25;
-        a      = a + 5;
+        a            = a + 5;
         a += 7;
         set_expected_result(10, 28.0F, 0x25, a);
     }
@@ -1839,51 +1839,51 @@ sfpi_test_noinline void test11()
     {
         // Use L0
         sfpi::vFloat h    = -0.3F;
-        vUInt l2a   = 0xA010; // Mulitply by -0.25, add 0.5
-        h           = lut_sign(h, l0a, l1a, l2a);
+        vUInt l2a         = 0xA010; // Mulitply by -0.25, add 0.5
+        h                 = lut_sign(h, l0a, l1a, l2a);
         sfpi::dst_reg[11] = h;
     }
     v_elseif (sfpi::dst_reg[0] == 2.0F)
     {
         // Use L0
         sfpi::vFloat h    = -0.3F;
-        vUInt l2a   = 0xA010; // Mulitply by -0.25, add 0.5
-        h           = lut(h, l0a, l1a, l2a);
+        vUInt l2a         = 0xA010; // Mulitply by -0.25, add 0.5
+        h                 = lut(h, l0a, l1a, l2a);
         sfpi::dst_reg[11] = h;
     }
     v_elseif (sfpi::dst_reg[0] == 3.0F)
     {
         // Use L0
-        sfpi::vFloat h  = -0.3F;
-        vUInt l2a = 0xA010; // Mulitply by -0.25, add 0.5
+        sfpi::vFloat h = -0.3F;
+        vUInt l2a      = 0xA010; // Mulitply by -0.25, add 0.5
         // Test used a bias on Grayskull, not supported on Wormhole
-        h           = lut_sign(h, l0a, l1a, l2a);
+        h                 = lut_sign(h, l0a, l1a, l2a);
         sfpi::dst_reg[11] = h;
     }
     v_elseif (sfpi::dst_reg[0] == 4.0F)
     {
         // Use L0
-        sfpi::vFloat h  = -0.3F;
-        vUInt l2a = 0xA010; // Mulitply by -0.25, add 0.5
+        sfpi::vFloat h = -0.3F;
+        vUInt l2a      = 0xA010; // Mulitply by -0.25, add 0.5
         // Test used a bias on Grayskull, not supported on Wormhole
-        h           = lut(h, l0a, l1a, l2a);
+        h                 = lut(h, l0a, l1a, l2a);
         sfpi::dst_reg[11] = h;
     }
     v_elseif (sfpi::dst_reg[0] == 5.0F)
     {
         // Use L1
-        sfpi::vFloat h  = 1.0F;
-        vUInt l2a = 0xA010; // Mulitply by -0.25, add 0.5
+        sfpi::vFloat h = 1.0F;
+        vUInt l2a      = 0xA010; // Mulitply by -0.25, add 0.5
         // Test used a bias on Grayskull, not supported on Wormhole
-        h           = lut(h, l0a, l1a, l2a);
+        h                 = lut(h, l0a, l1a, l2a);
         sfpi::dst_reg[11] = h;
     }
     v_elseif (sfpi::dst_reg[0] == 6.0F)
     {
         // Use L2
         sfpi::vFloat h    = 4.0F;
-        vUInt l2a   = 0xA010; // Mulitply by -0.25, add 0.5
-        h           = lut_sign(h, l0a, l1a, l2a);
+        vUInt l2a         = 0xA010; // Mulitply by -0.25, add 0.5
+        h                 = lut_sign(h, l0a, l1a, l2a);
         sfpi::dst_reg[11] = h;
     }
     v_endif;
@@ -1905,51 +1905,51 @@ sfpi_test_noinline void test11()
         {
             // Use L0
             sfpi::vFloat h    = -0.3F;
-            vUInt l2b   = 0x9000;
-            h           = lut_sign(h, l0b, l1b, l2b);
+            vUInt l2b         = 0x9000;
+            h                 = lut_sign(h, l0b, l1b, l2b);
             sfpi::dst_reg[11] = h;
         }
         v_elseif (sfpi::dst_reg[0] == 8.0F)
         {
             // Use L0
             sfpi::vFloat h    = -0.3F;
-            vUInt l2b   = 0x9000;
-            h           = lut(h, l0b, l1b, l2b);
+            vUInt l2b         = 0x9000;
+            h                 = lut(h, l0b, l1b, l2b);
             sfpi::dst_reg[11] = h;
         }
         v_elseif (sfpi::dst_reg[0] == 9.0F)
         {
             // Use L0
-            sfpi::vFloat h  = -0.3F;
-            vUInt l2b = 0x9000;
+            sfpi::vFloat h = -0.3F;
+            vUInt l2b      = 0x9000;
             // Test used a bias on Grayskull, not supported on Wormhole
-            h           = lut_sign(h, l0b, l1b, l2b);
+            h                 = lut_sign(h, l0b, l1b, l2b);
             sfpi::dst_reg[11] = h;
         }
         v_elseif (sfpi::dst_reg[0] == 10.0F)
         {
             // Use L0
-            sfpi::vFloat h  = -0.3F;
-            vUInt l2b = 0x9000;
+            sfpi::vFloat h = -0.3F;
+            vUInt l2b      = 0x9000;
             // Test used a bias on Grayskull, not supported on Wormhole
-            h           = lut(h, l0b, l1b, l2b);
+            h                 = lut(h, l0b, l1b, l2b);
             sfpi::dst_reg[11] = h;
         }
         v_elseif (sfpi::dst_reg[0] == 11.0F)
         {
             // Use L1
-            sfpi::vFloat h  = 1.0F;
-            vUInt l2b = 0x9000;
+            sfpi::vFloat h = 1.0F;
+            vUInt l2b      = 0x9000;
             // Test used a bias on Grayskull, not supported on Wormhole
-            h           = lut(h, l0b, l1b, l2b);
+            h                 = lut(h, l0b, l1b, l2b);
             sfpi::dst_reg[11] = h;
         }
         v_elseif (sfpi::dst_reg[0] == 12.0F)
         {
             // Use L2
             sfpi::vFloat h    = 4.0F;
-            vUInt l2b   = 0x9000;
-            h           = lut_sign(h, l0b, l1b, l2b);
+            vUInt l2b         = 0x9000;
+            h                 = lut_sign(h, l0b, l1b, l2b);
             sfpi::dst_reg[11] = h;
         }
         v_endif;
@@ -1963,25 +1963,25 @@ sfpi_test_noinline void test11()
         v_if (sfpi::dst_reg[0] == 13.0f)
         {
             sfpi::vFloat h    = -0.25f;
-            h           = lut2(h, l0, l1, l2);
+            h                 = lut2(h, l0, l1, l2);
             sfpi::dst_reg[11] = h; // .25 * 2 + 3 = -3.5 (sign retain)
         }
         v_elseif (sfpi::dst_reg[0] == 14.0f)
         {
             sfpi::vFloat h    = 1.25f;
-            h           = lut2(h, l0, l1, l2);
+            h                 = lut2(h, l0, l1, l2);
             sfpi::dst_reg[11] = h; // 1.25 * 4 + 5 = 10 (sign retain)
         }
         v_elseif (sfpi::dst_reg[0] == 15.0f)
         {
             sfpi::vFloat h    = -2.25f;
-            h           = lut2(h, l0, l1, l2);
+            h                 = lut2(h, l0, l1, l2);
             sfpi::dst_reg[11] = h; // 2.25 * 6 + 7 = 13.5 + 7 = -20.5 (sign retain)
         }
         v_elseif (sfpi::dst_reg[0] == 16.0f)
         {
             sfpi::vFloat h    = -0.25f;
-            h           = lut2_sign(h, l0, l1, l2);
+            h                 = lut2_sign(h, l0, l1, l2);
             sfpi::dst_reg[11] = h; // .25 * 2 + 3 = 3.5 (sign update)
         }
         v_endif;
@@ -1998,25 +1998,25 @@ sfpi_test_noinline void test11()
         v_if (sfpi::dst_reg[0] == 17.0f)
         {
             sfpi::vFloat h    = -0.25f;
-            h           = lut2(h, a0, a1, a2, b0, b1, b2);
+            h                 = lut2(h, a0, a1, a2, b0, b1, b2);
             sfpi::dst_reg[11] = h; // .25 * 2 + 3 = -3.5 (sign retain)
         }
         v_elseif (sfpi::dst_reg[0] == 18.0f)
         {
             sfpi::vFloat h    = 1.25f;
-            h           = lut2(h, a0, a1, a2, b0, b1, b2);
+            h                 = lut2(h, a0, a1, a2, b0, b1, b2);
             sfpi::dst_reg[11] = h; // 1.25 * 4 + 5 = 10 (sign retain)
         }
         v_elseif (sfpi::dst_reg[0] == 19.0f)
         {
             sfpi::vFloat h    = -3.0f;
-            h           = lut2(h, a0, a1, a2, b0, b1, b2);
+            h                 = lut2(h, a0, a1, a2, b0, b1, b2);
             sfpi::dst_reg[11] = h; // 3 * 6 + 7 = 18 + 7 = -25.0 (sign retain)
         }
         v_elseif (sfpi::dst_reg[0] == 20.0f)
         {
             sfpi::vFloat h    = -0.25f;
-            h           = lut2_sign(h, a0, a1, a2, b0, b1, b2);
+            h                 = lut2_sign(h, a0, a1, a2, b0, b1, b2);
             sfpi::dst_reg[11] = h; // .25 * 2 + 3 = 3.5 (sign update)
         }
         v_endif;
@@ -2034,43 +2034,43 @@ sfpi_test_noinline void test11()
         v_if (sfpi::dst_reg[0] == 21.0f)
         {
             sfpi::vFloat h    = -0.25f;
-            h           = lut2(h, a01, a23, a34, b01, b23, b34);
+            h                 = lut2(h, a01, a23, a34, b01, b23, b34);
             sfpi::dst_reg[11] = h; // .25 * 2 + 3 = -3.5 (sign retain)
         }
         v_elseif (sfpi::dst_reg[0] == 22.0f)
         {
             sfpi::vFloat h    = 0.75f;
-            h           = lut2(h, a01, a23, a34, b01, b23, b34);
+            h                 = lut2(h, a01, a23, a34, b01, b23, b34);
             sfpi::dst_reg[11] = h; // .75 * 4 + 5 = 8
         }
         v_elseif (sfpi::dst_reg[0] == 23.0f)
         {
             sfpi::vFloat h    = -1.25f;
-            h           = lut2(h, a01, a23, a34, b01, b23, b34);
+            h                 = lut2(h, a01, a23, a34, b01, b23, b34);
             sfpi::dst_reg[11] = h; // 1.25 * 6 + 7 = 7.5 + 7 = -14.5 (sign retain)
         }
         v_elseif (sfpi::dst_reg[0] == 24.0f)
         {
             sfpi::vFloat h    = -1.75f;
-            h           = lut2(h, a01, a23, a34, b01, b23, b34);
+            h                 = lut2(h, a01, a23, a34, b01, b23, b34);
             sfpi::dst_reg[11] = h; // 1.75 * 8 + 9 = 14 + 9 = -23 (sign retain)
         }
         v_elseif (sfpi::dst_reg[0] == 25.0f)
         {
             sfpi::vFloat h    = 2.5f;
-            h           = lut2(h, a01, a23, a34, b01, b23, b34);
+            h                 = lut2(h, a01, a23, a34, b01, b23, b34);
             sfpi::dst_reg[11] = h; // 2.5 * 10 + 11 = 25 + 11 = 36.0
         }
         v_elseif (sfpi::dst_reg[0] == 26.0f)
         {
             sfpi::vFloat h    = 3.5f;
-            h           = lut2(h, a01, a23, a34, b01, b23, b34);
+            h                 = lut2(h, a01, a23, a34, b01, b23, b34);
             sfpi::dst_reg[11] = h; // 3.5 * 12 + 13 = 42 + 13 = 55.0
         }
         v_elseif (sfpi::dst_reg[0] == 27.0f)
         {
             sfpi::vFloat h    = -0.25f;
-            h           = lut2_sign(h, a01, a23, a34, b01, b23, b34);
+            h                 = lut2_sign(h, a01, a23, a34, b01, b23, b34);
             sfpi::dst_reg[11] = h; // .25 * 2 + 3 = 3.5 (sign update)
         }
         v_endif;
@@ -2106,25 +2106,25 @@ sfpi_test_noinline void test11()
         v_if (sfpi::dst_reg[0] == 28.0f)
         {
             sfpi::vFloat h    = -1.75f;
-            h           = lut2(h, a01, a23, a34, b01, b23, b34, 2);
+            h                 = lut2(h, a01, a23, a34, b01, b23, b34, 2);
             sfpi::dst_reg[11] = h; // 1.75 * 8 + 9 = 14 + 9 = -23 (sign retain)
         }
         v_elseif (sfpi::dst_reg[0] == 29.0f)
         {
             sfpi::vFloat h    = 3.5f;
-            h           = lut2(h, a01, a23, a34, b01, b23, b34, 2);
+            h                 = lut2(h, a01, a23, a34, b01, b23, b34, 2);
             sfpi::dst_reg[11] = h; // 3.5 * 10 + 11 = 35 + 11 = 46.0
         }
         v_elseif (sfpi::dst_reg[0] == 30.0f)
         {
             sfpi::vFloat h    = 4.5f;
-            h           = lut2(h, a01, a23, a34, b01, b23, b34, 2);
+            h                 = lut2(h, a01, a23, a34, b01, b23, b34, 2);
             sfpi::dst_reg[11] = h; // 4.5 * 12 + 13 = 54 + 13 = 67.0
         }
         v_elseif (sfpi::dst_reg[0] == 31.0f)
         {
             sfpi::vFloat h    = -0.25f;
-            h           = lut2_sign(h, a01, a23, a34, b01, b23, b34, 2);
+            h                 = lut2_sign(h, a01, a23, a34, b01, b23, b34, 2);
             sfpi::dst_reg[11] = h; // .25 * 2 + 3 = 3.5 (sign update)
         }
         v_endif;
@@ -2240,15 +2240,15 @@ sfpi_test_noinline void test12(int imm)
     v_elseif (sfpi::dst_reg[0] == 12.0F)
     {
         sfpi::vFloat tmp  = 1024.0F;
-        int man     = 0x75019a + 35 - imm;
+        int man           = 0x75019a + 35 - imm;
         sfpi::vFloat tmp2 = setman(tmp, man);
         sfpi::dst_reg[12] = tmp2;
     }
     v_elseif (sfpi::dst_reg[0] == 13.0F)
     {
-        int exp        = 0x007F + 35 - imm; // Exponent in low bits
+        int exp              = 0x007F + 35 - imm; // Exponent in low bits
         sfpi::vFloat sgn_man = -1664.0F;          // 1024 + 512 + 128 or 1101
-        sgn_man        = setexp(sgn_man, exp);
+        sgn_man              = setexp(sgn_man, exp);
         sfpi::dst_reg[12]    = sgn_man;
     }
     v_endif;
@@ -2294,7 +2294,7 @@ sfpi_test_noinline void test12(int imm)
         sfpi::vFloat a          = 130.0F;
         sfpi::dst_reg[imm - 23] = a;
         __builtin_rvtt_sfpnop(); // XXXXXX remove me when compiler is fixed
-        a           = sfpi::dst_reg[12];
+        a                 = sfpi::dst_reg[12];
         sfpi::dst_reg[12] = a + 1.0F;
     }
     v_endif;
@@ -2638,8 +2638,8 @@ sfpi_test_noinline void test14(int imm)
         v_else
         {
             sfpi::vFloat c = vConst0 * vConst0 + vConst0;
-            b        = -a;
-            a        = c;
+            b              = -a;
+            a              = c;
         }
         v_endif;
         v_if (sfpi::dst_reg[0] == 0.0F || sfpi::dst_reg[0] == 1.0F)
@@ -2662,8 +2662,8 @@ sfpi_test_noinline void test14(int imm)
             v_if ((tmp = lz(a)) != 0)
             {
                 sfpi::vFloat c = vConst0 * vConst0 + vConst0;
-                b        = -a;
-                a        = c;
+                b              = -a;
+                a              = c;
             }
             v_endif;
         }
@@ -2688,8 +2688,8 @@ sfpi_test_noinline void test14(int imm)
             v_if ((tmp = exexp(a)) >= 0)
             {
                 sfpi::vFloat c = vConst0 * vConst0 + vConst0;
-                b        = -a;
-                a        = c;
+                b              = -a;
+                a              = c;
             }
             v_endif;
         }
@@ -2715,8 +2715,8 @@ sfpi_test_noinline void test14(int imm)
             v_if (tmp >= 2)
             {
                 sfpi::vFloat c = vConst0 * vConst0 + vConst0;
-                b        = -a;
-                a        = c;
+                b              = -a;
+                a              = c;
             }
             v_endif;
         }

--- a/tt_llk_wormhole_b0/common/inc/ckernel_sfpi.h
+++ b/tt_llk_wormhole_b0/common/inc/ckernel_sfpi.h
@@ -77,7 +77,7 @@ sfpi_inline vType reduce_bool4(vType a, vType b, vType c, vType d, int reference
     }
     v_endif;
 
-    vUInt result = 0;
+    sfpi::vUInt result = 0;
     v_if (result1 == 1 && result2 == 1)
     {
         result = 1;
@@ -172,7 +172,7 @@ sfpi_test_noinline void test3()
     v_if (sfpi::dst_reg[0] == 8.0F)
     {
         // This will be a ushort w/ 1 load (not sign extended)
-        vUInt a          = 0x8F80U;
+        sfpi::vUInt a    = 0x8F80U;
         sfpi::dst_reg[3] = a | 0x3f800000;
     }
     v_endif;
@@ -186,7 +186,7 @@ sfpi_test_noinline void test3()
 
     v_if (sfpi::dst_reg[0] == 10.0F)
     {
-        vUInt a          = static_cast<unsigned short>(0x3f80);
+        sfpi::vUInt a    = static_cast<unsigned short>(0x3f80);
         sfpi::dst_reg[3] = a | 0x3f800000;
     }
     v_endif;
@@ -200,7 +200,7 @@ sfpi_test_noinline void test3()
 
     v_if (sfpi::dst_reg[0] == 12.0F)
     {
-        vUInt a          = 0x3F80A3D7;
+        sfpi::vUInt a    = 0x3F80A3D7;
         sfpi::dst_reg[3] = a;
     }
     v_endif;
@@ -926,27 +926,27 @@ sfpi_test_noinline void test6()
 
     v_if (sfpi::dst_reg[0] == 20.0F)
     {
-        vUInt v = 25;
+        sfpi::vUInt v = 25;
         set_expected_result(6, 4.0F, 25, reinterpret<sfpi::vInt>(v));
     }
     v_elseif (sfpi::dst_reg[0] == 21.0F)
     {
-        vUInt a = 20;
-        a       = a - 12;
+        sfpi::vUInt a = 20;
+        a             = a - 12;
         set_expected_result(6, 8.0F, 8, reinterpret<sfpi::vInt>(a));
     }
     v_elseif (sfpi::dst_reg[0] == 22.0F)
     {
-        vUInt a = 18;
-        vUInt b = 6;
-        a       = a - b;
+        sfpi::vUInt a = 18;
+        sfpi::vUInt b = 6;
+        a             = a - b;
         set_expected_result(6, 16.0F, 12, reinterpret<sfpi::vInt>(a));
     }
     v_elseif (sfpi::dst_reg[0] == 23.0F)
     {
-        vUInt a = 14;
-        vUInt b = 5;
-        a       = b - a;
+        sfpi::vUInt a = 14;
+        sfpi::vUInt b = 5;
+        a             = b - a;
         set_expected_result(6, 32.0F, -9, reinterpret<sfpi::vInt>(a));
     }
     v_endif;
@@ -1260,16 +1260,16 @@ sfpi_test_noinline void test8()
     sfpi::dst_reg[8] = -sfpi::dst_reg[0];
     v_if (sfpi::dst_reg[0] == 1.0F)
     {
-        vUInt a = 0x05FF;
-        vUInt b = 0x0AAA;
+        sfpi::vUInt a = 0x05FF;
+        sfpi::vUInt b = 0x0AAA;
         b &= a;
         set_expected_result(8, 16.0F, 0x00AA, static_cast<sfpi::vInt>(b));
     }
     v_elseif (sfpi::dst_reg[0] == 2.0F)
     {
-        vUInt a = 0x05FF;
-        vUInt b = 0x0AAA;
-        vUInt c = a & b;
+        sfpi::vUInt a = 0x05FF;
+        sfpi::vUInt b = 0x0AAA;
+        sfpi::vUInt c = a & b;
         set_expected_result(8, 16.0F, 0x00AA, static_cast<sfpi::vInt>(c));
     }
     v_elseif (sfpi::dst_reg[0] == 3.0F)
@@ -1290,16 +1290,16 @@ sfpi_test_noinline void test8()
 
     v_if (sfpi::dst_reg[0] == 5.0F)
     {
-        vUInt a = 0x0111;
-        vUInt b = 0x0444;
+        sfpi::vUInt a = 0x0111;
+        sfpi::vUInt b = 0x0444;
         b |= a;
         set_expected_result(8, 20.0F, 0x0555, static_cast<sfpi::vInt>(b));
     }
     v_elseif (sfpi::dst_reg[0] == 6.0F)
     {
-        vUInt a = 0x0111;
-        vUInt b = 0x0444;
-        vUInt c = b | a;
+        sfpi::vUInt a = 0x0111;
+        sfpi::vUInt b = 0x0444;
+        sfpi::vUInt c = b | a;
         set_expected_result(8, 20.0F, 0x0555, static_cast<sfpi::vInt>(c));
     }
     v_elseif (sfpi::dst_reg[0] == 7.0F)
@@ -1320,8 +1320,8 @@ sfpi_test_noinline void test8()
 
     v_if (sfpi::dst_reg[0] == 9.0F)
     {
-        vUInt a = 0x0AAA;
-        a       = ~a;
+        sfpi::vUInt a = 0x0AAA;
+        a             = ~a;
         a &= 0x0FFF; // Tricky since ~ flips upper bits that immediates can't access
         set_expected_result(8, 22.0F, 0x0555, static_cast<sfpi::vInt>(a));
     }
@@ -1514,9 +1514,9 @@ sfpi_test_noinline void test8()
 
     v_if (sfpi::dst_reg[0] == 30.0F)
     {
-        vUInt a = 0xA5A5;
-        vUInt b = 0xFF00;
-        vUInt c = a ^ b;
+        sfpi::vUInt a = 0xA5A5;
+        sfpi::vUInt b = 0xFF00;
+        sfpi::vUInt c = a ^ b;
         set_expected_result(8, 64.0F, 0x5AA5, c);
     }
     v_endif;
@@ -1620,19 +1620,19 @@ sfpi_test_noinline void test9()
     }
     v_elseif (sfpi::dst_reg[0] == 9.0F)
     {
-        vUInt a      = 0xFFFFU;
-        sfpi::vInt b = lz(a);
+        sfpi::vUInt a = 0xFFFFU;
+        sfpi::vInt b  = lz(a);
         set_expected_result(9, 30.0F, 0x10, b);
     }
     v_elseif (sfpi::dst_reg[0] < 13.0F)
     {
         sfpi::vFloat a = sfpi::dst_reg[0] - 11.0F;
-        vUInt b;
+        sfpi::vUInt b;
 
         // Relies on if chain above...
         v_if (sfpi::dst_reg[0] >= 7.0F)
         {
-            b = sfpi::reinterpret<vUInt>(lz(a));
+            b = sfpi::reinterpret<sfpi::vUInt>(lz(a));
             v_if (b != 32)
             {
                 sfpi::dst_reg[9] = 60.0F;
@@ -1745,29 +1745,29 @@ sfpi_test_noinline void test10()
     sfpi::dst_reg[10] = -sfpi::dst_reg[0];
     v_if (sfpi::dst_reg[0] == 1.0F)
     {
-        vUInt a          = 0x015;
+        sfpi::vUInt a    = 0x015;
         sfpi::vInt shift = 6;
-        vUInt b          = shft(a, shift);
+        sfpi::vUInt b    = shft(a, shift);
         // Could write better tests if we could return and test the int result
         set_expected_result(10, 20.0F, 0x0540, static_cast<sfpi::vInt>(b));
     }
     v_elseif (sfpi::dst_reg[0] == 2.0F)
     {
-        vUInt a = 0x2AAA;
-        vUInt b = shft(a, -4);
+        sfpi::vUInt a = 0x2AAA;
+        sfpi::vUInt b = shft(a, -4);
         set_expected_result(10, 22.0F, 0x02AA, static_cast<sfpi::vInt>(b));
     }
     v_elseif (sfpi::dst_reg[0] == 3.0F)
     {
-        vUInt a          = 0xAAAAU;
+        sfpi::vUInt a    = 0xAAAAU;
         sfpi::vInt shift = -6;
-        vUInt b          = shft(a, shift);
+        sfpi::vUInt b    = shft(a, shift);
         set_expected_result(10, 24.0F, 0x02AA, static_cast<sfpi::vInt>(b));
     }
     v_elseif (sfpi::dst_reg[0] == 4.0F)
     {
-        vUInt a = 0x005A;
-        vUInt b = shft(a, 4);
+        sfpi::vUInt a = 0x005A;
+        sfpi::vUInt b = shft(a, 4);
         set_expected_result(10, 26.0F, 0x05A0, static_cast<sfpi::vInt>(b));
     }
     v_elseif (sfpi::dst_reg[0] == 5.0F)
@@ -1833,13 +1833,13 @@ sfpi_test_noinline void test11()
     // SFPLUT, SFPLOADL<n>
     sfpi::dst_reg[11] = -sfpi::dst_reg[0];
 
-    vUInt l0a = 0xFF30; // Multiply by 0.0, add 0.125
-    vUInt l1a = 0X3020; // Multiply by 0.125, add 0.25
+    sfpi::vUInt l0a = 0xFF30; // Multiply by 0.0, add 0.125
+    sfpi::vUInt l1a = 0X3020; // Multiply by 0.125, add 0.25
     v_if (sfpi::dst_reg[0] == 1.0F)
     {
         // Use L0
         sfpi::vFloat h    = -0.3F;
-        vUInt l2a         = 0xA010; // Mulitply by -0.25, add 0.5
+        sfpi::vUInt l2a   = 0xA010; // Mulitply by -0.25, add 0.5
         h                 = lut_sign(h, l0a, l1a, l2a);
         sfpi::dst_reg[11] = h;
     }
@@ -1847,15 +1847,15 @@ sfpi_test_noinline void test11()
     {
         // Use L0
         sfpi::vFloat h    = -0.3F;
-        vUInt l2a         = 0xA010; // Mulitply by -0.25, add 0.5
+        sfpi::vUInt l2a   = 0xA010; // Mulitply by -0.25, add 0.5
         h                 = lut(h, l0a, l1a, l2a);
         sfpi::dst_reg[11] = h;
     }
     v_elseif (sfpi::dst_reg[0] == 3.0F)
     {
         // Use L0
-        sfpi::vFloat h = -0.3F;
-        vUInt l2a      = 0xA010; // Mulitply by -0.25, add 0.5
+        sfpi::vFloat h  = -0.3F;
+        sfpi::vUInt l2a = 0xA010; // Mulitply by -0.25, add 0.5
         // Test used a bias on Grayskull, not supported on Wormhole
         h                 = lut_sign(h, l0a, l1a, l2a);
         sfpi::dst_reg[11] = h;
@@ -1863,8 +1863,8 @@ sfpi_test_noinline void test11()
     v_elseif (sfpi::dst_reg[0] == 4.0F)
     {
         // Use L0
-        sfpi::vFloat h = -0.3F;
-        vUInt l2a      = 0xA010; // Mulitply by -0.25, add 0.5
+        sfpi::vFloat h  = -0.3F;
+        sfpi::vUInt l2a = 0xA010; // Mulitply by -0.25, add 0.5
         // Test used a bias on Grayskull, not supported on Wormhole
         h                 = lut(h, l0a, l1a, l2a);
         sfpi::dst_reg[11] = h;
@@ -1872,8 +1872,8 @@ sfpi_test_noinline void test11()
     v_elseif (sfpi::dst_reg[0] == 5.0F)
     {
         // Use L1
-        sfpi::vFloat h = 1.0F;
-        vUInt l2a      = 0xA010; // Mulitply by -0.25, add 0.5
+        sfpi::vFloat h  = 1.0F;
+        sfpi::vUInt l2a = 0xA010; // Mulitply by -0.25, add 0.5
         // Test used a bias on Grayskull, not supported on Wormhole
         h                 = lut(h, l0a, l1a, l2a);
         sfpi::dst_reg[11] = h;
@@ -1882,7 +1882,7 @@ sfpi_test_noinline void test11()
     {
         // Use L2
         sfpi::vFloat h    = 4.0F;
-        vUInt l2a         = 0xA010; // Mulitply by -0.25, add 0.5
+        sfpi::vUInt l2a   = 0xA010; // Mulitply by -0.25, add 0.5
         h                 = lut_sign(h, l0a, l1a, l2a);
         sfpi::dst_reg[11] = h;
     }
@@ -1897,7 +1897,7 @@ sfpi_test_noinline void test11()
         // These are fakedout w/ emule
         TTI_SFPLOADI(0, SFPLOADI_MOD0_USHORT, 0xFF20); // Mulitply by 0.0, add 0.25
         TTI_SFPLOADI(1, SFPLOADI_MOD0_USHORT, 0x2010); // Mulitply by 0.25, add 0.5
-        vUInt l0b, l1b;
+        sfpi::vUInt l0b, l1b;
         l0b = l_reg[LRegs::LReg0];
         l1b = l_reg[LRegs::LReg1];
 
@@ -1905,7 +1905,7 @@ sfpi_test_noinline void test11()
         {
             // Use L0
             sfpi::vFloat h    = -0.3F;
-            vUInt l2b         = 0x9000;
+            sfpi::vUInt l2b   = 0x9000;
             h                 = lut_sign(h, l0b, l1b, l2b);
             sfpi::dst_reg[11] = h;
         }
@@ -1913,15 +1913,15 @@ sfpi_test_noinline void test11()
         {
             // Use L0
             sfpi::vFloat h    = -0.3F;
-            vUInt l2b         = 0x9000;
+            sfpi::vUInt l2b   = 0x9000;
             h                 = lut(h, l0b, l1b, l2b);
             sfpi::dst_reg[11] = h;
         }
         v_elseif (sfpi::dst_reg[0] == 9.0F)
         {
             // Use L0
-            sfpi::vFloat h = -0.3F;
-            vUInt l2b      = 0x9000;
+            sfpi::vFloat h  = -0.3F;
+            sfpi::vUInt l2b = 0x9000;
             // Test used a bias on Grayskull, not supported on Wormhole
             h                 = lut_sign(h, l0b, l1b, l2b);
             sfpi::dst_reg[11] = h;
@@ -1929,8 +1929,8 @@ sfpi_test_noinline void test11()
         v_elseif (sfpi::dst_reg[0] == 10.0F)
         {
             // Use L0
-            sfpi::vFloat h = -0.3F;
-            vUInt l2b      = 0x9000;
+            sfpi::vFloat h  = -0.3F;
+            sfpi::vUInt l2b = 0x9000;
             // Test used a bias on Grayskull, not supported on Wormhole
             h                 = lut(h, l0b, l1b, l2b);
             sfpi::dst_reg[11] = h;
@@ -1938,8 +1938,8 @@ sfpi_test_noinline void test11()
         v_elseif (sfpi::dst_reg[0] == 11.0F)
         {
             // Use L1
-            sfpi::vFloat h = 1.0F;
-            vUInt l2b      = 0x9000;
+            sfpi::vFloat h  = 1.0F;
+            sfpi::vUInt l2b = 0x9000;
             // Test used a bias on Grayskull, not supported on Wormhole
             h                 = lut(h, l0b, l1b, l2b);
             sfpi::dst_reg[11] = h;
@@ -1948,7 +1948,7 @@ sfpi_test_noinline void test11()
         {
             // Use L2
             sfpi::vFloat h    = 4.0F;
-            vUInt l2b         = 0x9000;
+            sfpi::vUInt l2b   = 0x9000;
             h                 = lut_sign(h, l0b, l1b, l2b);
             sfpi::dst_reg[11] = h;
         }
@@ -1957,9 +1957,9 @@ sfpi_test_noinline void test11()
 
     // lut2 3 entry 16 bit
     {
-        vUInt l0 = (s2vFloat16a(2.0f).get() << 16) | s2vFloat16a(3.0f).get();
-        vUInt l1 = (s2vFloat16a(4.0f).get() << 16) | s2vFloat16a(5.0f).get();
-        vUInt l2 = (s2vFloat16a(6.0f).get() << 16) | s2vFloat16a(7.0f).get();
+        sfpi::vUInt l0 = (s2vFloat16a(2.0f).get() << 16) | s2vFloat16a(3.0f).get();
+        sfpi::vUInt l1 = (s2vFloat16a(4.0f).get() << 16) | s2vFloat16a(5.0f).get();
+        sfpi::vUInt l2 = (s2vFloat16a(6.0f).get() << 16) | s2vFloat16a(7.0f).get();
         v_if (sfpi::dst_reg[0] == 13.0f)
         {
             sfpi::vFloat h    = -0.25f;
@@ -2024,13 +2024,13 @@ sfpi_test_noinline void test11()
 
     // lut2 6 entry 16 bit mode 1
     {
-        vUInt a01 = (s2vFloat16a(4.0f).get() << 16) | s2vFloat16a(2.0f).get();
-        vUInt a23 = (s2vFloat16a(8.0f).get() << 16) | s2vFloat16a(6.0f).get();
+        sfpi::vUInt a01 = (s2vFloat16a(4.0f).get() << 16) | s2vFloat16a(2.0f).get();
+        sfpi::vUInt a23 = (s2vFloat16a(8.0f).get() << 16) | s2vFloat16a(6.0f).get();
         ;
-        vUInt a34 = (s2vFloat16a(12.0f).get() << 16) | s2vFloat16a(10.0f).get();
-        vUInt b01 = (s2vFloat16a(5.0f).get() << 16) | s2vFloat16a(3.0f).get();
-        vUInt b23 = (s2vFloat16a(9.0f).get() << 16) | s2vFloat16a(7.0f).get();
-        vUInt b34 = (s2vFloat16a(13.0f).get() << 16) | s2vFloat16a(11.0f).get();
+        sfpi::vUInt a34 = (s2vFloat16a(12.0f).get() << 16) | s2vFloat16a(10.0f).get();
+        sfpi::vUInt b01 = (s2vFloat16a(5.0f).get() << 16) | s2vFloat16a(3.0f).get();
+        sfpi::vUInt b23 = (s2vFloat16a(9.0f).get() << 16) | s2vFloat16a(7.0f).get();
+        sfpi::vUInt b34 = (s2vFloat16a(13.0f).get() << 16) | s2vFloat16a(11.0f).get();
         v_if (sfpi::dst_reg[0] == 21.0f)
         {
             sfpi::vFloat h    = -0.25f;
@@ -2078,13 +2078,13 @@ sfpi_test_noinline void test11()
 
     // lut2 6 entry 16 bit mode 2
     {
-        vUInt a01 = (s2vFloat16a(4.0f).get() << 16) | s2vFloat16a(2.0f).get();
-        vUInt a23 = (s2vFloat16a(8.0f).get() << 16) | s2vFloat16a(6.0f).get();
+        sfpi::vUInt a01 = (s2vFloat16a(4.0f).get() << 16) | s2vFloat16a(2.0f).get();
+        sfpi::vUInt a23 = (s2vFloat16a(8.0f).get() << 16) | s2vFloat16a(6.0f).get();
         ;
-        vUInt a34 = (s2vFloat16a(12.0f).get() << 16) | s2vFloat16a(10.0f).get();
-        vUInt b01 = (s2vFloat16a(5.0f).get() << 16) | s2vFloat16a(3.0f).get();
-        vUInt b23 = (s2vFloat16a(9.0f).get() << 16) | s2vFloat16a(7.0f).get();
-        vUInt b34 = (s2vFloat16a(13.0f).get() << 16) | s2vFloat16a(11.0f).get();
+        sfpi::vUInt a34 = (s2vFloat16a(12.0f).get() << 16) | s2vFloat16a(10.0f).get();
+        sfpi::vUInt b01 = (s2vFloat16a(5.0f).get() << 16) | s2vFloat16a(3.0f).get();
+        sfpi::vUInt b23 = (s2vFloat16a(9.0f).get() << 16) | s2vFloat16a(7.0f).get();
+        sfpi::vUInt b34 = (s2vFloat16a(13.0f).get() << 16) | s2vFloat16a(11.0f).get();
 
         // Can't fit all the tests into 32 elements, skipping a few that are
         // the most redundant to prior tests here
@@ -2209,13 +2209,13 @@ sfpi_test_noinline void test12(int imm)
 
     v_if (sfpi::dst_reg[0] == 7.0F)
     {
-        vUInt a = 0x4000;
+        sfpi::vUInt a = 0x4000;
         a >>= imm - 25;
         set_expected_result(12, 64.0F, 0x0010, reinterpret<sfpi::vInt>(a));
     }
     v_elseif (sfpi::dst_reg[0] == 8.0F)
     {
-        vUInt a = 1;
+        sfpi::vUInt a = 1;
         a <<= imm - 25;
         set_expected_result(12, 128.0F, 0x0400, reinterpret<sfpi::vInt>(a));
     }
@@ -3132,33 +3132,33 @@ sfpi_test_noinline void test15()
 
     sfpi::dst_reg[15] = -sfpi::dst_reg[0];
     {
-        vUInt a = vConstTileId + 0x100;
-        vUInt b = vConstTileId + 0x200;
-        vUInt c = vConstTileId + 0x300;
-        vUInt d = vConstTileId + 0x400;
+        sfpi::vUInt a = vConstTileId + 0x100;
+        sfpi::vUInt b = vConstTileId + 0x200;
+        sfpi::vUInt c = vConstTileId + 0x300;
+        sfpi::vUInt d = vConstTileId + 0x400;
 
         subvec_transp(a, b, c, d);
 
-        vUInt base = vConstTileId >> 4;
+        sfpi::vUInt base = vConstTileId >> 4;
         base <<= 8;
         base += 0x100;
 
         // Load expected value, subtract actual value. result is 0 if correct
-        vUInt eff  = 0xF;
-        vUInt cmpa = base | (vConstTileId & eff);
+        sfpi::vUInt eff  = 0xF;
+        sfpi::vUInt cmpa = base | (vConstTileId & eff);
         cmpa -= a;
-        vUInt cmpb = base | ((vConstTileId & eff) + 0x10);
+        sfpi::vUInt cmpb = base | ((vConstTileId & eff) + 0x10);
         cmpb -= b;
-        vUInt cmpc = base | ((vConstTileId & eff) + 0x20);
+        sfpi::vUInt cmpc = base | ((vConstTileId & eff) + 0x20);
         cmpc -= c;
-        vUInt cmpd = base | ((vConstTileId & eff) + 0x30);
+        sfpi::vUInt cmpd = base | ((vConstTileId & eff) + 0x30);
         cmpd -= d;
 
         // The above completes this test, now to make the results reportable
         // in less than 4 full width vectors
 
         // Reduce across a, b, c, d
-        vUInt result = reduce_bool4(cmpa, cmpb, cmpc, cmpd, 0);
+        sfpi::vUInt result = reduce_bool4(cmpa, cmpb, cmpc, cmpd, 0);
 
         // We care about xyz
         // Use the thing we're testing to test the result by putting xyz result
@@ -3166,7 +3166,7 @@ sfpi_test_noinline void test15()
         subvec_transp(result, cmpb, cmpc, cmpd);
 
         // Reduce result (only care about first subbvec, rest along for the ride)
-        vUInt final = reduce_bool4(result, cmpb, cmpc, cmpd, 1);
+        sfpi::vUInt final = reduce_bool4(result, cmpb, cmpc, cmpd, 1);
 
         v_if (sfpi::dst_reg[0] < 8.0F)
         {
@@ -3177,10 +3177,10 @@ sfpi_test_noinline void test15()
 
     {
         // subvec_shflror1
-        vUInt src = vConstTileId;
-        vUInt dst = subvec_shflror1(src);
+        sfpi::vUInt src = vConstTileId;
+        sfpi::vUInt dst = subvec_shflror1(src);
 
-        vUInt cmpdst = vConstTileId - 2;
+        sfpi::vUInt cmpdst = vConstTileId - 2;
         // first element in the subvec
         v_if ((vConstTileId & 0xF) == 0)
         {
@@ -3189,12 +3189,12 @@ sfpi_test_noinline void test15()
         v_endif;
         dst -= cmpdst;
 
-        vUInt tmp1 = 1;
-        vUInt tmp2 = 1;
-        vUInt tmp3 = 1;
+        sfpi::vUInt tmp1 = 1;
+        sfpi::vUInt tmp2 = 1;
+        sfpi::vUInt tmp3 = 1;
         subvec_transp(tmp1, dst, tmp2, tmp3);
 
-        vUInt final = reduce_bool4(dst, tmp1, tmp2, tmp3, 0);
+        sfpi::vUInt final = reduce_bool4(dst, tmp1, tmp2, tmp3, 0);
         v_if (sfpi::dst_reg[0] >= 8.0F && sfpi::dst_reg[0] < 16.0F)
         {
             set_expected_result(15, 16.0F, 1, final);
@@ -3204,10 +3204,10 @@ sfpi_test_noinline void test15()
 
     {
         // subvec_shflshr1
-        vUInt src = vConstTileId;
-        vUInt dst = subvec_shflshr1(src);
+        sfpi::vUInt src = vConstTileId;
+        sfpi::vUInt dst = subvec_shflshr1(src);
 
-        vUInt cmpdst = vConstTileId - 2;
+        sfpi::vUInt cmpdst = vConstTileId - 2;
         // first element in the subvec
         v_if ((vConstTileId & 0xF) == 0)
         {
@@ -3216,12 +3216,12 @@ sfpi_test_noinline void test15()
         v_endif;
         dst -= cmpdst;
 
-        vUInt tmp1 = 1;
-        vUInt tmp2 = 1;
-        vUInt tmp3 = 1;
+        sfpi::vUInt tmp1 = 1;
+        sfpi::vUInt tmp2 = 1;
+        sfpi::vUInt tmp3 = 1;
         subvec_transp(tmp1, tmp2, dst, tmp3);
 
-        vUInt final = reduce_bool4(tmp1, dst, tmp2, tmp3, 0);
+        sfpi::vUInt final = reduce_bool4(tmp1, dst, tmp2, tmp3, 0);
         v_if (sfpi::dst_reg[0] >= 16.0F && sfpi::dst_reg[0] < 24.0F)
         {
             set_expected_result(15, 24.0F, 1, final);
@@ -3233,7 +3233,7 @@ sfpi_test_noinline void test15()
     // interesting if/when we implement LOADMACRO
     v_if (sfpi::dst_reg[0] == 16.0F) {
         // Wrapper doesn't emit shft2 bit shift, test directly
-        vUInt a = 0x005A;
+        sfpi::vUInt a = 0x005A;
 
         a.get() = __builtin_rvtt_sfpshft2_i(a.get(), 4);
         set_expected_result(16, 10.0F, 0x05A0, a);
@@ -3242,8 +3242,8 @@ sfpi_test_noinline void test15()
 
     v_if (sfpi::dst_reg[0] == 17.0F) {
         // Wrapper doesn't emit shft2 bit shift, test directly
-        vUInt a = 0x005A;
-        vUInt b = 4;
+        sfpi::vUInt a = 0x005A;
+        sfpi::vUInt b = 4;
 
         a.get() = __builtin_rvtt_sfpshft2_v(a.get(), b.get());
         set_expected_result(16, 20.0F, 0x05A0, a);
@@ -3328,7 +3328,7 @@ void test16()
     v_endif;
     v_if (sfpi::dst_reg[0] == 14.0F)
     {
-        vUInt descale = 8;
+        sfpi::vUInt descale = 8;
         set_expected_result(16, 80.0f, 0xeb, int32_to_uint8(0xea00, descale));
     }
     v_endif;
@@ -3339,7 +3339,7 @@ void test16()
     v_endif;
     v_if (sfpi::dst_reg[0] == 16.0F)
     {
-        vUInt descale = 8;
+        sfpi::vUInt descale = 8;
         set_expected_result(16, 112.0f, 0xf, int32_to_int8(0xea0, descale));
     }
     v_endif;
@@ -3370,8 +3370,8 @@ void test17()
     // Test sign-magnitude for ints
     v_if (sfpi::dst_reg[0] == 2.0F)
     {
-        vUInt x = -1;
-        vUInt y = -2;
+        sfpi::vUInt x = -1;
+        sfpi::vUInt y = -2;
         vec_min_max(x, y);
         set_expected_result(17, 23.0f, -1, x);
     }

--- a/tt_llk_wormhole_b0/common/inc/ckernel_sfpu.h
+++ b/tt_llk_wormhole_b0/common/inc/ckernel_sfpu.h
@@ -45,8 +45,6 @@
 #include "sfpu/ckernel_sfpu_trigonometry.h"
 #include "sfpu/ckernel_sfpu_typecast.h"
 
-// using namespace sfpi;
-
 // namespace ckernel
 // {
 // namespace sfpu

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_abs.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_abs.h
@@ -6,8 +6,6 @@
 
 #include "sfpi.h"
 
-using namespace sfpi;
-
 namespace ckernel
 {
 namespace sfpu

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_abs.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_abs.h
@@ -4,10 +4,6 @@
 
 #pragma once
 
-#include "ckernel_defs.h"
-#include "ckernel.h"
-#include "noc_nonblocking_api.h"
-
 #include "sfpi.h"
 
 using namespace sfpi;

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_abs.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_abs.h
@@ -4,6 +4,10 @@
 
 #pragma once
 
+#include "ckernel_defs.h"
+#include "ckernel.h"
+#include "noc_nonblocking_api.h"
+
 #include "sfpi.h"
 
 using namespace sfpi;

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_abs.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_abs.h
@@ -19,9 +19,9 @@ inline void _calculate_abs_(const int iterations)
     // SFPU microcode
     for (int d = 0; d < iterations; d++)
     {
-        vFloat v   = dst_reg[0];
-        dst_reg[0] = sfpi::abs(v);
-        dst_reg++;
+        sfpi::vFloat v   = sfpi::dst_reg[0];
+        sfpi::dst_reg[0] = sfpi::abs(v);
+        sfpi::dst_reg++;
     }
 }
 

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_abs.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_abs.h
@@ -4,9 +4,6 @@
 
 #pragma once
 
-#include "ckernel.h"
-#include "ckernel_defs.h"
-#include "noc_nonblocking_api.h"
 #include "sfpi.h"
 
 using namespace sfpi;

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_add_int32.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_add_int32.h
@@ -32,7 +32,7 @@ inline void _add_int32_(const uint dst_offset)
         TTI_SFPIADD(0, 1, 0, 4);
         // LREG_0 -> dest as int32
         TTI_SFPSTORE(0, sfpload_instr_mod, 3, 0);
-        dst_reg++;
+        sfpi::dst_reg++;
     }
 }
 

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_add_int32.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_add_int32.h
@@ -4,13 +4,8 @@
 
 #pragma once
 
-#include "ckernel_defs.h"
-#include "ckernel.h"
-#include "noc_nonblocking_api.h"
-
 #include "sfpi.h"
-
-using namespace sfpi;
+#include "ckernel_ops.h"
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_add_int32.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_add_int32.h
@@ -4,12 +4,8 @@
 
 #pragma once
 
-#include "ckernel.h"
-#include "ckernel_defs.h"
-#include "noc_nonblocking_api.h"
 #include "sfpi.h"
-
-using namespace sfpi;
+#include "ckernel_ops.h"
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_add_int32.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_add_int32.h
@@ -4,8 +4,8 @@
 
 #pragma once
 
-#include "sfpi.h"
 #include "ckernel_ops.h"
+#include "sfpi.h"
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_add_int32.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_add_int32.h
@@ -4,8 +4,13 @@
 
 #pragma once
 
+#include "ckernel_defs.h"
+#include "ckernel.h"
+#include "noc_nonblocking_api.h"
+
 #include "sfpi.h"
-#include "ckernel_ops.h"
+
+using namespace sfpi;
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_binary.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_binary.h
@@ -4,13 +4,10 @@
 
 #pragma once
 
-#include "ckernel.h"
-#include "ckernel_defs.h"
-#include "noc_nonblocking_api.h"
-#include "ckernel_sfpu_exp.h"
 #include "sfpi.h"
-
-using namespace sfpi;
+#include "ckernel_sfpu_exp.h"
+#include "ckernel_sfpu_recip.h"
+#include "ckernel_sfpu_binary.h"
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_binary.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_binary.h
@@ -24,13 +24,13 @@ enum class BinaryOp : uint8_t
     POW  = 5
 };
 
-sfpi_inline vFloat _calculate_sfpu_binary_power_(vFloat base, vFloat pow)
+sfpi_inline sfpi::vFloat _calculate_sfpu_binary_power_(sfpi::vFloat base, sfpi::vFloat pow)
 {
-    vFloat original_base = base;
+    sfpi::vFloat original_base = base;
 
     // Check for integer power
-    vInt pow_int       = float_to_int16(pow, 0); // int16 should be plenty, since large powers will approach 0/Inf
-    vFloat pow_rounded = int32_to_float(pow_int, 0);
+    sfpi::vInt pow_int       = float_to_int16(pow, 0); // int16 should be plenty, since large powers will approach 0/Inf
+    sfpi::vFloat pow_rounded = int32_to_float(pow_int, 0);
     v_if (pow_rounded == pow)
     {
         // if pow is integer, set base to positive
@@ -39,23 +39,23 @@ sfpi_inline vFloat _calculate_sfpu_binary_power_(vFloat base, vFloat pow)
     v_endif;
 
     // Normalize base to calculation range
-    vFloat x = setexp(base, 127); // set exp to exp bias (put base in range of 1-2)
+    sfpi::vFloat x = setexp(base, 127); // set exp to exp bias (put base in range of 1-2)
 
     // 3rd order polynomial approx - determined using rminimax over [1,2]
-    vFloat series_result = x * (x * (x * 0x2.44734p-4f - 0xd.e712ap-4f) + 0x2.4f5388p+0f) - 0x1.952992p+0f;
+    sfpi::vFloat series_result = x * (x * (x * 0x2.44734p-4f - 0xd.e712ap-4f) + 0x2.4f5388p+0f) - 0x1.952992p+0f;
 
     // Convert exponent to float
-    vInt exp = exexp(base);
+    sfpi::vInt exp = exexp(base);
     v_if (exp < 0)
     {
         exp = setsgn(~exp + 1, 1);
     }
     v_endif;
-    vFloat expf = int32_to_float(exp, 0);
+    sfpi::vFloat expf = int32_to_float(exp, 0);
 
     // De-normalize to original range
-    vFloat vConstLn2  = 0.692871f;
-    vFloat log_result = expf * vConstLn2 + series_result; // exp correction: ln(1+x) + exp*ln(2)
+    sfpi::vFloat vConstLn2  = 0.692871f;
+    sfpi::vFloat log_result = expf * vConstLn2 + series_result; // exp correction: ln(1+x) + exp*ln(2)
 
     // Base case when input is 0. ln(0) = -inf
     v_if (base == 0.0f)
@@ -65,10 +65,10 @@ sfpi_inline vFloat _calculate_sfpu_binary_power_(vFloat base, vFloat pow)
     v_endif;
 
     // Take exp(pow * log(base)) to produce base^pow
-    vFloat val = pow * log_result;
+    sfpi::vFloat val = pow * log_result;
 
     // Force sign to 0 (make number positive)
-    vFloat result = _sfpu_exp_(setsgn(val, 0));
+    sfpi::vFloat result = _sfpu_exp_(setsgn(val, 0));
 
     v_if (val < 0)
     {
@@ -107,9 +107,9 @@ inline void _calculate_sfpu_binary_(const uint dst_offset)
     for (int d = 0; d < ITERATIONS; d++)
     {
         constexpr uint dst_tile_size = 32;
-        vFloat in0                   = dst_reg[0];
-        vFloat in1                   = dst_reg[dst_offset * dst_tile_size];
-        vFloat result                = 0.0f;
+        sfpi::vFloat in0                   = sfpi::dst_reg[0];
+        sfpi::vFloat in1                   = sfpi::dst_reg[dst_offset * dst_tile_size];
+        sfpi::vFloat result                = 0.0f;
 
         if constexpr (BINOP == BinaryOp::ADD)
         {
@@ -157,8 +157,8 @@ inline void _calculate_sfpu_binary_(const uint dst_offset)
             result = _calculate_sfpu_binary_power_(in0, in1);
         }
 
-        dst_reg[0] = result;
-        dst_reg++;
+        sfpi::dst_reg[0] = result;
+        sfpi::dst_reg++;
     }
 }
 

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_binary.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_binary.h
@@ -4,13 +4,10 @@
 
 #pragma once
 
-#include "ckernel.h"
-#include "ckernel_defs.h"
-#include "ckernel_sfpu_exp.h"
-#include "noc_nonblocking_api.h"
 #include "sfpi.h"
-
-using namespace sfpi;
+#include "ckernel_sfpu_exp.h"
+#include "ckernel_sfpu_recip.h"
+#include "ckernel_sfpu_binary.h"
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_binary.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_binary.h
@@ -4,10 +4,13 @@
 
 #pragma once
 
-#include "sfpi.h"
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "noc_nonblocking_api.h"
 #include "ckernel_sfpu_exp.h"
-#include "ckernel_sfpu_recip.h"
-#include "ckernel_sfpu_binary.h"
+#include "sfpi.h"
+
+using namespace sfpi;
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_binary.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_binary.h
@@ -34,7 +34,7 @@ sfpi_inline sfpi::vFloat _calculate_sfpu_binary_power_(sfpi::vFloat base, sfpi::
     v_if (pow_rounded == pow)
     {
         // if pow is integer, set base to positive
-        base = setsgn(base, 0);
+        base = sfpi::setsgn(base, 0);
     }
     v_endif;
 
@@ -48,7 +48,7 @@ sfpi_inline sfpi::vFloat _calculate_sfpu_binary_power_(sfpi::vFloat base, sfpi::
     sfpi::vInt exp = exexp(base);
     v_if (exp < 0)
     {
-        exp = setsgn(~exp + 1, 1);
+        exp = sfpi::setsgn(~exp + 1, 1);
     }
     v_endif;
     sfpi::vFloat expf = int32_to_float(exp, 0);
@@ -68,7 +68,7 @@ sfpi_inline sfpi::vFloat _calculate_sfpu_binary_power_(sfpi::vFloat base, sfpi::
     sfpi::vFloat val = pow * log_result;
 
     // Force sign to 0 (make number positive)
-    sfpi::vFloat result = _sfpu_exp_(setsgn(val, 0));
+    sfpi::vFloat result = _sfpu_exp_(sfpi::setsgn(val, 0));
 
     v_if (val < 0)
     {
@@ -85,7 +85,7 @@ sfpi_inline sfpi::vFloat _calculate_sfpu_binary_power_(sfpi::vFloat base, sfpi::
             // if pow is odd integer, set result to negative
             v_if (pow_int & 0x1)
             {
-                result = setsgn(result, 1);
+                result = sfpi::setsgn(result, 1);
             }
             v_endif;
         }
@@ -134,7 +134,7 @@ inline void _calculate_sfpu_binary_(const uint dst_offset)
                 v_else
                 {
                     result = std::numeric_limits<float>::infinity();
-                    result = setsgn(result, in0);
+                    result = sfpi::setsgn(result, in0);
                 }
                 v_endif;
             }
@@ -144,7 +144,7 @@ inline void _calculate_sfpu_binary_(const uint dst_offset)
             }
             v_else
             {
-                result = in0 * setsgn(_sfpu_reciprocal_<4>(in1), in1);
+                result = in0 * sfpi::setsgn(_sfpu_reciprocal_<4>(in1), in1);
             }
             v_endif;
         }

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_binary.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_binary.h
@@ -4,10 +4,10 @@
 
 #pragma once
 
-#include "sfpi.h"
+#include "ckernel_sfpu_binary.h"
 #include "ckernel_sfpu_exp.h"
 #include "ckernel_sfpu_recip.h"
-#include "ckernel_sfpu_binary.h"
+#include "sfpi.h"
 
 namespace ckernel
 {
@@ -107,9 +107,9 @@ inline void _calculate_sfpu_binary_(const uint dst_offset)
     for (int d = 0; d < ITERATIONS; d++)
     {
         constexpr uint dst_tile_size = 32;
-        sfpi::vFloat in0                   = sfpi::dst_reg[0];
-        sfpi::vFloat in1                   = sfpi::dst_reg[dst_offset * dst_tile_size];
-        sfpi::vFloat result                = 0.0f;
+        sfpi::vFloat in0             = sfpi::dst_reg[0];
+        sfpi::vFloat in1             = sfpi::dst_reg[dst_offset * dst_tile_size];
+        sfpi::vFloat result          = 0.0f;
 
         if constexpr (BINOP == BinaryOp::ADD)
         {
@@ -140,7 +140,7 @@ inline void _calculate_sfpu_binary_(const uint dst_offset)
             }
             v_elseif (in0 == in1)
             {
-                result = vConst1;
+                result = sfpi::vConst1;
             }
             v_else
             {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_binary_bitwise.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_binary_bitwise.h
@@ -4,8 +4,13 @@
 
 #pragma once
 
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "noc_nonblocking_api.h"
 #include "sfpi.h"
-#include "ckernel_ops.h"
+#include <limits.h>
+
+using namespace sfpi;
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_binary_bitwise.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_binary_bitwise.h
@@ -4,14 +4,8 @@
 
 #pragma once
 
-#include <limits.h>
-
-#include "ckernel.h"
-#include "ckernel_defs.h"
-#include "noc_nonblocking_api.h"
 #include "sfpi.h"
-
-using namespace sfpi;
+#include "ckernel_ops.h"
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_binary_bitwise.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_binary_bitwise.h
@@ -44,7 +44,7 @@ inline void _calculate_sfpu_binary_bitwise_(const uint dst_offset)
         }
 
         TTI_SFPSTORE(0, 4, 3, 0);
-        dst_reg++;
+        sfpi::dst_reg++;
     }
 }
 

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_binary_bitwise.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_binary_bitwise.h
@@ -4,8 +4,8 @@
 
 #pragma once
 
-#include "sfpi.h"
 #include "ckernel_ops.h"
+#include "sfpi.h"
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_binary_bitwise.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_binary_bitwise.h
@@ -4,13 +4,8 @@
 
 #pragma once
 
-#include "ckernel.h"
-#include "ckernel_defs.h"
-#include "noc_nonblocking_api.h"
 #include "sfpi.h"
-#include <limits.h>
-
-using namespace sfpi;
+#include "ckernel_ops.h"
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_cast_fp32_to_fp16a.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_cast_fp32_to_fp16a.h
@@ -18,12 +18,12 @@ inline void _cast_fp32_to_fp16a_(const int iterations)
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
     {
-        // vFloat val = dst_reg[0];
-        // dst_reg[0] = float_to_fp16a(val, 0);
+        // sfpi::vFloat val = sfpi::dst_reg[0];
+        // sfpi::dst_reg[0] = float_to_fp16a(val, 0);
         TTI_SFPLOAD(0, 0, 3, 0);
         TTI_SFP_STOCH_RND(0, 0, 0, 0, 0, 8);
         TTI_SFPSTORE(0, 1, 3, 0);
-        dst_reg++;
+        sfpi::dst_reg++;
     }
 }
 

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_cast_fp32_to_fp16a.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_cast_fp32_to_fp16a.h
@@ -4,13 +4,8 @@
 
 #pragma once
 
-#include "ckernel_defs.h"
-#include "ckernel.h"
-#include "noc_nonblocking_api.h"
-
 #include "sfpi.h"
-
-using namespace sfpi;
+#include "ckernel_ops.h"
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_cast_fp32_to_fp16a.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_cast_fp32_to_fp16a.h
@@ -4,12 +4,8 @@
 
 #pragma once
 
-#include "ckernel.h"
-#include "ckernel_defs.h"
-#include "noc_nonblocking_api.h"
 #include "sfpi.h"
-
-using namespace sfpi;
+#include "ckernel_ops.h"
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_cast_fp32_to_fp16a.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_cast_fp32_to_fp16a.h
@@ -4,8 +4,8 @@
 
 #pragma once
 
-#include "sfpi.h"
 #include "ckernel_ops.h"
+#include "sfpi.h"
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_cast_fp32_to_fp16a.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_cast_fp32_to_fp16a.h
@@ -4,8 +4,13 @@
 
 #pragma once
 
+#include "ckernel_defs.h"
+#include "ckernel.h"
+#include "noc_nonblocking_api.h"
+
 #include "sfpi.h"
-#include "ckernel_ops.h"
+
+using namespace sfpi;
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_clamp.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_clamp.h
@@ -4,8 +4,13 @@
 
 #pragma once
 
+#include "ckernel_defs.h"
+#include "ckernel.h"
+#include "noc_nonblocking_api.h"
+
 #include "sfpi.h"
-#include "sfpi_fp16.h"
+
+using namespace sfpi;
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_clamp.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_clamp.h
@@ -23,12 +23,12 @@ inline void _calculate_clamp_(const int iterations, uint param0, uint param1, ui
     s2vFloat16::Format format = s2vFloat16::fp16a;
 
     // SFPU microcode
-    vFloat min = s2vFloat16(param0, format);
-    vFloat max = s2vFloat16(param1, format);
+    sfpi::vFloat min = s2vFloat16(param0, format);
+    sfpi::vFloat max = s2vFloat16(param1, format);
 #pragma GCC unroll 0
     for (int d = 0; d < iterations; d++)
     {
-        vFloat val = dst_reg[0];
+        sfpi::vFloat val = sfpi::dst_reg[0];
 
         v_if (val < min)
         {
@@ -40,9 +40,9 @@ inline void _calculate_clamp_(const int iterations, uint param0, uint param1, ui
         }
         v_endif;
 
-        dst_reg[0] = val + s2vFloat16b(param2); // 12 bits
+        sfpi::dst_reg[0] = val + s2vFloat16b(param2); // 12 bits
 
-        dst_reg++;
+        sfpi::dst_reg++;
     }
 }
 

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_clamp.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_clamp.h
@@ -20,11 +20,11 @@ inline void _calculate_clamp_(const int iterations, uint param0, uint param1, ui
     // param1 = max
 
     // uint format = (param0 >> 16)&0x1;
-    s2vFloat16::Format format = s2vFloat16::fp16a;
+    sfpi::s2vFloat16::Format format = sfpi::s2vFloat16::fp16a;
 
     // SFPU microcode
-    sfpi::vFloat min = s2vFloat16(param0, format);
-    sfpi::vFloat max = s2vFloat16(param1, format);
+    sfpi::vFloat min = sfpi::s2vFloat16(param0, format);
+    sfpi::vFloat max = sfpi::s2vFloat16(param1, format);
 #pragma GCC unroll 0
     for (int d = 0; d < iterations; d++)
     {
@@ -32,15 +32,15 @@ inline void _calculate_clamp_(const int iterations, uint param0, uint param1, ui
 
         v_if (val < min)
         {
-            val = s2vFloat16(param0, format);
+            val = sfpi::s2vFloat16(param0, format);
         }
         v_elseif (val >= max)
         {
-            val = s2vFloat16(param1, format);
+            val = sfpi::s2vFloat16(param1, format);
         }
         v_endif;
 
-        sfpi::dst_reg[0] = val + s2vFloat16b(param2); // 12 bits
+        sfpi::dst_reg[0] = val + sfpi::s2vFloat16b(param2); // 12 bits
 
         sfpi::dst_reg++;
     }

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_clamp.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_clamp.h
@@ -4,13 +4,8 @@
 
 #pragma once
 
-#include "ckernel_defs.h"
-#include "ckernel.h"
-#include "noc_nonblocking_api.h"
-
 #include "sfpi.h"
-
-using namespace sfpi;
+#include "sfpi_fp16.h"
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_clamp.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_clamp.h
@@ -4,12 +4,8 @@
 
 #pragma once
 
-#include "ckernel.h"
-#include "ckernel_defs.h"
-#include "noc_nonblocking_api.h"
 #include "sfpi.h"
-
-using namespace sfpi;
+#include "sfpi_fp16.h"
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_comp.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_comp.h
@@ -4,14 +4,8 @@
 
 #pragma once
 
-#include "ckernel_defs.h"
-#include "ckernel.h"
-#include "noc_nonblocking_api.h"
-#include "ckernel_sfpu_is_fp16_zero.h"
-
 #include "sfpi.h"
-
-using namespace sfpi;
+#include "ckernel_sfpu_is_fp16_zero.h"
 
 namespace ckernel
 {
@@ -30,7 +24,6 @@ sfpi_inline void _calculate_comp_init_flag_(bool check, vFloat& flag1, vFloat& f
 template <bool APPROXIMATION_MODE, bool invert_output, bool check_zero, bool second_check, bool is_less_than_equal_zero, int ITERATIONS>
 inline void _calculate_comp_(const int iterations, uint exponent_size_8)
 {
-
     // output_0 and output_1 hold the outputs use use when a zero or negative check is true/false.
     // False = 0.0 = kCONST_0 (5/8-bit exponent format)
     // True  = 1.0 = kCONST_1_FP16B (8-bit exponent format)

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_comp.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_comp.h
@@ -4,8 +4,14 @@
 
 #pragma once
 
-#include "sfpi.h"
+#include "ckernel_defs.h"
+#include "ckernel.h"
+#include "noc_nonblocking_api.h"
 #include "ckernel_sfpu_is_fp16_zero.h"
+
+#include "sfpi.h"
+
+using namespace sfpi;
 
 namespace ckernel
 {
@@ -24,6 +30,7 @@ sfpi_inline void _calculate_comp_init_flag_(bool check, vFloat& flag1, vFloat& f
 template <bool APPROXIMATION_MODE, bool invert_output, bool check_zero, bool second_check, bool is_less_than_equal_zero, int ITERATIONS>
 inline void _calculate_comp_(const int iterations, uint exponent_size_8)
 {
+
     // output_0 and output_1 hold the outputs use use when a zero or negative check is true/false.
     // False = 0.0 = kCONST_0 (5/8-bit exponent format)
     // True  = 1.0 = kCONST_1_FP16B (8-bit exponent format)

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_comp.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_comp.h
@@ -4,8 +4,8 @@
 
 #pragma once
 
-#include "sfpi.h"
 #include "ckernel_sfpu_is_fp16_zero.h"
+#include "sfpi.h"
 
 namespace ckernel
 {
@@ -73,7 +73,7 @@ inline void _calculate_comp_(const int iterations, uint exponent_size_8)
             // Result will be either 0x0000(0.0) or 0x3F80(1.0)
             if constexpr (is_less_than_equal_zero)
             {
-                result = reinterpret<sfpi::vFloat>(reinterpret<vUInt>(flag1) | reinterpret<vUInt>(flag2));
+                result = reinterpret<sfpi::vFloat>(sfpi::reinterpret<sfpi::vUInt>(flag1) | sfpi::reinterpret<sfpi::vUInt>(flag2));
             }
             else
             {
@@ -83,7 +83,7 @@ inline void _calculate_comp_(const int iterations, uint exponent_size_8)
                 // Do a bitwise And (flag1 & flag2) to get > condition.
                 // flag2 >= 0 AND flag1 != 0 => DST is Greater than zero
                 // Result will be either 0x0000(0.0) or 0x3F80(1.0)
-                result = reinterpret<sfpi::vFloat>(reinterpret<vUInt>(flag1) & reinterpret<vUInt>(flag2));
+                result = sfpi::reinterpret<sfpi::vFloat>(sfpi::reinterpret<sfpi::vUInt>(flag1) & sfpi::reinterpret<sfpi::vUInt>(flag2));
             }
         }
         else

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_comp.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_comp.h
@@ -12,7 +12,7 @@ namespace ckernel
 namespace sfpu
 {
 
-sfpi_inline void _calculate_comp_init_flag_(bool check, vFloat& flag1, vFloat& flag2, float init)
+sfpi_inline void _calculate_comp_init_flag_(bool check, sfpi::vFloat& flag1, sfpi::vFloat& flag2, float init)
 {
     flag1 = init;
     if (check)
@@ -35,8 +35,8 @@ inline void _calculate_comp_(const int iterations, uint exponent_size_8)
 
     for (int d = 0; d < iterations; d++)
     {
-        vFloat v = dst_reg[0];
-        vFloat flag1, flag2;
+        sfpi::vFloat v = sfpi::dst_reg[0];
+        sfpi::vFloat flag1, flag2;
         if constexpr (check_zero)
         {
             v_if (_sfpu_is_fp16_zero_(v, exponent_size_8))
@@ -62,7 +62,7 @@ inline void _calculate_comp_(const int iterations, uint exponent_size_8)
             v_endif;
         }
 
-        vFloat result;
+        sfpi::vFloat result;
         if constexpr (second_check)
         {
             // less_than_equal_zero
@@ -73,7 +73,7 @@ inline void _calculate_comp_(const int iterations, uint exponent_size_8)
             // Result will be either 0x0000(0.0) or 0x3F80(1.0)
             if constexpr (is_less_than_equal_zero)
             {
-                result = reinterpret<vFloat>(reinterpret<vUInt>(flag1) | reinterpret<vUInt>(flag2));
+                result = reinterpret<sfpi::vFloat>(reinterpret<vUInt>(flag1) | reinterpret<vUInt>(flag2));
             }
             else
             {
@@ -83,7 +83,7 @@ inline void _calculate_comp_(const int iterations, uint exponent_size_8)
                 // Do a bitwise And (flag1 & flag2) to get > condition.
                 // flag2 >= 0 AND flag1 != 0 => DST is Greater than zero
                 // Result will be either 0x0000(0.0) or 0x3F80(1.0)
-                result = reinterpret<vFloat>(reinterpret<vUInt>(flag1) & reinterpret<vUInt>(flag2));
+                result = reinterpret<sfpi::vFloat>(reinterpret<vUInt>(flag1) & reinterpret<vUInt>(flag2));
             }
         }
         else
@@ -91,9 +91,9 @@ inline void _calculate_comp_(const int iterations, uint exponent_size_8)
             result = flag1;
         }
 
-        dst_reg[0] = result;
+        sfpi::dst_reg[0] = result;
 
-        dst_reg++;
+        sfpi::dst_reg++;
     }
 }
 

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_comp.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_comp.h
@@ -4,13 +4,8 @@
 
 #pragma once
 
-#include "ckernel.h"
-#include "ckernel_defs.h"
-#include "ckernel_sfpu_is_fp16_zero.h"
-#include "noc_nonblocking_api.h"
 #include "sfpi.h"
-
-using namespace sfpi;
+#include "ckernel_sfpu_is_fp16_zero.h"
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_comp.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_comp.h
@@ -73,7 +73,7 @@ inline void _calculate_comp_(const int iterations, uint exponent_size_8)
             // Result will be either 0x0000(0.0) or 0x3F80(1.0)
             if constexpr (is_less_than_equal_zero)
             {
-                result = reinterpret<sfpi::vFloat>(sfpi::reinterpret<sfpi::vUInt>(flag1) | sfpi::reinterpret<sfpi::vUInt>(flag2));
+                result = sfpi::reinterpret<sfpi::vFloat>(sfpi::reinterpret<sfpi::vUInt>(flag1) | sfpi::reinterpret<sfpi::vUInt>(flag2));
             }
             else
             {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_cumsum.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_cumsum.h
@@ -4,13 +4,8 @@
 
 #pragma once
 
-#include "ckernel_defs.h"
-#include "ckernel.h"
-#include "noc_nonblocking_api.h"
-
 #include "sfpi.h"
-
-using namespace sfpi;
+#include "ckernel_ops.h"
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_cumsum.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_cumsum.h
@@ -4,12 +4,8 @@
 
 #pragma once
 
-#include "ckernel.h"
-#include "ckernel_defs.h"
-#include "noc_nonblocking_api.h"
 #include "sfpi.h"
-
-using namespace sfpi;
+#include "ckernel_ops.h"
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_cumsum.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_cumsum.h
@@ -4,8 +4,8 @@
 
 #pragma once
 
-#include "sfpi.h"
 #include "ckernel_ops.h"
+#include "sfpi.h"
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_cumsum.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_cumsum.h
@@ -4,8 +4,13 @@
 
 #pragma once
 
+#include "ckernel_defs.h"
+#include "ckernel.h"
+#include "noc_nonblocking_api.h"
+
 #include "sfpi.h"
-#include "ckernel_ops.h"
+
+using namespace sfpi;
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_dropout.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_dropout.h
@@ -4,10 +4,11 @@
 
 #pragma once
 
-#include "ckernel.h"
-#include "ckernel_defs.h"
-#include "noc_nonblocking_api.h"
+#include <cstdint>
+
 #include "sfpi.h"
+#include "ckernel_ops.h"
+#include "debug/fw_debug.h"
 
 using namespace sfpi;
 

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_dropout.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_dropout.h
@@ -8,7 +8,7 @@
 
 #include "sfpi.h"
 #include "ckernel_ops.h"
-#include "debug/fw_debug.h"
+// #include "debug/fw_debug.h"
 
 using namespace sfpi;
 
@@ -24,8 +24,8 @@ inline void _calculate_dropout_(const int iterations, uint probability, uint sca
 {
     // SFPU microcode
 
-    FWLOG1("calculate_dropout() -- probability:%x", probability);
-    FWLOG1("calculate_dropout() -- scale:%x", scale);
+    // FWLOG1("calculate_dropout() -- probability:%x", probability);
+    // FWLOG1("calculate_dropout() -- scale:%x", scale);
 
     TT_SFPLOADI(p_sfpu::LREG1, 10, scale & 0xFFFF);
     TT_SFPLOADI(p_sfpu::LREG1, 8, scale >> 16);
@@ -36,7 +36,7 @@ inline void _calculate_dropout_(const int iterations, uint probability, uint sca
     {
         ////////////////////////
         // Scale samples
-        // dst_reg[0] = dst_reg[0] * s2vFloat16b(scale);
+        // sfpi::dst_reg[0] = sfpi::dst_reg[0] * s2vFloat16b(scale);
         ///////////////////////
         TTI_SFPLOAD(p_sfpu::LREG0, 0, 3, 0);
         TTI_SFPMUL(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpu::LCONST_0, p_sfpu::LREG0, 0);
@@ -53,14 +53,14 @@ inline void _calculate_dropout_(const int iterations, uint probability, uint sca
         ////////////////////////
         // Drop samples
         // v_if (rand < probability)
-        //   dst_reg[0] = vConst0;
+        //   sfpi::dst_reg[0] = vConst0;
         ///////////////////////
         TTI_SFPIADD(0, p_sfpu::LREG2, p_sfpu::LREG3, 10);
         TTI_SFPMOV(0, p_sfpu::LCONST_0, p_sfpu::LREG0, 0);
         TTI_SFPENCC(0, 0, 0, 0);
         TTI_SFPSTORE(0, 0, 3, 0);
 
-        dst_reg++;
+        sfpi::dst_reg++;
     }
 }
 

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_dropout.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_dropout.h
@@ -4,11 +4,11 @@
 
 #pragma once
 
-#include <cstdint>
+#include "ckernel_defs.h"
+#include "ckernel.h"
+#include "noc_nonblocking_api.h"
 
 #include "sfpi.h"
-#include "ckernel_ops.h"
-#include "debug/fw_debug.h"
 
 using namespace sfpi;
 

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_dropout.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_dropout.h
@@ -4,11 +4,11 @@
 
 #pragma once
 
-#include "ckernel_defs.h"
-#include "ckernel.h"
-#include "noc_nonblocking_api.h"
+#include <cstdint>
 
 #include "sfpi.h"
+#include "ckernel_ops.h"
+#include "debug/fw_debug.h"
 
 using namespace sfpi;
 

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_dropout.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_dropout.h
@@ -6,11 +6,10 @@
 
 #include <cstdint>
 
-#include "sfpi.h"
 #include "ckernel_ops.h"
-// #include "debug/fw_debug.h"
+#include "sfpi.h"
 
-using namespace sfpi;
+// #include "debug/fw_debug.h"
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_exp.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_exp.h
@@ -182,6 +182,12 @@ void _calculate_exponential_(const int iterations, uint16_t exp_base_scale_facto
     {
         // Unroll 8 best for approx, unroll 0 for precise, compiler figures this out
         for (int d = 0; d < iterations; d++)
+    {
+        vFloat val = dst_reg[0];
+        if constexpr(SCALE_EN){
+            val = val * s2vFloat16a(exp_base_scale_factor);
+        }
+        if constexpr (APPROXIMATION_MODE)
         {
             vFloat val = dst_reg[0];
             if constexpr(SCALE_EN){
@@ -201,31 +207,31 @@ void _calculate_exponential_(const int iterations, uint16_t exp_base_scale_facto
                     vInt adj_exp          = vConstIntPrgm2;
                     val                   = val * vConstLn2Recip + c23_73;
 
-                    // Remove Exponent of 7 and bias the Mantissa to 127.
-                    vInt val_short = adj_exp + reinterpret<vInt>(val);
+                // Remove Exponent of 7 and bias the Mantissa to 127.
+                vInt val_short = adj_exp + reinterpret<vInt>(val);
 
-                    // SHL to move integer bits to exponent
-                    val_short <<= 10 - p_exp::FRAC_BITS;
-                    dst_reg[0] = reinterpret<vFloat>(val_short);
-                }
-                v_endif;
+                // SHL to move integer bits to exponent
+                val_short <<= 10 - p_exp::FRAC_BITS;
+                dst_reg[0] = reinterpret<vFloat>(val_short);
             }
-            else
-            {
-                // Force sign to 0 (make number positive)
+            v_endif;
+        }
+        else
+        {
+            // Force sign to 0 (make number positive)
                 vFloat result = _sfpu_exp_(setsgn(val, 0));
 
                 v_if (val < 0)
                 {
                     result = _sfpu_reciprocal_(result);
-                }
-                v_endif;
+            }
+            v_endif;
 
                 dst_reg[0] = result;
-            }
-
-            dst_reg++;
         }
+
+        dst_reg++;
+    }
     }
 }
 

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_exp.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_exp.h
@@ -4,10 +4,14 @@
 
 #pragma once
 
-#include "sfpi.h"
-#include "sfpi_fp16.h"
+#include "ckernel_defs.h"
+#include "ckernel.h"
+#include "noc_nonblocking_api.h"
 #include "ckernel_sfpu_recip.h"
-#include "ckernel_sfpu_exp.h"
+
+#include "sfpi.h"
+
+using namespace sfpi;
 
 namespace ckernel
 {
@@ -182,50 +186,50 @@ void _calculate_exponential_(const int iterations, uint16_t exp_base_scale_facto
     {
         // Unroll 8 best for approx, unroll 0 for precise, compiler figures this out
         for (int d = 0; d < iterations; d++)
-    {
-        vFloat val = dst_reg[0];
-        if constexpr(SCALE_EN){
-            val = val * s2vFloat16a(exp_base_scale_factor);
-        }
-        if constexpr (APPROXIMATION_MODE)
         {
-            v_if (val>=89){
-                vFloat val_inf = std::numeric_limits<float>::infinity();
-                dst_reg[0] = val_inf;
-            } v_elseif(val<-42){
-                    dst_reg[0] = 0.0f;
-            } v_else {
-                // * by 1/ln2 and add convert to 7.3 FxP format
+            vFloat val = dst_reg[0];
+            if constexpr(SCALE_EN){
+                val = val * s2vFloat16a(exp_base_scale_factor);
+            }
+            if constexpr (APPROXIMATION_MODE)
+            {
+                v_if (val>=89){
+                    vFloat val_inf = std::numeric_limits<float>::infinity();
+                    dst_reg[0] = val_inf;
+                } v_elseif(val<-42){
+                        dst_reg[0] = 0.0f;
+                } v_else {
+                    // * by 1/ln2 and add convert to 7.3 FxP format
                     vFloat vConstLn2Recip = vConstFloatPrgm0;
                     vFloat c23_73         = vConstFloatPrgm1;
                     vInt adj_exp          = vConstIntPrgm2;
                     val                   = val * vConstLn2Recip + c23_73;
 
-                // Remove Exponent of 7 and bias the Mantissa to 127.
-                vInt val_short = adj_exp + reinterpret<vInt>(val);
+                    // Remove Exponent of 7 and bias the Mantissa to 127.
+                    vInt val_short = adj_exp + reinterpret<vInt>(val);
 
-                // SHL to move integer bits to exponent
-                val_short <<= 10 - p_exp::FRAC_BITS;
-                dst_reg[0] = reinterpret<vFloat>(val_short);
+                    // SHL to move integer bits to exponent
+                    val_short <<= 10 - p_exp::FRAC_BITS;
+                    dst_reg[0] = reinterpret<vFloat>(val_short);
+                }
+                v_endif;
             }
-            v_endif;
-        }
-        else
-        {
-            // Force sign to 0 (make number positive)
+            else
+            {
+                // Force sign to 0 (make number positive)
                 vFloat result = _sfpu_exp_(setsgn(val, 0));
 
                 v_if (val < 0)
                 {
                     result = _sfpu_reciprocal_(result);
-            }
-            v_endif;
+                }
+                v_endif;
 
                 dst_reg[0] = result;
-        }
+            }
 
-        dst_reg++;
-    }
+            dst_reg++;
+        }
     }
 }
 

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_exp.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_exp.h
@@ -4,10 +4,10 @@
 
 #pragma once
 
+#include "ckernel_sfpu_exp.h"
+#include "ckernel_sfpu_recip.h"
 #include "sfpi.h"
 #include "sfpi_fp16.h"
-#include "ckernel_sfpu_recip.h"
-#include "ckernel_sfpu_exp.h"
 
 namespace ckernel
 {
@@ -25,8 +25,8 @@ sfpi_inline sfpi::vFloat _sfpu_exp_(sfpi::vFloat val)
     v_endif;
 
     // Run series in Horner form
-    sfpi::vFloat tmp = val * vConst0p8373 + sfpi::s2vFloat16b(0.863281);
-    val        = val * tmp + vConst1;
+    sfpi::vFloat tmp = val * sfpi::vConst0p8373 + sfpi::s2vFloat16b(0.863281);
+    val              = val * tmp + sfpi::vConst1;
 
     v_if (exp >= 0)
     {
@@ -55,23 +55,23 @@ sfpi_inline sfpi::vFloat _calculate_exponential_body_(sfpi::vFloat in)
         constexpr uint SP_BIAS  = 127 << FRAC_BITS;
 
         // * by 1/ln2 and add convert to 7.3 FxP format
-        sfpi::vFloat vConstLn2Recip = vConstFloatPrgm0;
+        sfpi::vFloat vConstLn2Recip = sfpi::vConstFloatPrgm0;
         sfpi::vFloat conv           = in * vConstLn2Recip;
 
         // Clear exp bits
         sfpi::vInt c23_73 = p_exp::C23_73;
-        sfpi::vInt tmp    = reinterpret<sfpi::vInt>(conv) - c23_73;
+        sfpi::vInt tmp    = sfpi::reinterpret<sfpi::vInt>(conv) - c23_73;
 
         // Add bias
         tmp += SP_BIAS;
 
         // SHL to move integer bits to exponent
-        out = reinterpret<sfpi::vFloat>(tmp << (10 - FRAC_BITS));
+        out = sfpi::reinterpret<sfpi::vFloat>(tmp << (10 - FRAC_BITS));
     }
     else
     {
         // Force sign to 0 (make number positive)
-        out = _sfpu_exp_(setsgn(in, 0));
+        out = _sfpu_exp_(sfpi::setsgn(in, 0));
 
         v_if (in < 0)
         {
@@ -184,25 +184,31 @@ void _calculate_exponential_(const int iterations, uint16_t exp_base_scale_facto
         for (int d = 0; d < iterations; d++)
         {
             sfpi::vFloat val = sfpi::dst_reg[0];
-            if constexpr(SCALE_EN){
-                val = val * s2vFloat16a(exp_base_scale_factor);
+            if constexpr (SCALE_EN)
+            {
+                val = val * sfpi::s2vFloat16a(exp_base_scale_factor);
             }
             if constexpr (APPROXIMATION_MODE)
             {
-                v_if (val>=89){
+                v_if (val >= 89)
+                {
                     sfpi::vFloat val_inf = std::numeric_limits<float>::infinity();
-                    sfpi::dst_reg[0] = val_inf;
-                } v_elseif(val<-42){
-                        sfpi::dst_reg[0] = 0.0f;
-                } v_else {
+                    sfpi::dst_reg[0]     = val_inf;
+                }
+                v_elseif (val < -42)
+                {
+                    sfpi::dst_reg[0] = 0.0f;
+                }
+                v_else
+                {
                     // * by 1/ln2 and add convert to 7.3 FxP format
-                    sfpi::vFloat vConstLn2Recip = vConstFloatPrgm0;
-                    sfpi::vFloat c23_73         = vConstFloatPrgm1;
-                    sfpi::vInt adj_exp          = vConstIntPrgm2;
-                    val                   = val * vConstLn2Recip + c23_73;
+                    sfpi::vFloat vConstLn2Recip = sfpi::vConstFloatPrgm0;
+                    sfpi::vFloat c23_73         = sfpi::vConstFloatPrgm1;
+                    sfpi::vInt adj_exp          = sfpi::vConstIntPrgm2;
+                    val                         = val * vConstLn2Recip + c23_73;
 
                     // Remove Exponent of 7 and bias the Mantissa to 127.
-                    sfpi::vInt val_short = adj_exp + reinterpret<sfpi::vInt>(val);
+                    sfpi::vInt val_short = adj_exp + sfpi::reinterpret<sfpi::vInt>(val);
 
                     // SHL to move integer bits to exponent
                     val_short <<= 10 - p_exp::FRAC_BITS;
@@ -348,15 +354,15 @@ inline void _init_exponential_()
     }
     else if constexpr (APPROXIMATION_MODE)
     {
-        vConstFloatPrgm0 = 1.442695f; // ln2_recip
-        vConstFloatPrgm1 = s2vFloat16b(p_exp::C23_73);
-        vConstFloatPrgm2 = s2vFloat16b(p_exp::ADJ_EXP);
+        sfpi::vConstFloatPrgm0 = 1.442695f; // ln2_recip
+        sfpi::vConstFloatPrgm1 = sfpi::s2vFloat16b(p_exp::C23_73);
+        sfpi::vConstFloatPrgm2 = sfpi::s2vFloat16b(p_exp::ADJ_EXP);
     }
     else
     {
-        vConstFloatPrgm0 = 1.442695f; // ln2_recip
-        vConstFloatPrgm1 = 2.0f;
-        vConstFloatPrgm2 = 0.863281f;
+        sfpi::vConstFloatPrgm0 = 1.442695f; // ln2_recip
+        sfpi::vConstFloatPrgm1 = 2.0f;
+        sfpi::vConstFloatPrgm2 = 0.863281f;
     }
 }
 

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_exp.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_exp.h
@@ -14,10 +14,10 @@ namespace ckernel
 namespace sfpu
 {
 
-sfpi_inline vFloat _sfpu_exp_(vFloat val)
+sfpi_inline sfpi::vFloat _sfpu_exp_(sfpi::vFloat val)
 {
     // If exponent is > -1 extract it and replace with -1
-    vInt exp = exexp(val);
+    sfpi::vInt exp = exexp(val);
     v_if (exp >= 0)
     {
         val = setexp(val, 126);
@@ -25,7 +25,7 @@ sfpi_inline vFloat _sfpu_exp_(vFloat val)
     v_endif;
 
     // Run series in Horner form
-    vFloat tmp = val * vConst0p8373 + s2vFloat16b(0.863281);
+    sfpi::vFloat tmp = val * vConst0p8373 + sfpi::s2vFloat16b(0.863281);
     val        = val * tmp + vConst1;
 
     v_if (exp >= 0)
@@ -45,9 +45,9 @@ sfpi_inline vFloat _sfpu_exp_(vFloat val)
 }
 
 template <bool APPROXIMATION_MODE>
-sfpi_inline vFloat _calculate_exponential_body_(vFloat in)
+sfpi_inline sfpi::vFloat _calculate_exponential_body_(sfpi::vFloat in)
 {
-    vFloat out;
+    sfpi::vFloat out;
 
     if constexpr (APPROXIMATION_MODE)
     {
@@ -55,18 +55,18 @@ sfpi_inline vFloat _calculate_exponential_body_(vFloat in)
         constexpr uint SP_BIAS  = 127 << FRAC_BITS;
 
         // * by 1/ln2 and add convert to 7.3 FxP format
-        vFloat vConstLn2Recip = vConstFloatPrgm0;
-        vFloat conv           = in * vConstLn2Recip;
+        sfpi::vFloat vConstLn2Recip = vConstFloatPrgm0;
+        sfpi::vFloat conv           = in * vConstLn2Recip;
 
         // Clear exp bits
-        vInt c23_73 = p_exp::C23_73;
-        vInt tmp    = reinterpret<vInt>(conv) - c23_73;
+        sfpi::vInt c23_73 = p_exp::C23_73;
+        sfpi::vInt tmp    = reinterpret<sfpi::vInt>(conv) - c23_73;
 
         // Add bias
         tmp += SP_BIAS;
 
         // SHL to move integer bits to exponent
-        out = reinterpret<vFloat>(tmp << (10 - FRAC_BITS));
+        out = reinterpret<sfpi::vFloat>(tmp << (10 - FRAC_BITS));
     }
     else
     {
@@ -183,37 +183,37 @@ void _calculate_exponential_(const int iterations, uint16_t exp_base_scale_facto
         // Unroll 8 best for approx, unroll 0 for precise, compiler figures this out
         for (int d = 0; d < iterations; d++)
         {
-            vFloat val = dst_reg[0];
+            sfpi::vFloat val = sfpi::dst_reg[0];
             if constexpr(SCALE_EN){
                 val = val * s2vFloat16a(exp_base_scale_factor);
             }
             if constexpr (APPROXIMATION_MODE)
             {
                 v_if (val>=89){
-                    vFloat val_inf = std::numeric_limits<float>::infinity();
-                    dst_reg[0] = val_inf;
+                    sfpi::vFloat val_inf = std::numeric_limits<float>::infinity();
+                    sfpi::dst_reg[0] = val_inf;
                 } v_elseif(val<-42){
-                        dst_reg[0] = 0.0f;
+                        sfpi::dst_reg[0] = 0.0f;
                 } v_else {
                     // * by 1/ln2 and add convert to 7.3 FxP format
-                    vFloat vConstLn2Recip = vConstFloatPrgm0;
-                    vFloat c23_73         = vConstFloatPrgm1;
-                    vInt adj_exp          = vConstIntPrgm2;
+                    sfpi::vFloat vConstLn2Recip = vConstFloatPrgm0;
+                    sfpi::vFloat c23_73         = vConstFloatPrgm1;
+                    sfpi::vInt adj_exp          = vConstIntPrgm2;
                     val                   = val * vConstLn2Recip + c23_73;
 
                     // Remove Exponent of 7 and bias the Mantissa to 127.
-                    vInt val_short = adj_exp + reinterpret<vInt>(val);
+                    sfpi::vInt val_short = adj_exp + reinterpret<sfpi::vInt>(val);
 
                     // SHL to move integer bits to exponent
                     val_short <<= 10 - p_exp::FRAC_BITS;
-                    dst_reg[0] = reinterpret<vFloat>(val_short);
+                    sfpi::dst_reg[0] = reinterpret<sfpi::vFloat>(val_short);
                 }
                 v_endif;
             }
             else
             {
                 // Force sign to 0 (make number positive)
-                vFloat result = _sfpu_exp_(setsgn(val, 0));
+                sfpi::vFloat result = _sfpu_exp_(setsgn(val, 0));
 
                 v_if (val < 0)
                 {
@@ -221,10 +221,10 @@ void _calculate_exponential_(const int iterations, uint16_t exp_base_scale_facto
                 }
                 v_endif;
 
-                dst_reg[0] = result;
+                sfpi::dst_reg[0] = result;
             }
 
-            dst_reg++;
+            sfpi::dst_reg++;
         }
     }
 }

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_exp.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_exp.h
@@ -4,14 +4,10 @@
 
 #pragma once
 
-#include "ckernel_defs.h"
-#include "ckernel.h"
-#include "noc_nonblocking_api.h"
-#include "ckernel_sfpu_recip.h"
-
 #include "sfpi.h"
-
-using namespace sfpi;
+#include "sfpi_fp16.h"
+#include "ckernel_sfpu_recip.h"
+#include "ckernel_sfpu_exp.h"
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_exp.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_exp.h
@@ -212,14 +212,14 @@ void _calculate_exponential_(const int iterations, uint16_t exp_base_scale_facto
 
                     // SHL to move integer bits to exponent
                     val_short <<= 10 - p_exp::FRAC_BITS;
-                    sfpi::dst_reg[0] = reinterpret<sfpi::vFloat>(val_short);
+                    sfpi::dst_reg[0] = sfpi::reinterpret<sfpi::vFloat>(val_short);
                 }
                 v_endif;
             }
             else
             {
                 // Force sign to 0 (make number positive)
-                sfpi::vFloat result = _sfpu_exp_(setsgn(val, 0));
+                sfpi::vFloat result = _sfpu_exp_(sfpi::setsgn(val, 0));
 
                 v_if (val < 0)
                 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_exp.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_exp.h
@@ -4,13 +4,10 @@
 
 #pragma once
 
-#include "ckernel.h"
-#include "ckernel_defs.h"
-#include "ckernel_sfpu_recip.h"
-#include "noc_nonblocking_api.h"
 #include "sfpi.h"
-
-using namespace sfpi;
+#include "sfpi_fp16.h"
+#include "ckernel_sfpu_recip.h"
+#include "ckernel_sfpu_exp.h"
 
 namespace ckernel
 {
@@ -185,56 +182,50 @@ void _calculate_exponential_(const int iterations, uint16_t exp_base_scale_facto
     {
         // Unroll 8 best for approx, unroll 0 for precise, compiler figures this out
         for (int d = 0; d < iterations; d++)
+    {
+        vFloat val = dst_reg[0];
+        if constexpr(SCALE_EN){
+            val = val * s2vFloat16a(exp_base_scale_factor);
+        }
+        if constexpr (APPROXIMATION_MODE)
         {
-            vFloat val = dst_reg[0];
-            if constexpr (SCALE_EN)
-            {
-                val = val * s2vFloat16a(exp_base_scale_factor);
-            }
-            if constexpr (APPROXIMATION_MODE)
-            {
-                v_if (val >= 89)
-                {
-                    vFloat val_inf = std::numeric_limits<float>::infinity();
-                    dst_reg[0]     = val_inf;
-                }
-                v_elseif (val < -42)
-                {
+            v_if (val>=89){
+                vFloat val_inf = std::numeric_limits<float>::infinity();
+                dst_reg[0] = val_inf;
+            } v_elseif(val<-42){
                     dst_reg[0] = 0.0f;
-                }
-                v_else
-                {
-                    // * by 1/ln2 and add convert to 7.3 FxP format
+            } v_else {
+                // * by 1/ln2 and add convert to 7.3 FxP format
                     vFloat vConstLn2Recip = vConstFloatPrgm0;
                     vFloat c23_73         = vConstFloatPrgm1;
                     vInt adj_exp          = vConstIntPrgm2;
                     val                   = val * vConstLn2Recip + c23_73;
 
-                    // Remove Exponent of 7 and bias the Mantissa to 127.
-                    vInt val_short = adj_exp + reinterpret<vInt>(val);
+                // Remove Exponent of 7 and bias the Mantissa to 127.
+                vInt val_short = adj_exp + reinterpret<vInt>(val);
 
-                    // SHL to move integer bits to exponent
-                    val_short <<= 10 - p_exp::FRAC_BITS;
-                    dst_reg[0] = reinterpret<vFloat>(val_short);
-                }
-                v_endif;
+                // SHL to move integer bits to exponent
+                val_short <<= 10 - p_exp::FRAC_BITS;
+                dst_reg[0] = reinterpret<vFloat>(val_short);
             }
-            else
-            {
-                // Force sign to 0 (make number positive)
+            v_endif;
+        }
+        else
+        {
+            // Force sign to 0 (make number positive)
                 vFloat result = _sfpu_exp_(setsgn(val, 0));
 
                 v_if (val < 0)
                 {
                     result = _sfpu_reciprocal_(result);
-                }
-                v_endif;
+            }
+            v_endif;
 
                 dst_reg[0] = result;
-            }
-
-            dst_reg++;
         }
+
+        dst_reg++;
+    }
     }
 }
 

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_exp.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_exp.h
@@ -4,10 +4,14 @@
 
 #pragma once
 
-#include "sfpi.h"
-#include "sfpi_fp16.h"
+#include "ckernel_defs.h"
+#include "ckernel.h"
+#include "noc_nonblocking_api.h"
 #include "ckernel_sfpu_recip.h"
-#include "ckernel_sfpu_exp.h"
+
+#include "sfpi.h"
+
+using namespace sfpi;
 
 namespace ckernel
 {
@@ -182,12 +186,6 @@ void _calculate_exponential_(const int iterations, uint16_t exp_base_scale_facto
     {
         // Unroll 8 best for approx, unroll 0 for precise, compiler figures this out
         for (int d = 0; d < iterations; d++)
-    {
-        vFloat val = dst_reg[0];
-        if constexpr(SCALE_EN){
-            val = val * s2vFloat16a(exp_base_scale_factor);
-        }
-        if constexpr (APPROXIMATION_MODE)
         {
             vFloat val = dst_reg[0];
             if constexpr(SCALE_EN){
@@ -207,31 +205,31 @@ void _calculate_exponential_(const int iterations, uint16_t exp_base_scale_facto
                     vInt adj_exp          = vConstIntPrgm2;
                     val                   = val * vConstLn2Recip + c23_73;
 
-                // Remove Exponent of 7 and bias the Mantissa to 127.
-                vInt val_short = adj_exp + reinterpret<vInt>(val);
+                    // Remove Exponent of 7 and bias the Mantissa to 127.
+                    vInt val_short = adj_exp + reinterpret<vInt>(val);
 
-                // SHL to move integer bits to exponent
-                val_short <<= 10 - p_exp::FRAC_BITS;
-                dst_reg[0] = reinterpret<vFloat>(val_short);
+                    // SHL to move integer bits to exponent
+                    val_short <<= 10 - p_exp::FRAC_BITS;
+                    dst_reg[0] = reinterpret<vFloat>(val_short);
+                }
+                v_endif;
             }
-            v_endif;
-        }
-        else
-        {
-            // Force sign to 0 (make number positive)
+            else
+            {
+                // Force sign to 0 (make number positive)
                 vFloat result = _sfpu_exp_(setsgn(val, 0));
 
                 v_if (val < 0)
                 {
                     result = _sfpu_reciprocal_(result);
-            }
-            v_endif;
+                }
+                v_endif;
 
                 dst_reg[0] = result;
-        }
+            }
 
-        dst_reg++;
-    }
+            dst_reg++;
+        }
     }
 }
 

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_gelu.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_gelu.h
@@ -15,13 +15,13 @@ namespace sfpu
 {
 
 template <bool APPROXIMATION_MODE>
-inline vFloat _calculate_gelu_core_(vFloat in)
+inline sfpi::vFloat _calculate_gelu_core_(sfpi::vFloat in)
 {
     // SFPU microcode:
     // result = (APPROX_MODE == 1)
     //   ? (1 + erf(x/sqrt(2)))
     //   : (1 + tanh( sqrt(2/pi) * (x + 0.044715*x^3) )
-    vFloat result;
+    sfpi::vFloat result;
     if constexpr (APPROXIMATION_MODE)
     {
         result = in;
@@ -49,26 +49,26 @@ inline void _calculate_gelu_(const int iterations)
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
     {
-        // vFloat in = dst_reg[0];
-        // vFloat result = calculate_gelu_core<APPROXIMATION_MODE>(in);
+        // sfpi::vFloat in = sfpi::dst_reg[0];
+        // sfpi::vFloat result = calculate_gelu_core<APPROXIMATION_MODE>(in);
 
-        // vFloat half_in = in * half;
+        // sfpi::vFloat half_in = in * half;
         // result = lut(result, l0, l1, l2);
         // result = half_in * result + half_in;
 
-        // dst_reg[0] = result;
+        // sfpi::dst_reg[0] = result;
 
-        vFloat in      = dst_reg[0];
-        vFloat half    = vConstFloatPrgm0;
-        vFloat half_in = in * half;
-        vFloat result  = lut2_sign(in, l0, l1, l2, l4, l5, l6);
+        sfpi::vFloat in      = sfpi::dst_reg[0];
+        sfpi::vFloat half    = vConstFloatPrgm0;
+        sfpi::vFloat half_in = in * half;
+        sfpi::vFloat result  = lut2_sign(in, l0, l1, l2, l4, l5, l6);
         result         = half_in + result;
 
-        dst_reg[0] = result;
+        sfpi::dst_reg[0] = result;
 
-        dst_reg++;
+        sfpi::dst_reg++;
 
-        // dst_reg++;
+        // sfpi::dst_reg++;
         // TTI_SFPLOAD(3, 0, 1/*load addr mode*/,0);    // load from dest
         ////TTI_SFPMUL(3,11,9,7,0);           // lreg7 = 0.5*lreg3
         // TTI_SFPLUTFP32(7, 2);                // lreg7= LUT(3)
@@ -102,15 +102,15 @@ inline void _calculate_gelu_derivative_(const int iterations)
 #pragma GCC unroll 0
         for (int d = 0; d < iterations; d++)
         {
-            vFloat val = dst_reg[0];
+            sfpi::vFloat val = sfpi::dst_reg[0];
             val        = lut2(val, l0, l1, l2, l4, l5, l6, lut_mode);
             v_if (val < 0.0F)
             {
                 val = val + 1.0f;
             }
             v_endif;
-            dst_reg[0] = val;
-            dst_reg++;
+            sfpi::dst_reg[0] = val;
+            sfpi::dst_reg++;
         }
 
         l_reg[LRegs::LReg0] = l0;
@@ -131,21 +131,21 @@ inline void _calculate_gelu_derivative_(const int iterations)
 #pragma GCC unroll 0
         for (int d = 0; d < iterations; d++)
         {
-            vFloat in             = dst_reg[0];
-            vFloat neg_half_sq_in = in * in * -0.5f;
+            sfpi::vFloat in             = sfpi::dst_reg[0];
+            sfpi::vFloat neg_half_sq_in = in * in * -0.5f;
 
             // exp = e^(val)
-            vFloat exp = _calculate_exponential_body_<false>(neg_half_sq_in);
+            sfpi::vFloat exp = _calculate_exponential_body_<false>(neg_half_sq_in);
 
             // exp = exp * 1/sqrt(2*pi)
-            vFloat partial = exp * in * s2vFloat16b(0.3989423F);
+            sfpi::vFloat partial = exp * in * s2vFloat16b(0.3989423F);
 
-            vFloat result = _calculate_gelu_core_<true>(in);
+            sfpi::vFloat result = _calculate_gelu_core_<true>(in);
 
             result = lut(result, l0, l1, imm2);
 
-            dst_reg[0] = partial + result + 0.5f;
-            dst_reg++;
+            sfpi::dst_reg[0] = partial + result + 0.5f;
+            sfpi::dst_reg++;
         }
 
         l_reg[LRegs::LReg0] = l0;

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_gelu.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_gelu.h
@@ -4,10 +4,15 @@
 
 #pragma once
 
-#include "sfpi.h"
-#include "sfpi_fp16.h"
+#include "ckernel_defs.h"
+#include "ckernel.h"
+#include "noc_nonblocking_api.h"
 #include "ckernel_sfpu_exp.h"
 #include "ckernel_sfpu_load_config.h"
+
+#include "sfpi.h"
+
+using namespace sfpi;
 
 namespace ckernel
 {
@@ -227,7 +232,7 @@ inline void _init_gelu_derivative_()
         _sfpu_load_imm32_(4, imm3);
         _sfpu_load_imm32_(5, imm4);
         _sfpu_load_imm32_(6, imm5);
-        } else {
+    } else {
         imm0 = 0x28FF;
         imm1 = 0x3020;
         _sfpu_load_imm16_(0, imm0);

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_gelu.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_gelu.h
@@ -4,15 +4,10 @@
 
 #pragma once
 
-#include "ckernel_defs.h"
-#include "ckernel.h"
-#include "noc_nonblocking_api.h"
+#include "sfpi.h"
+#include "sfpi_fp16.h"
 #include "ckernel_sfpu_exp.h"
 #include "ckernel_sfpu_load_config.h"
-
-#include "sfpi.h"
-
-using namespace sfpi;
 
 namespace ckernel
 {
@@ -232,7 +227,7 @@ inline void _init_gelu_derivative_()
         _sfpu_load_imm32_(4, imm3);
         _sfpu_load_imm32_(5, imm4);
         _sfpu_load_imm32_(6, imm5);
-    } else {
+        } else {
         imm0 = 0x28FF;
         imm1 = 0x3020;
         _sfpu_load_imm16_(0, imm0);

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_gelu.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_gelu.h
@@ -4,10 +4,10 @@
 
 #pragma once
 
-#include "sfpi.h"
-#include "sfpi_fp16.h"
 #include "ckernel_sfpu_exp.h"
 #include "ckernel_sfpu_load_config.h"
+#include "sfpi.h"
+#include "sfpi_fp16.h"
 
 namespace ckernel
 {
@@ -29,8 +29,8 @@ inline sfpi::vFloat _calculate_gelu_core_(sfpi::vFloat in)
     else
     {
         // f = (0.044715*x^3 + x)
-        result = (in * in) * (in * s2vFloat16b(0.044715f)) + in;
-        result *= s2vFloat16b(0.79788f);
+        result = (in * in) * (in * sfpi::s2vFloat16b(0.044715f)) + in;
+        result *= sfpi::s2vFloat16b(0.79788f);
     }
 
     return result;
@@ -39,12 +39,12 @@ inline sfpi::vFloat _calculate_gelu_core_(sfpi::vFloat in)
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void _calculate_gelu_(const int iterations)
 {
-    vUInt l0 = l_reg[LRegs::LReg0];
-    vUInt l1 = l_reg[LRegs::LReg1];
-    vUInt l2 = l_reg[LRegs::LReg2];
-    vUInt l4 = l_reg[LRegs::LReg4];
-    vUInt l5 = l_reg[LRegs::LReg5];
-    vUInt l6 = l_reg[LRegs::LReg6];
+    sfpi::vUInt l0 = sfpi::l_reg[sfpi::LRegs::LReg0];
+    sfpi::vUInt l1 = sfpi::l_reg[sfpi::LRegs::LReg1];
+    sfpi::vUInt l2 = sfpi::l_reg[sfpi::LRegs::LReg2];
+    sfpi::vUInt l4 = sfpi::l_reg[sfpi::LRegs::LReg4];
+    sfpi::vUInt l5 = sfpi::l_reg[sfpi::LRegs::LReg5];
+    sfpi::vUInt l6 = sfpi::l_reg[sfpi::LRegs::LReg6];
 
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
@@ -59,10 +59,10 @@ inline void _calculate_gelu_(const int iterations)
         // sfpi::dst_reg[0] = result;
 
         sfpi::vFloat in      = sfpi::dst_reg[0];
-        sfpi::vFloat half    = vConstFloatPrgm0;
+        sfpi::vFloat half    = sfpi::vConstFloatPrgm0;
         sfpi::vFloat half_in = in * half;
         sfpi::vFloat result  = lut2_sign(in, l0, l1, l2, l4, l5, l6);
-        result         = half_in + result;
+        result               = half_in + result;
 
         sfpi::dst_reg[0] = result;
 
@@ -76,12 +76,12 @@ inline void _calculate_gelu_(const int iterations)
         // TTI_SFPSTORE(3, 0, 3/*store_addr_mod3*/, 0);   // and INCRWC by 4 using mode 3
     }
 
-    l_reg[LRegs::LReg0] = l0;
-    l_reg[LRegs::LReg1] = l1;
-    l_reg[LRegs::LReg2] = l2;
-    l_reg[LRegs::LReg4] = l4;
-    l_reg[LRegs::LReg5] = l5;
-    l_reg[LRegs::LReg6] = l6;
+    sfpi::l_reg[sfpi::LRegs::LReg0] = l0;
+    sfpi::l_reg[sfpi::LRegs::LReg1] = l1;
+    sfpi::l_reg[sfpi::LRegs::LReg2] = l2;
+    sfpi::l_reg[sfpi::LRegs::LReg4] = l4;
+    sfpi::l_reg[sfpi::LRegs::LReg5] = l5;
+    sfpi::l_reg[sfpi::LRegs::LReg6] = l6;
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
@@ -91,19 +91,19 @@ inline void _calculate_gelu_derivative_(const int iterations)
     {
         constexpr int lut_mode = 1; // SFPLUTFP32_MOD0_FP16_6ENTRY_TABLE1
 
-        vUInt l0 = l_reg[LRegs::LReg0];
-        vUInt l1 = l_reg[LRegs::LReg1];
-        vUInt l2 = l_reg[LRegs::LReg2];
-        vUInt l4 = l_reg[LRegs::LReg4];
-        vUInt l5 = l_reg[LRegs::LReg5];
-        vUInt l6 = l_reg[LRegs::LReg6];
+        sfpi::vUInt l0 = sfpi::l_reg[sfpi::LRegs::LReg0];
+        sfpi::vUInt l1 = sfpi::l_reg[sfpi::LRegs::LReg1];
+        sfpi::vUInt l2 = sfpi::l_reg[sfpi::LRegs::LReg2];
+        sfpi::vUInt l4 = sfpi::l_reg[sfpi::LRegs::LReg4];
+        sfpi::vUInt l5 = sfpi::l_reg[sfpi::LRegs::LReg5];
+        sfpi::vUInt l6 = sfpi::l_reg[sfpi::LRegs::LReg6];
 
 // SFPU microcode:
 #pragma GCC unroll 0
         for (int d = 0; d < iterations; d++)
         {
             sfpi::vFloat val = sfpi::dst_reg[0];
-            val        = lut2(val, l0, l1, l2, l4, l5, l6, lut_mode);
+            val              = lut2(val, l0, l1, l2, l4, l5, l6, lut_mode);
             v_if (val < 0.0F)
             {
                 val = val + 1.0f;
@@ -113,19 +113,19 @@ inline void _calculate_gelu_derivative_(const int iterations)
             sfpi::dst_reg++;
         }
 
-        l_reg[LRegs::LReg0] = l0;
-        l_reg[LRegs::LReg1] = l1;
-        l_reg[LRegs::LReg2] = l2;
-        l_reg[LRegs::LReg4] = l4;
-        l_reg[LRegs::LReg5] = l5;
-        l_reg[LRegs::LReg6] = l6;
+        sfpi::l_reg[sfpi::LRegs::LReg0] = l0;
+        sfpi::l_reg[sfpi::LRegs::LReg1] = l1;
+        sfpi::l_reg[sfpi::LRegs::LReg2] = l2;
+        sfpi::l_reg[sfpi::LRegs::LReg4] = l4;
+        sfpi::l_reg[sfpi::LRegs::LReg5] = l5;
+        sfpi::l_reg[sfpi::LRegs::LReg6] = l6;
     }
     else
     {
         constexpr uint imm2 = 0xFF10;
 
-        vUInt l0 = l_reg[LRegs::LReg0];
-        vUInt l1 = l_reg[LRegs::LReg1];
+        sfpi::vUInt l0 = sfpi::l_reg[sfpi::LRegs::LReg0];
+        sfpi::vUInt l1 = sfpi::l_reg[sfpi::LRegs::LReg1];
 
 // SFPU microcode:
 #pragma GCC unroll 0
@@ -138,7 +138,7 @@ inline void _calculate_gelu_derivative_(const int iterations)
             sfpi::vFloat exp = _calculate_exponential_body_<false>(neg_half_sq_in);
 
             // exp = exp * 1/sqrt(2*pi)
-            sfpi::vFloat partial = exp * in * s2vFloat16b(0.3989423F);
+            sfpi::vFloat partial = exp * in * sfpi::s2vFloat16b(0.3989423F);
 
             sfpi::vFloat result = _calculate_gelu_core_<true>(in);
 
@@ -148,15 +148,15 @@ inline void _calculate_gelu_derivative_(const int iterations)
             sfpi::dst_reg++;
         }
 
-        l_reg[LRegs::LReg0] = l0;
-        l_reg[LRegs::LReg1] = l1;
+        sfpi::l_reg[sfpi::LRegs::LReg0] = l0;
+        sfpi::l_reg[sfpi::LRegs::LReg1] = l1;
     }
 }
 
 template <bool APPROXIMATION_MODE>
 inline void _init_gelu_()
 {
-    vConstFloatPrgm0 = 0.5f;
+    sfpi::vConstFloatPrgm0 = 0.5f;
 
     // // >= 3.0f
     // lreg2_hi=0.50;//3800
@@ -189,9 +189,9 @@ inline void _init_gelu_()
 template <bool APPROXIMATION_MODE>
 inline void _init_gelu_derivative_()
 {
-    vConstFloatPrgm0 = 1.442695f; // ln2_recip
-    vConstFloatPrgm1 = 2.0f;
-    vConstFloatPrgm2 = 0.863281f;
+    sfpi::vConstFloatPrgm0 = 1.442695f; // ln2_recip
+    sfpi::vConstFloatPrgm1 = 2.0f;
+    sfpi::vConstFloatPrgm2 = 0.863281f;
 
     uint imm0;
     uint imm1;
@@ -227,7 +227,9 @@ inline void _init_gelu_derivative_()
         _sfpu_load_imm32_(4, imm3);
         _sfpu_load_imm32_(5, imm4);
         _sfpu_load_imm32_(6, imm5);
-    } else {
+    }
+    else
+    {
         imm0 = 0x28FF;
         imm1 = 0x3020;
         _sfpu_load_imm16_(0, imm0);

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_gelu.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_gelu.h
@@ -4,10 +4,15 @@
 
 #pragma once
 
-#include "sfpi.h"
-#include "sfpi_fp16.h"
+#include "ckernel_defs.h"
+#include "ckernel.h"
+#include "noc_nonblocking_api.h"
 #include "ckernel_sfpu_exp.h"
 #include "ckernel_sfpu_load_config.h"
+
+#include "sfpi.h"
+
+using namespace sfpi;
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_gelu.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_gelu.h
@@ -227,7 +227,7 @@ inline void _init_gelu_derivative_()
         _sfpu_load_imm32_(4, imm3);
         _sfpu_load_imm32_(5, imm4);
         _sfpu_load_imm32_(6, imm5);
-        } else {
+    } else {
         imm0 = 0x28FF;
         imm1 = 0x3020;
         _sfpu_load_imm16_(0, imm0);

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_gelu.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_gelu.h
@@ -4,14 +4,10 @@
 
 #pragma once
 
-#include "ckernel.h"
-#include "ckernel_defs.h"
+#include "sfpi.h"
+#include "sfpi_fp16.h"
 #include "ckernel_sfpu_exp.h"
 #include "ckernel_sfpu_load_config.h"
-#include "noc_nonblocking_api.h"
-#include "sfpi.h"
-
-using namespace sfpi;
 
 namespace ckernel
 {
@@ -231,9 +227,7 @@ inline void _init_gelu_derivative_()
         _sfpu_load_imm32_(4, imm3);
         _sfpu_load_imm32_(5, imm4);
         _sfpu_load_imm32_(6, imm5);
-    }
-    else
-    {
+        } else {
         imm0 = 0x28FF;
         imm1 = 0x3020;
         _sfpu_load_imm16_(0, imm0);

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_hardtanh.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_hardtanh.h
@@ -4,8 +4,13 @@
 
 #pragma once
 
+#include "ckernel_defs.h"
+#include "ckernel.h"
+#include "noc_nonblocking_api.h"
+
 #include "sfpi.h"
-#include "sfpi_fp16.h"
+
+using namespace sfpi;
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_hardtanh.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_hardtanh.h
@@ -20,9 +20,9 @@ inline void _calculate_hardtanh_(const int iterations, uint param0, uint param1,
     // param1 = -(pos_threshold - neg_threshold)
     // param2 = -(pos_threshold)
 
-    sfpi::vFloat p0 = s2vFloat16(param0);
-    sfpi::vFloat p1 = s2vFloat16(param1);
-    sfpi::vFloat p2 = s2vFloat16(param2);
+    sfpi::vFloat p0 = sfpi::s2vFloat16(param0);
+    sfpi::vFloat p1 = sfpi::s2vFloat16(param1);
+    sfpi::vFloat p2 = sfpi::s2vFloat16(param2);
 // SFPU microcode
 #pragma GCC unroll 0
     for (int d = 0; d < iterations; d++)

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_hardtanh.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_hardtanh.h
@@ -20,14 +20,14 @@ inline void _calculate_hardtanh_(const int iterations, uint param0, uint param1,
     // param1 = -(pos_threshold - neg_threshold)
     // param2 = -(pos_threshold)
 
-    vFloat p0 = s2vFloat16(param0);
-    vFloat p1 = s2vFloat16(param1);
-    vFloat p2 = s2vFloat16(param2);
+    sfpi::vFloat p0 = s2vFloat16(param0);
+    sfpi::vFloat p1 = s2vFloat16(param1);
+    sfpi::vFloat p2 = s2vFloat16(param2);
 // SFPU microcode
 #pragma GCC unroll 0
     for (int d = 0; d < iterations; d++)
     {
-        vFloat val = dst_reg[0];
+        sfpi::vFloat val = sfpi::dst_reg[0];
 
         val += p0; // 12 bits
         v_if (val < 0.0f)
@@ -45,9 +45,9 @@ inline void _calculate_hardtanh_(const int iterations, uint param0, uint param1,
 
         val += p2; // 12 bits
 
-        dst_reg[0] = val;
+        sfpi::dst_reg[0] = val;
 
-        dst_reg++;
+        sfpi::dst_reg++;
     }
 }
 

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_hardtanh.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_hardtanh.h
@@ -4,13 +4,8 @@
 
 #pragma once
 
-#include "ckernel_defs.h"
-#include "ckernel.h"
-#include "noc_nonblocking_api.h"
-
 #include "sfpi.h"
-
-using namespace sfpi;
+#include "sfpi_fp16.h"
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_hardtanh.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_hardtanh.h
@@ -4,12 +4,8 @@
 
 #pragma once
 
-#include "ckernel.h"
-#include "ckernel_defs.h"
-#include "noc_nonblocking_api.h"
 #include "sfpi.h"
-
-using namespace sfpi;
+#include "sfpi_fp16.h"
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_is_fp16_zero.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_is_fp16_zero.h
@@ -4,7 +4,13 @@
 
 #pragma once
 
+#include "ckernel_defs.h"
+#include "ckernel.h"
+#include "noc_nonblocking_api.h"
+
 #include "sfpi.h"
+
+using namespace sfpi;
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_is_fp16_zero.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_is_fp16_zero.h
@@ -4,13 +4,7 @@
 
 #pragma once
 
-#include "ckernel_defs.h"
-#include "ckernel.h"
-#include "noc_nonblocking_api.h"
-
 #include "sfpi.h"
-
-using namespace sfpi;
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_is_fp16_zero.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_is_fp16_zero.h
@@ -11,7 +11,7 @@ namespace ckernel
 namespace sfpu
 {
 
-sfpi_inline vInt _sfpu_is_fp16_zero_(const vFloat& v, uint exponent_size_8)
+sfpi_inline sfpi::vInt _sfpu_is_fp16_zero_(const sfpi::vFloat& v, uint exponent_size_8)
 {
     if (exponent_size_8)
     {
@@ -23,8 +23,8 @@ sfpi_inline vInt _sfpu_is_fp16_zero_(const vFloat& v, uint exponent_size_8)
         // fp16a
         // if math data format is fp16, SFPU will convert 5 bit exp to 8 bit exp
         // in grayskull, this unconditionally adds bias value to exp (even for zero)
-        vInt tmp = 0x3800; // loads {0, 8'd112, 10'b0}
-        tmp += reinterpret<vInt>(v);
+        sfpi::vInt tmp = 0x3800; // loads {0, 8'd112, 10'b0}
+        tmp += reinterpret<sfpi::vInt>(v);
 
         return tmp == 0;
     }

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_is_fp16_zero.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_is_fp16_zero.h
@@ -24,7 +24,7 @@ sfpi_inline sfpi::vInt _sfpu_is_fp16_zero_(const sfpi::vFloat& v, uint exponent_
         // if math data format is fp16, SFPU will convert 5 bit exp to 8 bit exp
         // in grayskull, this unconditionally adds bias value to exp (even for zero)
         sfpi::vInt tmp = 0x3800; // loads {0, 8'd112, 10'b0}
-        tmp += reinterpret<sfpi::vInt>(v);
+        tmp += sfpi::reinterpret<sfpi::vInt>(v);
 
         return tmp == 0;
     }

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_is_fp16_zero.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_is_fp16_zero.h
@@ -4,12 +4,7 @@
 
 #pragma once
 
-#include "ckernel.h"
-#include "ckernel_defs.h"
-#include "noc_nonblocking_api.h"
 #include "sfpi.h"
-
-using namespace sfpi;
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_load_config.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_load_config.h
@@ -4,13 +4,8 @@
 
 #pragma once
 
-#include "ckernel_defs.h"
-#include "ckernel.h"
-#include "noc_nonblocking_api.h"
-
 #include "sfpi.h"
-
-using namespace sfpi;
+#include "ckernel_ops.h"
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_load_config.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_load_config.h
@@ -4,12 +4,8 @@
 
 #pragma once
 
-#include "ckernel.h"
-#include "ckernel_defs.h"
-#include "noc_nonblocking_api.h"
 #include "sfpi.h"
-
-using namespace sfpi;
+#include "ckernel_ops.h"
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_load_config.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_load_config.h
@@ -4,8 +4,8 @@
 
 #pragma once
 
-#include "sfpi.h"
 #include "ckernel_ops.h"
+#include "sfpi.h"
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_load_config.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_load_config.h
@@ -4,8 +4,13 @@
 
 #pragma once
 
+#include "ckernel_defs.h"
+#include "ckernel.h"
+#include "noc_nonblocking_api.h"
+
 #include "sfpi.h"
-#include "ckernel_ops.h"
+
+using namespace sfpi;
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_log.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_log.h
@@ -18,8 +18,8 @@ sfpi_inline void _calculate_log_body_(const uint log_base_scale_factor)
     ////////////////////////////
     // Load From dest + "normalize to calculation range"
     ////////////////////////////
-    vFloat in = dst_reg[0];
-    vFloat x  = setexp(in, 127); // set exp to exp bias (put in range of 1-2)
+    sfpi::vFloat in = sfpi::dst_reg[0];
+    sfpi::vFloat x  = setexp(in, 127); // set exp to exp bias (put in range of 1-2)
 
     // XXXXXX ask Namal? if we can derive the coefficients below to higher precision
     ////////////////////////////
@@ -34,28 +34,28 @@ sfpi_inline void _calculate_log_body_(const uint log_base_scale_factor)
     // D' = -A + B - C + D
     // A':0.1058, B':-0.7116, C':2.0871, D':-1.4753
     ////////////////////////////
-    vFloat a = vConstFloatPrgm1;
-    vFloat b = vConstFloatPrgm2;
+    sfpi::vFloat a = sfpi::vConstFloatPrgm1;
+    sfpi::vFloat b = sfpi::vConstFloatPrgm2;
     // XXXXX try variants of the below: B'=.7122, C'=2.0869
-    vFloat series_result = x * (x * (x * a + b) + 2.0871) + -1.4753f;
+    sfpi::vFloat series_result = x * (x * (x * a + b) + 2.0871) + -1.4753f;
 
     ////////////////////////////
     // Convert exponent to float
     ////////////////////////////
-    vInt exp = exexp(in);
+    sfpi::vInt exp = exexp(in);
     v_if (exp < 0)
     {
-        exp = setsgn(~exp + 1, 1);
+        exp = sfpi::setsgn(~exp + 1, 1);
     }
     v_endif;
 
-    vFloat expf      = int32_to_float(exp, 0);
-    vFloat vConstLn2 = vConstFloatPrgm0;
-    vFloat result    = expf * vConstLn2 + series_result; // exp correction: ln(1+x) + exp*ln(2)
+    sfpi::vFloat expf      = int32_to_float(exp, 0);
+    sfpi::vFloat vConstLn2 = sfpi::vConstFloatPrgm0;
+    sfpi::vFloat result    = expf * vConstLn2 + series_result; // exp correction: ln(1+x) + exp*ln(2)
 
     if constexpr (HAS_BASE_SCALING)
     {
-        result *= s2vFloat16a(log_base_scale_factor);
+        result *= sfpi::s2vFloat16a(log_base_scale_factor);
     }
 
     ////////////////////////////
@@ -67,7 +67,7 @@ sfpi_inline void _calculate_log_body_(const uint log_base_scale_factor)
     }
     v_endif;
 
-    dst_reg[0] = result;
+    sfpi::dst_reg[0] = result;
 }
 
 template <bool APPROXIMATION_MODE, bool HAS_BASE_SCALING, int ITERATIONS>
@@ -77,18 +77,18 @@ inline void _calculate_log_(const int iterations, uint log_base_scale_factor)
     for (int d = 0; d < iterations; d++)
     {
         _calculate_log_body_<HAS_BASE_SCALING>(log_base_scale_factor);
-        dst_reg++;
+        sfpi::dst_reg++;
     }
 }
 
 template <bool APPROXIMATION_MODE>
 inline void _init_log_()
 {
-    vConstFloatPrgm0 = 0.692871f; // ln2
+    sfpi::vConstFloatPrgm0 = 0.692871f; // ln2
 
     // XXXXX could do these to higher precision
-    vConstFloatPrgm1 = 0.1058f;
-    vConstFloatPrgm2 = -0.7166f;
+    sfpi::vConstFloatPrgm1 = 0.1058f;
+    sfpi::vConstFloatPrgm2 = -0.7166f;
 }
 
 } // namespace sfpu

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_log.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_log.h
@@ -4,8 +4,13 @@
 
 #pragma once
 
+#include "ckernel_defs.h"
+#include "ckernel.h"
+#include "noc_nonblocking_api.h"
+
 #include "sfpi.h"
-#include "sfpi_fp16.h"
+
+using namespace sfpi;
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_log.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_log.h
@@ -4,13 +4,8 @@
 
 #pragma once
 
-#include "ckernel_defs.h"
-#include "ckernel.h"
-#include "noc_nonblocking_api.h"
-
 #include "sfpi.h"
-
-using namespace sfpi;
+#include "sfpi_fp16.h"
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_log.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_log.h
@@ -4,12 +4,8 @@
 
 #pragma once
 
-#include "ckernel.h"
-#include "ckernel_defs.h"
-#include "noc_nonblocking_api.h"
 #include "sfpi.h"
-
-using namespace sfpi;
+#include "sfpi_fp16.h"
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_max.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_max.h
@@ -4,7 +4,13 @@
 
 #pragma once
 
+#include "ckernel_defs.h"
+#include "ckernel.h"
+#include "noc_nonblocking_api.h"
+
 #include "sfpi.h"
+
+using namespace sfpi;
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_max.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_max.h
@@ -4,13 +4,7 @@
 
 #pragma once
 
-#include "ckernel_defs.h"
-#include "ckernel.h"
-#include "noc_nonblocking_api.h"
-
 #include "sfpi.h"
-
-using namespace sfpi;
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_max.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_max.h
@@ -16,15 +16,15 @@ inline void _calculate_max_(const int iterations)
 {
     for (int d = 0; d < iterations; d++)
     {
-        vFloat a = dst_reg[0];
-        vFloat b = dst_reg[32];
+        sfpi::vFloat a = sfpi::dst_reg[0];
+        sfpi::vFloat b = sfpi::dst_reg[32];
         v_if (a < b)
         {
-            dst_reg[0] = b;
+            sfpi::dst_reg[0] = b;
         }
         v_endif;
 
-        dst_reg++;
+        sfpi::dst_reg++;
     }
 }
 

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_max.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_max.h
@@ -4,12 +4,7 @@
 
 #pragma once
 
-#include "ckernel.h"
-#include "ckernel_defs.h"
-#include "noc_nonblocking_api.h"
 #include "sfpi.h"
-
-using namespace sfpi;
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_max_int32.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_max_int32.h
@@ -4,7 +4,13 @@
 
 #pragma once
 
-#include "ckernel_ops.h"
+#include "ckernel_defs.h"
+#include "ckernel.h"
+#include "noc_nonblocking_api.h"
+
+#include "sfpi.h"
+
+using namespace sfpi;
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_max_int32.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_max_int32.h
@@ -4,13 +4,7 @@
 
 #pragma once
 
-#include "ckernel_defs.h"
-#include "ckernel.h"
-#include "noc_nonblocking_api.h"
-
-#include "sfpi.h"
-
-using namespace sfpi;
+#include "ckernel_ops.h"
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_max_int32.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_max_int32.h
@@ -4,12 +4,7 @@
 
 #pragma once
 
-#include "ckernel.h"
-#include "ckernel_defs.h"
-#include "noc_nonblocking_api.h"
-#include "sfpi.h"
-
-using namespace sfpi;
+#include "ckernel_ops.h"
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_max_int32.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_max_int32.h
@@ -22,7 +22,7 @@ inline void _calculate_max_int32_(const int iterations)
         TTI_SFPIADD(0, 2, 1, 2);
         TTI_SFPSTORE(0, 12, 3, 0);
         TTI_SFPENCC(0x003, 0, 0, 10);
-        dst_reg++;
+        sfpi::dst_reg++;
     }
 }
 

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_power.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_power.h
@@ -4,7 +4,13 @@
 
 #pragma once
 
+#include "ckernel_defs.h"
+#include "ckernel.h"
+#include "noc_nonblocking_api.h"
+
 #include "sfpi.h"
+
+using namespace sfpi;
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_power.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_power.h
@@ -4,13 +4,7 @@
 
 #pragma once
 
-#include "ckernel_defs.h"
-#include "ckernel.h"
-#include "noc_nonblocking_api.h"
-
 #include "sfpi.h"
-
-using namespace sfpi;
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_power.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_power.h
@@ -16,16 +16,16 @@ inline void _calculate_power_(const int iterations, uint exponent)
 {
     for (int d = 0; d < iterations; d++)
     {
-        vFloat in     = dst_reg[0];
-        vFloat result = in * in;
+        sfpi::vFloat in     = sfpi::dst_reg[0];
+        sfpi::vFloat result = in * in;
         for (uint i = 2; i < exponent; i++)
         {
             result *= in;
         }
 
-        dst_reg[0] = result;
+        sfpi::dst_reg[0] = result;
 
-        dst_reg++;
+        sfpi::dst_reg++;
     }
 }
 

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_power.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_power.h
@@ -4,12 +4,7 @@
 
 #pragma once
 
-#include "ckernel.h"
-#include "ckernel_defs.h"
-#include "noc_nonblocking_api.h"
 #include "sfpi.h"
-
-using namespace sfpi;
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_quant.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_quant.h
@@ -4,9 +4,9 @@
 
 #pragma once
 
-#include "sfpi.h"
 #include "ckernel_ops.h"
 #include "ckernel_sfpu_load_config.h"
+#include "sfpi.h"
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_quant.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_quant.h
@@ -4,14 +4,9 @@
 
 #pragma once
 
-#include "ckernel_defs.h"
-#include "ckernel.h"
-#include "noc_nonblocking_api.h"
-#include "ckernel_sfpu_load_config.h"
-
 #include "sfpi.h"
-
-using namespace sfpi;
+#include "ckernel_ops.h"
+#include "ckernel_sfpu_load_config.h"
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_quant.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_quant.h
@@ -4,13 +4,9 @@
 
 #pragma once
 
-#include "ckernel.h"
-#include "ckernel_defs.h"
-#include "ckernel_sfpu_load_config.h"
-#include "noc_nonblocking_api.h"
 #include "sfpi.h"
-
-using namespace sfpi;
+#include "ckernel_ops.h"
+#include "ckernel_sfpu_load_config.h"
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_quant.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_quant.h
@@ -35,7 +35,7 @@ inline void _quant_int32_(const uint dst_offset)
         TTI_SFP_STOCH_RND(0, 0, 9, 0, 0, 3);
         // LREG_0 -> dest as int32
         TTI_SFPSTORE(0, SIGN_MAGNITUDE_FORMAT ? 4 : 12, 3, 0);
-        dst_reg++;
+        sfpi::dst_reg++;
     }
 }
 
@@ -63,7 +63,7 @@ inline void _requant_int32_(const uint dst_offset)
         TTI_SFP_STOCH_RND(0, 0, 9, 0, 0, 3);
         // LREG_0 -> dest as int32
         TTI_SFPSTORE(0, SIGN_MAGNITUDE_FORMAT ? 4 : 12, 3, 0);
-        dst_reg++;
+        sfpi::dst_reg++;
     }
 }
 
@@ -91,7 +91,7 @@ inline void _dequant_int32_(const uint dst_offset)
         TTI_NOP;
         // LREG_0 -> dest as fp32
         TTI_SFPSTORE(0, 3, 3, 0);
-        dst_reg++;
+        sfpi::dst_reg++;
     }
 }
 

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_quant.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_quant.h
@@ -4,9 +4,14 @@
 
 #pragma once
 
-#include "sfpi.h"
-#include "ckernel_ops.h"
+#include "ckernel_defs.h"
+#include "ckernel.h"
+#include "noc_nonblocking_api.h"
 #include "ckernel_sfpu_load_config.h"
+
+#include "sfpi.h"
+
+using namespace sfpi;
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_recip.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_recip.h
@@ -4,7 +4,13 @@
 
 #pragma once
 
+#include "ckernel_defs.h"
+#include "ckernel.h"
+#include "noc_nonblocking_api.h"
+
 #include "sfpi.h"
+
+using namespace sfpi;
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_recip.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_recip.h
@@ -4,13 +4,7 @@
 
 #pragma once
 
-#include "ckernel_defs.h"
-#include "ckernel.h"
-#include "noc_nonblocking_api.h"
-
 #include "sfpi.h"
-
-using namespace sfpi;
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_recip.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_recip.h
@@ -15,7 +15,7 @@ template <int max_iter = 3>
 sfpi_inline sfpi::vFloat _sfpu_reciprocal_(const sfpi::vFloat in)
 {
     // Force sign to 1 (make number negative)
-    sfpi::vFloat val = setsgn(in, 1);
+    sfpi::vFloat val = sfpi::setsgn(in, 1);
 
     val = setexp(val, 126); // Set exponent to 126 to make the number in 0.5-1
     // Use 1.44 as first guess at x, ideal value would be 1.33.
@@ -73,7 +73,7 @@ inline void _calculate_reciprocal_(const int iterations)
         }
         else
         {
-            sfpi::dst_reg[0] = reinterpret<sfpi::vFloat>(float_to_fp16b(out, 0));
+            sfpi::dst_reg[0] = sfpi::reinterpret<sfpi::vFloat>(float_to_fp16b(out, 0));
         }
 
         sfpi::dst_reg++;

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_recip.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_recip.h
@@ -21,8 +21,8 @@ sfpi_inline sfpi::vFloat _sfpu_reciprocal_(const sfpi::vFloat in)
     // Use 1.44 as first guess at x, ideal value would be 1.33.
     // Grayskull has hardwired 1.44 and uses it to avoid a load.
     // We use it here for consistency.
-    sfpi::vFloat vConstLn2Recip = vConstFloatPrgm0;
-    sfpi::vFloat two            = vConstFloatPrgm1;
+    sfpi::vFloat vConstLn2Recip = sfpi::vConstFloatPrgm0;
+    sfpi::vFloat two            = sfpi::vConstFloatPrgm1;
     sfpi::vFloat result         = vConstLn2Recip * (val * vConstLn2Recip + two);
 
     for (int s_iter = 0; s_iter < (max_iter - 1); s_iter++)
@@ -83,8 +83,8 @@ inline void _calculate_reciprocal_(const int iterations)
 template <bool APPROXIMATION_MODE>
 inline void _init_reciprocal_()
 {
-    vConstFloatPrgm0 = 1.442695f; // ln2_recip
-    vConstFloatPrgm1 = 2.0f;
+    sfpi::vConstFloatPrgm0 = 1.442695f; // ln2_recip
+    sfpi::vConstFloatPrgm1 = 2.0f;
 }
 
 } // namespace sfpu

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_recip.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_recip.h
@@ -12,26 +12,26 @@ namespace sfpu
 {
 
 template <int max_iter = 3>
-sfpi_inline vFloat _sfpu_reciprocal_(const vFloat in)
+sfpi_inline sfpi::vFloat _sfpu_reciprocal_(const sfpi::vFloat in)
 {
     // Force sign to 1 (make number negative)
-    vFloat val = setsgn(in, 1);
+    sfpi::vFloat val = setsgn(in, 1);
 
     val = setexp(val, 126); // Set exponent to 126 to make the number in 0.5-1
     // Use 1.44 as first guess at x, ideal value would be 1.33.
     // Grayskull has hardwired 1.44 and uses it to avoid a load.
     // We use it here for consistency.
-    vFloat vConstLn2Recip = vConstFloatPrgm0;
-    vFloat two            = vConstFloatPrgm1;
-    vFloat result         = vConstLn2Recip * (val * vConstLn2Recip + two);
+    sfpi::vFloat vConstLn2Recip = vConstFloatPrgm0;
+    sfpi::vFloat two            = vConstFloatPrgm1;
+    sfpi::vFloat result         = vConstLn2Recip * (val * vConstLn2Recip + two);
 
     for (int s_iter = 0; s_iter < (max_iter - 1); s_iter++)
     {
         result = result * (val * result + two);
     }
 
-    vInt orig_exp = exexp(in);
-    vInt new_exp  = exexp(result);
+    sfpi::vInt orig_exp = exexp(in);
+    sfpi::vInt new_exp  = exexp(result);
 
     // "Subtract" exponents, and re-bias.
     // Execute: -1 - exp, then exp += 127
@@ -57,8 +57,8 @@ inline void _calculate_reciprocal_(const int iterations)
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
     {
-        vFloat in  = dst_reg[0];
-        vFloat out = _sfpu_reciprocal_<APPROXIMATION_MODE ? 2 : 3>(in);
+        sfpi::vFloat in  = sfpi::dst_reg[0];
+        sfpi::vFloat out = _sfpu_reciprocal_<APPROXIMATION_MODE ? 2 : 3>(in);
 
         v_if (in < 0.0F)
         {
@@ -69,14 +69,14 @@ inline void _calculate_reciprocal_(const int iterations)
 
         if constexpr (is_fp32_dest_acc_en || APPROXIMATION_MODE)
         {
-            dst_reg[0] = out;
+            sfpi::dst_reg[0] = out;
         }
         else
         {
-            dst_reg[0] = reinterpret<vFloat>(float_to_fp16b(out, 0));
+            sfpi::dst_reg[0] = reinterpret<sfpi::vFloat>(float_to_fp16b(out, 0));
         }
 
-        dst_reg++;
+        sfpi::dst_reg++;
     }
 }
 

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_recip.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_recip.h
@@ -4,12 +4,7 @@
 
 #pragma once
 
-#include "ckernel.h"
-#include "ckernel_defs.h"
-#include "noc_nonblocking_api.h"
 #include "sfpi.h"
-
-using namespace sfpi;
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_relu.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_relu.h
@@ -4,14 +4,9 @@
 
 #pragma once
 
-#include "ckernel.h"
-#include "ckernel_defs.h"
-#include "noc_nonblocking_api.h"
-#include "ckernel_sfpu_converter.h"
-
 #include "sfpi.h"
-
-using namespace sfpi;
+#include "sfpi_fp16.h"
+#include "ckernel_sfpu_converter.h"
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_relu.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_relu.h
@@ -4,9 +4,14 @@
 
 #pragma once
 
-#include "sfpi.h"
-#include "sfpi_fp16.h"
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "noc_nonblocking_api.h"
 #include "ckernel_sfpu_converter.h"
+
+#include "sfpi.h"
+
+using namespace sfpi;
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_relu.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_relu.h
@@ -4,13 +4,9 @@
 
 #pragma once
 
-#include "ckernel.h"
-#include "ckernel_defs.h"
-#include "ckernel_sfpu_converter.h"
-#include "noc_nonblocking_api.h"
 #include "sfpi.h"
-
-using namespace sfpi;
+#include "sfpi_fp16.h"
+#include "ckernel_sfpu_converter.h"
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_relu.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_relu.h
@@ -16,12 +16,12 @@ namespace sfpu
 template <bool APPROXIMATION_MODE>
 inline void _calculate_lrelu_(const int iterations, uint slope)
 {
-    vFloat s = Converter::to_float(slope);
+    sfpi::vFloat s = Converter::to_float(slope);
 
 #pragma GCC unroll 0
     for (int d = 0; d < iterations; d++)
     {
-        vFloat v = dst_reg[0];
+        sfpi::vFloat v = sfpi::dst_reg[0];
 
         v_if (v < 0.0f)
         {
@@ -29,19 +29,19 @@ inline void _calculate_lrelu_(const int iterations, uint slope)
         }
         v_endif;
 
-        dst_reg[0] = v;
+        sfpi::dst_reg[0] = v;
 
-        dst_reg++;
+        sfpi::dst_reg++;
     }
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void _relu_max_(const int iterations, uint uint_threshold)
 {
-    vFloat threshold = s2vFloat16(uint_threshold, s2vFloat16::fp16a);
+    sfpi::vFloat threshold = s2vFloat16(uint_threshold, s2vFloat16::fp16a);
     for (int d = 0; d < iterations; d++)
     {
-        vFloat a = dst_reg[0];
+        sfpi::vFloat a = sfpi::dst_reg[0];
         v_if (a > threshold)
         {
             a = threshold;
@@ -52,25 +52,25 @@ inline void _relu_max_(const int iterations, uint uint_threshold)
             a = 0.0f;
         }
         v_endif;
-        dst_reg[0] = a;
-        dst_reg++;
+        sfpi::dst_reg[0] = a;
+        sfpi::dst_reg++;
     }
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void _relu_min_(const int iterations, uint uint_threshold)
 {
-    vFloat threshold = s2vFloat16(uint_threshold, s2vFloat16::fp16a);
+    sfpi::vFloat threshold = s2vFloat16(uint_threshold, s2vFloat16::fp16a);
     for (int d = 0; d < iterations; d++)
     {
-        vFloat a = dst_reg[0];
+        sfpi::vFloat a = sfpi::dst_reg[0];
         v_if (a < threshold)
         {
             a = 0.0f;
         }
         v_endif;
-        dst_reg[0] = a;
-        dst_reg++;
+        sfpi::dst_reg[0] = a;
+        sfpi::dst_reg++;
     }
 }
 

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_relu.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_relu.h
@@ -4,9 +4,9 @@
 
 #pragma once
 
+#include "ckernel_sfpu_converter.h"
 #include "sfpi.h"
 #include "sfpi_fp16.h"
-#include "ckernel_sfpu_converter.h"
 
 namespace ckernel
 {
@@ -38,7 +38,7 @@ inline void _calculate_lrelu_(const int iterations, uint slope)
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void _relu_max_(const int iterations, uint uint_threshold)
 {
-    sfpi::vFloat threshold = s2vFloat16(uint_threshold, s2vFloat16::fp16a);
+    sfpi::vFloat threshold = sfpi::s2vFloat16(uint_threshold, sfpi::s2vFloat16::fp16a);
     for (int d = 0; d < iterations; d++)
     {
         sfpi::vFloat a = sfpi::dst_reg[0];
@@ -60,7 +60,7 @@ inline void _relu_max_(const int iterations, uint uint_threshold)
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void _relu_min_(const int iterations, uint uint_threshold)
 {
-    sfpi::vFloat threshold = s2vFloat16(uint_threshold, s2vFloat16::fp16a);
+    sfpi::vFloat threshold = sfpi::s2vFloat16(uint_threshold, sfpi::s2vFloat16::fp16a);
     for (int d = 0; d < iterations; d++)
     {
         sfpi::vFloat a = sfpi::dst_reg[0];

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_reshuffle_rows.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_reshuffle_rows.h
@@ -4,9 +4,13 @@
 
 #pragma once
 
+#include "ckernel_defs.h"
+#include "ckernel.h"
+#include "noc_nonblocking_api.h"
+
 #include "sfpi.h"
-#include "ckernel_instr_params.h"
-#include "ckernel_addrmod.h"
+
+using namespace sfpi;
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_reshuffle_rows.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_reshuffle_rows.h
@@ -4,12 +4,9 @@
 
 #pragma once
 
-#include "ckernel.h"
-#include "ckernel_defs.h"
-#include "noc_nonblocking_api.h"
 #include "sfpi.h"
-
-using namespace sfpi;
+#include "ckernel_instr_params.h"
+#include "ckernel_addrmod.h"
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_reshuffle_rows.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_reshuffle_rows.h
@@ -4,13 +4,9 @@
 
 #pragma once
 
-#include "ckernel_defs.h"
-#include "ckernel.h"
-#include "noc_nonblocking_api.h"
-
 #include "sfpi.h"
-
-using namespace sfpi;
+#include "ckernel_instr_params.h"
+#include "ckernel_addrmod.h"
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_reshuffle_rows.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_reshuffle_rows.h
@@ -4,9 +4,9 @@
 
 #pragma once
 
-#include "sfpi.h"
-#include "ckernel_instr_params.h"
 #include "ckernel_addrmod.h"
+#include "ckernel_instr_params.h"
+#include "sfpi.h"
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_shift.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_shift.h
@@ -4,13 +4,8 @@
 
 #pragma once
 
-#include "ckernel_defs.h"
-#include "ckernel.h"
-#include "noc_nonblocking_api.h"
-
 #include "sfpi.h"
-
-using namespace sfpi;
+#include "ckernel_ops.h"
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_shift.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_shift.h
@@ -4,12 +4,8 @@
 
 #pragma once
 
-#include "ckernel.h"
-#include "ckernel_defs.h"
-#include "noc_nonblocking_api.h"
 #include "sfpi.h"
-
-using namespace sfpi;
+#include "ckernel_ops.h"
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_shift.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_shift.h
@@ -4,8 +4,8 @@
 
 #pragma once
 
-#include "sfpi.h"
 #include "ckernel_ops.h"
+#include "sfpi.h"
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_shift.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_shift.h
@@ -4,8 +4,13 @@
 
 #pragma once
 
+#include "ckernel_defs.h"
+#include "ckernel.h"
+#include "noc_nonblocking_api.h"
+
 #include "sfpi.h"
-#include "ckernel_ops.h"
+
+using namespace sfpi;
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_shift.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_shift.h
@@ -32,7 +32,7 @@ inline void _calculate_binary_left_shift_(const uint dst_offset)
         TTI_SFPSHFT(0, 1, 0, 0);
         // store result
         TTI_SFPSTORE(0, 4, 3, 0);
-        dst_reg++;
+        sfpi::dst_reg++;
     }
 }
 
@@ -60,7 +60,7 @@ inline void _calculate_binary_right_shift_(const uint dst_offset)
         TTI_SFPENCC(0, 0, 0, 0);
         // store result
         TTI_SFPSTORE(0, 4, 3, 0);
-        dst_reg++;
+        sfpi::dst_reg++;
     }
 }
 

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_sigmoid.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_sigmoid.h
@@ -4,8 +4,8 @@
 
 #pragma once
 
-#include "sfpi.h"
 #include "ckernel_sfpu_load_config.h"
+#include "sfpi.h"
 
 namespace ckernel
 {
@@ -16,12 +16,12 @@ template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void _calculate_sigmoid_(const int iterations)
 {
     constexpr int lut_mode = 0; // SFPLUTFP32_MOD0_FP16_6ENTRY_TABLE1
-    vUInt l0               = l_reg[LRegs::LReg0];
-    vUInt l1               = l_reg[LRegs::LReg1];
-    vUInt l2               = l_reg[LRegs::LReg2];
-    vUInt l4               = l_reg[LRegs::LReg4];
-    vUInt l5               = l_reg[LRegs::LReg5];
-    vUInt l6               = l_reg[LRegs::LReg6];
+    sfpi::vUInt l0         = sfpi::l_reg[sfpi::LRegs::LReg0];
+    sfpi::vUInt l1         = sfpi::l_reg[sfpi::LRegs::LReg1];
+    sfpi::vUInt l2         = sfpi::l_reg[sfpi::LRegs::LReg2];
+    sfpi::vUInt l4         = sfpi::l_reg[sfpi::LRegs::LReg4];
+    sfpi::vUInt l5         = sfpi::l_reg[sfpi::LRegs::LReg5];
+    sfpi::vUInt l6         = sfpi::l_reg[sfpi::LRegs::LReg6];
 
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
@@ -33,12 +33,12 @@ inline void _calculate_sigmoid_(const int iterations)
         sfpi::dst_reg++;
     }
 
-    l_reg[LRegs::LReg0] = l0;
-    l_reg[LRegs::LReg1] = l1;
-    l_reg[LRegs::LReg2] = l2;
-    l_reg[LRegs::LReg4] = l4;
-    l_reg[LRegs::LReg5] = l5;
-    l_reg[LRegs::LReg6] = l6;
+    sfpi::l_reg[sfpi::LRegs::LReg0] = l0;
+    sfpi::l_reg[sfpi::LRegs::LReg1] = l1;
+    sfpi::l_reg[sfpi::LRegs::LReg2] = l2;
+    sfpi::l_reg[sfpi::LRegs::LReg4] = l4;
+    sfpi::l_reg[sfpi::LRegs::LReg5] = l5;
+    sfpi::l_reg[sfpi::LRegs::LReg6] = l6;
 }
 
 template <bool APPROXIMATION_MODE>

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_sigmoid.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_sigmoid.h
@@ -4,14 +4,8 @@
 
 #pragma once
 
-#include "ckernel_defs.h"
-#include "ckernel.h"
-#include "noc_nonblocking_api.h"
-#include "ckernel_sfpu_load_config.h"
-
 #include "sfpi.h"
-
-using namespace sfpi;
+#include "ckernel_sfpu_load_config.h"
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_sigmoid.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_sigmoid.h
@@ -26,11 +26,11 @@ inline void _calculate_sigmoid_(const int iterations)
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
     {
-        vFloat val = dst_reg[0];
+        sfpi::vFloat val = sfpi::dst_reg[0];
 
-        dst_reg[0] = lut2(val, l0, l1, l2, l4, l5, l6, lut_mode) + 0.5f;
+        sfpi::dst_reg[0] = lut2(val, l0, l1, l2, l4, l5, l6, lut_mode) + 0.5f;
 
-        dst_reg++;
+        sfpi::dst_reg++;
     }
 
     l_reg[LRegs::LReg0] = l0;

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_sigmoid.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_sigmoid.h
@@ -4,13 +4,8 @@
 
 #pragma once
 
-#include "ckernel.h"
-#include "ckernel_defs.h"
-#include "ckernel_sfpu_load_config.h"
-#include "noc_nonblocking_api.h"
 #include "sfpi.h"
-
-using namespace sfpi;
+#include "ckernel_sfpu_load_config.h"
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_sigmoid.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_sigmoid.h
@@ -4,8 +4,14 @@
 
 #pragma once
 
-#include "sfpi.h"
+#include "ckernel_defs.h"
+#include "ckernel.h"
+#include "noc_nonblocking_api.h"
 #include "ckernel_sfpu_load_config.h"
+
+#include "sfpi.h"
+
+using namespace sfpi;
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_sign.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_sign.h
@@ -4,14 +4,8 @@
 
 #pragma once
 
-#include "ckernel_defs.h"
-#include "ckernel.h"
-#include "noc_nonblocking_api.h"
-#include "ckernel_sfpu_is_fp16_zero.h"
-
 #include "sfpi.h"
-
-using namespace sfpi;
+#include "ckernel_sfpu_is_fp16_zero.h"
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_sign.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_sign.h
@@ -20,11 +20,11 @@ inline void _calculate_sign_(const int iterations, uint exponent_size_8)
 #pragma GCC unroll 0
     for (int d = 0; d < iterations; d++)
     {
-        vFloat v   = dst_reg[0];
-        dst_reg[0] = vConst1;
+        sfpi::vFloat v   = sfpi::dst_reg[0];
+        sfpi::dst_reg[0] = vConst1;
         v_if (v < 0.0F)
         {
-            dst_reg[0] = vConstNeg1;
+            sfpi::dst_reg[0] = vConstNeg1;
         }
         v_endif;
 
@@ -32,11 +32,11 @@ inline void _calculate_sign_(const int iterations, uint exponent_size_8)
         // param0 != 0 is Float16 format and exp bias needs to be removed for zero check.
         v_if (_sfpu_is_fp16_zero_(v, exponent_size_8))
         {
-            dst_reg[0] = vConst0;
+            sfpi::dst_reg[0] = vConst0;
         }
         v_endif;
 
-        dst_reg++;
+        sfpi::dst_reg++;
     }
 }
 

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_sign.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_sign.h
@@ -4,13 +4,8 @@
 
 #pragma once
 
-#include "ckernel.h"
-#include "ckernel_defs.h"
-#include "ckernel_sfpu_is_fp16_zero.h"
-#include "noc_nonblocking_api.h"
 #include "sfpi.h"
-
-using namespace sfpi;
+#include "ckernel_sfpu_is_fp16_zero.h"
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_sign.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_sign.h
@@ -4,8 +4,14 @@
 
 #pragma once
 
-#include "sfpi.h"
+#include "ckernel_defs.h"
+#include "ckernel.h"
+#include "noc_nonblocking_api.h"
 #include "ckernel_sfpu_is_fp16_zero.h"
+
+#include "sfpi.h"
+
+using namespace sfpi;
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_sign.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_sign.h
@@ -4,8 +4,8 @@
 
 #pragma once
 
-#include "sfpi.h"
 #include "ckernel_sfpu_is_fp16_zero.h"
+#include "sfpi.h"
 
 namespace ckernel
 {
@@ -21,10 +21,10 @@ inline void _calculate_sign_(const int iterations, uint exponent_size_8)
     for (int d = 0; d < iterations; d++)
     {
         sfpi::vFloat v   = sfpi::dst_reg[0];
-        sfpi::dst_reg[0] = vConst1;
+        sfpi::dst_reg[0] = sfpi::vConst1;
         v_if (v < 0.0F)
         {
-            sfpi::dst_reg[0] = vConstNeg1;
+            sfpi::dst_reg[0] = sfpi::vConstNeg1;
         }
         v_endif;
 
@@ -32,7 +32,7 @@ inline void _calculate_sign_(const int iterations, uint exponent_size_8)
         // param0 != 0 is Float16 format and exp bias needs to be removed for zero check.
         v_if (_sfpu_is_fp16_zero_(v, exponent_size_8))
         {
-            sfpi::dst_reg[0] = vConst0;
+            sfpi::dst_reg[0] = sfpi::vConst0;
         }
         v_endif;
 

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_sqrt.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_sqrt.h
@@ -4,8 +4,13 @@
 
 #pragma once
 
+#include "ckernel_defs.h"
+#include "ckernel.h"
+#include "noc_nonblocking_api.h"
+
 #include "sfpi.h"
-#include "sfpi_fp16.h"
+
+using namespace sfpi;
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_sqrt.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_sqrt.h
@@ -18,19 +18,19 @@ inline void _calculate_sqrt_(const int iterations)
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
     {
-        vFloat val = dst_reg[0];
+        sfpi::vFloat val = sfpi::dst_reg[0];
 
         if constexpr (APPROXIMATION_MODE)
         {
-            vUInt magic = vConstIntPrgm0;
+            sfpi::vUInt magic = sfpi::vConstIntPrgm0;
 
             // sqrt initial approximation
             //  adjust bias
-            vUInt val_s = magic + reinterpret<vUInt>(val);
+            sfpi::vUInt val_s = magic + sfpi::reinterpret<sfpi::vUInt>(val);
 
             // approximation of square root
             val_s >>= 1;
-            dst_reg[0] = reinterpret<vFloat>(val_s);
+            sfpi::dst_reg[0] = sfpi::reinterpret<sfpi::vFloat>(val_s);
         }
         else
         {
@@ -39,8 +39,8 @@ inline void _calculate_sqrt_(const int iterations)
             // u.i = SQRT_MAGIC_F - (u.i >> 1);
             v_if (val != 0.0f)
             {
-                vUInt magic   = vConstIntPrgm0;
-                vFloat approx = reinterpret<vFloat>(magic - (reinterpret<vUInt>(val) >> 1));
+                sfpi::vUInt magic   = sfpi::vConstIntPrgm0;
+                sfpi::vFloat approx = sfpi::reinterpret<sfpi::vFloat>(magic - (sfpi::reinterpret<sfpi::vUInt>(val) >> 1));
 
                 // Reciproot iterations
                 for (int r = 0; r < RECIPROCAL_ITERATIONS; r++)
@@ -49,12 +49,12 @@ inline void _calculate_sqrt_(const int iterations)
                     approx = ((approx * approx) * (val * -0.5f) + 1.5f) * approx;
                 }
 
-                dst_reg[0] = approx * val;
+                sfpi::dst_reg[0] = approx * val;
             }
             v_endif;
         }
 
-        dst_reg++;
+        sfpi::dst_reg++;
     }
 }
 
@@ -63,11 +63,11 @@ inline void _init_sqrt_()
 {
     if (APPROXIMATION_MODE)
     {
-        vConstFloatPrgm0 = s2vFloat16b(127 << 7);
+        sfpi::vConstFloatPrgm0 = sfpi::s2vFloat16b(127 << 7);
     }
     else
     {
-        vConstFloatPrgm0 = s2vFloat16b(0x5f37);
+        sfpi::vConstFloatPrgm0 = sfpi::s2vFloat16b(0x5f37);
     }
 }
 

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_sqrt.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_sqrt.h
@@ -4,13 +4,8 @@
 
 #pragma once
 
-#include "ckernel_defs.h"
-#include "ckernel.h"
-#include "noc_nonblocking_api.h"
-
 #include "sfpi.h"
-
-using namespace sfpi;
+#include "sfpi_fp16.h"
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_sqrt.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_sqrt.h
@@ -4,12 +4,8 @@
 
 #pragma once
 
-#include "ckernel.h"
-#include "ckernel_defs.h"
-#include "noc_nonblocking_api.h"
 #include "sfpi.h"
-
-using namespace sfpi;
+#include "sfpi_fp16.h"
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_square.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_square.h
@@ -4,7 +4,13 @@
 
 #pragma once
 
+#include "ckernel_defs.h"
+#include "ckernel.h"
+#include "noc_nonblocking_api.h"
+
 #include "sfpi.h"
+
+using namespace sfpi;
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_square.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_square.h
@@ -4,13 +4,7 @@
 
 #pragma once
 
-#include "ckernel_defs.h"
-#include "ckernel.h"
-#include "noc_nonblocking_api.h"
-
 #include "sfpi.h"
-
-using namespace sfpi;
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_square.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_square.h
@@ -17,12 +17,12 @@ inline void _calculate_square_(const int iterations)
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
     {
-        vFloat in     = dst_reg[0];
-        vFloat result = in * in;
+        sfpi::vFloat in     = sfpi::dst_reg[0];
+        sfpi::vFloat result = in * in;
 
-        dst_reg[0] = result;
+        sfpi::dst_reg[0] = result;
 
-        dst_reg++;
+        sfpi::dst_reg++;
     }
 }
 

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_square.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_square.h
@@ -4,12 +4,7 @@
 
 #pragma once
 
-#include "ckernel.h"
-#include "ckernel_defs.h"
-#include "noc_nonblocking_api.h"
 #include "sfpi.h"
-
-using namespace sfpi;
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_sub_int32.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_sub_int32.h
@@ -4,13 +4,8 @@
 
 #pragma once
 
-#include "ckernel_defs.h"
-#include "ckernel.h"
-#include "noc_nonblocking_api.h"
-
 #include "sfpi.h"
-
-using namespace sfpi;
+#include "ckernel_ops.h"
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_sub_int32.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_sub_int32.h
@@ -33,7 +33,7 @@ inline void _sub_int32_(const uint dst_offset)
         TTI_SFPIADD(0 /*imm*/, 1 /*lreg*/, 0 /*ldest*/, 6 /*imod*/);
         // LREG_0 -> dest as int32
         TTI_SFPSTORE(0 /*lreg_ind*/, sfpload_instr_mod, 3 /*addr_mode*/, 0 /*dest*/);
-        dst_reg++;
+        sfpi::dst_reg++;
     }
 }
 

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_sub_int32.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_sub_int32.h
@@ -4,12 +4,8 @@
 
 #pragma once
 
-#include "ckernel.h"
-#include "ckernel_defs.h"
-#include "noc_nonblocking_api.h"
 #include "sfpi.h"
-
-using namespace sfpi;
+#include "ckernel_ops.h"
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_sub_int32.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_sub_int32.h
@@ -4,8 +4,8 @@
 
 #pragma once
 
-#include "sfpi.h"
 #include "ckernel_ops.h"
+#include "sfpi.h"
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_sub_int32.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_sub_int32.h
@@ -4,8 +4,13 @@
 
 #pragma once
 
+#include "ckernel_defs.h"
+#include "ckernel.h"
+#include "noc_nonblocking_api.h"
+
 #include "sfpi.h"
-#include "ckernel_ops.h"
+
+using namespace sfpi;
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_tanh.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_tanh.h
@@ -4,14 +4,8 @@
 
 #pragma once
 
-#include "ckernel_defs.h"
-#include "ckernel.h"
-#include "noc_nonblocking_api.h"
-#include "ckernel_sfpu_load_config.h"
-
 #include "sfpi.h"
-
-using namespace sfpi;
+#include "ckernel_sfpu_load_config.h"
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_tanh.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_tanh.h
@@ -4,13 +4,8 @@
 
 #pragma once
 
-#include "ckernel.h"
-#include "ckernel_defs.h"
-#include "ckernel_sfpu_load_config.h"
-#include "noc_nonblocking_api.h"
 #include "sfpi.h"
-
-using namespace sfpi;
+#include "ckernel_sfpu_load_config.h"
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_tanh.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_tanh.h
@@ -4,8 +4,14 @@
 
 #pragma once
 
-#include "sfpi.h"
+#include "ckernel_defs.h"
+#include "ckernel.h"
+#include "noc_nonblocking_api.h"
 #include "ckernel_sfpu_load_config.h"
+
+#include "sfpi.h"
+
+using namespace sfpi;
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_tanh.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_tanh.h
@@ -23,11 +23,11 @@ inline void _calculate_tanh_(const int iterations)
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
     {
-        vFloat val = dst_reg[0];
+        sfpi::vFloat val = sfpi::dst_reg[0];
         val        = lut(val, l0, l1, l2);
-        dst_reg[0] = val;
+        sfpi::dst_reg[0] = val;
 
-        dst_reg++;
+        sfpi::dst_reg++;
     }
 
     l_reg[LRegs::LReg0] = l0;

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_tanh.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_tanh.h
@@ -4,8 +4,8 @@
 
 #pragma once
 
-#include "sfpi.h"
 #include "ckernel_sfpu_load_config.h"
+#include "sfpi.h"
 
 namespace ckernel
 {
@@ -16,23 +16,23 @@ template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void _calculate_tanh_(const int iterations)
 {
     // SFPU microcode
-    vUInt l0 = l_reg[LRegs::LReg0];
-    vUInt l1 = l_reg[LRegs::LReg1];
-    vUInt l2 = l_reg[LRegs::LReg2];
+    sfpi::vUInt l0 = sfpi::l_reg[sfpi::LRegs::LReg0];
+    sfpi::vUInt l1 = sfpi::l_reg[sfpi::LRegs::LReg1];
+    sfpi::vUInt l2 = sfpi::l_reg[sfpi::LRegs::LReg2];
 
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
     {
         sfpi::vFloat val = sfpi::dst_reg[0];
-        val        = lut(val, l0, l1, l2);
+        val              = lut(val, l0, l1, l2);
         sfpi::dst_reg[0] = val;
 
         sfpi::dst_reg++;
     }
 
-    l_reg[LRegs::LReg0] = l0;
-    l_reg[LRegs::LReg1] = l1;
-    l_reg[LRegs::LReg2] = l2;
+    sfpi::l_reg[sfpi::LRegs::LReg0] = l0;
+    sfpi::l_reg[sfpi::LRegs::LReg1] = l1;
+    sfpi::l_reg[sfpi::LRegs::LReg2] = l2;
 }
 
 template <bool APPROXIMATION_MODE>

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_tanh_derivative.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_tanh_derivative.h
@@ -4,7 +4,13 @@
 
 #pragma once
 
+#include "ckernel_defs.h"
+#include "ckernel.h"
+#include "noc_nonblocking_api.h"
+
 #include "sfpi.h"
+
+using namespace sfpi;
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_tanh_derivative.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_tanh_derivative.h
@@ -4,13 +4,7 @@
 
 #pragma once
 
-#include "ckernel_defs.h"
-#include "ckernel.h"
-#include "noc_nonblocking_api.h"
-
 #include "sfpi.h"
-
-using namespace sfpi;
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_tanh_derivative.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_tanh_derivative.h
@@ -14,9 +14,9 @@ namespace sfpu
 template <bool APPROXIMATION_MODE, int WITH_PRECOMPUTED_TANH, int ITERATIONS>
 inline void _calculate_tanh_derivative_(const int iterations)
 {
-    vUInt l0 = l_reg[LRegs::LReg0];
-    vUInt l1 = l_reg[LRegs::LReg1];
-    vUInt l2 = l_reg[LRegs::LReg2];
+    sfpi::vUInt l0 = sfpi::l_reg[sfpi::LRegs::LReg0];
+    sfpi::vUInt l1 = sfpi::l_reg[sfpi::LRegs::LReg1];
+    sfpi::vUInt l2 = sfpi::l_reg[sfpi::LRegs::LReg2];
 
     // tanh'(x) = 1 - (tanh(x))^2
     for (int d = 0; d < iterations; d++)
@@ -28,15 +28,15 @@ inline void _calculate_tanh_derivative_(const int iterations)
             val = lut(val, l0, l1, l2);
         }
 
-        val        = val * (-val) + vConst1;
+        val              = val * (-val) + sfpi::vConst1;
         sfpi::dst_reg[0] = val;
 
         sfpi::dst_reg++;
     }
 
-    l_reg[LRegs::LReg0] = l0;
-    l_reg[LRegs::LReg1] = l1;
-    l_reg[LRegs::LReg2] = l2;
+    sfpi::l_reg[sfpi::LRegs::LReg0] = l0;
+    sfpi::l_reg[sfpi::LRegs::LReg1] = l1;
+    sfpi::l_reg[sfpi::LRegs::LReg2] = l2;
 }
 
 } // namespace sfpu

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_tanh_derivative.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_tanh_derivative.h
@@ -4,12 +4,7 @@
 
 #pragma once
 
-#include "ckernel.h"
-#include "ckernel_defs.h"
-#include "noc_nonblocking_api.h"
 #include "sfpi.h"
-
-using namespace sfpi;
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_tanh_derivative.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_tanh_derivative.h
@@ -21,7 +21,7 @@ inline void _calculate_tanh_derivative_(const int iterations)
     // tanh'(x) = 1 - (tanh(x))^2
     for (int d = 0; d < iterations; d++)
     {
-        vFloat val = dst_reg[0];
+        sfpi::vFloat val = sfpi::dst_reg[0];
 
         if constexpr (!WITH_PRECOMPUTED_TANH)
         {
@@ -29,9 +29,9 @@ inline void _calculate_tanh_derivative_(const int iterations)
         }
 
         val        = val * (-val) + vConst1;
-        dst_reg[0] = val;
+        sfpi::dst_reg[0] = val;
 
-        dst_reg++;
+        sfpi::dst_reg++;
     }
 
     l_reg[LRegs::LReg0] = l0;

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_topk.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_topk.h
@@ -4,12 +4,14 @@
 
 #pragma once
 
-#include "sfpi.h"
+#include "ckernel_defs.h"
 #include "ckernel.h"
-#include "ckernel_ops.h"
-#include "ckernel_addrmod.h"
-#include "ckernel_instr_params.h"
+#include "noc_nonblocking_api.h"
 #include "ckernel_sfpu_load_config.h"
+
+#include "sfpi.h"
+
+using namespace sfpi;
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_topk.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_topk.h
@@ -4,13 +4,12 @@
 
 #pragma once
 
-#include "ckernel.h"
-#include "ckernel_defs.h"
-#include "ckernel_sfpu_load_config.h"
-#include "noc_nonblocking_api.h"
 #include "sfpi.h"
-
-using namespace sfpi;
+#include "ckernel.h"
+#include "ckernel_ops.h"
+#include "ckernel_addrmod.h"
+#include "ckernel_instr_params.h"
+#include "ckernel_sfpu_load_config.h"
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_topk.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_topk.h
@@ -4,14 +4,12 @@
 
 #pragma once
 
-#include "ckernel_defs.h"
-#include "ckernel.h"
-#include "noc_nonblocking_api.h"
-#include "ckernel_sfpu_load_config.h"
-
 #include "sfpi.h"
-
-using namespace sfpi;
+#include "ckernel.h"
+#include "ckernel_ops.h"
+#include "ckernel_addrmod.h"
+#include "ckernel_instr_params.h"
+#include "ckernel_sfpu_load_config.h"
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_topk.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_topk.h
@@ -4,12 +4,12 @@
 
 #pragma once
 
-#include "sfpi.h"
 #include "ckernel.h"
-#include "ckernel_ops.h"
 #include "ckernel_addrmod.h"
 #include "ckernel_instr_params.h"
+#include "ckernel_ops.h"
 #include "ckernel_sfpu_load_config.h"
+#include "sfpi.h"
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_trigonometry.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_trigonometry.h
@@ -4,7 +4,13 @@
 
 #pragma once
 
+#include "ckernel_defs.h"
+#include "ckernel.h"
+#include "noc_nonblocking_api.h"
+
 #include "sfpi.h"
+
+using namespace sfpi;
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_trigonometry.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_trigonometry.h
@@ -4,13 +4,7 @@
 
 #pragma once
 
-#include "ckernel_defs.h"
-#include "ckernel.h"
-#include "noc_nonblocking_api.h"
-
 #include "sfpi.h"
-
-using namespace sfpi;
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_trigonometry.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_trigonometry.h
@@ -79,10 +79,10 @@ inline void _calculate_sine_(const int iterations)
     for (int d = 0; d < iterations; d++)
     {
         sfpi::vFloat v             = sfpi::dst_reg[0];
-        v                    = 0.318309886183791f * v; // *1/pi to get number of pi rads.
+        v                          = 0.318309886183791f * v; // *1/pi to get number of pi rads.
         sfpi::vInt whole_v         = float_to_int16(v, 0);
         sfpi::vFloat whole_v_float = int32_to_float(whole_v, 0);
-        v                    = v - whole_v_float;
+        v                          = v - whole_v_float;
         v *= 3.141592653589793f; // fractional * pi to get it in [-pi:pi]
         v       = _sfpu_sine_maclaurin_series_<APPROXIMATION_MODE>(v);
         whole_v = whole_v & 0x1;
@@ -104,10 +104,10 @@ inline void _calculate_cosine_(const int iterations)
     for (int d = 0; d < iterations; d++)
     {
         sfpi::vFloat v             = sfpi::dst_reg[0];
-        v                    = 0.318309886183791f * v; // *1/pi to get number of pi rads.
+        v                          = 0.318309886183791f * v; // *1/pi to get number of pi rads.
         sfpi::vInt whole_v         = float_to_int16(v, 0);
         sfpi::vFloat whole_v_float = int32_to_float(whole_v, 0);
-        v                    = v - whole_v_float;
+        v                          = v - whole_v_float;
         v *= 3.141592653589793f; // fractional * pi to get it in [-pi:pi]
         v       = _sfpu_cosine_maclaurin_series_<APPROXIMATION_MODE>(v);
         whole_v = whole_v & 0x1;

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_trigonometry.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_trigonometry.h
@@ -12,13 +12,13 @@ namespace sfpu
 {
 
 template <bool APPROXIMATION_MODE>
-sfpi_inline vFloat _sfpu_sine_maclaurin_series_(vFloat val)
+sfpi_inline sfpi::vFloat _sfpu_sine_maclaurin_series_(sfpi::vFloat val)
 {
     // Good for [-pi:pi]
     // Mclauren series = x - x^3/3! + x^5/5! - x^7/7! + x^9/9! - x^11/11!
-    vFloat tmp = val;
+    sfpi::vFloat tmp = val;
     // x
-    vFloat output = tmp;
+    sfpi::vFloat output = tmp;
     // x^3/3!
     tmp = tmp * val * val;
     output += -0.166666666 * tmp;
@@ -43,14 +43,14 @@ sfpi_inline vFloat _sfpu_sine_maclaurin_series_(vFloat val)
 }
 
 template <bool APPROXIMATION_MODE>
-sfpi_inline vFloat _sfpu_cosine_maclaurin_series_(vFloat val)
+sfpi_inline sfpi::vFloat _sfpu_cosine_maclaurin_series_(sfpi::vFloat val)
 {
     // Good for [-pi:pi]
     // Mclauren series = 1 - x^2/2! + x^4/4! - x^6/6! + x^8/8! - x^10/10! + x^12/12!
     // 1
-    vFloat output = 1.0f;
+    sfpi::vFloat output = 1.0f;
     // x^2/2!
-    vFloat tmp = val * val;
+    sfpi::vFloat tmp = val * val;
     output += -0.5 * tmp;
     // x^4/4!
     tmp = tmp * val * val;
@@ -78,10 +78,10 @@ inline void _calculate_sine_(const int iterations)
     // SFPU microcode
     for (int d = 0; d < iterations; d++)
     {
-        vFloat v             = dst_reg[0];
+        sfpi::vFloat v             = sfpi::dst_reg[0];
         v                    = 0.318309886183791f * v; // *1/pi to get number of pi rads.
-        vInt whole_v         = float_to_int16(v, 0);
-        vFloat whole_v_float = int32_to_float(whole_v, 0);
+        sfpi::vInt whole_v         = float_to_int16(v, 0);
+        sfpi::vFloat whole_v_float = int32_to_float(whole_v, 0);
         v                    = v - whole_v_float;
         v *= 3.141592653589793f; // fractional * pi to get it in [-pi:pi]
         v       = _sfpu_sine_maclaurin_series_<APPROXIMATION_MODE>(v);
@@ -92,8 +92,8 @@ inline void _calculate_sine_(const int iterations)
             v *= -1;
         }
         v_endif;
-        dst_reg[0] = v;
-        dst_reg++;
+        sfpi::dst_reg[0] = v;
+        sfpi::dst_reg++;
     }
 }
 
@@ -103,10 +103,10 @@ inline void _calculate_cosine_(const int iterations)
     // SFPU microcode
     for (int d = 0; d < iterations; d++)
     {
-        vFloat v             = dst_reg[0];
+        sfpi::vFloat v             = sfpi::dst_reg[0];
         v                    = 0.318309886183791f * v; // *1/pi to get number of pi rads.
-        vInt whole_v         = float_to_int16(v, 0);
-        vFloat whole_v_float = int32_to_float(whole_v, 0);
+        sfpi::vInt whole_v         = float_to_int16(v, 0);
+        sfpi::vFloat whole_v_float = int32_to_float(whole_v, 0);
         v                    = v - whole_v_float;
         v *= 3.141592653589793f; // fractional * pi to get it in [-pi:pi]
         v       = _sfpu_cosine_maclaurin_series_<APPROXIMATION_MODE>(v);
@@ -117,8 +117,8 @@ inline void _calculate_cosine_(const int iterations)
             v *= -1;
         }
         v_endif;
-        dst_reg[0] = v;
-        dst_reg++;
+        sfpi::dst_reg[0] = v;
+        sfpi::dst_reg++;
     }
 }
 

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_trigonometry.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_trigonometry.h
@@ -4,12 +4,7 @@
 
 #pragma once
 
-#include "ckernel.h"
-#include "ckernel_defs.h"
-#include "noc_nonblocking_api.h"
 #include "sfpi.h"
-
-using namespace sfpi;
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_typecast.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_typecast.h
@@ -78,7 +78,7 @@ inline void _calculate_typecast_fp16b_to_int32_()
             // check sign
             v_if (in < 0)
             {
-                tmp = reinterpret<sfpi::vInt>(setsgn(reinterpret<sfpi::vFloat>(tmp), 1));
+                tmp = sfpi::reinterpret<sfpi::vInt>(sfpi::setsgn(sfpi::reinterpret<sfpi::vFloat>(tmp), 1));
             }
             v_endif sfpi::dst_reg[0] = tmp;
         }
@@ -92,7 +92,7 @@ inline void _calculate_typecast_fp16b_to_int32_()
             // check sign
             v_if (in < 0)
             {
-                man = reinterpret<sfpi::vInt>(sfpi::setsgn(sfpi::reinterpret<sfpi::vFloat>(man), 1));
+                man = sfpi::reinterpret<sfpi::vInt>(sfpi::setsgn(sfpi::reinterpret<sfpi::vFloat>(man), 1));
             }
             v_endif sfpi::dst_reg[0] = man;
         }
@@ -167,7 +167,7 @@ inline void _calculate_typecast_fp16b_to_uint32_()
             {
                 // set to uint32 max value in case of overflow
                 sfpi::vInt tmp   = std::numeric_limits<int32_t>::max();
-                sfpi::dst_reg[0] = setsgn(reinterpret<sfpi::vFloat>(tmp), 1);
+                sfpi::dst_reg[0] = sfpi::setsgn(reinterpret<sfpi::vFloat>(tmp), 1);
             }
             v_elseif (exp == 31)
             {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_typecast.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_typecast.h
@@ -4,14 +4,8 @@
 
 #pragma once
 
-#include <limits>
-
-#include "ckernel.h"
-#include "ckernel_defs.h"
-#include "noc_nonblocking_api.h"
 #include "sfpi.h"
-
-using namespace sfpi;
+#include "ckernel.h"
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_typecast.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_typecast.h
@@ -4,8 +4,14 @@
 
 #pragma once
 
-#include "sfpi.h"
+#include "ckernel_defs.h"
 #include "ckernel.h"
+#include "noc_nonblocking_api.h"
+#include <limits>
+
+#include "sfpi.h"
+
+using namespace sfpi;
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_typecast.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_typecast.h
@@ -167,7 +167,7 @@ inline void _calculate_typecast_fp16b_to_uint32_()
             {
                 // set to uint32 max value in case of overflow
                 sfpi::vInt tmp   = std::numeric_limits<int32_t>::max();
-                sfpi::dst_reg[0] = sfpi::setsgn(reinterpret<sfpi::vFloat>(tmp), 1);
+                sfpi::dst_reg[0] = sfpi::setsgn(sfpi::reinterpret<sfpi::vFloat>(tmp), 1);
             }
             v_elseif (exp == 31)
             {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_typecast.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_typecast.h
@@ -4,8 +4,8 @@
 
 #pragma once
 
-#include "sfpi.h"
 #include "ckernel.h"
+#include "sfpi.h"
 
 namespace ckernel
 {
@@ -88,11 +88,11 @@ inline void _calculate_typecast_fp16b_to_int32_()
             sfpi::vInt man = exman8(in);
             // shift the mantissa by (23-exponent) to the right
             sfpi::vInt shift = exp - 23;
-            man        = shft(reinterpret<vUInt>(man), shift);
+            man              = sfpi::shft(sfpi::reinterpret<sfpi::vUInt>(man), shift);
             // check sign
             v_if (in < 0)
             {
-                man = reinterpret<sfpi::vInt>(setsgn(reinterpret<sfpi::vFloat>(man), 1));
+                man = reinterpret<sfpi::vInt>(sfpi::setsgn(sfpi::reinterpret<sfpi::vFloat>(man), 1));
             }
             v_endif sfpi::dst_reg[0] = man;
         }
@@ -175,9 +175,9 @@ inline void _calculate_typecast_fp16b_to_uint32_()
                 sfpi::vInt man = exman9(in);
                 // shift the mantissa by (23-exponent) to the right
                 sfpi::vInt shift = exp - 23;
-                man        = shft(reinterpret<vUInt>(man), shift);
+                man              = sfpi::shft(sfpi::reinterpret<sfpi::vUInt>(man), shift);
                 // add hidden bit back (due to bug when shifting a 1 into MSB)
-                sfpi::dst_reg[0] = setsgn(reinterpret<sfpi::vFloat>(man), 1);
+                sfpi::dst_reg[0] = sfpi::setsgn(sfpi::reinterpret<sfpi::vFloat>(man), 1);
             }
             v_else
             {
@@ -185,7 +185,7 @@ inline void _calculate_typecast_fp16b_to_uint32_()
                 sfpi::vInt man = exman8(in);
                 // shift the mantissa by (23-exponent) to the right
                 sfpi::vInt shift = exp - 23;
-                man        = shft(reinterpret<vUInt>(man), shift);
+                man              = sfpi::shft(sfpi::reinterpret<sfpi::vUInt>(man), shift);
                 sfpi::dst_reg[0] = man;
             }
             v_endif

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_typecast.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_typecast.h
@@ -4,14 +4,8 @@
 
 #pragma once
 
-#include "ckernel_defs.h"
-#include "ckernel.h"
-#include "noc_nonblocking_api.h"
-#include <limits>
-
 #include "sfpi.h"
-
-using namespace sfpi;
+#include "ckernel.h"
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_typecast.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_typecast.h
@@ -24,7 +24,7 @@ inline void _calculate_typecast_fp16b_to_uint16_()
         TTI_SFPENCC(0, 0, 0, 0);
         TTI_SFP_STOCH_RND(0, 0, 2, 0, 1, 14);
         TTI_SFPSTORE(1, 6, 3, 0);
-        dst_reg++;
+        sfpi::dst_reg++;
     }
 }
 
@@ -38,7 +38,7 @@ inline void _calculate_typecast_uint16_to_fp16b_()
         TTI_SFPCAST(0, 1, 0);
         TTI_SFP_STOCH_RND(0, 0, 3, 1, 2, 1);
         TTI_SFPSTORE(2, 2, 3, 0);
-        dst_reg++;
+        sfpi::dst_reg++;
     }
 }
 
@@ -52,7 +52,7 @@ inline void _calculate_typecast_int32_to_fp16b_()
         TTI_SFPCAST(0, 1, 0);
         TTI_SFP_STOCH_RND(0, 0, 3, 1, 2, 1);
         TTI_SFPSTORE(2, 2, 3, 0);
-        dst_reg++;
+        sfpi::dst_reg++;
     }
 }
 
@@ -62,43 +62,43 @@ inline void _calculate_typecast_fp16b_to_int32_()
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++)
     {
-        vFloat in = dst_reg[0];
+        sfpi::vFloat in = sfpi::dst_reg[0];
 
         // extract exponent
-        vInt exp = exexp(in);
+        sfpi::vInt exp = exexp(in);
 
         v_if (exp < 0)
         {
-            dst_reg[0] = 0;
+            sfpi::dst_reg[0] = 0;
         }
         v_elseif (exp > 30)
         {
             // set to int32 max value in case of overflow
-            vInt tmp = std::numeric_limits<int32_t>::max();
+            sfpi::vInt tmp = std::numeric_limits<int32_t>::max();
             // check sign
             v_if (in < 0)
             {
-                tmp = reinterpret<vInt>(setsgn(reinterpret<vFloat>(tmp), 1));
+                tmp = reinterpret<sfpi::vInt>(setsgn(reinterpret<sfpi::vFloat>(tmp), 1));
             }
-            v_endif dst_reg[0] = tmp;
+            v_endif sfpi::dst_reg[0] = tmp;
         }
         v_else
         {
             // extract mantissa
-            vInt man = exman8(in);
+            sfpi::vInt man = exman8(in);
             // shift the mantissa by (23-exponent) to the right
-            vInt shift = exp - 23;
+            sfpi::vInt shift = exp - 23;
             man        = shft(reinterpret<vUInt>(man), shift);
             // check sign
             v_if (in < 0)
             {
-                man = reinterpret<vInt>(setsgn(reinterpret<vFloat>(man), 1));
+                man = reinterpret<sfpi::vInt>(setsgn(reinterpret<sfpi::vFloat>(man), 1));
             }
-            v_endif dst_reg[0] = man;
+            v_endif sfpi::dst_reg[0] = man;
         }
         v_endif
 
-            dst_reg++;
+            sfpi::dst_reg++;
     }
 }
 
@@ -111,7 +111,7 @@ inline void _calculate_typecast_fp32_to_fp16b_()
         TTI_SFPLOAD(0, 0, 3, 0);
         TTI_SFP_STOCH_RND(0, 0, 2, 0, 1, 1);
         TTI_SFPSTORE(1, 0, 3, 0);
-        dst_reg++;
+        sfpi::dst_reg++;
     }
 }
 
@@ -124,7 +124,7 @@ inline void _calculate_typecast_uint16_to_fp32_()
         TTI_SFPLOAD(0, 6, 3, 0);
         TTI_SFPCAST(0, 1, 0);
         TTI_SFPSTORE(1, 3, 3, 0);
-        dst_reg++;
+        sfpi::dst_reg++;
     }
 }
 
@@ -137,7 +137,7 @@ inline void _calculate_typecast_int32_to_fp32_()
         TTI_SFPLOAD(0, 12, 3, 0);
         TTI_SFPCAST(0, 1, 0);
         TTI_SFPSTORE(1, 3, 3, 0);
-        dst_reg++;
+        sfpi::dst_reg++;
     }
 }
 
@@ -147,52 +147,52 @@ inline void _calculate_typecast_fp16b_to_uint32_()
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++)
     {
-        vFloat in = dst_reg[0];
+        sfpi::vFloat in = sfpi::dst_reg[0];
 
         // check sign
         v_if (in <= 0)
         {
-            dst_reg[0] = 0;
+            sfpi::dst_reg[0] = 0;
         }
         v_else
         {
             // extract exponent
-            vInt exp = exexp(in);
+            sfpi::vInt exp = exexp(in);
 
             v_if (exp < 0)
             {
-                dst_reg[0] = 0;
+                sfpi::dst_reg[0] = 0;
             }
             v_elseif (exp > 31)
             {
                 // set to uint32 max value in case of overflow
-                vInt tmp   = std::numeric_limits<int32_t>::max();
-                dst_reg[0] = setsgn(reinterpret<vFloat>(tmp), 1);
+                sfpi::vInt tmp   = std::numeric_limits<int32_t>::max();
+                sfpi::dst_reg[0] = setsgn(reinterpret<sfpi::vFloat>(tmp), 1);
             }
             v_elseif (exp == 31)
             {
                 // extract mantissa without hidden bit
-                vInt man = exman9(in);
+                sfpi::vInt man = exman9(in);
                 // shift the mantissa by (23-exponent) to the right
-                vInt shift = exp - 23;
+                sfpi::vInt shift = exp - 23;
                 man        = shft(reinterpret<vUInt>(man), shift);
                 // add hidden bit back (due to bug when shifting a 1 into MSB)
-                dst_reg[0] = setsgn(reinterpret<vFloat>(man), 1);
+                sfpi::dst_reg[0] = setsgn(reinterpret<sfpi::vFloat>(man), 1);
             }
             v_else
             {
                 // extract mantissa
-                vInt man = exman8(in);
+                sfpi::vInt man = exman8(in);
                 // shift the mantissa by (23-exponent) to the right
-                vInt shift = exp - 23;
+                sfpi::vInt shift = exp - 23;
                 man        = shft(reinterpret<vUInt>(man), shift);
-                dst_reg[0] = man;
+                sfpi::dst_reg[0] = man;
             }
             v_endif
         }
         v_endif
 
-            dst_reg++;
+            sfpi::dst_reg++;
     }
 }
 
@@ -210,7 +210,7 @@ inline void _calculate_typecast_uint32_to_fp16b_()
         TTI_SFPADDI(0x4f00, 3, 0); // 2^31
         TTI_SFPENCC(0, 0, 0, 0);
         TTI_SFPSTORE(3, 2, 3, 0);
-        dst_reg++;
+        sfpi::dst_reg++;
     }
 }
 
@@ -227,7 +227,7 @@ inline void _calculate_typecast_uint32_to_fp32_()
         TTI_SFPADDI(0x4f00, 2, 0); // 2^31
         TTI_SFPENCC(0, 0, 0, 0);
         TTI_SFPSTORE(2, 3, 3, 0);
-        dst_reg++;
+        sfpi::dst_reg++;
     }
 }
 
@@ -239,7 +239,7 @@ inline void _calculate_typecast_uint16_to_uint32_()
     {
         TTI_SFPLOAD(0, 6, 3, 0);
         TTI_SFPSTORE(0, 4, 3, 0);
-        dst_reg++;
+        sfpi::dst_reg++;
     }
 }
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-llk/issues/20

### Problem description
Using using namespace in header files is generally considered bad practice because it can lead to namespace pollution and unexpected name conflicts. When you include a header file that uses using namespace, it brings all the names from the specified namespace into the global namespace of any file that includes it. This can cause name collisions and make the code harder to understand and maintain.

### What's changed
This PR originated as a bounty by an external contributor (see [PR #31](https://github.com/tenstorrent/tt-llk/pull/31)). We decided to assist since the contributor does not have access to the Blackhole card.

This PR removes the `using namespace sfpi` declaration. 

The following declarations are yet to be removed and will be addressed in separate PRs:
- `using namespace ckernel;`
- `using namespace ckernel::unpacker;`
- `using namespace ckernel::packer;`

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14106218031) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14106221514) CI passes (if applicable)
