### PR TITLE
#20 Remove using namespaces from blackhole

### DIFF
--- a/tests/sources/eltwise_unary_datacopy_test.cpp
+++ b/tests/sources/eltwise_unary_datacopy_test.cpp
@@ -26,6 +26,8 @@ const bool unpack_to_dest = true;
 const bool unpack_to_dest = false;
 #endif
 
+using namespace ckernel;
+
 #ifdef LLK_TRISC_UNPACK
 
 #include "llk_unpack_A.h"

--- a/tests/sources/eltwise_unary_sfpu_test.cpp
+++ b/tests/sources/eltwise_unary_sfpu_test.cpp
@@ -22,6 +22,8 @@ const bool is_fp32_dest_acc_en = true;
 const bool is_fp32_dest_acc_en = false;
 #endif
 
+using namespace ckernel;
+
 #ifdef LLK_TRISC_UNPACK
 
 #include "llk_unpack_A.h"
@@ -48,7 +50,7 @@ void run_kernel()
 #include "params.h"
 
 using namespace ckernel;
-using namespace ckernel::sfpu;
+using namespace sfpu;
 
 namespace
 {
@@ -57,15 +59,15 @@ void call_sfpu_operation(SfpuType operation)
     switch (operation)
     {
         case SfpuType::sqrt:
-            ckernel::sfpu::_init_sqrt_<APPROX_MODE>();
-            ckernel::sfpu::_calculate_sqrt_<APPROX_MODE, 0, 10>(10);
+            sfpu::_init_sqrt_<APPROX_MODE>();
+            sfpu::_calculate_sqrt_<APPROX_MODE, 0, 10>(10);
             break;
         case SfpuType::log:
-            ckernel::sfpu::_init_log_<APPROX_MODE>();
-            ckernel::sfpu::_calculate_log_<APPROX_MODE, false, 10>(10, 0);
+            sfpu::_init_log_<APPROX_MODE>();
+            sfpu::_calculate_log_<APPROX_MODE, false, 10>(10, 0);
             break;
         case SfpuType::square:
-            ckernel::sfpu::_calculate_square_<APPROX_MODE, 10>(10);
+            sfpu::_calculate_square_<APPROX_MODE, 10>(10);
             break;
         default:
             return;

--- a/tests/sources/fill_dest_test.cpp
+++ b/tests/sources/fill_dest_test.cpp
@@ -19,6 +19,8 @@ const bool is_fp32_dest_acc_en = true;
 const bool is_fp32_dest_acc_en = false;
 #endif
 
+using namespace ckernel;
+
 #ifdef LLK_TRISC_UNPACK
 
 #include "llk_unpack_AB.h"
@@ -46,8 +48,6 @@ void run_kernel()
 #include "llk_math_common.h"
 #include "llk_math_eltwise_binary.h"
 #include "params.h"
-
-using namespace ckernel;
 
 void run_kernel()
 {

--- a/tests/sources/matmul_test.cpp
+++ b/tests/sources/matmul_test.cpp
@@ -20,6 +20,8 @@ const bool is_fp32_dest_acc_en = true;
 const bool is_fp32_dest_acc_en = false;
 #endif
 
+using namespace ckernel;
+
 #ifdef LLK_TRISC_UNPACK
 
 #include "llk_unpack_AB_matmul.h"

--- a/tests/sources/multiple_tiles_eltwise_test.cpp
+++ b/tests/sources/multiple_tiles_eltwise_test.cpp
@@ -19,6 +19,8 @@ const bool is_fp32_dest_acc_en = true;
 const bool is_fp32_dest_acc_en = false;
 #endif
 
+using namespace ckernel;
+
 #ifdef LLK_TRISC_UNPACK
 
 #include "llk_unpack_AB.h"

--- a/tests/sources/pack_untilize_test.cpp
+++ b/tests/sources/pack_untilize_test.cpp
@@ -19,6 +19,8 @@ const bool is_fp32_dest_acc_en = true;
 const bool is_fp32_dest_acc_en = false;
 #endif
 
+using namespace ckernel;
+
 #ifdef LLK_TRISC_UNPACK
 
 #include "llk_unpack_A.h"

--- a/tests/sources/unpack_tilize_test.cpp
+++ b/tests/sources/unpack_tilize_test.cpp
@@ -18,6 +18,8 @@ const bool is_fp32_dest_acc_en = true;
 const bool is_fp32_dest_acc_en = false;
 #endif
 
+using namespace ckernel;
+
 #ifdef LLK_TRISC_UNPACK
 
 #include "llk_unpack_common.h"

--- a/tests/sources/unpack_untilize_test.cpp
+++ b/tests/sources/unpack_untilize_test.cpp
@@ -19,6 +19,8 @@ const bool is_fp32_dest_acc_en = true;
 const bool is_fp32_dest_acc_en = false;
 #endif
 
+using namespace ckernel;
+
 #ifdef LLK_TRISC_UNPACK
 
 #include "llk_unpack_A.h"

--- a/tt_llk_blackhole/common/inc/ckernel_sfpi.h
+++ b/tt_llk_blackhole/common/inc/ckernel_sfpi.h
@@ -17,8 +17,6 @@
 #define sfpi_test_noinline
 #endif
 
-using namespace ckernel;
-
 namespace sfpi_test
 {
 

--- a/tt_llk_blackhole/common/inc/cmath_common.h
+++ b/tt_llk_blackhole/common/inc/cmath_common.h
@@ -21,8 +21,6 @@
 #define FUSE_SQRT_RECIP 0
 #endif
 
-using namespace ckernel;
-
 namespace ckernel::math
 {
 

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_cumsum.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_cumsum.h
@@ -149,7 +149,7 @@ inline void _calculate_cumsum_(const bool first)
 template <bool APPROXIMATION_MODE /*unused*/>
 inline void _cumsum_init_()
 {
-    load_replay_buf<0, 16, 0>(
+    ckernel::load_replay_buf<0, 16, 0>(
         []
         {
             TTI_SFPADD(10, 7, 0, 0, 0);

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_topk.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_topk.h
@@ -136,7 +136,7 @@ inline void bitonic_topk_ph3_st4_to_1(bool dir, bool &init_replay, int replay_st
 
     if (init_replay)
     {
-        load_replay_buf(
+        ckernel::load_replay_buf(
             replay_start,
             7,
             1,
@@ -302,7 +302,7 @@ inline void _bitonic_topk_phases_steps(const int idir, const int i_end_phase, co
                             // Groups of 16 datums being sorted at the same time
                             if (init_load)
                             {
-                                load_replay_buf<0, 8, true>([] { bitonic_topk_load16(4, 8); });
+                                ckernel::load_replay_buf<0, 8, true>([] { bitonic_topk_load16(4, 8); });
                                 init_load = false;
                             }
                             else
@@ -311,7 +311,7 @@ inline void _bitonic_topk_phases_steps(const int idir, const int i_end_phase, co
                             }
                             if (init_phase)
                             {
-                                load_replay_buf<16, 7, true>([] { bitonic_topk_ph0_st1_to_1(); });
+                                ckernel::load_replay_buf<16, 7, true>([] { bitonic_topk_ph0_st1_to_1(); });
                                 init_phase = false;
                             }
                             else
@@ -320,7 +320,7 @@ inline void _bitonic_topk_phases_steps(const int idir, const int i_end_phase, co
                             }
                             if (init_store)
                             {
-                                load_replay_buf<8, 8, true>([] { bitonic_topk_store16<true>(4, 8); });
+                                ckernel::load_replay_buf<8, 8, true>([] { bitonic_topk_store16<true>(4, 8); });
                                 init_store = false;
                             }
                             else
@@ -336,7 +336,7 @@ inline void _bitonic_topk_phases_steps(const int idir, const int i_end_phase, co
                             TTI_REPLAY(0, 8, 0, 0);
                             if (init_phase)
                             {
-                                load_replay_buf<16, 8, true>([] { bitonic_topk_ph1_st2_to_1(); });
+                                ckernel::load_replay_buf<16, 8, true>([] { bitonic_topk_ph1_st2_to_1(); });
                                 init_phase = false;
                             }
                             else
@@ -352,7 +352,7 @@ inline void _bitonic_topk_phases_steps(const int idir, const int i_end_phase, co
                             TTI_REPLAY(0, 8, 0, 0);
                             if (init_phase)
                             {
-                                load_replay_buf<16, 13, true>([] { bitonic_topk_ph2_st3_to_1(); });
+                                ckernel::load_replay_buf<16, 13, true>([] { bitonic_topk_ph2_st3_to_1(); });
                                 init_phase = false;
                             }
                             else
@@ -521,7 +521,7 @@ inline void _bitonic_topk_rebuild(const bool idir, const int m_iter, const int k
                             // Groups of 8 datums being sorted at the same time
                             if (init_rebuild)
                             {
-                                load_replay_buf<0, 24, true>(
+                                ckernel::load_replay_buf<0, 24, true>(
                                     [ld_offset]
                                     {
                                         bitonic_topk_load8(0, ld_offset);
@@ -547,7 +547,7 @@ inline void _bitonic_topk_rebuild(const bool idir, const int m_iter, const int k
                             // Groups of 16 datums being sorted at the same time
                             if (init_rebuild)
                             {
-                                load_replay_buf<0, 28, true>(
+                                ckernel::load_replay_buf<0, 28, true>(
                                     [ld_offset, ld_dist]
                                     {
                                         bitonic_topk_load16(ld_offset, ld_dist);
@@ -574,7 +574,7 @@ inline void _bitonic_topk_rebuild(const bool idir, const int m_iter, const int k
                         // Groups of 16 datums being sorted at the same time
                         if (init_rebuild)
                         {
-                            load_replay_buf<0, 32, true>(
+                            ckernel::load_replay_buf<0, 32, true>(
                                 [ld_offset]
                                 {
                                     bitonic_topk_load16(4, ld_offset);
@@ -601,9 +601,9 @@ inline void _bitonic_topk_rebuild(const bool idir, const int m_iter, const int k
                         // Groups of 16 datums being sorted at the same time
                         if (init_rebuild)
                         {
-                            load_replay_buf<0, 8, true>([] { bitonic_topk_load16(4, 8); });
+                            ckernel::load_replay_buf<0, 8, true>([] { bitonic_topk_load16(4, 8); });
                             bitonic_topk_ph3_st4_to_1(dir, init_rebuild, 8);
-                            load_replay_buf<15, 12, true>(
+                            ckernel::load_replay_buf<15, 12, true>(
                                 []
                                 {
                                     bitonic_topk_store16<true>(4, 8);
@@ -673,9 +673,9 @@ inline void _bitonic_topk_rebuild(const bool idir, const int m_iter, const int k
                     {
                         if (init_rebuild)
                         {
-                            load_replay_buf<0, 8, true>([] { bitonic_topk_load16(4, 8); });
+                            ckernel::load_replay_buf<0, 8, true>([] { bitonic_topk_load16(4, 8); });
                             bitonic_topk_ph3_st4_to_1(dir, init_rebuild, 8);
-                            load_replay_buf<15, 8, true>([] { bitonic_topk_store16<true>(4, 8); });
+                            ckernel::load_replay_buf<15, 8, true>([] { bitonic_topk_store16<true>(4, 8); });
                         }
                         else
                         {

--- a/tt_llk_blackhole/llk_lib/llk_math_common.h
+++ b/tt_llk_blackhole/llk_lib/llk_math_common.h
@@ -14,36 +14,34 @@
 #include "ckernel_perf_api.h"
 #endif
 
-using namespace ckernel::math;
-
 template <bool untilize_en = false, bool skip_inputs = false>
 inline void _llk_math_hw_configure_(const std::uint32_t srca_data_format, const std::uint32_t srcb_data_format)
 {
     // Need to wait for all DEST accesses to be finished before changing
     // remap_addrs and swizzle_32b bits
-    tensix_sync();
-    while (semaphore_read(semaphore::MATH_PACK) > 0)
+    ckernel::tensix_sync();
+    while (ckernel::semaphore_read(ckernel::semaphore::MATH_PACK) > 0)
     {
     }; // Wait for previous packs to finish before claiming all dest
 
     // Untilize mode needs dest read access with a stride of 16
     // Following bits are needed for enabling stride of 16
-    cfg_reg_rmw_tensix<DEST_ACCESS_CFG_remap_addrs_RMW>(untilize_en);
-    cfg_reg_rmw_tensix<DEST_ACCESS_CFG_swizzle_32b_RMW>(untilize_en);
+    ckernel::cfg_reg_rmw_tensix<DEST_ACCESS_CFG_remap_addrs_RMW>(untilize_en);
+    ckernel::cfg_reg_rmw_tensix<DEST_ACCESS_CFG_swizzle_32b_RMW>(untilize_en);
 
     // Legacy mode for ZEROACC
-    cfg_reg_rmw_tensix<DEST_ACCESS_CFG_zeroacc_absolute_tile_mode_RMW>(1);
+    ckernel::cfg_reg_rmw_tensix<DEST_ACCESS_CFG_zeroacc_absolute_tile_mode_RMW>(1);
 
     if constexpr (skip_inputs == false)
     {
-        TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::MATH);
+        TTI_STALLWAIT(ckernel::p_stall::STALL_CFG, ckernel::p_stall::MATH);
         uint int8_math_enabled = ((uint)(srca_data_format & 0xF) == (uint)DataFormat::Int8) || ((uint)(srcb_data_format & 0xF) == (uint)DataFormat::Int8) ||
                                  ((uint)srca_data_format == (uint)DataFormat::Int32) || ((uint)srcb_data_format == (uint)DataFormat::Int32);
-        cfg_reg_rmw_tensix<ALU_ACC_CTRL_INT8_math_enabled_RMW>(int8_math_enabled);
+        ckernel::cfg_reg_rmw_tensix<ALU_ACC_CTRL_INT8_math_enabled_RMW>(int8_math_enabled);
     }
 }
 
-template <DstSync Dst>
+template <ckernel::DstSync Dst>
 inline void _llk_math_wait_for_dest_available_()
 {
     // These liteweight functions for sync with packer imply
@@ -54,11 +52,11 @@ inline void _llk_math_wait_for_dest_available_()
         math_dest_wait();
     }
 #else
-    math_dest_wait();
+    ckernel::math::math_dest_wait();
 #endif
 }
 
-template <DstSync Dst, bool is_fp32_dest_acc_en = false>
+template <ckernel::DstSync Dst, bool is_fp32_dest_acc_en = false>
 inline void _llk_math_dest_section_done_()
 {
 #ifdef PERF_DUMP
@@ -69,22 +67,22 @@ inline void _llk_math_dest_section_done_()
 #endif
 
     constexpr uint32_t DEST_NUM_TILES_SHIFT = is_fp32_dest_acc_en ? (1) : (0);
-    constexpr uint32_t DEST_NUM_TILES       = DEST_NUM_TILES_FP16 >> DEST_NUM_TILES_SHIFT;
+    constexpr uint32_t DEST_NUM_TILES       = ckernel::DEST_NUM_TILES_FP16 >> DEST_NUM_TILES_SHIFT;
 
-    set_math_semaphores();
-    if constexpr ((Dst == DstSync::SyncHalf) || (Dst == DstSync::SyncTile2))
+    ckernel::math::set_math_semaphores();
+    if constexpr ((Dst == ckernel::DstSync::SyncHalf) || (Dst == ckernel::DstSync::SyncTile2))
     {
         math_sync_tile_dst_index = 0;
-        dest_section_flip();
+        ckernel::math::dest_section_flip();
     }
-    else if constexpr (Dst == DstSync::SyncTile16)
+    else if constexpr (Dst == ckernel::DstSync::SyncTile16)
     {
         math_sync_tile_dst_index++;
         math_sync_tile_dst_index &= (DEST_NUM_TILES - 1);
     }
 }
 
-template <DstSync Dst, bool is_fp32_dest_acc_en = false>
+template <ckernel::DstSync Dst, bool is_fp32_dest_acc_en = false>
 inline void _llk_math_pack_sync_init_()
 {
 #ifdef PERF_DUMP
@@ -93,40 +91,40 @@ inline void _llk_math_pack_sync_init_()
         return;
     }
 #endif
-    tensix_sync();
-    while (semaphore_read(semaphore::MATH_PACK) > 0)
+    ckernel::tensix_sync();
+    while (ckernel::semaphore_read(ckernel::semaphore::MATH_PACK) > 0)
     {
     }; // Wait for previous packs to finish before claiming all dest
-    if constexpr (Dst == DstSync::SyncFull)
+    if constexpr (Dst == ckernel::DstSync::SyncFull)
     {
-        TTI_SEMINIT(1, 0, p_stall::SEMAPHORE_1);
-        reset_dest_offset_id();
-        set_dest_section_base<StartZero>();
+        TTI_SEMINIT(1, 0, ckernel::p_stall::SEMAPHORE_1);
+        ckernel::reset_dest_offset_id();
+        ckernel::math::set_dest_section_base<ckernel::StartZero>();
     }
-    else if constexpr (Dst == DstSync::SyncHalf)
+    else if constexpr (Dst == ckernel::DstSync::SyncHalf)
     {
-        TTI_SEMINIT(2, 0, p_stall::SEMAPHORE_1);
-        reset_dest_offset_id();
-        set_dest_section_base<StartZero>();
+        TTI_SEMINIT(2, 0, ckernel::p_stall::SEMAPHORE_1);
+        ckernel::reset_dest_offset_id();
+        ckernel::math::set_dest_section_base<ckernel::StartZero>();
     }
-    else if constexpr (Dst == DstSync::SyncTile2)
+    else if constexpr (Dst == ckernel::DstSync::SyncTile2)
     {
-        TTI_SEMINIT(2, 0, p_stall::SEMAPHORE_1);
-        reset_dest_offset_id();
-        set_dest_section_base<StartZero>();
+        TTI_SEMINIT(2, 0, ckernel::p_stall::SEMAPHORE_1);
+        ckernel::reset_dest_offset_id();
+        ckernel::math::set_dest_section_base<ckernel::StartZero>();
         math_sync_tile_dst_index = 0;
     }
     else
     {
-        static_assert(Dst == DstSync::SyncTile16);
+        static_assert(Dst == ckernel::DstSync::SyncTile16);
 
         constexpr uint32_t DEST_NUM_TILES_SHIFT = is_fp32_dest_acc_en ? (1) : (0);
-        constexpr uint32_t DEST_NUM_TILES       = DEST_NUM_TILES_FP16 >> DEST_NUM_TILES_SHIFT;
+        constexpr uint32_t DEST_NUM_TILES       = ckernel::DEST_NUM_TILES_FP16 >> DEST_NUM_TILES_SHIFT;
         constexpr uint32_t SEM_INIT_MAX         = (DEST_NUM_TILES < 15) ? DEST_NUM_TILES : 15;
 
-        TTI_SEMINIT(SEM_INIT_MAX, 0, p_stall::SEMAPHORE_1);
-        reset_dest_offset_id();
-        set_dest_section_base<StartZero>();
+        TTI_SEMINIT(SEM_INIT_MAX, 0, ckernel::p_stall::SEMAPHORE_1);
+        ckernel::reset_dest_offset_id();
+        ckernel::math::set_dest_section_base<ckernel::StartZero>();
         math_sync_tile_dst_index = 0;
     }
 }
@@ -136,7 +134,7 @@ inline void _llk_math_get_tile_(std::uint32_t tile_index, std::uint32_t* p_tile)
 {
     if constexpr (mail2math)
     {
-        *p_tile = mailbox_read(ThreadId::UnpackThreadId);
+        *p_tile = ckernel::mailbox_read(ckernel::ThreadId::UnpackThreadId);
     }
     else
     {
@@ -149,18 +147,18 @@ inline void _llk_math_release_tile_()
 {
     if constexpr (mail2math)
     {
-        semaphore_get(semaphore::UNPACK_OPERAND_SYNC);
+        ckernel::semaphore_get(ckernel::semaphore::UNPACK_OPERAND_SYNC);
     }
 }
 
 inline void _llk_math_debug_dump_(std::uint8_t* data, std::uint32_t byte_size)
 {
-    debug_dump(data, byte_size);
+    ckernel::debug_dump(data, byte_size);
 }
 
 inline void _llk_math_debug_dump_seek_(std::uint8_t offset)
 {
-    debug_dump_seek(offset);
+    ckernel::debug_dump_seek(offset);
 }
 
 // Following functions do not need to program ALU_FORMAT_SPEC_REG0_SrcA/ALU_FORMAT_SPEC_REG1_SrcB
@@ -171,9 +169,9 @@ inline void _llk_math_reconfig_data_format_srca_(const std::uint32_t srca_data_f
     if constexpr (to_from_int8)
     {
         static_assert(is_fp32_dest_acc_en, "Reconfiguring math to/from Int8 formats requires FP32 Dest mode enabled");
-        TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::MATH);
+        TTI_STALLWAIT(ckernel::p_stall::STALL_CFG, ckernel::p_stall::MATH);
         uint int8_math_enabled = ((uint)(srca_data_format & 0xF) == (uint)DataFormat::Int8) || ((uint)srca_data_format == (uint)DataFormat::Int32);
-        cfg_reg_rmw_tensix<ALU_ACC_CTRL_INT8_math_enabled_RMW>(int8_math_enabled);
+        ckernel::cfg_reg_rmw_tensix<ALU_ACC_CTRL_INT8_math_enabled_RMW>(int8_math_enabled);
     }
 }
 
@@ -183,9 +181,9 @@ inline void _llk_math_reconfig_data_format_srcb_(const std::uint32_t srcb_data_f
     if constexpr (to_from_int8)
     {
         static_assert(is_fp32_dest_acc_en, "Reconfiguring math to/from Int8 formats requires FP32 Dest mode enabled");
-        TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::MATH);
+        TTI_STALLWAIT(ckernel::p_stall::STALL_CFG, ckernel::p_stall::MATH);
         uint int8_math_enabled = ((uint)(srcb_data_format & 0xF) == (uint)DataFormat::Int8) || ((uint)srcb_data_format == (uint)DataFormat::Int32);
-        cfg_reg_rmw_tensix<ALU_ACC_CTRL_INT8_math_enabled_RMW>(int8_math_enabled);
+        ckernel::cfg_reg_rmw_tensix<ALU_ACC_CTRL_INT8_math_enabled_RMW>(int8_math_enabled);
     }
 }
 
@@ -195,19 +193,19 @@ inline void _llk_math_reconfig_data_format_(const std::uint32_t srca_data_format
     if constexpr (to_from_int8)
     {
         static_assert(is_fp32_dest_acc_en, "Reconfiguring math to/from Int8 formats requires FP32 Dest mode enabled");
-        TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::MATH);
+        TTI_STALLWAIT(ckernel::p_stall::STALL_CFG, ckernel::p_stall::MATH);
         uint int8_math_enabled = ((uint)(srca_data_format & 0xF) == (uint)DataFormat::Int8) || ((uint)(srcb_data_format & 0xF) == (uint)DataFormat::Int8) ||
                                  ((uint)srca_data_format == (uint)DataFormat::Int32) || ((uint)srcb_data_format == (uint)DataFormat::Int32);
-        cfg_reg_rmw_tensix<ALU_ACC_CTRL_INT8_math_enabled_RMW>(int8_math_enabled);
+        ckernel::cfg_reg_rmw_tensix<ALU_ACC_CTRL_INT8_math_enabled_RMW>(int8_math_enabled);
     }
 }
 
 inline std::uint32_t _llk_math_get_compute_special_value_flags_()
 {
-    return reg_read(RISCV_DEBUG_REG_FPU_STICKY_BITS);
+    return ckernel::reg_read(RISCV_DEBUG_REG_FPU_STICKY_BITS);
 }
 
 inline void _llk_math_clear_compute_special_value_flags_()
 {
-    reg_write(RISCV_DEBUG_REG_FPU_STICKY_BITS, 0);
+    ckernel::reg_write(RISCV_DEBUG_REG_FPU_STICKY_BITS, 0);
 }

--- a/tt_llk_blackhole/llk_lib/llk_math_eltwise_binary.h
+++ b/tt_llk_blackhole/llk_lib/llk_math_eltwise_binary.h
@@ -12,48 +12,46 @@
 #include "cmath_common.h"
 #include "llk_math_common.h"
 
-using namespace ckernel;
-
 // local function declarations
 inline void eltwise_binary_configure_addrmod();
 
-template <EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE>
+template <ckernel::EltwiseBinaryReuseDestType binary_reuse_dest = ckernel::EltwiseBinaryReuseDestType::NONE>
 inline void eltwise_binary_reuse_dest_as_src()
 {
-    if constexpr (binary_reuse_dest == EltwiseBinaryReuseDestType::DEST_TO_SRCA)
+    if constexpr (binary_reuse_dest == ckernel::EltwiseBinaryReuseDestType::DEST_TO_SRCA)
     {
-        move_d2a_fixed_face(ADDR_MOD_1);
+        ckernel::math::move_d2a_fixed_face(ckernel::ADDR_MOD_1);
     }
-    else if constexpr (binary_reuse_dest == EltwiseBinaryReuseDestType::DEST_TO_SRCB)
+    else if constexpr (binary_reuse_dest == ckernel::EltwiseBinaryReuseDestType::DEST_TO_SRCB)
     {
-        move_d2b_fixed_face(ADDR_MOD_1);
+        ckernel::math::move_d2b_fixed_face(ckernel::ADDR_MOD_1);
     }
 }
 
 template <
-    EltwiseBinaryType eltwise_binary_type,
-    BroadcastType src_b_bcast_type,
-    DstSync Dst,
-    int NUM_FIDELITY_PHASES                      = 0,
-    EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE,
-    bool is_fp32_dest_acc_en                     = false>
+    ckernel::EltwiseBinaryType eltwise_binary_type,
+    ckernel::BroadcastType src_b_bcast_type,
+    ckernel::DstSync Dst,
+    int NUM_FIDELITY_PHASES                               = 0,
+    ckernel::EltwiseBinaryReuseDestType binary_reuse_dest = ckernel::EltwiseBinaryReuseDestType::NONE,
+    bool is_fp32_dest_acc_en                              = false>
 inline void _llk_math_eltwise_binary_(const std::uint32_t num_faces, uint dst_index, const bool clear_fp32_dst_acc)
 {
     constexpr bool high_fidelity     = (NUM_FIDELITY_PHASES > 0);
-    constexpr uint32_t ZERO_ACC_MODE = p_zeroacc::CLR_16;
+    constexpr uint32_t ZERO_ACC_MODE = ckernel::p_zeroacc::CLR_16;
 
-    if constexpr ((Dst == DstSync::SyncTile16) || (Dst == DstSync::SyncTile2))
+    if constexpr ((Dst == ckernel::DstSync::SyncTile16) || (Dst == ckernel::DstSync::SyncTile2))
     {
-        math::set_dst_write_addr<DstTileLayout::Default, DstTileShape::Tile32x32>(math_sync_tile_dst_index);
+        ckernel::math::set_dst_write_addr<ckernel::DstTileLayout::Default, ckernel::DstTileShape::Tile32x32>(math_sync_tile_dst_index);
 
-        if constexpr (eltwise_binary_type == ELWMUL)
+        if constexpr (eltwise_binary_type == ckernel::ELWMUL)
         {
             if (is_fp32_dest_acc_en && clear_fp32_dst_acc)
             {
 #pragma GCC unroll 0
                 for (std::uint32_t i = 0; i < 8; i++)
                 {
-                    TT_ZEROACC(ZERO_ACC_MODE, is_fp32_dest_acc_en, 0, ADDR_MOD_1, (math_sync_tile_dst_index << 3) + i);
+                    TT_ZEROACC(ZERO_ACC_MODE, is_fp32_dest_acc_en, 0, ckernel::ADDR_MOD_1, (math_sync_tile_dst_index << 3) + i);
                 }
             }
             else
@@ -61,14 +59,15 @@ inline void _llk_math_eltwise_binary_(const std::uint32_t num_faces, uint dst_in
 #pragma GCC unroll 0
                 for (std::uint32_t i = 0; i < 4; i++)
                 {
-                    TT_ZEROACC(ZERO_ACC_MODE, is_fp32_dest_acc_en, 0, ADDR_MOD_1, (math_sync_tile_dst_index << 2) + i);
+                    TT_ZEROACC(ZERO_ACC_MODE, is_fp32_dest_acc_en, 0, ckernel::ADDR_MOD_1, (math_sync_tile_dst_index << 2) + i);
                 }
             }
         }
-        else if constexpr (binary_reuse_dest != EltwiseBinaryReuseDestType::NONE)
+        else if constexpr (binary_reuse_dest != ckernel::EltwiseBinaryReuseDestType::NONE)
         {
             static_assert(
-                !(binary_reuse_dest != EltwiseBinaryReuseDestType::NONE && (Dst == DstSync::SyncTile16) || (Dst == DstSync::SyncTile2)),
+                !(binary_reuse_dest != ckernel::EltwiseBinaryReuseDestType::NONE && (Dst == ckernel::DstSync::SyncTile16) ||
+                  (Dst == ckernel::DstSync::SyncTile2)),
                 "Dst clear in DstSync::SyncTile16 or DstSync::SyncTile2 dst sync mode is not supported!");
             /*
             if (clear_dest_acc) {
@@ -89,59 +88,59 @@ inline void _llk_math_eltwise_binary_(const std::uint32_t num_faces, uint dst_in
     }
     else
     {
-        math::set_dst_write_addr<DstTileLayout::Default, DstTileShape::Tile32x32>(dst_index);
+        ckernel::math::set_dst_write_addr<ckernel::DstTileLayout::Default, ckernel::DstTileShape::Tile32x32>(dst_index);
     }
 
-    if constexpr ((eltwise_binary_type == ELWADD) || (eltwise_binary_type == ELWSUB))
+    if constexpr ((eltwise_binary_type == ckernel::ELWADD) || (eltwise_binary_type == ckernel::ELWSUB))
     {
-        if constexpr (src_b_bcast_type == BroadcastType::COL)
+        if constexpr (src_b_bcast_type == ckernel::BroadcastType::COL)
         {
             // Mop for col broadcast only does 2 outerloops.  Needs to clear B manually and call twice
-            constexpr uint32_t outerloop = (binary_reuse_dest != EltwiseBinaryReuseDestType::NONE) ? 2 : 1;
+            constexpr uint32_t outerloop = (binary_reuse_dest != ckernel::EltwiseBinaryReuseDestType::NONE) ? 2 : 1;
 #pragma GCC unroll 0
             for (std::uint32_t face_num = 0; face_num < outerloop; face_num++)
             {
                 eltwise_binary_reuse_dest_as_src<binary_reuse_dest>();
-                ckernel_template::run(instrn_buffer);
+                ckernel::ckernel_template::run(ckernel::instrn_buffer);
             }
-            TTI_SETRWC(p_setrwc::CLR_B, 0, 0, 0, 0, 0);
+            TTI_SETRWC(ckernel::p_setrwc::CLR_B, 0, 0, 0, 0, 0);
 #pragma GCC unroll 0
             for (std::uint32_t face_num = 0; face_num < outerloop; face_num++)
             {
                 eltwise_binary_reuse_dest_as_src<binary_reuse_dest>();
-                ckernel_template::run(instrn_buffer);
+                ckernel::ckernel_template::run(ckernel::instrn_buffer);
             }
-            TTI_SETRWC(p_setrwc::CLR_B, 0, 0, 0, 0, 0);
+            TTI_SETRWC(ckernel::p_setrwc::CLR_B, 0, 0, 0, 0, 0);
         }
         else
         {
-            constexpr uint32_t outerloop = (binary_reuse_dest != EltwiseBinaryReuseDestType::NONE) ? 4 : 1;
+            constexpr uint32_t outerloop = (binary_reuse_dest != ckernel::EltwiseBinaryReuseDestType::NONE) ? 4 : 1;
 #pragma GCC unroll 0
             for (std::uint32_t face_num = 0; face_num < outerloop; face_num++)
             {
                 eltwise_binary_reuse_dest_as_src<binary_reuse_dest>();
-                ckernel_template::run(instrn_buffer);
+                ckernel::ckernel_template::run(ckernel::instrn_buffer);
             }
             // Manually clear B once mop is done for scaler bcast
-            if constexpr (src_b_bcast_type == BroadcastType::SCALAR)
+            if constexpr (src_b_bcast_type == ckernel::BroadcastType::SCALAR)
             {
-                TTI_SETRWC(p_setrwc::CLR_B, 0, 0, 0, 0, p_setrwc::SET_D);
+                TTI_SETRWC(ckernel::p_setrwc::CLR_B, 0, 0, 0, 0, ckernel::p_setrwc::SET_D);
             }
         }
     }
-    else if constexpr (eltwise_binary_type == ELWMUL)
+    else if constexpr (eltwise_binary_type == ckernel::ELWMUL)
     {
-        if constexpr (src_b_bcast_type == BroadcastType::COL)
+        if constexpr (src_b_bcast_type == ckernel::BroadcastType::COL)
         {
             // Mop for col broadcast only does 2 outerloops.  Needs to clear B manually and call twice
-            constexpr uint32_t outerloop = (binary_reuse_dest != EltwiseBinaryReuseDestType::NONE) ? 2 : 1;
+            constexpr uint32_t outerloop = (binary_reuse_dest != ckernel::EltwiseBinaryReuseDestType::NONE) ? 2 : 1;
             if constexpr (high_fidelity)
             {
 #pragma GCC unroll 0
                 for (std::uint32_t face_num = 0; face_num < 2; face_num++)
                 {
                     eltwise_binary_reuse_dest_as_src<binary_reuse_dest>();
-                    if constexpr (binary_reuse_dest != EltwiseBinaryReuseDestType::NONE)
+                    if constexpr (binary_reuse_dest != ckernel::EltwiseBinaryReuseDestType::NONE)
                     {
                         // We clear the DEST face-by-face, given the DEST base, tile index and face index
                         if (is_fp32_dest_acc_en && clear_fp32_dst_acc)
@@ -150,8 +149,9 @@ inline void _llk_math_eltwise_binary_(const std::uint32_t num_faces, uint dst_in
                                 ZERO_ACC_MODE,
                                 1 /*clear fp32*/,
                                 0,
-                                ADDR_MOD_1,
-                                (get_dest_buffer_base_32b() + get_dest_index_in_faces(dst_index, (0 + face_num)))); // Clear faces 0 & 1
+                                ckernel::ADDR_MOD_1,
+                                (ckernel::math::get_dest_buffer_base_32b() +
+                                 ckernel::math::get_dest_index_in_faces(dst_index, (0 + face_num)))); // Clear faces 0 & 1
                         }
                         else
                         {
@@ -159,11 +159,12 @@ inline void _llk_math_eltwise_binary_(const std::uint32_t num_faces, uint dst_in
                                 ZERO_ACC_MODE,
                                 0 /*clear fp32*/,
                                 0,
-                                ADDR_MOD_1,
-                                (get_dest_buffer_base_16b() + get_dest_index_in_faces(dst_index, (0 + face_num)))); // Clear faces 0 & 1
+                                ckernel::ADDR_MOD_1,
+                                (ckernel::math::get_dest_buffer_base_16b() +
+                                 ckernel::math::get_dest_index_in_faces(dst_index, (0 + face_num)))); // Clear faces 0 & 1
                         }
                     }
-                    ckernel_template::run(instrn_buffer);
+                    ckernel::ckernel_template::run(ckernel::instrn_buffer);
                 }
             }
             else
@@ -172,7 +173,7 @@ inline void _llk_math_eltwise_binary_(const std::uint32_t num_faces, uint dst_in
                 for (std::uint32_t face_num = 0; face_num < outerloop; face_num++)
                 {
                     eltwise_binary_reuse_dest_as_src<binary_reuse_dest>();
-                    if constexpr (binary_reuse_dest != EltwiseBinaryReuseDestType::NONE)
+                    if constexpr (binary_reuse_dest != ckernel::EltwiseBinaryReuseDestType::NONE)
                     {
                         // We clear the DEST face-by-face, given the DEST base, tile index and face index
                         if (is_fp32_dest_acc_en && clear_fp32_dst_acc)
@@ -181,8 +182,9 @@ inline void _llk_math_eltwise_binary_(const std::uint32_t num_faces, uint dst_in
                                 ZERO_ACC_MODE,
                                 1 /*clear fp32*/,
                                 0,
-                                ADDR_MOD_1,
-                                (get_dest_buffer_base_32b() + get_dest_index_in_faces(dst_index, (0 + face_num)))); // Clear faces 0 & 1
+                                ckernel::ADDR_MOD_1,
+                                (ckernel::math::get_dest_buffer_base_32b() +
+                                 ckernel::math::get_dest_index_in_faces(dst_index, (0 + face_num)))); // Clear faces 0 & 1
                         }
                         else
                         {
@@ -190,21 +192,22 @@ inline void _llk_math_eltwise_binary_(const std::uint32_t num_faces, uint dst_in
                                 ZERO_ACC_MODE,
                                 0 /*clear fp32*/,
                                 0,
-                                ADDR_MOD_1,
-                                (get_dest_buffer_base_16b() + get_dest_index_in_faces(dst_index, (0 + face_num)))); // Clear faces 0 & 1
+                                ckernel::ADDR_MOD_1,
+                                (ckernel::math::get_dest_buffer_base_16b() +
+                                 ckernel::math::get_dest_index_in_faces(dst_index, (0 + face_num)))); // Clear faces 0 & 1
                         }
                     }
-                    ckernel_template::run(instrn_buffer);
+                    ckernel::ckernel_template::run(ckernel::instrn_buffer);
                 }
             }
-            TTI_SETRWC(p_setrwc::CLR_B, 0, 0, 0, 0, 0);
+            TTI_SETRWC(ckernel::p_setrwc::CLR_B, 0, 0, 0, 0, 0);
             if constexpr (high_fidelity)
             {
 #pragma GCC unroll 0
                 for (std::uint32_t face_num = 0; face_num < 2; face_num++)
                 {
                     eltwise_binary_reuse_dest_as_src<binary_reuse_dest>();
-                    if constexpr (binary_reuse_dest != EltwiseBinaryReuseDestType::NONE)
+                    if constexpr (binary_reuse_dest != ckernel::EltwiseBinaryReuseDestType::NONE)
                     {
                         // We clear the DEST face-by-face, given the DEST base, tile index and face index
                         if (is_fp32_dest_acc_en && clear_fp32_dst_acc)
@@ -213,8 +216,9 @@ inline void _llk_math_eltwise_binary_(const std::uint32_t num_faces, uint dst_in
                                 ZERO_ACC_MODE,
                                 1 /*clear fp32*/,
                                 0,
-                                ADDR_MOD_1,
-                                (get_dest_buffer_base_32b() + get_dest_index_in_faces(dst_index, (2 + face_num)))); // Clear faces 2 & 3
+                                ckernel::ADDR_MOD_1,
+                                (ckernel::math::get_dest_buffer_base_32b() +
+                                 ckernel::math::get_dest_index_in_faces(dst_index, (2 + face_num)))); // Clear faces 2 & 3
                         }
                         else
                         {
@@ -222,11 +226,12 @@ inline void _llk_math_eltwise_binary_(const std::uint32_t num_faces, uint dst_in
                                 ZERO_ACC_MODE,
                                 0 /*clear fp32*/,
                                 0,
-                                ADDR_MOD_1,
-                                (get_dest_buffer_base_16b() + get_dest_index_in_faces(dst_index, (2 + face_num)))); // Clear faces 2 & 3
+                                ckernel::ADDR_MOD_1,
+                                (ckernel::math::get_dest_buffer_base_16b() +
+                                 ckernel::math::get_dest_index_in_faces(dst_index, (2 + face_num)))); // Clear faces 2 & 3
                         }
                     }
-                    ckernel_template::run(instrn_buffer);
+                    ckernel::ckernel_template::run(ckernel::instrn_buffer);
                 }
             }
             else
@@ -235,7 +240,7 @@ inline void _llk_math_eltwise_binary_(const std::uint32_t num_faces, uint dst_in
                 for (std::uint32_t face_num = 0; face_num < outerloop; face_num++)
                 {
                     eltwise_binary_reuse_dest_as_src<binary_reuse_dest>();
-                    if constexpr (binary_reuse_dest != EltwiseBinaryReuseDestType::NONE)
+                    if constexpr (binary_reuse_dest != ckernel::EltwiseBinaryReuseDestType::NONE)
                     {
                         // We clear the DEST face-by-face, given the DEST base, tile index and face index
                         if (is_fp32_dest_acc_en && clear_fp32_dst_acc)
@@ -244,8 +249,9 @@ inline void _llk_math_eltwise_binary_(const std::uint32_t num_faces, uint dst_in
                                 ZERO_ACC_MODE,
                                 1 /*clear fp32*/,
                                 0,
-                                ADDR_MOD_1,
-                                (get_dest_buffer_base_32b() + get_dest_index_in_faces(dst_index, (2 + face_num)))); // Clear faces 2 & 3
+                                ckernel::ADDR_MOD_1,
+                                (ckernel::math::get_dest_buffer_base_32b() +
+                                 ckernel::math::get_dest_index_in_faces(dst_index, (2 + face_num)))); // Clear faces 2 & 3
                         }
                         else
                         {
@@ -253,40 +259,49 @@ inline void _llk_math_eltwise_binary_(const std::uint32_t num_faces, uint dst_in
                                 ZERO_ACC_MODE,
                                 0 /*clear fp32*/,
                                 0,
-                                ADDR_MOD_1,
-                                (get_dest_buffer_base_16b() + get_dest_index_in_faces(dst_index, (2 + face_num)))); // Clear faces 2 & 3
+                                ckernel::ADDR_MOD_1,
+                                (ckernel::math::get_dest_buffer_base_16b() +
+                                 ckernel::math::get_dest_index_in_faces(dst_index, (2 + face_num)))); // Clear faces 2 & 3
                         }
                     }
-                    ckernel_template::run(instrn_buffer);
+                    ckernel::ckernel_template::run(ckernel::instrn_buffer);
                 }
             }
-            TTI_SETRWC(p_setrwc::CLR_B, 0, 0, 0, 0, 0);
+            TTI_SETRWC(ckernel::p_setrwc::CLR_B, 0, 0, 0, 0, 0);
         }
         else
         {
             // Row and no broadcasted behaves similarly
-            const uint32_t outerloop = (binary_reuse_dest != EltwiseBinaryReuseDestType::NONE) ? num_faces : 1;
+            const uint32_t outerloop = (binary_reuse_dest != ckernel::EltwiseBinaryReuseDestType::NONE) ? num_faces : 1;
             if constexpr (high_fidelity)
             {
 #pragma GCC unroll 0
                 for (std::uint32_t face_num = 0; face_num < num_faces; face_num++)
                 {
                     eltwise_binary_reuse_dest_as_src<binary_reuse_dest>();
-                    if constexpr (binary_reuse_dest != EltwiseBinaryReuseDestType::NONE)
+                    if constexpr (binary_reuse_dest != ckernel::EltwiseBinaryReuseDestType::NONE)
                     {
                         // We clear the DEST face-by-face, given the DEST base, tile index and face index
                         if (is_fp32_dest_acc_en && clear_fp32_dst_acc)
                         {
                             TT_ZEROACC(
-                                ZERO_ACC_MODE, 1 /*clear fp32*/, 0, ADDR_MOD_1, (get_dest_buffer_base_32b() + get_dest_index_in_faces(dst_index, face_num)));
+                                ZERO_ACC_MODE,
+                                1 /*clear fp32*/,
+                                0,
+                                ckernel::ADDR_MOD_1,
+                                (ckernel::math::get_dest_buffer_base_32b() + ckernel::math::get_dest_index_in_faces(dst_index, face_num)));
                         }
                         else
                         {
                             TT_ZEROACC(
-                                ZERO_ACC_MODE, 0 /*clear fp32*/, 0, ADDR_MOD_1, (get_dest_buffer_base_16b() + get_dest_index_in_faces(dst_index, face_num)));
+                                ZERO_ACC_MODE,
+                                0 /*clear fp32*/,
+                                0,
+                                ckernel::ADDR_MOD_1,
+                                (ckernel::math::get_dest_buffer_base_16b() + ckernel::math::get_dest_index_in_faces(dst_index, face_num)));
                         }
                     }
-                    ckernel_template::run(instrn_buffer);
+                    ckernel::ckernel_template::run(ckernel::instrn_buffer);
                 }
             }
             else
@@ -295,26 +310,34 @@ inline void _llk_math_eltwise_binary_(const std::uint32_t num_faces, uint dst_in
                 for (std::uint32_t face_num = 0; face_num < outerloop; face_num++)
                 {
                     eltwise_binary_reuse_dest_as_src<binary_reuse_dest>();
-                    if constexpr (binary_reuse_dest != EltwiseBinaryReuseDestType::NONE)
+                    if constexpr (binary_reuse_dest != ckernel::EltwiseBinaryReuseDestType::NONE)
                     {
                         // We clear the DEST face-by-face, given the DEST base, tile index and face index
                         if (is_fp32_dest_acc_en && clear_fp32_dst_acc)
                         {
                             TT_ZEROACC(
-                                ZERO_ACC_MODE, 1 /*clear fp32*/, 0, ADDR_MOD_1, (get_dest_buffer_base_32b() + get_dest_index_in_faces(dst_index, face_num)));
+                                ZERO_ACC_MODE,
+                                1 /*clear fp32*/,
+                                0,
+                                ckernel::ADDR_MOD_1,
+                                (ckernel::math::get_dest_buffer_base_32b() + ckernel::math::get_dest_index_in_faces(dst_index, face_num)));
                         }
                         else
                         {
                             TT_ZEROACC(
-                                ZERO_ACC_MODE, 0 /*clear fp32*/, 0, ADDR_MOD_1, (get_dest_buffer_base_16b() + get_dest_index_in_faces(dst_index, face_num)));
+                                ZERO_ACC_MODE,
+                                0 /*clear fp32*/,
+                                0,
+                                ckernel::ADDR_MOD_1,
+                                (ckernel::math::get_dest_buffer_base_16b() + ckernel::math::get_dest_index_in_faces(dst_index, face_num)));
                         }
                     }
-                    ckernel_template::run(instrn_buffer);
+                    ckernel::ckernel_template::run(ckernel::instrn_buffer);
                 }
             }
-            if constexpr (src_b_bcast_type == BroadcastType::SCALAR)
+            if constexpr (src_b_bcast_type == ckernel::BroadcastType::SCALAR)
             {
-                TTI_SETRWC(p_setrwc::CLR_B, 0, 0, 0, 0, p_setrwc::SET_D);
+                TTI_SETRWC(ckernel::p_setrwc::CLR_B, 0, 0, 0, 0, ckernel::p_setrwc::SET_D);
             }
         }
     }
@@ -322,159 +345,159 @@ inline void _llk_math_eltwise_binary_(const std::uint32_t num_faces, uint dst_in
     {
         FWASSERT("Unsupported op!", false);
     }
-    math::clear_dst_reg_addr();
+    ckernel::math::clear_dst_reg_addr();
 }
 
-template <EltwiseBinaryType eltwise_binary_type, BroadcastType bcast_type, std::uint32_t FIDELITY_INCREMENT>
+template <ckernel::EltwiseBinaryType eltwise_binary_type, ckernel::BroadcastType bcast_type, std::uint32_t FIDELITY_INCREMENT>
 inline void eltwise_binary_configure_addrmod()
 {
     // Use srcA for data movement
-    if constexpr ((eltwise_binary_type == ELWADD) || (eltwise_binary_type == ELWSUB) || (eltwise_binary_type == ELWMUL))
+    if constexpr ((eltwise_binary_type == ckernel::ELWADD) || (eltwise_binary_type == ckernel::ELWSUB) || (eltwise_binary_type == ckernel::ELWMUL))
     {
-        if constexpr (bcast_type == BroadcastType::NONE || bcast_type == BroadcastType::COL)
+        if constexpr (bcast_type == ckernel::BroadcastType::NONE || bcast_type == ckernel::BroadcastType::COL)
         {
-            addr_mod_t {
+            ckernel::addr_mod_t {
                 .srca = {.incr = 8},
                 .srcb = {.incr = 8},
                 .dest = {.incr = 8},
             }
-                .set(ADDR_MOD_0);
+                .set(ckernel::ADDR_MOD_0);
         }
-        else if constexpr (bcast_type == BroadcastType::ROW || bcast_type == BroadcastType::SCALAR)
+        else if constexpr (bcast_type == ckernel::BroadcastType::ROW || bcast_type == ckernel::BroadcastType::SCALAR)
         {
-            addr_mod_t {
+            ckernel::addr_mod_t {
                 .srca = {.incr = 8},
                 .srcb = {.incr = 0},
                 .dest = {.incr = 8},
             }
-                .set(ADDR_MOD_0);
+                .set(ckernel::ADDR_MOD_0);
         }
-        addr_mod_t {
+        ckernel::addr_mod_t {
             .srca = {.incr = 0},
             .srcb = {.incr = 0},
             .dest = {.incr = 0},
         }
-            .set(ADDR_MOD_1);
+            .set(ckernel::ADDR_MOD_1);
 
-        addr_mod_t {
+        ckernel::addr_mod_t {
             .srca = {.incr = 0, .clr = 1}, .srcb = {.incr = 0, .clr = 1}, .dest = {.incr = 0, .clr = 0, .cr = 1}, .fidelity = {.incr = FIDELITY_INCREMENT}}
-            .set(ADDR_MOD_2);
+            .set(ckernel::ADDR_MOD_2);
 
-        addr_mod_t {
+        ckernel::addr_mod_t {
             .srca     = {.incr = 0, .clr = 1},
             .srcb     = {.incr = 0, .clr = 1},
             .dest     = {.incr = 8, .clr = 0, .cr = 0, .c_to_cr = 1},
             .fidelity = {.incr = 0, .clr = 1}}
-            .set(ADDR_MOD_3);
+            .set(ckernel::ADDR_MOD_3);
     }
 }
 
 template <
-    EltwiseBinaryType eltwise_binary_type,
-    BroadcastType bcast_type,
-    int NUM_FIDELITY_PHASES                      = 0,
-    EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE>
+    ckernel::EltwiseBinaryType eltwise_binary_type,
+    ckernel::BroadcastType bcast_type,
+    int NUM_FIDELITY_PHASES                               = 0,
+    ckernel::EltwiseBinaryReuseDestType binary_reuse_dest = ckernel::EltwiseBinaryReuseDestType::NONE>
 inline void eltwise_binary_configure_mop(const std::uint32_t acc_to_dest = 0, const std::uint32_t num_faces = 4)
 {
     constexpr bool high_fidelity = (NUM_FIDELITY_PHASES > 0);
-    const uint addr_mod          = ADDR_MOD_0;
+    const uint addr_mod          = ckernel::ADDR_MOD_0;
     constexpr uint innerloop     = 16 >> 3; // 8 rows per eltwise op at a time.
     uint outerloop               = num_faces;
-    auto broadcast_type          = p_elwise::SRCB_NO_BCAST;
-    if constexpr (bcast_type == BroadcastType::COL)
+    auto broadcast_type          = ckernel::p_elwise::SRCB_NO_BCAST;
+    if constexpr (bcast_type == ckernel::BroadcastType::COL)
     {
         // The mop only runs for 2 outer loops and mop is called twice for col broadcast
         outerloop      = 2;
-        broadcast_type = p_elwise::SRCB_BCAST_COL;
+        broadcast_type = ckernel::p_elwise::SRCB_BCAST_COL;
     }
-    else if constexpr (bcast_type == BroadcastType::ROW)
+    else if constexpr (bcast_type == ckernel::BroadcastType::ROW)
     {
-        broadcast_type = p_elwise::SRCB_BCAST_ROW;
+        broadcast_type = ckernel::p_elwise::SRCB_BCAST_ROW;
     }
-    else if constexpr (bcast_type == BroadcastType::SCALAR)
+    else if constexpr (bcast_type == ckernel::BroadcastType::SCALAR)
     {
-        broadcast_type = p_elwise::SRCB_BCAST_ALL;
+        broadcast_type = ckernel::p_elwise::SRCB_BCAST_ALL;
     }
 
-    if constexpr (binary_reuse_dest != EltwiseBinaryReuseDestType::NONE)
+    if constexpr (binary_reuse_dest != ckernel::EltwiseBinaryReuseDestType::NONE)
     {
         outerloop = 1;
     }
 
     // Scalar and Col broadcast should not Clear B within a mop.  This is controlled outside of MOP.
-    if constexpr (bcast_type == BroadcastType::COL || bcast_type == BroadcastType::SCALAR)
+    if constexpr (bcast_type == ckernel::BroadcastType::COL || bcast_type == ckernel::BroadcastType::SCALAR)
     {
-        if constexpr (eltwise_binary_type == ELWADD)
+        if constexpr (eltwise_binary_type == ckernel::ELWADD)
         {
-            ckernel_template tmp(outerloop, innerloop, TT_OP_ELWADD(0, acc_to_dest, broadcast_type, addr_mod, 0));
-            tmp.set_end_op(TT_OP_SETRWC(p_setrwc::CLR_A, p_setrwc::CR_AB, 0, 0, 0, p_setrwc::SET_AB));
-            tmp.program(instrn_buffer);
+            ckernel::ckernel_template tmp(outerloop, innerloop, TT_OP_ELWADD(0, acc_to_dest, broadcast_type, addr_mod, 0));
+            tmp.set_end_op(TT_OP_SETRWC(ckernel::p_setrwc::CLR_A, ckernel::p_setrwc::CR_AB, 0, 0, 0, ckernel::p_setrwc::SET_AB));
+            tmp.program(ckernel::instrn_buffer);
         }
-        else if constexpr (eltwise_binary_type == ELWSUB)
+        else if constexpr (eltwise_binary_type == ckernel::ELWSUB)
         {
-            ckernel_template tmp(outerloop, innerloop, TT_OP_ELWSUB(0, acc_to_dest, broadcast_type, addr_mod, 0));
-            tmp.set_end_op(TT_OP_SETRWC(p_setrwc::CLR_A, p_setrwc::CR_AB, 0, 0, 0, p_setrwc::SET_AB));
-            tmp.program(instrn_buffer);
+            ckernel::ckernel_template tmp(outerloop, innerloop, TT_OP_ELWSUB(0, acc_to_dest, broadcast_type, addr_mod, 0));
+            tmp.set_end_op(TT_OP_SETRWC(ckernel::p_setrwc::CLR_A, ckernel::p_setrwc::CR_AB, 0, 0, 0, ckernel::p_setrwc::SET_AB));
+            tmp.program(ckernel::instrn_buffer);
         }
-        else if constexpr (eltwise_binary_type == ELWMUL)
+        else if constexpr (eltwise_binary_type == ckernel::ELWMUL)
         {
-            ckernel_template tmp(high_fidelity ? NUM_FIDELITY_PHASES : outerloop, innerloop, TT_OP_ELWMUL(0, 0, broadcast_type, addr_mod, 0));
+            ckernel::ckernel_template tmp(high_fidelity ? NUM_FIDELITY_PHASES : outerloop, innerloop, TT_OP_ELWMUL(0, 0, broadcast_type, addr_mod, 0));
             if constexpr (high_fidelity)
             {
-                tmp.set_last_inner_loop_instr(TT_OP_ELWMUL(0, 0, broadcast_type, ADDR_MOD_2, 0)); // Incr fidelity last inst of inner loop
-                tmp.set_last_outer_loop_instr(TT_OP_ELWMUL(p_setrwc::CLR_A, 0, broadcast_type, ADDR_MOD_3, 0));
+                tmp.set_last_inner_loop_instr(TT_OP_ELWMUL(0, 0, broadcast_type, ckernel::ADDR_MOD_2, 0)); // Incr fidelity last inst of inner loop
+                tmp.set_last_outer_loop_instr(TT_OP_ELWMUL(ckernel::p_setrwc::CLR_A, 0, broadcast_type, ckernel::ADDR_MOD_3, 0));
             }
             else
             {
-                tmp.set_end_op(TT_OP_SETRWC(p_setrwc::CLR_A, p_setrwc::CR_AB, 0, 0, 0, p_setrwc::SET_AB));
+                tmp.set_end_op(TT_OP_SETRWC(ckernel::p_setrwc::CLR_A, ckernel::p_setrwc::CR_AB, 0, 0, 0, ckernel::p_setrwc::SET_AB));
             }
-            tmp.program(instrn_buffer);
+            tmp.program(ckernel::instrn_buffer);
         }
     }
     else
     {
-        if constexpr (eltwise_binary_type == ELWADD)
+        if constexpr (eltwise_binary_type == ckernel::ELWADD)
         {
-            ckernel_template tmp(outerloop, innerloop, TT_OP_ELWADD(0, acc_to_dest, broadcast_type, addr_mod, 0));
-            tmp.set_end_op(TT_OP_SETRWC(p_setrwc::CLR_AB, p_setrwc::CR_AB, 0, 0, 0, p_setrwc::SET_AB));
-            tmp.program(instrn_buffer);
+            ckernel::ckernel_template tmp(outerloop, innerloop, TT_OP_ELWADD(0, acc_to_dest, broadcast_type, addr_mod, 0));
+            tmp.set_end_op(TT_OP_SETRWC(ckernel::p_setrwc::CLR_AB, ckernel::p_setrwc::CR_AB, 0, 0, 0, ckernel::p_setrwc::SET_AB));
+            tmp.program(ckernel::instrn_buffer);
         }
-        else if constexpr (eltwise_binary_type == ELWSUB)
+        else if constexpr (eltwise_binary_type == ckernel::ELWSUB)
         {
-            ckernel_template tmp(outerloop, innerloop, TT_OP_ELWSUB(0, acc_to_dest, broadcast_type, addr_mod, 0));
-            tmp.set_end_op(TT_OP_SETRWC(p_setrwc::CLR_AB, p_setrwc::CR_AB, 0, 0, 0, p_setrwc::SET_AB));
-            tmp.program(instrn_buffer);
+            ckernel::ckernel_template tmp(outerloop, innerloop, TT_OP_ELWSUB(0, acc_to_dest, broadcast_type, addr_mod, 0));
+            tmp.set_end_op(TT_OP_SETRWC(ckernel::p_setrwc::CLR_AB, ckernel::p_setrwc::CR_AB, 0, 0, 0, ckernel::p_setrwc::SET_AB));
+            tmp.program(ckernel::instrn_buffer);
         }
-        else if constexpr (eltwise_binary_type == ELWMUL)
+        else if constexpr (eltwise_binary_type == ckernel::ELWMUL)
         {
-            ckernel_template tmp(high_fidelity ? NUM_FIDELITY_PHASES : outerloop, innerloop, TT_OP_ELWMUL(0, 0, broadcast_type, addr_mod, 0));
+            ckernel::ckernel_template tmp(high_fidelity ? NUM_FIDELITY_PHASES : outerloop, innerloop, TT_OP_ELWMUL(0, 0, broadcast_type, addr_mod, 0));
             if constexpr (high_fidelity)
             {
-                tmp.set_last_inner_loop_instr(TT_OP_ELWMUL(0, 0, broadcast_type, ADDR_MOD_2, 0)); // Incr fidelity last inst of inner loop
-                tmp.set_last_outer_loop_instr(TT_OP_ELWMUL(p_setrwc::CLR_AB, 0, broadcast_type, ADDR_MOD_3, 0));
+                tmp.set_last_inner_loop_instr(TT_OP_ELWMUL(0, 0, broadcast_type, ckernel::ADDR_MOD_2, 0)); // Incr fidelity last inst of inner loop
+                tmp.set_last_outer_loop_instr(TT_OP_ELWMUL(ckernel::p_setrwc::CLR_AB, 0, broadcast_type, ckernel::ADDR_MOD_3, 0));
             }
             else
             {
-                tmp.set_end_op(TT_OP_SETRWC(p_setrwc::CLR_AB, p_setrwc::CR_AB, 0, 0, 0, p_setrwc::SET_AB));
+                tmp.set_end_op(TT_OP_SETRWC(ckernel::p_setrwc::CLR_AB, ckernel::p_setrwc::CR_AB, 0, 0, 0, ckernel::p_setrwc::SET_AB));
             }
-            tmp.program(instrn_buffer);
+            tmp.program(ckernel::instrn_buffer);
         }
     }
 }
 
 template <
-    EltwiseBinaryType eltwise_binary_type,
-    BroadcastType src_b_bcast_type,
-    int MATH_FIDELITY_DESC                       = 0,
-    EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE>
+    ckernel::EltwiseBinaryType eltwise_binary_type,
+    ckernel::BroadcastType src_b_bcast_type,
+    int MATH_FIDELITY_DESC                                = 0,
+    ckernel::EltwiseBinaryReuseDestType binary_reuse_dest = ckernel::EltwiseBinaryReuseDestType::NONE>
 inline void _llk_math_eltwise_binary_init_(const std::uint32_t num_faces, const std::uint32_t transpose, const std::uint32_t acc_to_dest)
 {
-    constexpr int MATH_FIDELITY_PHASES    = get_math_num_fidelity_phases(MATH_FIDELITY_DESC);
-    constexpr int MATH_FIDELITY_INCREMENT = get_math_fidelity_increment(MATH_FIDELITY_DESC);
+    constexpr int MATH_FIDELITY_PHASES    = ckernel::math::get_math_num_fidelity_phases(MATH_FIDELITY_DESC);
+    constexpr int MATH_FIDELITY_INCREMENT = ckernel::math::get_math_fidelity_increment(MATH_FIDELITY_DESC);
 
     eltwise_binary_configure_addrmod<eltwise_binary_type, src_b_bcast_type, MATH_FIDELITY_INCREMENT>();
 
-    if constexpr ((eltwise_binary_type == ELWADD) || (eltwise_binary_type == ELWSUB) || (eltwise_binary_type == ELWMUL))
+    if constexpr ((eltwise_binary_type == ckernel::ELWADD) || (eltwise_binary_type == ckernel::ELWSUB) || (eltwise_binary_type == ckernel::ELWMUL))
     {
         eltwise_binary_configure_mop<eltwise_binary_type, src_b_bcast_type, MATH_FIDELITY_PHASES, binary_reuse_dest>(acc_to_dest, num_faces);
     }
@@ -485,5 +508,5 @@ inline void _llk_math_eltwise_binary_init_(const std::uint32_t num_faces, const 
 
     TTI_SETC16(CLR_DVALID_SrcA_Disable_ADDR32, 0);
 
-    math::reset_counters(p_setrwc::SET_ABD_F);
+    ckernel::math::reset_counters(ckernel::p_setrwc::SET_ABD_F);
 }

--- a/tt_llk_blackhole/llk_lib/llk_math_eltwise_binary_sfpu.h
+++ b/tt_llk_blackhole/llk_lib/llk_math_eltwise_binary_sfpu.h
@@ -14,8 +14,6 @@
 #include "cmath_common.h"
 #include "llk_math_common.h"
 
-using namespace ckernel;
-
 // local function declarations
 inline void eltwise_binary_sfpu_configure_addrmod()
 {
@@ -23,7 +21,7 @@ inline void eltwise_binary_sfpu_configure_addrmod()
     //       A2D, which is using ADDR_MOD_0 and ADDR_MOD_2, so use one
     //       that doesn't conflict!
 
-    addr_mod_t {
+    ckernel::addr_mod_t {
         .srca = {.incr = 0},
         .srcb = {.incr = 0},
         .dest = {.incr = 0},
@@ -33,35 +31,35 @@ inline void eltwise_binary_sfpu_configure_addrmod()
 
 inline void eltwise_binary_sfpu_configure_mop();
 
-template <DstSync Dst>
+template <ckernel::DstSync Dst>
 inline void _llk_math_eltwise_binary_sfpu_start_(const uint dst_index)
 {
-    if constexpr ((Dst == DstSync::SyncTile16) || (Dst == DstSync::SyncTile2))
+    if constexpr ((Dst == ckernel::DstSync::SyncTile16) || (Dst == ckernel::DstSync::SyncTile2))
     {
-        math::set_dst_write_addr<DstTileLayout::Default, DstTileShape::Tile32x32>(math_sync_tile_dst_index);
+        ckernel::math::set_dst_write_addr<ckernel::DstTileLayout::Default, ckernel::DstTileShape::Tile32x32>(math_sync_tile_dst_index);
     }
     else
     {
-        math::set_dst_write_addr<DstTileLayout::Default, DstTileShape::Tile32x32>(dst_index);
+        ckernel::math::set_dst_write_addr<ckernel::DstTileLayout::Default, ckernel::DstTileShape::Tile32x32>(dst_index);
     }
-    TTI_STALLWAIT(p_stall::STALL_SFPU, p_stall::MATH);
+    TTI_STALLWAIT(ckernel::p_stall::STALL_SFPU, ckernel::p_stall::MATH);
 }
 
 inline void _llk_math_eltwise_binary_sfpu_done_()
 {
-    math::clear_dst_reg_addr();
+    ckernel::math::clear_dst_reg_addr();
 }
 
 inline void _llk_math_eltwise_binary_sfpu_inc_dst_face_addr_()
 {
-    math::inc_dst_addr<8>();
-    math::inc_dst_addr<8>();
+    ckernel::math::inc_dst_addr<8>();
+    ckernel::math::inc_dst_addr<8>();
 }
 
 template <SfpuType sfpu_op>
 inline void _llk_math_eltwise_binary_sfpu_init_()
 {
-    sfpu::_init_sfpu_config_reg();
+    ckernel::sfpu::_init_sfpu_config_reg();
     eltwise_binary_sfpu_configure_addrmod();
-    math::reset_counters(p_setrwc::SET_ABD_F);
+    ckernel::math::reset_counters(ckernel::p_setrwc::SET_ABD_F);
 }

--- a/tt_llk_blackhole/llk_lib/llk_math_eltwise_unary_datacopy.h
+++ b/tt_llk_blackhole/llk_lib/llk_math_eltwise_unary_datacopy.h
@@ -13,28 +13,31 @@
 #include "cmath_common.h"
 #include "llk_math_common.h"
 
-using namespace ckernel;
-
 // local function declarations
 inline void eltwise_unary_configure_addrmod();
 
-template <DataCopyType type, DstSync Dst, BroadcastType src_b_bcast_type = BroadcastType::NONE, bool is_fp32_dest_acc_en = false, bool unpack_to_dest = false>
+template <
+    ckernel::DataCopyType type,
+    ckernel::DstSync Dst,
+    ckernel::BroadcastType src_b_bcast_type = ckernel::BroadcastType::NONE,
+    bool is_fp32_dest_acc_en                = false,
+    bool unpack_to_dest                     = false>
 inline void _llk_math_eltwise_unary_datacopy_(const std::uint32_t dst_index, const std::uint32_t src_format, const std::uint32_t dst_format)
 {
     std::uint32_t constexpr num_faces = 4;
 
     // For 32bit data, each half of DEST can take 16 tiles. Since dest offset is returned as if 16bit data are used, we need to
     // adjust it to offset in faces for 32bit data.
-    std::uint32_t dest_base_offset_in_faces = get_dest_buffer_base() >> 5;
+    std::uint32_t dest_base_offset_in_faces = ckernel::get_dest_buffer_base() >> 5;
     std::uint32_t dst_index_in_faces        = dst_index << 2; // Each tile has 4 faces;
 
-    if (unpack_to_dest && is_32bit_input(src_format, dst_format))
+    if (unpack_to_dest && ckernel::math::is_32bit_input(src_format, dst_format))
     {
 #if SKIP_UNP == 1
 #else
-        math_unpack_to_dest_math_ready();
-        math::set_dst_write_addr<DstTileLayout::Default, DstTileShape::Tile32x32, true>(dst_index);
-        math::math_unpack_to_dest_tile_ready();
+        ckernel::math::math_unpack_to_dest_math_ready();
+        ckernel::math::set_dst_write_addr<ckernel::DstTileLayout::Default, ckernel::DstTileShape::Tile32x32, true>(dst_index);
+        ckernel::math::math_unpack_to_dest_tile_ready();
 
         // Due to bug in Blackhole Tensix (more details in budabackend/#2730) when an event with side effect of clearing DEST zero flags
         // (such as Unpack-to-dest or RISC-to-dest) and a ZEROACC instruction from packer occur in the same cycle,
@@ -46,38 +49,38 @@ inline void _llk_math_eltwise_unary_datacopy_(const std::uint32_t dst_index, con
         for (std::uint32_t i = 0; i < num_faces; i++)
         {
             // Clears zero flags in DEST for one face.
-            TT_ZEROACC(p_zeroacc::CLR_16, 0, 1 /*clear zero flags*/, ADDR_MOD_3, dest_base_offset_in_faces + dst_index_in_faces + i);
+            TT_ZEROACC(ckernel::p_zeroacc::CLR_16, 0, 1 /*clear zero flags*/, ckernel::ADDR_MOD_3, dest_base_offset_in_faces + dst_index_in_faces + i);
         }
 #endif
     }
     else
     {
-        if constexpr ((Dst == DstSync::SyncTile16) || (Dst == DstSync::SyncTile2))
+        if constexpr ((Dst == ckernel::DstSync::SyncTile16) || (Dst == ckernel::DstSync::SyncTile2))
         {
-            math::set_dst_write_addr<DstTileLayout::Default, DstTileShape::Tile32x32>(math_sync_tile_dst_index);
+            ckernel::math::set_dst_write_addr<ckernel::DstTileLayout::Default, ckernel::DstTileShape::Tile32x32>(math_sync_tile_dst_index);
         }
         else
         {
-            math::set_dst_write_addr<DstTileLayout::Default, DstTileShape::Tile32x32>(dst_index);
+            ckernel::math::set_dst_write_addr<ckernel::DstTileLayout::Default, ckernel::DstTileShape::Tile32x32>(dst_index);
         }
 
-        if constexpr (type == A2D)
+        if constexpr (type == ckernel::A2D)
         {
-            ckernel_template::run(instrn_buffer);
+            ckernel::ckernel_template::run(ckernel::instrn_buffer);
         }
-        else if constexpr (type == B2D)
+        else if constexpr (type == ckernel::B2D)
         {
-            if constexpr (src_b_bcast_type == BroadcastType::COL)
+            if constexpr (src_b_bcast_type == ckernel::BroadcastType::COL)
             {
                 // Mop for col broadcast only does 2 outerloops.  Needs to clear B manually and call twice
-                ckernel_template::run(instrn_buffer);
-                TTI_SETRWC(p_setrwc::CLR_B, 0, 0, 0, 0, 0);
-                ckernel_template::run(instrn_buffer);
-                TTI_SETRWC(p_setrwc::CLR_AB, 0, 0, 0, 0, 0);
+                ckernel::ckernel_template::run(ckernel::instrn_buffer);
+                TTI_SETRWC(ckernel::p_setrwc::CLR_B, 0, 0, 0, 0, 0);
+                ckernel::ckernel_template::run(ckernel::instrn_buffer);
+                TTI_SETRWC(ckernel::p_setrwc::CLR_AB, 0, 0, 0, 0, 0);
             }
             else
             {
-                ckernel_template::run(instrn_buffer);
+                ckernel::ckernel_template::run(ckernel::instrn_buffer);
             }
         }
         else
@@ -85,110 +88,115 @@ inline void _llk_math_eltwise_unary_datacopy_(const std::uint32_t dst_index, con
             FWASSERT("Unsupported op!", false);
         }
 
-        math::clear_dst_reg_addr();
+        ckernel::math::clear_dst_reg_addr();
     }
 }
 
-template <DataCopyType type, BroadcastType bcast_type = BroadcastType::NONE>
+template <ckernel::DataCopyType type, ckernel::BroadcastType bcast_type = ckernel::BroadcastType::NONE>
 inline void eltwise_unary_configure_addrmod()
 {
-    addr_mod_t {
+    ckernel::addr_mod_t {
         .srca = {.incr = 0},
         .srcb = {.incr = 0},
         .dest = {.incr = 0},
     }
-        .set(ADDR_MOD_3);
+        .set(ckernel::ADDR_MOD_3);
 
     // Use srcA for data movement
-    if constexpr (type == A2D)
+    if constexpr (type == ckernel::A2D)
     {
-        addr_mod_t {
+        ckernel::addr_mod_t {
             .srca = {.incr = 1},
             .srcb = {.incr = 0},
             .dest = {.incr = 1},
         }
-            .set(ADDR_MOD_0);
+            .set(ckernel::ADDR_MOD_0);
 
         // Just unpack into A and move to Dest
-        addr_mod_t {
+        ckernel::addr_mod_t {
             .srca = {.incr = 8},
             .srcb = {.incr = 0},
             .dest = {.incr = 8},
         }
-            .set(ADDR_MOD_2);
+            .set(ckernel::ADDR_MOD_2);
     }
     else
     {
-        if constexpr (bcast_type == BroadcastType::ROW || bcast_type == BroadcastType::SCALAR)
+        if constexpr (bcast_type == ckernel::BroadcastType::ROW || bcast_type == ckernel::BroadcastType::SCALAR)
         {
-            addr_mod_t {
+            ckernel::addr_mod_t {
                 .srca = {.incr = 0},
                 .srcb = {.incr = 0},
                 .dest = {.incr = 1},
             }
-                .set(ADDR_MOD_0);
+                .set(ckernel::ADDR_MOD_0);
 
             // Just unpack into B and move to Dest
-            addr_mod_t {
+            ckernel::addr_mod_t {
                 .srca = {.incr = 0},
                 .srcb = {.incr = 0},
                 .dest = {.incr = 8},
             }
-                .set(ADDR_MOD_2);
+                .set(ckernel::ADDR_MOD_2);
         }
         else
         {
-            addr_mod_t {
+            ckernel::addr_mod_t {
                 .srca = {.incr = 0},
                 .srcb = {.incr = 1},
                 .dest = {.incr = 1},
             }
-                .set(ADDR_MOD_0);
+                .set(ckernel::ADDR_MOD_0);
 
             // Just unpack into B and move to Dest
-            addr_mod_t {
+            ckernel::addr_mod_t {
                 .srca = {.incr = 0},
                 .srcb = {.incr = 8},
                 .dest = {.incr = 8},
             }
-                .set(ADDR_MOD_2);
+                .set(ckernel::ADDR_MOD_2);
         }
     }
 }
 
-template <DataCopyType type, BroadcastType bcast_type = BroadcastType::NONE, bool tilize = false, bool is_fp32_dest_acc_en = false, bool is_int_fpu_en = false>
+template <
+    ckernel::DataCopyType type,
+    ckernel::BroadcastType bcast_type = ckernel::BroadcastType::NONE,
+    bool tilize                       = false,
+    bool is_fp32_dest_acc_en          = false,
+    bool is_int_fpu_en                = false>
 inline void eltwise_unary_configure_mop(uint rows_per_inst, uint total_rows, const uint num_faces, const uint dst_format)
 {
     // always move 32x32 tile, packed as 16x16x4
 
-    if constexpr (type == A2D)
+    if constexpr (type == ckernel::A2D)
     {
-        uint addr_mod  = (rows_per_inst == p_mova2d::MOV_1_ROW) ? ADDR_MOD_0 : ADDR_MOD_2;
-        uint innerloop = (rows_per_inst == p_mova2d::MOV_1_ROW) ? total_rows : (total_rows >> 3);
+        uint addr_mod  = (rows_per_inst == ckernel::p_mova2d::MOV_1_ROW) ? ckernel::ADDR_MOD_0 : ckernel::ADDR_MOD_2;
+        uint innerloop = (rows_per_inst == ckernel::p_mova2d::MOV_1_ROW) ? total_rows : (total_rows >> 3);
         uint outerloop = tilize ? 1 : num_faces;
 
         if (((is_fp32_dest_acc_en || is_int_fpu_en) && !(dst_format == (uint)DataFormat::UInt16)) || (dst_format == (uint)DataFormat::UInt8))
         {
             // use elwadd to handle unpacking data into src A as fp16, but dest is in fp32 mode OR to handle uint8 datums
-            ckernel_template tmp(outerloop, innerloop, TT_OP_ELWADD(0, 0, p_elwise::SRCB_NO_BCAST, ADDR_MOD_2, 0));
-            tmp.set_end_op(TT_OP_SETRWC(p_setrwc::CLR_AB, 0, 0, 0, 0, p_setrwc::SET_AB));
-            tmp.program(instrn_buffer);
+            ckernel::ckernel_template tmp(outerloop, innerloop, TT_OP_ELWADD(0, 0, ckernel::p_elwise::SRCB_NO_BCAST, ckernel::ADDR_MOD_2, 0));
+            tmp.set_end_op(TT_OP_SETRWC(ckernel::p_setrwc::CLR_AB, 0, 0, 0, 0, ckernel::p_setrwc::SET_AB));
+            tmp.program(ckernel::instrn_buffer);
         }
         else
         {
-            ckernel_template tmp(outerloop, innerloop, TT_OP_MOVA2D(0, 0, ADDR_MOD_2, p_mova2d::MOV_8_ROWS, 0));
-            tmp.set_end_op(TT_OP_SETRWC(p_setrwc::CLR_AB, 0, 0, 0, 0, p_setrwc::SET_AB));
-            tmp.program(instrn_buffer);
+            ckernel::ckernel_template tmp(outerloop, innerloop, TT_OP_MOVA2D(0, 0, ckernel::ADDR_MOD_2, ckernel::p_mova2d::MOV_8_ROWS, 0));
+            tmp.set_end_op(TT_OP_SETRWC(ckernel::p_setrwc::CLR_AB, 0, 0, 0, 0, ckernel::p_setrwc::SET_AB));
+            tmp.program(ckernel::instrn_buffer);
         }
     }
-    else if constexpr (type == B2D)
+    else if constexpr (type == ckernel::B2D)
     {
-        uint addr_mod       = (rows_per_inst == p_movb2d::MOV_1_ROW) ? ADDR_MOD_0 : ADDR_MOD_2;
-        uint innerloop      = (rows_per_inst == p_movb2d::MOV_1_ROW) ? total_rows : (total_rows >> 2);
+        uint addr_mod       = (rows_per_inst == ckernel::p_movb2d::MOV_1_ROW) ? ckernel::ADDR_MOD_0 : ckernel::ADDR_MOD_2;
+        uint innerloop      = (rows_per_inst == ckernel::p_movb2d::MOV_1_ROW) ? total_rows : (total_rows >> 2);
         uint outerloop      = 4;
-        auto broadcast_type = p_movb2d::MOV_1_ROW; // No broadcast;
+        auto broadcast_type = ckernel::p_movb2d::MOV_1_ROW; // No broadcast;
 
-        if constexpr (bcast_type == BroadcastType::COL)
+        if constexpr (bcast_type == ckernel::BroadcastType::COL)
         {
             innerloop = 16 >> 3; // elwadd produces 8 rows per op
             // The mop only runs for 2 outer loops and mop is called twice for col broadcast
@@ -197,54 +205,54 @@ inline void eltwise_unary_configure_mop(uint rows_per_inst, uint total_rows, con
             // MOVB2D with column broadcast doesn't work due to the bug in FPU tile
             // which masks dest write enable signals when instrn_mode[1:0] == 2'b01
             // ELTWADD with zeros will be used as a workaround
-            broadcast_type = p_elwise::SRCB_BCAST_COL;
+            broadcast_type = ckernel::p_elwise::SRCB_BCAST_COL;
         }
-        else if constexpr (bcast_type == BroadcastType::ROW)
+        else if constexpr (bcast_type == ckernel::BroadcastType::ROW)
         {
             innerloop      = (total_rows >> 3);
-            broadcast_type = p_movb2d::MOV_8_ROW_BRCST;
+            broadcast_type = ckernel::p_movb2d::MOV_8_ROW_BRCST;
         }
-        else if constexpr (bcast_type == BroadcastType::SCALAR)
+        else if constexpr (bcast_type == ckernel::BroadcastType::SCALAR)
         {
             // ELTWADD with zeros will be used as a workaround
             outerloop      = 1;
             innerloop      = num_faces * (total_rows >> 3);
-            broadcast_type = p_elwise::SRCB_BCAST_ALL;
+            broadcast_type = ckernel::p_elwise::SRCB_BCAST_ALL;
         }
 
-        if constexpr (bcast_type == BroadcastType::SCALAR)
+        if constexpr (bcast_type == ckernel::BroadcastType::SCALAR)
         {
-            ckernel_template tmp(outerloop, innerloop, TT_OP_ELWADD(0, 0, broadcast_type, addr_mod, 0));
-            tmp.set_end_op(TT_OP_SETRWC(p_setrwc::CLR_AB, 0, 0, 0, 0, 0));
-            tmp.program(instrn_buffer);
+            ckernel::ckernel_template tmp(outerloop, innerloop, TT_OP_ELWADD(0, 0, broadcast_type, addr_mod, 0));
+            tmp.set_end_op(TT_OP_SETRWC(ckernel::p_setrwc::CLR_AB, 0, 0, 0, 0, 0));
+            tmp.program(ckernel::instrn_buffer);
         }
-        else if constexpr (bcast_type == BroadcastType::COL)
+        else if constexpr (bcast_type == ckernel::BroadcastType::COL)
         {
-            ckernel_template tmp(outerloop, innerloop, TT_OP_ELWADD(0, 0, broadcast_type, addr_mod, 0));
-            tmp.set_end_op(TT_OP_SETRWC(0, p_setrwc::CR_B, 0, 0, 0, p_setrwc::SET_B));
-            tmp.program(instrn_buffer);
+            ckernel::ckernel_template tmp(outerloop, innerloop, TT_OP_ELWADD(0, 0, broadcast_type, addr_mod, 0));
+            tmp.set_end_op(TT_OP_SETRWC(0, ckernel::p_setrwc::CR_B, 0, 0, 0, ckernel::p_setrwc::SET_B));
+            tmp.program(ckernel::instrn_buffer);
         }
-        else if constexpr (bcast_type == BroadcastType::ROW)
+        else if constexpr (bcast_type == ckernel::BroadcastType::ROW)
         {
-            ckernel_template tmp(outerloop, innerloop, TT_OP_MOVB2D(0, 0, addr_mod, broadcast_type, 0));
-            tmp.set_end_op(TT_OP_SETRWC(p_setrwc::CLR_B, p_setrwc::CR_B, 0, 0, 0, p_setrwc::SET_B));
-            tmp.program(instrn_buffer);
+            ckernel::ckernel_template tmp(outerloop, innerloop, TT_OP_MOVB2D(0, 0, addr_mod, broadcast_type, 0));
+            tmp.set_end_op(TT_OP_SETRWC(ckernel::p_setrwc::CLR_B, ckernel::p_setrwc::CR_B, 0, 0, 0, ckernel::p_setrwc::SET_B));
+            tmp.program(ckernel::instrn_buffer);
         }
         else
         {
-            ckernel_template tmp(outerloop, innerloop, TT_OP_MOVB2D(0, 0, addr_mod, rows_per_inst, 0));
-            tmp.set_end_op(TT_OP_SETRWC(p_setrwc::CLR_B, p_setrwc::CR_B, 0, 0, 0, p_setrwc::SET_B));
-            tmp.program(instrn_buffer);
+            ckernel::ckernel_template tmp(outerloop, innerloop, TT_OP_MOVB2D(0, 0, addr_mod, rows_per_inst, 0));
+            tmp.set_end_op(TT_OP_SETRWC(ckernel::p_setrwc::CLR_B, ckernel::p_setrwc::CR_B, 0, 0, 0, ckernel::p_setrwc::SET_B));
+            tmp.program(ckernel::instrn_buffer);
         }
     }
 }
 
 template <
-    DataCopyType type,
-    BroadcastType src_b_bcast_type = BroadcastType::NONE,
-    bool tilize                    = false,
-    bool is_fp32_dest_acc_en       = false,
-    bool is_int_fpu_en             = false>
+    ckernel::DataCopyType type,
+    ckernel::BroadcastType src_b_bcast_type = ckernel::BroadcastType::NONE,
+    bool tilize                             = false,
+    bool is_fp32_dest_acc_en                = false,
+    bool is_int_fpu_en                      = false>
 // within_face_16x16_transpose is used by unpacker, math does not transpose
 inline void _llk_math_eltwise_unary_datacopy_init_(
     const std::uint32_t transpose_of_faces          = 0 /*unused*/,
@@ -254,14 +262,15 @@ inline void _llk_math_eltwise_unary_datacopy_init_(
 {
     eltwise_unary_configure_addrmod<type, src_b_bcast_type>();
 
-    if constexpr (type == A2D)
+    if constexpr (type == ckernel::A2D)
     {
         const uint num_rows = tilize ? 64 : 16;
-        eltwise_unary_configure_mop<type, src_b_bcast_type, tilize, is_fp32_dest_acc_en, is_int_fpu_en>(p_mova2d::MOV_8_ROWS, num_rows, num_faces, dst_format);
+        eltwise_unary_configure_mop<type, src_b_bcast_type, tilize, is_fp32_dest_acc_en, is_int_fpu_en>(
+            ckernel::p_mova2d::MOV_8_ROWS, num_rows, num_faces, dst_format);
     }
-    else if constexpr (type == B2D)
+    else if constexpr (type == ckernel::B2D)
     {
-        eltwise_unary_configure_mop<type, src_b_bcast_type>(p_movb2d::MOV_4_ROWS, 16, num_faces, dst_format);
+        eltwise_unary_configure_mop<type, src_b_bcast_type>(ckernel::p_movb2d::MOV_4_ROWS, 16, num_faces, dst_format);
     }
     else
     {
@@ -270,5 +279,5 @@ inline void _llk_math_eltwise_unary_datacopy_init_(
 
     TTI_SETC16(CLR_DVALID_SrcA_Disable_ADDR32, 0);
 
-    math::reset_counters(p_setrwc::SET_ABD_F);
+    ckernel::math::reset_counters(ckernel::p_setrwc::SET_ABD_F);
 }

--- a/tt_llk_blackhole/llk_lib/llk_math_eltwise_unary_sfpi.h
+++ b/tt_llk_blackhole/llk_lib/llk_math_eltwise_unary_sfpi.h
@@ -14,8 +14,6 @@
 #include "cmath_common.h"
 #include "llk_math_common.h"
 
-using namespace ckernel;
-
 template <SfpiTestType sfpu_type>
 void static_assert_sfpi_type_dependent()
 {
@@ -28,155 +26,155 @@ inline void eltwise_unary_sfpi_configure_addrmod()
     // NOTE: this kernel is typically used in conjunction with
     //       A2D, which is using ADDR_MOD_0 and ADDR_MOD_2, so use one
     //       that doesn't conflict!
-    addr_mod_t {
+    ckernel::addr_mod_t {
         .srca = {.incr = 0},
         .srcb = {.incr = 0},
         .dest = {.incr = 0},
     }
-        .set(ADDR_MOD_3);
+        .set(ckernel::ADDR_MOD_3);
 }
 
 inline void eltwise_unary_sfpi_configure_mop();
 
-template <SfpiTestType sfpu_op, DstSync Dst>
+template <SfpiTestType sfpu_op, ckernel::DstSync Dst>
 inline void llk_math_eltwise_unary_sfpi(uint dst_index, uint param0 = 0, uint param1 = 0, uint param2 = 0, uint param3 = 0, uint param4 = 0, uint param5 = 0)
 {
-    TTI_STALLWAIT(p_stall::STALL_SFPU, p_stall::MATH);
-    if constexpr ((Dst == DstSync::SyncTile16) || (Dst == DstSync::SyncTile2))
+    TTI_STALLWAIT(ckernel::p_stall::STALL_SFPU, ckernel::p_stall::MATH);
+    if constexpr ((Dst == ckernel::DstSync::SyncTile16) || (Dst == ckernel::DstSync::SyncTile2))
     {
-        math::set_dst_write_addr<DstTileLayout::Default, DstTileShape::Tile32x32>(math_sync_tile_dst_index);
+        math::set_dst_write_addr<ckernel::DstTileLayout::Default, ckernel::DstTileShape::Tile32x32>(math_sync_tile_dst_index);
     }
     else
     {
-        math::set_dst_write_addr<DstTileLayout::Default, DstTileShape::Tile32x32>(dst_index);
+        math::set_dst_write_addr<ckernel::DstTileLayout::Default, ckernel::DstTileShape::Tile32x32>(dst_index);
     }
 
     int face = 0;
     sfpi_test::calculate_sfpi<sfpu_op>(param0, param1, param2, param3, param4, param5);
-    TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_D, 8, 0, 0, p_setrwc::SET_D);
-    TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_D, 8, 0, 0, p_setrwc::SET_D);
+    TTI_SETRWC(ckernel::p_setrwc::CLR_NONE, ckernel::p_setrwc::CR_D, 8, 0, 0, ckernel::p_setrwc::SET_D);
+    TTI_SETRWC(ckernel::p_setrwc::CLR_NONE, ckernel::p_setrwc::CR_D, 8, 0, 0, ckernel::p_setrwc::SET_D);
 
-    math::clear_dst_reg_addr();
+    ckernel::math::clear_dst_reg_addr();
 }
 
 inline void llk_math_eltwise_unary_sfpi_init(uint param0 = 0, uint param1 = 0, uint param2 = 0, uint param3 = 0, uint param4 = 0, uint param5 = 0)
 {
     sfpu::_init_sfpu_config_reg();
     eltwise_unary_sfpi_configure_addrmod();
-    math::reset_counters(p_setrwc::SET_ABD_F);
+    ckernel::math::reset_counters(ckernel::p_setrwc::SET_ABD_F);
 }
 
 // New LLK SFPU APIs
 
-template <DstSync dst_sync>
+template <ckernel::DstSync dst_sync>
 inline void llk_math_eltwise_unary_sfpi_test1(uint dst_index)
 {
     llk_math_eltwise_unary_sfpi<SfpiTestType::test1, dst_sync>(dst_index);
 }
 
-template <DstSync dst_sync>
+template <ckernel::DstSync dst_sync>
 inline void llk_math_eltwise_unary_sfpi_test2(uint dst_index)
 {
     llk_math_eltwise_unary_sfpi<SfpiTestType::test2, dst_sync>(dst_index);
 }
 
-template <DstSync dst_sync>
+template <ckernel::DstSync dst_sync>
 inline void llk_math_eltwise_unary_sfpi_test3(uint dst_index)
 {
     llk_math_eltwise_unary_sfpi<SfpiTestType::test3, dst_sync>(dst_index);
 }
 
-template <DstSync dst_sync>
+template <ckernel::DstSync dst_sync>
 inline void llk_math_eltwise_unary_sfpi_test4(uint dst_index)
 {
     llk_math_eltwise_unary_sfpi<SfpiTestType::test4, dst_sync>(dst_index);
 }
 
-template <DstSync dst_sync>
+template <ckernel::DstSync dst_sync>
 inline void llk_math_eltwise_unary_sfpi_test5(uint dst_index)
 {
     llk_math_eltwise_unary_sfpi<SfpiTestType::test5, dst_sync>(dst_index);
 }
 
-template <DstSync dst_sync>
+template <ckernel::DstSync dst_sync>
 inline void llk_math_eltwise_unary_sfpi_test6(uint dst_index)
 {
     llk_math_eltwise_unary_sfpi<SfpiTestType::test6, dst_sync>(dst_index);
 }
 
-template <DstSync dst_sync>
+template <ckernel::DstSync dst_sync>
 inline void llk_math_eltwise_unary_sfpi_test7(uint dst_index)
 {
     llk_math_eltwise_unary_sfpi<SfpiTestType::test7, dst_sync>(dst_index);
 }
 
-template <DstSync dst_sync>
+template <ckernel::DstSync dst_sync>
 inline void llk_math_eltwise_unary_sfpi_test8(uint dst_index)
 {
     llk_math_eltwise_unary_sfpi<SfpiTestType::test8, dst_sync>(dst_index);
 }
 
-template <DstSync dst_sync>
+template <ckernel::DstSync dst_sync>
 inline void llk_math_eltwise_unary_sfpi_test9(uint dst_index)
 {
     llk_math_eltwise_unary_sfpi<SfpiTestType::test9, dst_sync>(dst_index);
 }
 
-template <DstSync dst_sync>
+template <ckernel::DstSync dst_sync>
 inline void llk_math_eltwise_unary_sfpi_test10(uint dst_index)
 {
     llk_math_eltwise_unary_sfpi<SfpiTestType::test10, dst_sync>(dst_index);
 }
 
-template <DstSync dst_sync>
+template <ckernel::DstSync dst_sync>
 inline void llk_math_eltwise_unary_sfpi_test11(uint dst_index)
 {
     llk_math_eltwise_unary_sfpi<SfpiTestType::test11, dst_sync>(dst_index);
 }
 
-template <DstSync dst_sync>
+template <ckernel::DstSync dst_sync>
 inline void llk_math_eltwise_unary_sfpi_test12(uint dst_index, uint param0)
 {
     llk_math_eltwise_unary_sfpi<SfpiTestType::test12, dst_sync>(dst_index, param0);
 }
 
-template <DstSync dst_sync>
+template <ckernel::DstSync dst_sync>
 inline void llk_math_eltwise_unary_sfpi_test13(uint dst_index, uint param0)
 {
     llk_math_eltwise_unary_sfpi<SfpiTestType::test13, dst_sync>(dst_index, param0);
 }
 
-template <DstSync dst_sync>
+template <ckernel::DstSync dst_sync>
 inline void llk_math_eltwise_unary_sfpi_test14(uint dst_index, uint param0)
 {
     llk_math_eltwise_unary_sfpi<SfpiTestType::test14, dst_sync>(dst_index, param0);
 }
 
-template <DstSync dst_sync>
+template <ckernel::DstSync dst_sync>
 inline void llk_math_eltwise_unary_sfpi_test15(uint dst_index)
 {
     llk_math_eltwise_unary_sfpi<SfpiTestType::test15, dst_sync>(dst_index);
 }
 
-template <DstSync dst_sync>
+template <ckernel::DstSync dst_sync>
 inline void llk_math_eltwise_unary_sfpi_test16(uint dst_index)
 {
     llk_math_eltwise_unary_sfpi<SfpiTestType::test16, dst_sync>(dst_index);
 }
 
-template <DstSync dst_sync>
+template <ckernel::DstSync dst_sync>
 inline void llk_math_eltwise_unary_sfpi_test17(uint dst_index)
 {
     llk_math_eltwise_unary_sfpi<SfpiTestType::test17, dst_sync>(dst_index);
 }
 
-template <DstSync dst_sync>
+template <ckernel::DstSync dst_sync>
 inline void llk_math_eltwise_unary_sfpi_test18(uint dst_index)
 {
     llk_math_eltwise_unary_sfpi<SfpiTestType::test18, dst_sync>(dst_index);
 }
 
-template <DstSync dst_sync>
+template <ckernel::DstSync dst_sync>
 inline void llk_math_eltwise_unary_sfpi_test19(uint dst_index)
 {
     llk_math_eltwise_unary_sfpi<SfpiTestType::test19, dst_sync>(dst_index);

--- a/tt_llk_blackhole/llk_lib/llk_math_eltwise_unary_sfpu.h
+++ b/tt_llk_blackhole/llk_lib/llk_math_eltwise_unary_sfpu.h
@@ -14,8 +14,6 @@
 #include "llk_math_common.h"
 #include "llk_sfpu_types.h"
 
-using namespace ckernel;
-
 // local function declarations
 template <SfpuType sfpu_op>
 inline void eltwise_unary_sfpu_configure_addrmod()
@@ -24,55 +22,55 @@ inline void eltwise_unary_sfpu_configure_addrmod()
     //       A2D, which is using ADDR_MOD_0 and ADDR_MOD_2, so use one
     //       that doesn't conflict!
 
-    addr_mod_t {
+    ckernel::addr_mod_t {
         .srca = {.incr = 0},
         .srcb = {.incr = 0},
         .dest = {.incr = 0},
     }
-        .set(ADDR_MOD_7);
+        .set(ckernel::ADDR_MOD_7);
 
     if (sfpu_op == SfpuType::topk_local_sort)
     {
-        addr_mod_t {
+        ckernel::addr_mod_t {
             .srca = {.incr = 0},
             .srcb = {.incr = 0},
             .dest = {.incr = 32},
         }
-            .set(ADDR_MOD_6);
+            .set(ckernel::ADDR_MOD_6);
     }
 }
 
 inline void eltwise_unary_sfpu_configure_mop();
 
-template <DstSync Dst>
+template <ckernel::DstSync Dst>
 inline void _llk_math_eltwise_unary_sfpu_start_(const uint dst_index)
 {
-    if constexpr ((Dst == DstSync::SyncTile16) || (Dst == DstSync::SyncTile2))
+    if constexpr ((Dst == ckernel::DstSync::SyncTile16) || (Dst == ckernel::DstSync::SyncTile2))
     {
-        math::set_dst_write_addr<DstTileLayout::Default, DstTileShape::Tile32x32>(math_sync_tile_dst_index);
+        ckernel::math::set_dst_write_addr<ckernel::DstTileLayout::Default, ckernel::DstTileShape::Tile32x32>(math_sync_tile_dst_index);
     }
     else
     {
-        math::set_dst_write_addr<DstTileLayout::Default, DstTileShape::Tile32x32>(dst_index);
+        ckernel::math::set_dst_write_addr<ckernel::DstTileLayout::Default, ckernel::DstTileShape::Tile32x32>(dst_index);
     }
-    TTI_STALLWAIT(p_stall::STALL_SFPU, p_stall::MATH);
+    TTI_STALLWAIT(ckernel::p_stall::STALL_SFPU, ckernel::p_stall::MATH);
 }
 
 inline void _llk_math_eltwise_unary_sfpu_done_()
 {
-    math::clear_dst_reg_addr();
+    ckernel::math::clear_dst_reg_addr();
 }
 
 inline void _llk_math_eltwise_unary_sfpu_inc_dst_face_addr_()
 {
-    math::inc_dst_addr<8>();
-    math::inc_dst_addr<8>();
+    ckernel::math::inc_dst_addr<8>();
+    ckernel::math::inc_dst_addr<8>();
 }
 
 template <SfpuType sfpu_op>
 inline void _llk_math_eltwise_unary_sfpu_init_()
 {
-    sfpu::_init_sfpu_config_reg();
+    ckernel::sfpu::_init_sfpu_config_reg();
     eltwise_unary_sfpu_configure_addrmod<sfpu_op>();
-    math::reset_counters(p_setrwc::SET_ABD_F);
+    ckernel::math::reset_counters(ckernel::p_setrwc::SET_ABD_F);
 }

--- a/tt_llk_blackhole/llk_lib/llk_math_matmul.h
+++ b/tt_llk_blackhole/llk_lib/llk_math_matmul.h
@@ -16,29 +16,27 @@
 #define HF 0
 #endif
 
-using namespace ckernel;
-
-template <int MATH_FIDELITY_DESC, DstTileFaceLayout FaceLayout = DstTileFaceLayout::ColMajor>
+template <int MATH_FIDELITY_DESC, ckernel::DstTileFaceLayout FaceLayout = ckernel::DstTileFaceLayout::ColMajor>
 inline void matmul_configure_addrmod(
     const bool transpose,
     const std::uint32_t ct_dim,
     const std::uint32_t rt_dim,
     const std::uint32_t kt_dim,
-    const std::uint32_t in0_tile_r_dim = TILE_R_DIM,
-    const std::uint32_t in0_tile_c_dim = TILE_C_DIM,
-    const std::uint32_t in1_tile_r_dim = TILE_R_DIM,
-    const std::uint32_t in1_tile_c_dim = TILE_C_DIM,
+    const std::uint32_t in0_tile_r_dim = ckernel::TILE_R_DIM,
+    const std::uint32_t in0_tile_c_dim = ckernel::TILE_C_DIM,
+    const std::uint32_t in1_tile_r_dim = ckernel::TILE_R_DIM,
+    const std::uint32_t in1_tile_c_dim = ckernel::TILE_C_DIM,
     const bool partial_face            = false)
 {
-    constexpr int NUM_FIDELITY_PHASES = get_math_num_fidelity_phases(MATH_FIDELITY_DESC);
+    constexpr int NUM_FIDELITY_PHASES = ckernel::math::get_math_num_fidelity_phases(MATH_FIDELITY_DESC);
     constexpr bool high_fidelity      = (NUM_FIDELITY_PHASES > 0);
-    constexpr int FIDELITY_INCREMENT  = high_fidelity ? get_math_fidelity_increment(MATH_FIDELITY_DESC) : 0;
+    constexpr int FIDELITY_INCREMENT  = high_fidelity ? ckernel::math::get_math_fidelity_increment(MATH_FIDELITY_DESC) : 0;
 
-    const bool is_in0_16x32 = (in0_tile_r_dim <= FACE_R_DIM) && (in0_tile_c_dim > FACE_C_DIM);
-    const bool is_in0_32x16 = (in0_tile_r_dim > FACE_R_DIM) && (in0_tile_c_dim <= FACE_C_DIM);
-    const bool is_in1_32x16 = (in1_tile_r_dim > FACE_R_DIM) && (in1_tile_c_dim <= FACE_C_DIM);
+    const bool is_in0_16x32 = (in0_tile_r_dim <= ckernel::FACE_R_DIM) && (in0_tile_c_dim > ckernel::FACE_C_DIM);
+    const bool is_in0_32x16 = (in0_tile_r_dim > ckernel::FACE_R_DIM) && (in0_tile_c_dim <= ckernel::FACE_C_DIM);
+    const bool is_in1_32x16 = (in1_tile_r_dim > ckernel::FACE_R_DIM) && (in1_tile_c_dim <= ckernel::FACE_C_DIM);
 
-    static_assert(FaceLayout == DstTileFaceLayout::RowMajor, "FaceLayout must be RowMajor");
+    static_assert(FaceLayout == ckernel::DstTileFaceLayout::RowMajor, "FaceLayout must be RowMajor");
 
     // MVMUL does D = B*A
 
@@ -47,84 +45,84 @@ inline void matmul_configure_addrmod(
     // SRCB -- 8 rows are needed
     // SRCA -- full 16x16 gets used -- hardware will pair cols of A with rows of B
     // D[8,16] = B[8,16] * A[16,16]
-    addr_mod_t {
+    ckernel::addr_mod_t {
         .srca = {.incr = 0, .clr = 0, .cr = 0},
         .srcb = {.incr = 8, .clr = 0, .cr = 0},
         .dest = {.incr = 8, .clr = 0, .cr = 0},
     }
-        .set(ADDR_MOD_0);
+        .set(ckernel::ADDR_MOD_0);
 
     // reset all, increment fidelity if we have more fidelity phases
-    addr_mod_t {
+    ckernel::addr_mod_t {
         .srca     = {.incr = 0, .clr = 1, .cr = 1},
         .srcb     = {.incr = 0, .clr = 1, .cr = 1},
         .dest     = {.incr = 0, .clr = 1, .cr = 1},
         .fidelity = {.incr = FIDELITY_INCREMENT, .clr = 0},
     }
-        .set(ADDR_MOD_5);
+        .set(ckernel::ADDR_MOD_5);
 
     if ((is_in0_16x32 && (!is_in1_32x16)) || is_in0_32x16)
     {
         if (transpose)
         {
-            addr_mod_t {
+            ckernel::addr_mod_t {
                 .srca = {.incr = 32, .clr = 0, .cr = 0},
                 .srcb = {.incr = 0, .clr = 0, .cr = 1}, // cr=16 before
                 .dest = {.incr = 8, .clr = 0, .cr = 0},
             }
-                .set(ADDR_MOD_1);
+                .set(ckernel::ADDR_MOD_1);
         }
         else
         {
-            addr_mod_t {
+            ckernel::addr_mod_t {
                 .srca = {.incr = 16, .clr = 0, .cr = 0},
                 .srcb = {.incr = 0, .clr = 0, .cr = 1}, // cr=16 before
                 .dest = {.incr = 8, .clr = 0, .cr = 0},
             }
-                .set(ADDR_MOD_1);
+                .set(ckernel::ADDR_MOD_1);
         }
     }
     else
     {
         if (is_in1_32x16)
         {
-            addr_mod_t {
+            ckernel::addr_mod_t {
                 .srca = {.incr = 16, .clr = 0, .cr = 0},
                 .srcb = {.incr = 8, .clr = 0, .cr = 0},
                 .dest = {.incr = 0, .clr = 0, .cr = 1},
             }
-                .set(ADDR_MOD_1);
+                .set(ckernel::ADDR_MOD_1);
         }
         else
         {
             if (transpose)
             {
-                addr_mod_t {
+                ckernel::addr_mod_t {
                     .srca = {.incr = 32, .clr = 0, .cr = 0},
                     .srcb = {.incr = 0, .clr = 0, .cr = 1},
                     .dest = {.incr = 8, .clr = 0, .cr = 0},
                 }
-                    .set(ADDR_MOD_1);
+                    .set(ckernel::ADDR_MOD_1);
             }
             else
             {
-                addr_mod_t {
+                ckernel::addr_mod_t {
                     //.srca = {.incr = srca_increment, .clr = 0, .cr = 0},
                     .srca = {.incr = 16, .clr = 0, .cr = 0},
                     .srcb = {.incr = 0, .clr = 0, .cr = 1},
                     .dest = {.incr = 8, .clr = 0, .cr = 0},
                 }
-                    .set(ADDR_MOD_1);
+                    .set(ckernel::ADDR_MOD_1);
             }
         }
     }
 
     if (is_in1_32x16)
     {
-        addr_mod_t {
+        ckernel::addr_mod_t {
             .srca = {.incr = 16, .clr = 0, .cr = 0}, .srcb = {.incr = 8, .clr = 0, .cr = 0}, .dest = {.incr = 0, .clr = 0, .cr = 1}, // cr=16
         }
-            .set(ADDR_MOD_2);
+            .set(ckernel::ADDR_MOD_2);
     }
     else if (is_in0_16x32 || is_in0_32x16)
     {
@@ -132,51 +130,51 @@ inline void matmul_configure_addrmod(
         {
             if (transpose)
             {
-                addr_mod_t {
+                ckernel::addr_mod_t {
                     .srca = {.incr = 32, .clr = 0, .cr = 0}, .srcb = {.incr = 0, .clr = 0, .cr = 0}, .dest = {.incr = 16, .clr = 0, .cr = 0},
                     // .bias = {.incr = 1},
                 }
-                    .set(ADDR_MOD_2);
+                    .set(ckernel::ADDR_MOD_2);
             }
             else
             {
-                addr_mod_t {
+                ckernel::addr_mod_t {
                     .srca = {.incr = 16, .clr = 0, .cr = 0}, .srcb = {.incr = 0, .clr = 0, .cr = 0}, .dest = {.incr = 16, .clr = 0, .cr = 0},
                     // .bias = {.incr = 1},
                 }
-                    .set(ADDR_MOD_2);
+                    .set(ckernel::ADDR_MOD_2);
             }
         }
         else
         {
             if (transpose)
             {
-                addr_mod_t {
+                ckernel::addr_mod_t {
                     .srca = {.incr = 32, .clr = 0, .cr = 0},
                     .srcb = {.incr = 0, .clr = 0, .cr = 1},
                     .dest = {.incr = 8, .clr = 0, .cr = 0},
                 }
-                    .set(ADDR_MOD_2);
+                    .set(ckernel::ADDR_MOD_2);
             }
             else
             {
-                addr_mod_t {
+                ckernel::addr_mod_t {
                     .srca = {.incr = 16, .clr = 0, .cr = 0},
                     .srcb = {.incr = 0, .clr = 0, .cr = 1},
                     .dest = {.incr = 8, .clr = 0, .cr = 0},
                 }
-                    .set(ADDR_MOD_2);
+                    .set(ckernel::ADDR_MOD_2);
             }
         }
     }
     else
     {
-        addr_mod_t {
+        ckernel::addr_mod_t {
             .srca = {.incr = 0, .clr = 0, .cr = 1},
             .srcb = {.incr = 32, .clr = 0, .cr = 1},
             .dest = {.incr = 8, .clr = 0, .cr = 0},
         }
-            .set(ADDR_MOD_2);
+            .set(ckernel::ADDR_MOD_2);
     }
 
     if (is_in0_16x32)
@@ -185,97 +183,97 @@ inline void matmul_configure_addrmod(
         {
             if (transpose)
             {
-                addr_mod_t {
+                ckernel::addr_mod_t {
                     .srca = {.incr = 16, .clr = 0, .cr = 1}, // srca=16
                     .srcb = {.incr = 16, .clr = 0, .cr = 0},
                     .dest = {.incr = 0, .clr = 1, .cr = 0},
                     // .bias = {.incr = 1},
                 }
-                    .set(ADDR_MOD_4);
+                    .set(ckernel::ADDR_MOD_4);
             }
             else
             {
-                addr_mod_t {
+                ckernel::addr_mod_t {
                     .srca = {.incr = 16, .clr = 0, .cr = 0}, .srcb = {.incr = 16, .clr = 0, .cr = 0}, .dest = {.incr = 0, .clr = 1, .cr = 0},
                     // .bias = {.incr = 1},
                 }
-                    .set(ADDR_MOD_4);
+                    .set(ckernel::ADDR_MOD_4);
             }
         }
         else
         {
             if (transpose)
             {
-                addr_mod_t {
+                ckernel::addr_mod_t {
                     .srca = {.incr = 16, .clr = 0, .cr = 1}, // srca=16
                     .srcb = {.incr = 16, .clr = 0, .cr = 1},
                     .dest = {.incr = 0, .clr = 0, .cr = 1},
                     // .bias = {.incr = 1},
                 }
-                    .set(ADDR_MOD_4);
+                    .set(ckernel::ADDR_MOD_4);
             }
             else
             {
-                addr_mod_t {
+                ckernel::addr_mod_t {
                     .srca = {.incr = 16, .clr = 0, .cr = 0}, .srcb = {.incr = 16, .clr = 0, .cr = 1}, .dest = {.incr = 0, .clr = 0, .cr = 1},
                     // .bias = {.incr = 1},
                 }
-                    .set(ADDR_MOD_4);
+                    .set(ckernel::ADDR_MOD_4);
             }
         }
     }
     else if (is_in0_32x16)
     {
-        addr_mod_t {
+        ckernel::addr_mod_t {
             .srca = {.incr = 0, .clr = 0, .cr = 1}, .srcb = {.incr = 16, .clr = 0, .cr = 1}, .dest = {.incr = 8, .clr = 0, .cr = 0},
             // .bias = {.incr = 1},
         }
-            .set(ADDR_MOD_4);
+            .set(ckernel::ADDR_MOD_4);
     }
     else if (is_in1_32x16)
     {
-        addr_mod_t {
+        ckernel::addr_mod_t {
             .srca = {.incr = 0, .clr = 0, .cr = 1}, .srcb = {.incr = 8, .clr = 0, .cr = 0}, .dest = {.incr = 16, .clr = 0, .cr = 1},
             // .bias = {.incr = 1},
         }
-            .set(ADDR_MOD_4);
+            .set(ckernel::ADDR_MOD_4);
     }
     else
     {
         if (transpose)
         {
-            addr_mod_t {
+            ckernel::addr_mod_t {
                 .srca = {.incr = 16, .clr = 0, .cr = 1},
                 .srcb = {.incr = 48, .clr = 0, .cr = 1}, // cr=32 before, cr+48=16 after wrapping
                 .dest = {.incr = 0, .clr = 0, .cr = 1},
                 // .bias = {.incr = 1},
             }
-                .set(ADDR_MOD_4);
+                .set(ckernel::ADDR_MOD_4);
         }
         else
         {
-            addr_mod_t {
+            ckernel::addr_mod_t {
                 .srca = {.incr = 32, .clr = 0, .cr = 1},
                 //.srca = {.incr = srca_set, .clr = 0, .cr = 1},
                 .srcb = {.incr = 48, .clr = 0, .cr = 1}, // cr=32 before, cr+48=16 after wrapping
                 .dest = {.incr = 0, .clr = 0, .cr = 1},
                 // .bias = {.incr = 1},
             }
-                .set(ADDR_MOD_4);
+                .set(ckernel::ADDR_MOD_4);
         }
     }
 }
 
-template <int NUM_FIDELITY_PHASES, DstTileFaceLayout FaceLayout = DstTileFaceLayout::ColMajor>
+template <int NUM_FIDELITY_PHASES, ckernel::DstTileFaceLayout FaceLayout = ckernel::DstTileFaceLayout::ColMajor>
 inline void matmul_configure_mop(
     bool transpose,
     const std::uint32_t ct_dim,
     const std::uint32_t rt_dim,
     const std::uint32_t kt_dim,
-    const std::uint32_t in0_tile_r_dim = TILE_R_DIM,
-    const std::uint32_t in0_tile_c_dim = TILE_C_DIM,
-    const std::uint32_t in1_tile_r_dim = TILE_R_DIM,
-    const std::uint32_t in1_tile_c_dim = TILE_C_DIM,
+    const std::uint32_t in0_tile_r_dim = ckernel::TILE_R_DIM,
+    const std::uint32_t in0_tile_c_dim = ckernel::TILE_C_DIM,
+    const std::uint32_t in1_tile_r_dim = ckernel::TILE_R_DIM,
+    const std::uint32_t in1_tile_c_dim = ckernel::TILE_C_DIM,
     const bool partial_face            = false)
 {
     // in0 - loaded to SrcB
@@ -291,15 +289,15 @@ inline void matmul_configure_mop(
     const bool reuse_a        = ct_dim >= rt_dim;
     const std::uint32_t t_dim = reuse_a ? rt_dim : ct_dim;
 
-    const bool is_in0_16x32 = (in0_tile_r_dim <= FACE_R_DIM) && (in0_tile_c_dim > FACE_C_DIM);
-    const bool is_in1_32x16 = (in1_tile_r_dim > FACE_R_DIM) && (in1_tile_c_dim <= FACE_C_DIM);
-    const bool is_in0_32x16 = (in0_tile_r_dim > FACE_R_DIM) && (in0_tile_c_dim <= FACE_C_DIM);
-    const bool is_in1_16x32 = (in1_tile_r_dim <= FACE_R_DIM) && (in1_tile_c_dim > FACE_C_DIM);
+    const bool is_in0_16x32 = (in0_tile_r_dim <= ckernel::FACE_R_DIM) && (in0_tile_c_dim > ckernel::FACE_C_DIM);
+    const bool is_in1_32x16 = (in1_tile_r_dim > ckernel::FACE_R_DIM) && (in1_tile_c_dim <= ckernel::FACE_C_DIM);
+    const bool is_in0_32x16 = (in0_tile_r_dim > ckernel::FACE_R_DIM) && (in0_tile_c_dim <= ckernel::FACE_C_DIM);
+    const bool is_in1_16x32 = (in1_tile_r_dim <= ckernel::FACE_R_DIM) && (in1_tile_c_dim > ckernel::FACE_C_DIM);
 
     const std::uint32_t replay_buf_len =
         (is_in0_16x32 && is_in1_32x16) ? 4 : ((is_in0_16x32 || is_in1_32x16 || is_in0_32x16 || is_in1_16x32) ? (partial_face ? 4 : 8) : 16);
 
-    load_replay_buf(
+    ckernel::load_replay_buf(
         ckernel::math::replay_buf_offset,
         replay_buf_len,
         false,
@@ -310,111 +308,121 @@ inline void matmul_configure_mop(
             {
                 if (is_in0_16x32)
                 {
-                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B0A0 // srca=srca, srcb+=8,  dest+=8
-                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0); // B0A0 // srca+=16,  srcb+=8,  dest=0
-                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B1A1 // srca=srca, srcb+=8,  dest=+8, bias=1
+                    TTI_MVMUL(ckernel::p_setrwc::CLR_NONE, 0, ckernel::ADDR_MOD_0, 0); // B0A0 // srca=srca, srcb+=8,  dest+=8
+                    TTI_MVMUL(ckernel::p_setrwc::CLR_NONE, 0, ckernel::ADDR_MOD_1, 0); // B0A0 // srca+=16,  srcb+=8,  dest=0
+                    TTI_MVMUL(ckernel::p_setrwc::CLR_NONE, 0, ckernel::ADDR_MOD_0, 0); // B1A1 // srca=srca, srcb+=8,  dest=+8, bias=1
                 }
                 else
                 {
-                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B0A0 // srca=srca, srcb+=8,  dest+=8
-                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0); // B0A0 // srca+=16,  srcb+=8,  dest=0
-                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B1A1 // srca=srca, srcb+=8,  dest=+8
-                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_4, 0); // B1A1 // srca=0,    srcb+=8,  dest=16 (addr_mod_4), bias=0
+                    TTI_MVMUL(ckernel::p_setrwc::CLR_NONE, 0, ckernel::ADDR_MOD_0, 0); // B0A0 // srca=srca, srcb+=8,  dest+=8
+                    TTI_MVMUL(ckernel::p_setrwc::CLR_NONE, 0, ckernel::ADDR_MOD_1, 0); // B0A0 // srca+=16,  srcb+=8,  dest=0
+                    TTI_MVMUL(ckernel::p_setrwc::CLR_NONE, 0, ckernel::ADDR_MOD_0, 0); // B1A1 // srca=srca, srcb+=8,  dest=+8
+                    TTI_MVMUL(ckernel::p_setrwc::CLR_NONE, 0, ckernel::ADDR_MOD_4, 0); // B1A1 // srca=0,    srcb+=8,  dest=16 (addr_mod_4), bias=0
 
-                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B2A0 // srca=srca, srcb+=8,  dest+=8
-                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_2, 0); // B2A0 // srca+=16,  srcb+=8,  dest=16
-                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B3A1 // srca=srca, srcb+=8,  dest+=8
+                    TTI_MVMUL(ckernel::p_setrwc::CLR_NONE, 0, ckernel::ADDR_MOD_0, 0); // B2A0 // srca=srca, srcb+=8,  dest+=8
+                    TTI_MVMUL(ckernel::p_setrwc::CLR_NONE, 0, ckernel::ADDR_MOD_2, 0); // B2A0 // srca+=16,  srcb+=8,  dest=16
+                    TTI_MVMUL(ckernel::p_setrwc::CLR_NONE, 0, ckernel::ADDR_MOD_0, 0); // B3A1 // srca=srca, srcb+=8,  dest+=8
                 }
             }
             else if (is_in0_16x32 || is_in0_32x16)
             {
                 if (partial_face)
                 {
-                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_2, 0); // B0A0 // srca+=16,  srcb=0,   dest=+16
-                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_4, 0); // B0A1 // srca+=16,  srcb+=16,  dest=0 (addr_mod_4), bias=0
-                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_2, 0); // B1A2 // srca+=16,  srcb=0,  dest=+16
+                    TTI_MVMUL(ckernel::p_setrwc::CLR_NONE, 0, ckernel::ADDR_MOD_2, 0); // B0A0 // srca+=16,  srcb=0,   dest=+16
+                    TTI_MVMUL(ckernel::p_setrwc::CLR_NONE, 0, ckernel::ADDR_MOD_4, 0); // B0A1 // srca+=16,  srcb+=16,  dest=0 (addr_mod_4), bias=0
+                    TTI_MVMUL(ckernel::p_setrwc::CLR_NONE, 0, ckernel::ADDR_MOD_2, 0); // B1A2 // srca+=16,  srcb=0,  dest=+16
                 }
                 else
                 {
-                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B0A0 // srca=srca, srcb+=8,  dest+=8
-                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_2, 0); // B0A0 // srca+=16,  srcb=0,   dest+=8
-                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B0A1 // srca=srca, srcb+=8,  dest+=8
+                    TTI_MVMUL(ckernel::p_setrwc::CLR_NONE, 0, ckernel::ADDR_MOD_0, 0); // B0A0 // srca=srca, srcb+=8,  dest+=8
+                    TTI_MVMUL(ckernel::p_setrwc::CLR_NONE, 0, ckernel::ADDR_MOD_2, 0); // B0A0 // srca+=16,  srcb=0,   dest+=8
+                    TTI_MVMUL(ckernel::p_setrwc::CLR_NONE, 0, ckernel::ADDR_MOD_0, 0); // B0A1 // srca=srca, srcb+=8,  dest+=8
                     TTI_MVMUL(
-                        p_setrwc::CLR_NONE, 0, ADDR_MOD_4, 0); // B0A1 // srca+=16/=0,  srcb=16,  dest=0/+=8 (addr_mod_4), bias=0 // srca=0 dest+=8 if in0_32x16
+                        ckernel::p_setrwc::CLR_NONE,
+                        0,
+                        ckernel::ADDR_MOD_4,
+                        0); // B0A1 // srca+=16/=0,  srcb=16,  dest=0/+=8 (addr_mod_4), bias=0 // srca=0 dest+=8 if in0_32x16
 
-                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B1A2 // srca=srca, srcb+=8,  dest+=8
-                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0); // B1A2 // srca+=16,  srcb=16,  dest+=8/24 // dest+=24 if transposed
-                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B1A3 // srca=srca, srcb+=8,  dest+=8
+                    TTI_MVMUL(ckernel::p_setrwc::CLR_NONE, 0, ckernel::ADDR_MOD_0, 0); // B1A2 // srca=srca, srcb+=8,  dest+=8
+                    TTI_MVMUL(ckernel::p_setrwc::CLR_NONE, 0, ckernel::ADDR_MOD_1, 0); // B1A2 // srca+=16,  srcb=16,  dest+=8/24 // dest+=24 if transposed
+                    TTI_MVMUL(ckernel::p_setrwc::CLR_NONE, 0, ckernel::ADDR_MOD_0, 0); // B1A3 // srca=srca, srcb+=8,  dest+=8
                 }
             }
             else
             {
-                TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B0A0 // srca=srca, srcb+=8,  dest+=8
-                TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0); // B0A0 // srca+=16/32, srcb=0, dest+=8  // srca+=32 if transposed
-                TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B0A1 // srca=srca, srcb+=8,  dest+=8  // A1 -> A2 if transposed
-                TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_2, 0); // B0A1 // srca=0,    srcb=32,  dest+=8  // A1 -> A2 if transposed
+                TTI_MVMUL(ckernel::p_setrwc::CLR_NONE, 0, ckernel::ADDR_MOD_0, 0); // B0A0 // srca=srca, srcb+=8,  dest+=8
+                TTI_MVMUL(ckernel::p_setrwc::CLR_NONE, 0, ckernel::ADDR_MOD_1, 0); // B0A0 // srca+=16/32, srcb=0, dest+=8  // srca+=32 if transposed
+                TTI_MVMUL(ckernel::p_setrwc::CLR_NONE, 0, ckernel::ADDR_MOD_0, 0); // B0A1 // srca=srca, srcb+=8,  dest+=8  // A1 -> A2 if transposed
+                TTI_MVMUL(ckernel::p_setrwc::CLR_NONE, 0, ckernel::ADDR_MOD_2, 0); // B0A1 // srca=0,    srcb=32,  dest+=8  // A1 -> A2 if transposed
 
-                TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B2A0 // srca=srca, srcb+=8,  dest+=8
-                TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0); // B2A0 // srca+=16/32, srcb=0, dest+=8 // srca+=32 if transposed
-                TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B2A1 // srca=srca, srcb+=8,  dest+=8 // A1 -> A2 if transposed
+                TTI_MVMUL(ckernel::p_setrwc::CLR_NONE, 0, ckernel::ADDR_MOD_0, 0); // B2A0 // srca=srca, srcb+=8,  dest+=8
+                TTI_MVMUL(ckernel::p_setrwc::CLR_NONE, 0, ckernel::ADDR_MOD_1, 0); // B2A0 // srca+=16/32, srcb=0, dest+=8 // srca+=32 if transposed
+                TTI_MVMUL(ckernel::p_setrwc::CLR_NONE, 0, ckernel::ADDR_MOD_0, 0); // B2A1 // srca=srca, srcb+=8,  dest+=8 // A1 -> A2 if transposed
                 if (!is_in1_16x32)
                 {
-                    // TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B2A1 // srca=32/16,srcb=16,  dest=0 (addr_mod_4) // A1 -> A2 && srca=16 if transposed
-                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_4, 0); // B2A1 // srca=32/16,srcb=16,  dest=0 (addr_mod_4) // A1 -> A2 && srca=16 if transposed
+                    // TTI_MVMUL(ckernel::p_setrwc::CLR_NONE, 0, ckernel::ADDR_MOD_0, 0); // B2A1 // srca=32/16,srcb=16,  dest=0 (addr_mod_4) // A1 -> A2 &&
+                    // srca=16 if transposed
+                    TTI_MVMUL(
+                        ckernel::p_setrwc::CLR_NONE,
+                        0,
+                        ckernel::ADDR_MOD_4,
+                        0); // B2A1 // srca=32/16,srcb=16,  dest=0 (addr_mod_4) // A1 -> A2 && srca=16 if transposed
 
-                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B1A2 // srca=srca, srcb+=8,  dest+=8 // A2 -> A1 if transposed
-                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0); // B1A2 // srca+=16,  srcb=16,  dest+=8 // A2 -> A1 if transposed
-                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B1A3 // srca=srca, srcb+=8,  dest+=8
-                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_2, 0); // B1A3 // srca=32,   srcb=48,  dest+=8
+                    TTI_MVMUL(ckernel::p_setrwc::CLR_NONE, 0, ckernel::ADDR_MOD_0, 0); // B1A2 // srca=srca, srcb+=8,  dest+=8 // A2 -> A1 if transposed
+                    TTI_MVMUL(ckernel::p_setrwc::CLR_NONE, 0, ckernel::ADDR_MOD_1, 0); // B1A2 // srca+=16,  srcb=16,  dest+=8 // A2 -> A1 if transposed
+                    TTI_MVMUL(ckernel::p_setrwc::CLR_NONE, 0, ckernel::ADDR_MOD_0, 0); // B1A3 // srca=srca, srcb+=8,  dest+=8
+                    TTI_MVMUL(ckernel::p_setrwc::CLR_NONE, 0, ckernel::ADDR_MOD_2, 0); // B1A3 // srca=32,   srcb=48,  dest+=8
 
-                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B3A2 // srca=srca, srcb+=8,  dest+=8 // A2 -> A1 if transposed
-                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0); // B3A2 // srca+=16,  srcb=0,   dest+=8 // A2 -> A1 if transposed
-                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B3A3 // srca=srca, srcb+=8,  dest+=8
+                    TTI_MVMUL(ckernel::p_setrwc::CLR_NONE, 0, ckernel::ADDR_MOD_0, 0); // B3A2 // srca=srca, srcb+=8,  dest+=8 // A2 -> A1 if transposed
+                    TTI_MVMUL(ckernel::p_setrwc::CLR_NONE, 0, ckernel::ADDR_MOD_1, 0); // B3A2 // srca+=16,  srcb=0,   dest+=8 // A2 -> A1 if transposed
+                    TTI_MVMUL(ckernel::p_setrwc::CLR_NONE, 0, ckernel::ADDR_MOD_0, 0); // B3A3 // srca=srca, srcb+=8,  dest+=8
                 }
             }
 
             if constexpr (high_fidelity)
             {
-                // TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0); // B3A3 or B3A2 // reset srca/srcb/dest, increment phase (addr_mod_5)
-                TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_5, 0); // B3A3 or B3A2 // reset srca/srcb/dest, increment phase (addr_mod_5)
+                // TTI_MVMUL(ckernel::p_setrwc::CLR_NONE, 0, ckernel::ADDR_MOD_1, 0); // B3A3 or B3A2 // reset srca/srcb/dest, increment phase (addr_mod_5)
+                TTI_MVMUL(ckernel::p_setrwc::CLR_NONE, 0, ckernel::ADDR_MOD_5, 0); // B3A3 or B3A2 // reset srca/srcb/dest, increment phase (addr_mod_5)
             }
             else
             {
                 if (reuse_a)
                 {
-                    TTI_MVMUL(p_setrwc::CLR_A, 0, ADDR_MOD_5, 0); // B3A3 or B3A2 // reset srca/srcb/dest, increment phase (addr_mod_5), clear src A
+                    TTI_MVMUL(
+                        ckernel::p_setrwc::CLR_A, 0, ckernel::ADDR_MOD_5, 0); // B3A3 or B3A2 // reset srca/srcb/dest, increment phase (addr_mod_5), clear src A
                 }
                 else
                 {
-                    TTI_MVMUL(p_setrwc::CLR_B, 0, ADDR_MOD_5, 0); // B3A3 or B2A1 // reset srca/srcb/dest, increment phase (addr_mod_5), clear src A
+                    TTI_MVMUL(
+                        ckernel::p_setrwc::CLR_B, 0, ckernel::ADDR_MOD_5, 0); // B3A3 or B2A1 // reset srca/srcb/dest, increment phase (addr_mod_5), clear src A
                 }
             }
         });
 
     // TODO: can we commonize this?
     constexpr uint inner_loops = high_fidelity ? NUM_FIDELITY_PHASES : 1;
-    ckernel_template tmp(1 /* outer loop */, inner_loops, TT_OP_REPLAY(ckernel::math::replay_buf_offset, replay_buf_len, 0, 0));
+    ckernel::ckernel_template tmp(1 /* outer loop */, inner_loops, TT_OP_REPLAY(ckernel::math::replay_buf_offset, replay_buf_len, 0, 0));
 
     if constexpr (high_fidelity)
     {
         if (reuse_a)
         {
-            tmp.set_end_op(TT_OP_SETRWC(p_setrwc::CLR_A, 0, 0, 0, 0, p_setrwc::SET_ABD_F));
+            tmp.set_end_op(TT_OP_SETRWC(ckernel::p_setrwc::CLR_A, 0, 0, 0, 0, ckernel::p_setrwc::SET_ABD_F));
         }
         else
         {
-            tmp.set_end_op(TT_OP_SETRWC(p_setrwc::CLR_B, 0, 0, 0, 0, p_setrwc::SET_ABD_F));
+            tmp.set_end_op(TT_OP_SETRWC(ckernel::p_setrwc::CLR_B, 0, 0, 0, 0, ckernel::p_setrwc::SET_ABD_F));
         }
     }
-    tmp.program(instrn_buffer);
+    tmp.program(ckernel::instrn_buffer);
 }
 
-template <int MATH_FIDELITY_DESC, DstTileFaceLayout FaceLayout = DstTileFaceLayout::ColMajor>
+template <int MATH_FIDELITY_DESC, ckernel::DstTileFaceLayout FaceLayout = ckernel::DstTileFaceLayout::ColMajor>
 inline void _llk_math_matmul_init_(
-    const std::uint32_t in0_tile_r_dim = TILE_R_DIM,
-    const std::uint32_t in0_tile_c_dim = TILE_C_DIM,
-    const std::uint32_t in1_tile_r_dim = TILE_R_DIM,
-    const std::uint32_t in1_tile_c_dim = TILE_C_DIM,
+    const std::uint32_t in0_tile_r_dim = ckernel::TILE_R_DIM,
+    const std::uint32_t in0_tile_c_dim = ckernel::TILE_C_DIM,
+    const std::uint32_t in1_tile_r_dim = ckernel::TILE_R_DIM,
+    const std::uint32_t in1_tile_c_dim = ckernel::TILE_C_DIM,
     const bool partial_face            = false,
     const std::uint32_t transpose      = 0,
     const std::uint32_t ct_dim         = 1,
@@ -424,13 +432,13 @@ inline void _llk_math_matmul_init_(
     matmul_configure_addrmod<MATH_FIDELITY_DESC, FaceLayout>(
         transpose, ct_dim, rt_dim, kt_dim, in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face);
 
-    constexpr int MATH_FIDELITY_PHASES = get_math_num_fidelity_phases(MATH_FIDELITY_DESC);
+    constexpr int MATH_FIDELITY_PHASES = ckernel::math::get_math_num_fidelity_phases(MATH_FIDELITY_DESC);
     matmul_configure_mop<MATH_FIDELITY_PHASES, FaceLayout>(
         transpose > 0, ct_dim, rt_dim, kt_dim, in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face);
-    math::reset_counters(p_setrwc::SET_ABD_F);
+    ckernel::math::reset_counters(ckernel::p_setrwc::SET_ABD_F);
 }
 
-template <int MATH_FIDELITY_DESC, DstTileFaceLayout FaceLayout = DstTileFaceLayout::ColMajor>
+template <int MATH_FIDELITY_DESC, ckernel::DstTileFaceLayout FaceLayout = ckernel::DstTileFaceLayout::ColMajor>
 inline void _llk_math_matmul_(
     uint dst_index, const bool transpose = false, const std::uint32_t ct_dim = 1, const std::uint32_t rt_dim = 1, const std::uint32_t kt_dim = 1)
 {
@@ -442,20 +450,21 @@ inline void _llk_math_matmul_(
     {
         for (uint rut = 0; rut < rut_dim; rut++)
         {
-            math::set_dst_write_addr<DstTileLayout::Default, DstTileShape::Tile32x32>(dst_index + (reuse_a ? ct_dim * t + rut : t + rut * ct_dim));
+            ckernel::math::set_dst_write_addr<ckernel::DstTileLayout::Default, ckernel::DstTileShape::Tile32x32>(
+                dst_index + (reuse_a ? ct_dim * t + rut : t + rut * ct_dim));
 
-            ckernel_template::run(instrn_buffer);
+            ckernel::ckernel_template::run(ckernel::instrn_buffer);
 
             // Clear srcB or srcA at end of re-use (once per u block row)
             if (rut == (rut_dim - 1))
             {
                 if (reuse_a)
                 {
-                    TTI_SETRWC(p_setrwc::CLR_B, 0, 0, 0, 0, p_setrwc::SET_ABD_F);
+                    TTI_SETRWC(ckernel::p_setrwc::CLR_B, 0, 0, 0, 0, ckernel::p_setrwc::SET_ABD_F);
                 }
                 else
                 {
-                    TTI_SETRWC(p_setrwc::CLR_A, 0, 0, 0, 0, p_setrwc::SET_ABD_F);
+                    TTI_SETRWC(ckernel::p_setrwc::CLR_A, 0, 0, 0, 0, ckernel::p_setrwc::SET_ABD_F);
                 }
             }
         }

--- a/tt_llk_blackhole/llk_lib/llk_math_reduce.h
+++ b/tt_llk_blackhole/llk_lib/llk_math_reduce.h
@@ -13,292 +13,290 @@
 #include "cmath_common.h"
 #include "llk_math_common.h"
 
-using namespace ckernel;
-
 // local function declarations
 inline void reduce_configure_addrmod();
 
-template <ReduceDim dim, int num_fidelity_phases>
+template <ckernel::ReduceDim dim, int num_fidelity_phases>
 inline void reduce_configure_mop();
 
-template <PoolType type, ReduceDim dim, int MATH_FIDELITY_DESC = 0, bool is_fp32_dest_acc_en = false, bool is_int_fpu_en = false>
+template <ckernel::PoolType type, ckernel::ReduceDim dim, int MATH_FIDELITY_DESC = 0, bool is_fp32_dest_acc_en = false, bool is_int_fpu_en = false>
 inline void _llk_math_reduce_(const uint dst_index, bool narrow_tile = false, const uint num_faces = 4)
 {
-    constexpr int MATH_FIDELITY_PHASES = get_math_num_fidelity_phases(MATH_FIDELITY_DESC);
+    constexpr int MATH_FIDELITY_PHASES = ckernel::math::get_math_num_fidelity_phases(MATH_FIDELITY_DESC);
     constexpr bool HIGH_FIDELITY       = MATH_FIDELITY_PHASES > 0;
 
-    math::set_dst_write_addr<DstTileLayout::Default, DstTileShape::Tile32x32>(dst_index);
-    if constexpr (dim == ReduceDim::REDUCE_ROW)
+    ckernel::math::set_dst_write_addr<ckernel::DstTileLayout::Default, ckernel::DstTileShape::Tile32x32>(dst_index);
+    if constexpr (dim == ckernel::ReduceDim::REDUCE_ROW)
     {
         // Transpose for each face in src A done at unpacker, and pool
-        if constexpr (type == PoolType::MAX)
+        if constexpr (type == ckernel::PoolType::MAX)
         {
-            TTI_GMPOOL(p_setrwc::CLR_AB, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, 0);
+            TTI_GMPOOL(ckernel::p_setrwc::CLR_AB, ckernel::p_gpool::DIM_16X16, ckernel::ADDR_MOD_0, ckernel::p_gpool::INDEX_DIS, 0);
         }
         else
         {
             if constexpr (HIGH_FIDELITY)
             {
-                ckernel_template::run(instrn_buffer);
-                TTI_CLEARDVALID(p_setrwc::CLR_AB, 0);
+                ckernel::ckernel_template::run(ckernel::instrn_buffer);
+                TTI_CLEARDVALID(ckernel::p_setrwc::CLR_AB, 0);
             }
             else
             {
-                TTI_GAPOOL(p_setrwc::CLR_AB, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, 0);
+                TTI_GAPOOL(ckernel::p_setrwc::CLR_AB, ckernel::p_gpool::DIM_16X16, ckernel::ADDR_MOD_0, ckernel::p_gpool::INDEX_DIS, 0);
             }
         }
 
-        if constexpr (type == PoolType::MAX)
+        if constexpr (type == ckernel::PoolType::MAX)
         {
-            TTI_GMPOOL(p_setrwc::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, 0);
+            TTI_GMPOOL(ckernel::p_setrwc::CLR_NONE, ckernel::p_gpool::DIM_16X16, ckernel::ADDR_MOD_0, ckernel::p_gpool::INDEX_DIS, 0);
         }
         else
         {
             if constexpr (HIGH_FIDELITY)
             {
-                ckernel_template::run(instrn_buffer);
+                ckernel::ckernel_template::run(ckernel::instrn_buffer);
             }
             else
             {
-                TTI_GAPOOL(p_setrwc::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, 0);
+                TTI_GAPOOL(ckernel::p_setrwc::CLR_NONE, ckernel::p_gpool::DIM_16X16, ckernel::ADDR_MOD_0, ckernel::p_gpool::INDEX_DIS, 0);
             }
         }
 
         // Workaround for tenstorrent/budabackend#1948
         if constexpr (is_int_fpu_en)
         {
-            TTI_STALLWAIT(p_stall::STALL_SFPU, p_stall::MATH);
-            TTI_SFPLOAD(0, 4, ADDR_MOD_0, 0);
-            TTI_SFPSTORE(0, 5, ADDR_MOD_0, 0);
-            TTI_SFPLOAD(0, 4, ADDR_MOD_0, 2);
-            TTI_SFPSTORE(0, 5, ADDR_MOD_0, 2);
-            TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::WAIT_SFPU);
+            TTI_STALLWAIT(ckernel::p_stall::STALL_SFPU, ckernel::p_stall::MATH);
+            TTI_SFPLOAD(0, 4, ckernel::ADDR_MOD_0, 0);
+            TTI_SFPSTORE(0, 5, ckernel::ADDR_MOD_0, 0);
+            TTI_SFPLOAD(0, 4, ckernel::ADDR_MOD_0, 2);
+            TTI_SFPSTORE(0, 5, ckernel::ADDR_MOD_0, 2);
+            TTI_STALLWAIT(ckernel::p_stall::STALL_MATH, ckernel::p_stall::WAIT_SFPU);
             TTI_SETC16(FP16A_FORCE_Enable_ADDR32, 0x1);
         }
 
         // Move back to B and transpose
         // we avoid clobbering weights in src B by moving to rows 16 - 31
-        TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_D, 0, 0, 0, p_setrwc::SET_AB);
+        TTI_SETRWC(ckernel::p_setrwc::CLR_NONE, ckernel::p_setrwc::CR_D, 0, 0, 0, ckernel::p_setrwc::SET_AB);
         /*
         if constexpr (is_fp32_dest_acc_en) {
             if (0 == (((uint)unpack_dst_format[0]>>2)&0x1)) { // fp32 to fp16_a conversion
-                TTI_STALLWAIT(p_stall::STALL_SFPU, p_stall::MATH);
+                TTI_STALLWAIT(ckernel::p_stall::STALL_SFPU, ckernel::p_stall::MATH);
                 TTI_SFPLOAD(0, 0, 3, 0);
                 TTI_SFP_STOCH_RND(0,0,0,0,0,8);
                 TTI_SFPSTORE(0,1,3,0);
             }
         }
         */
-        TTI_MOVD2B(0, p_movd2b::SRC_ROW16_OFFSET, ADDR_MOD_0, p_movd2b::MOV_1_ROW, 0);
+        TTI_MOVD2B(0, ckernel::p_movd2b::SRC_ROW16_OFFSET, ckernel::ADDR_MOD_0, ckernel::p_movd2b::MOV_1_ROW, 0);
         // Note: transpose on src B on works on rows 16 - 31
         TTI_TRNSPSRCB;
-        TTI_MOVD2B(0, p_movd2b::SRC_ROW16_OFFSET, ADDR_MOD_0, p_movd2b::MOV_1_ROW, 0);
+        TTI_MOVD2B(0, ckernel::p_movd2b::SRC_ROW16_OFFSET, ckernel::ADDR_MOD_0, ckernel::p_movd2b::MOV_1_ROW, 0);
         if constexpr (is_int_fpu_en)
         {
             TTI_SETC16(FP16A_FORCE_Enable_ADDR32, 0x0);
         }
 
-        TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_B, 0, 8, 0, p_setrwc::SET_B);
-        TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_B, 0, 8, 0, p_setrwc::SET_B);
+        TTI_SETRWC(ckernel::p_setrwc::CLR_NONE, ckernel::p_setrwc::CR_B, 0, 8, 0, ckernel::p_setrwc::SET_B);
+        TTI_SETRWC(ckernel::p_setrwc::CLR_NONE, ckernel::p_setrwc::CR_B, 0, 8, 0, ckernel::p_setrwc::SET_B);
         TTI_ZEROSRC(0, 1, 0, 1); // Clear src A
-        TTI_ELWADD(0, 0, p_elwise::SRCB_NO_BCAST, ADDR_MOD_2, 0);
-        TTI_ELWADD(0, 0, p_elwise::SRCB_NO_BCAST, ADDR_MOD_2, 0);
+        TTI_ELWADD(0, 0, ckernel::p_elwise::SRCB_NO_BCAST, ckernel::ADDR_MOD_2, 0);
+        TTI_ELWADD(0, 0, ckernel::p_elwise::SRCB_NO_BCAST, ckernel::ADDR_MOD_2, 0);
 
         // Increment dest by 32 or 16 if narrow tile for the next accumulation
         if (!narrow_tile)
         {
-            TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_D, 8, 0, 0, p_setrwc::SET_D);
-            TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_D, 8, 0, 0, p_setrwc::SET_D);
+            TTI_SETRWC(ckernel::p_setrwc::CLR_NONE, ckernel::p_setrwc::CR_D, 8, 0, 0, ckernel::p_setrwc::SET_D);
+            TTI_SETRWC(ckernel::p_setrwc::CLR_NONE, ckernel::p_setrwc::CR_D, 8, 0, 0, ckernel::p_setrwc::SET_D);
         }
-        TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_D, 8, 0, 0, p_setrwc::SET_D);
-        TTI_SETRWC(p_setrwc::CLR_AB, p_setrwc::CR_D, 8, 0, 0, p_setrwc::SET_BD);
+        TTI_SETRWC(ckernel::p_setrwc::CLR_NONE, ckernel::p_setrwc::CR_D, 8, 0, 0, ckernel::p_setrwc::SET_D);
+        TTI_SETRWC(ckernel::p_setrwc::CLR_AB, ckernel::p_setrwc::CR_D, 8, 0, 0, ckernel::p_setrwc::SET_BD);
 
         /////////////////////
         // Second Tile Row //
         /////////////////////
 
         // Transpose at unpacker and pool
-        if constexpr (type == PoolType::MAX)
+        if constexpr (type == ckernel::PoolType::MAX)
         {
-            TTI_GMPOOL(p_setrwc::CLR_AB, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, 0);
+            TTI_GMPOOL(ckernel::p_setrwc::CLR_AB, ckernel::p_gpool::DIM_16X16, ckernel::ADDR_MOD_0, ckernel::p_gpool::INDEX_DIS, 0);
         }
         else
         {
             if constexpr (HIGH_FIDELITY)
             {
-                ckernel_template::run(instrn_buffer);
-                TTI_CLEARDVALID(p_setrwc::CLR_AB, 0);
+                ckernel::ckernel_template::run(ckernel::instrn_buffer);
+                TTI_CLEARDVALID(ckernel::p_setrwc::CLR_AB, 0);
             }
             else
             {
-                TTI_GAPOOL(p_setrwc::CLR_AB, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, 0);
+                TTI_GAPOOL(ckernel::p_setrwc::CLR_AB, ckernel::p_gpool::DIM_16X16, ckernel::ADDR_MOD_0, ckernel::p_gpool::INDEX_DIS, 0);
             }
         }
 
-        if constexpr (type == PoolType::MAX)
+        if constexpr (type == ckernel::PoolType::MAX)
         {
-            TTI_GMPOOL(p_setrwc::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, 0);
+            TTI_GMPOOL(ckernel::p_setrwc::CLR_NONE, ckernel::p_gpool::DIM_16X16, ckernel::ADDR_MOD_0, ckernel::p_gpool::INDEX_DIS, 0);
         }
         else
         {
             if constexpr (HIGH_FIDELITY)
             {
-                ckernel_template::run(instrn_buffer);
+                ckernel::ckernel_template::run(ckernel::instrn_buffer);
             }
             else
             {
-                TTI_GAPOOL(p_setrwc::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, 0);
+                TTI_GAPOOL(ckernel::p_setrwc::CLR_NONE, ckernel::p_gpool::DIM_16X16, ckernel::ADDR_MOD_0, ckernel::p_gpool::INDEX_DIS, 0);
             }
         }
         // Workaround for tenstorrent/budabackend#1948
         if constexpr (is_int_fpu_en)
         {
-            TTI_STALLWAIT(p_stall::STALL_SFPU, p_stall::MATH);
-            TTI_SFPLOAD(0, 4, ADDR_MOD_0, 0);
-            TTI_SFPSTORE(0, 5, ADDR_MOD_0, 0);
-            TTI_SFPLOAD(0, 4, ADDR_MOD_0, 2);
-            TTI_SFPSTORE(0, 5, ADDR_MOD_0, 2);
-            TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::WAIT_SFPU);
+            TTI_STALLWAIT(ckernel::p_stall::STALL_SFPU, ckernel::p_stall::MATH);
+            TTI_SFPLOAD(0, 4, ckernel::ADDR_MOD_0, 0);
+            TTI_SFPSTORE(0, 5, ckernel::ADDR_MOD_0, 0);
+            TTI_SFPLOAD(0, 4, ckernel::ADDR_MOD_0, 2);
+            TTI_SFPSTORE(0, 5, ckernel::ADDR_MOD_0, 2);
+            TTI_STALLWAIT(ckernel::p_stall::STALL_MATH, ckernel::p_stall::WAIT_SFPU);
             TTI_SETC16(FP16A_FORCE_Enable_ADDR32, 0x1);
         }
 
         // Move back to B and transpose
-        TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_D, 0, 0, 0, p_setrwc::SET_AB);
+        TTI_SETRWC(ckernel::p_setrwc::CLR_NONE, ckernel::p_setrwc::CR_D, 0, 0, 0, ckernel::p_setrwc::SET_AB);
         /*
         if constexpr (is_fp32_dest_acc_en) {
             if (0 == (((uint)unpack_dst_format[0]>>2)&0x1)) { // fp32 to fp16_a conversion
-                TTI_STALLWAIT(p_stall::STALL_SFPU, p_stall::MATH);
+                TTI_STALLWAIT(ckernel::p_stall::STALL_SFPU, ckernel::p_stall::MATH);
                 TTI_SFPLOAD(0, 0, 3, 0);
                 TTI_SFP_STOCH_RND(0,0,0,0,0,8);
                 TTI_SFPSTORE(0,1,3,0);
             }
         }
         */
-        TTI_MOVD2B(0, p_movd2b::SRC_ROW16_OFFSET, ADDR_MOD_0, p_movd2b::MOV_1_ROW, 0);
+        TTI_MOVD2B(0, ckernel::p_movd2b::SRC_ROW16_OFFSET, ckernel::ADDR_MOD_0, ckernel::p_movd2b::MOV_1_ROW, 0);
         // Note: transpose on src B on works on rows 16 - 31
         TTI_TRNSPSRCB;
-        TTI_MOVD2B(0, p_movd2b::SRC_ROW16_OFFSET, ADDR_MOD_0, p_movd2b::MOV_1_ROW, 0);
+        TTI_MOVD2B(0, ckernel::p_movd2b::SRC_ROW16_OFFSET, ckernel::ADDR_MOD_0, ckernel::p_movd2b::MOV_1_ROW, 0);
         if constexpr (is_int_fpu_en)
         {
             TTI_SETC16(FP16A_FORCE_Enable_ADDR32, 0x0);
         }
 
-        TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_B, 0, 8, 0, p_setrwc::SET_B);
-        TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_B, 0, 8, 0, p_setrwc::SET_B);
+        TTI_SETRWC(ckernel::p_setrwc::CLR_NONE, ckernel::p_setrwc::CR_B, 0, 8, 0, ckernel::p_setrwc::SET_B);
+        TTI_SETRWC(ckernel::p_setrwc::CLR_NONE, ckernel::p_setrwc::CR_B, 0, 8, 0, ckernel::p_setrwc::SET_B);
         TTI_ZEROSRC(0, 1, 0, 1); // Clear src A
-        TTI_ELWADD(0, 0, p_elwise::SRCB_NO_BCAST, ADDR_MOD_2, 0);
-        TTI_ELWADD(0, 0, p_elwise::SRCB_NO_BCAST, ADDR_MOD_2, 0);
+        TTI_ELWADD(0, 0, ckernel::p_elwise::SRCB_NO_BCAST, ckernel::ADDR_MOD_2, 0);
+        TTI_ELWADD(0, 0, ckernel::p_elwise::SRCB_NO_BCAST, ckernel::ADDR_MOD_2, 0);
 
         // Increment dest by 32 for next accumulation
-        TTI_SETRWC(p_setrwc::CLR_AB, 0, 0, 0, 0, p_setrwc::SET_BD);
+        TTI_SETRWC(ckernel::p_setrwc::CLR_AB, 0, 0, 0, 0, ckernel::p_setrwc::SET_BD);
     }
-    else if constexpr (dim == ReduceDim::REDUCE_COL)
+    else if constexpr (dim == ckernel::ReduceDim::REDUCE_COL)
     {
         const uint num_row_tiles = narrow_tile ? 2 : ((num_faces > 1) ? num_faces / 2 : 1);
         for (uint row_tile = 0; row_tile < num_row_tiles; row_tile++)
         {
             // Just pool
-            if constexpr (type == PoolType::MAX)
+            if constexpr (type == ckernel::PoolType::MAX)
             {
-                TTI_GMPOOL(p_setrwc::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, 0);
+                TTI_GMPOOL(ckernel::p_setrwc::CLR_NONE, ckernel::p_gpool::DIM_16X16, ckernel::ADDR_MOD_0, ckernel::p_gpool::INDEX_DIS, 0);
             }
             else
             {
                 if constexpr (HIGH_FIDELITY)
                 {
-                    ckernel_template::run(instrn_buffer);
+                    ckernel::ckernel_template::run(ckernel::instrn_buffer);
                 }
                 else
                 {
-                    TTI_GAPOOL(p_setrwc::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, 0);
+                    TTI_GAPOOL(ckernel::p_setrwc::CLR_NONE, ckernel::p_gpool::DIM_16X16, ckernel::ADDR_MOD_0, ckernel::p_gpool::INDEX_DIS, 0);
                 }
             }
             if ((!narrow_tile) && (num_faces > 1))
             {
-                TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_D, 8, 0, 0, p_setrwc::SET_D);
-                TTI_SETRWC(p_setrwc::CLR_AB, p_setrwc::CR_D, 8, 0, 0, p_setrwc::SET_D);
+                TTI_SETRWC(ckernel::p_setrwc::CLR_NONE, ckernel::p_setrwc::CR_D, 8, 0, 0, ckernel::p_setrwc::SET_D);
+                TTI_SETRWC(ckernel::p_setrwc::CLR_AB, ckernel::p_setrwc::CR_D, 8, 0, 0, ckernel::p_setrwc::SET_D);
 
-                if constexpr (type == PoolType::MAX)
+                if constexpr (type == ckernel::PoolType::MAX)
                 {
-                    TTI_GMPOOL(p_setrwc::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, 0);
+                    TTI_GMPOOL(ckernel::p_setrwc::CLR_NONE, ckernel::p_gpool::DIM_16X16, ckernel::ADDR_MOD_0, ckernel::p_gpool::INDEX_DIS, 0);
                 }
                 else
                 {
                     if constexpr (HIGH_FIDELITY)
                     {
-                        ckernel_template::run(instrn_buffer);
+                        ckernel::ckernel_template::run(ckernel::instrn_buffer);
                     }
                     else
                     {
-                        TTI_GAPOOL(p_setrwc::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, 0);
+                        TTI_GAPOOL(ckernel::p_setrwc::CLR_NONE, ckernel::p_gpool::DIM_16X16, ckernel::ADDR_MOD_0, ckernel::p_gpool::INDEX_DIS, 0);
                     }
                 }
             }
             // Reset Dest Counter
-            TTI_SETRWC(p_setrwc::CLR_AB, 0, 0, 0, 0, p_setrwc::SET_AD);
+            TTI_SETRWC(ckernel::p_setrwc::CLR_AB, 0, 0, 0, 0, ckernel::p_setrwc::SET_AD);
         }
     }
-    else if constexpr (dim == ReduceDim::REDUCE_SCALAR)
+    else if constexpr (dim == ckernel::ReduceDim::REDUCE_SCALAR)
     {
         for (int tile = 0; tile < 3; tile++)
         {
             // Wait and pool
-            if constexpr (type == PoolType::MAX)
+            if constexpr (type == ckernel::PoolType::MAX)
             {
-                TTI_GMPOOL(p_setrwc::CLR_AB, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, 4);
+                TTI_GMPOOL(ckernel::p_setrwc::CLR_AB, ckernel::p_gpool::DIM_16X16, ckernel::ADDR_MOD_0, ckernel::p_gpool::INDEX_DIS, 4);
             }
             else
             {
                 if constexpr (HIGH_FIDELITY)
                 {
-                    ckernel_template::run(instrn_buffer);
-                    TTI_CLEARDVALID(p_setrwc::CLR_AB, 0);
+                    ckernel::ckernel_template::run(ckernel::instrn_buffer);
+                    TTI_CLEARDVALID(ckernel::p_setrwc::CLR_AB, 0);
                 }
                 else
                 {
-                    TTI_GAPOOL(p_setrwc::CLR_AB, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, 4);
+                    TTI_GAPOOL(ckernel::p_setrwc::CLR_AB, ckernel::p_gpool::DIM_16X16, ckernel::ADDR_MOD_0, ckernel::p_gpool::INDEX_DIS, 4);
                 }
             }
         }
         // Wait and pool
-        if constexpr (type == PoolType::MAX)
+        if constexpr (type == ckernel::PoolType::MAX)
         {
-            TTI_GMPOOL(p_setrwc::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, 4);
+            TTI_GMPOOL(ckernel::p_setrwc::CLR_NONE, ckernel::p_gpool::DIM_16X16, ckernel::ADDR_MOD_0, ckernel::p_gpool::INDEX_DIS, 4);
         }
         else
         {
             if constexpr (HIGH_FIDELITY)
             {
-                ckernel_template::run(instrn_buffer);
+                ckernel::ckernel_template::run(ckernel::instrn_buffer);
             }
             else
             {
-                TTI_GAPOOL(p_setrwc::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, 4);
+                TTI_GAPOOL(ckernel::p_setrwc::CLR_NONE, ckernel::p_gpool::DIM_16X16, ckernel::ADDR_MOD_0, ckernel::p_gpool::INDEX_DIS, 4);
             }
         }
 
         // Need row in dest as column in src A
-        TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_D, 0, 0, 0, p_setrwc::SET_AB);
+        TTI_SETRWC(ckernel::p_setrwc::CLR_NONE, ckernel::p_setrwc::CR_D, 0, 0, 0, ckernel::p_setrwc::SET_AB);
         // copy over from dest to B and do transpose
         // use rows 16 - 31 in src B as scratch
-        TTI_MOVD2B(0, p_movd2b::SRC_ROW16_OFFSET, ADDR_MOD_0, p_movd2b::MOV_1_ROW, 4);
+        TTI_MOVD2B(0, ckernel::p_movd2b::SRC_ROW16_OFFSET, ckernel::ADDR_MOD_0, ckernel::p_movd2b::MOV_1_ROW, 4);
         TTI_GATESRCRST(0b1, 0b1);
         TTI_TRNSPSRCB;
         // gate math instructions until src B has been updated
         TTI_GATESRCRST(0b1, 0b1);
         // copy over all 16 rows from B to A
-        TTI_MOVB2A(p_movb2a::SRCA_ZERO_OFFSET + 0, ADDR_MOD_0, p_movb2a::MOV_4_ROWS, p_movb2a::SRCB_ROW16_OFFSET + 0);
-        TTI_MOVB2A(p_movb2a::SRCA_ZERO_OFFSET + 4, ADDR_MOD_0, p_movb2a::MOV_4_ROWS, p_movb2a::SRCB_ROW16_OFFSET + 4);
-        TTI_MOVB2A(p_movb2a::SRCA_ZERO_OFFSET + 8, ADDR_MOD_0, p_movb2a::MOV_4_ROWS, p_movb2a::SRCB_ROW16_OFFSET + 8);
-        TTI_MOVB2A(p_movb2a::SRCA_ZERO_OFFSET + 12, ADDR_MOD_0, p_movb2a::MOV_4_ROWS, p_movb2a::SRCB_ROW16_OFFSET + 12);
+        TTI_MOVB2A(p_movb2a::SRCA_ZERO_OFFSET + 0, ckernel::ADDR_MOD_0, p_movb2a::MOV_4_ROWS, p_movb2a::SRCB_ROW16_OFFSET + 0);
+        TTI_MOVB2A(p_movb2a::SRCA_ZERO_OFFSET + 4, ckernel::ADDR_MOD_0, p_movb2a::MOV_4_ROWS, p_movb2a::SRCB_ROW16_OFFSET + 4);
+        TTI_MOVB2A(p_movb2a::SRCA_ZERO_OFFSET + 8, ckernel::ADDR_MOD_0, p_movb2a::MOV_4_ROWS, p_movb2a::SRCB_ROW16_OFFSET + 8);
+        TTI_MOVB2A(p_movb2a::SRCA_ZERO_OFFSET + 12, ckernel::ADDR_MOD_0, p_movb2a::MOV_4_ROWS, p_movb2a::SRCB_ROW16_OFFSET + 12);
         // gate math instructions until src A has been updated by MOV instructions
         TTI_GATESRCRST(0b1, 0b1);
         // zero out scratch in dest
-        TTI_ZEROACC(p_zeroacc::CLR_SPECIFIC, 0, 0, ADDR_MOD_0, 4);
+        TTI_ZEROACC(p_zeroacc::CLR_SPECIFIC, 0, 0, ckernel::ADDR_MOD_0, 4);
 
-        if constexpr (type == PoolType::MAX)
+        if constexpr (type == ckernel::PoolType::MAX)
         {
-            TTI_GMPOOL(p_setrwc::CLR_AB, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, 0);
+            TTI_GMPOOL(ckernel::p_setrwc::CLR_AB, ckernel::p_gpool::DIM_16X16, ckernel::ADDR_MOD_0, ckernel::p_gpool::INDEX_DIS, 0);
         }
         else
         {
@@ -306,63 +304,73 @@ inline void _llk_math_reduce_(const uint dst_index, bool narrow_tile = false, co
             {
                 for (int i = 0; i < MATH_FIDELITY_PHASES - 1; i++)
                 {
-                    TTI_GAPOOL(p_setrwc::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_3, p_gpool::INDEX_DIS, 0);
+                    TTI_GAPOOL(ckernel::p_setrwc::CLR_NONE, ckernel::p_gpool::DIM_16X16, ckernel::ADDR_MOD_3, ckernel::p_gpool::INDEX_DIS, 0);
                 }
             }
-            TTI_GAPOOL(p_setrwc::CLR_AB, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, 0);
+            TTI_GAPOOL(ckernel::p_setrwc::CLR_AB, ckernel::p_gpool::DIM_16X16, ckernel::ADDR_MOD_0, ckernel::p_gpool::INDEX_DIS, 0);
         }
     }
 }
 
-template <PoolType type, int MATH_FIDELITY_DESC>
+template <ckernel::PoolType type, int MATH_FIDELITY_DESC>
 inline void reduce_configure_addrmod()
 {
     constexpr int NUM_FIDELITY_PHASES = get_math_num_fidelity_phases(MATH_FIDELITY_DESC);
     constexpr int FIDELITY_INCREMENT  = get_math_fidelity_increment(MATH_FIDELITY_DESC);
     constexpr bool HIGH_FIDELITY      = NUM_FIDELITY_PHASES > 0;
 
-    addr_mod_t {.srca = {.incr = 0}, .srcb = {.incr = 0}, .dest = {.incr = 0}, .fidelity = {.incr = 0, .clr = 1}}.set(ADDR_MOD_0);
+    ckernel::addr_mod_t {.srca = {.incr = 0}, .srcb = {.incr = 0}, .dest = {.incr = 0}, .fidelity = {.incr = 0, .clr = 1}}.set(ckernel::ADDR_MOD_0);
 
-    addr_mod_t {
+    ckernel::addr_mod_t {
         .srca = {.incr = 0},
         .srcb = {.incr = 1},
         .dest = {.incr = 1},
     }
-        .set(ADDR_MOD_1);
+        .set(ckernel::ADDR_MOD_1);
 
-    addr_mod_t {
+    ckernel::addr_mod_t {
         .srca = {.incr = 0},
         .srcb = {.incr = 8},
         .dest = {.incr = 8},
     }
-        .set(ADDR_MOD_2);
+        .set(ckernel::ADDR_MOD_2);
 
     if constexpr (HIGH_FIDELITY)
     {
-        addr_mod_t {.srca = {.incr = 0}, .srcb = {.incr = 0}, .dest = {.incr = 0}, .fidelity = {.incr = FIDELITY_INCREMENT}}.set(ADDR_MOD_3);
+        ckernel::addr_mod_t {.srca = {.incr = 0}, .srcb = {.incr = 0}, .dest = {.incr = 0}, .fidelity = {.incr = FIDELITY_INCREMENT}}.set(ckernel::ADDR_MOD_3);
     }
 }
 
-template <ReduceDim dim, int num_fidelity_phases>
+template <ckernel::ReduceDim dim, int num_fidelity_phases>
 inline void reduce_configure_mop()
 {
-    if constexpr (dim == ReduceDim::REDUCE_SCALAR)
+    if constexpr (dim == ckernel::ReduceDim::REDUCE_SCALAR)
     {
-        ckernel_template tmp(1, num_fidelity_phases, TT_OP_GAPOOL(p_setrwc::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_3, p_gpool::INDEX_DIS, 4));
-        tmp.set_last_inner_loop_instr(TT_OP_GAPOOL(p_setrwc::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, 4));
-        tmp.set_last_outer_loop_instr(TT_OP_GAPOOL(p_setrwc::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, 4));
-        tmp.program(instrn_buffer);
+        ckernel::ckernel_template tmp(
+            1,
+            num_fidelity_phases,
+            TT_OP_GAPOOL(ckernel::p_setrwc::CLR_NONE, ckernel::p_gpool::DIM_16X16, ckernel::ADDR_MOD_3, ckernel::p_gpool::INDEX_DIS, 4));
+        tmp.set_last_inner_loop_instr(
+            TT_OP_GAPOOL(ckernel::p_setrwc::CLR_NONE, ckernel::p_gpool::DIM_16X16, ckernel::ADDR_MOD_0, ckernel::p_gpool::INDEX_DIS, 4));
+        tmp.set_last_outer_loop_instr(
+            TT_OP_GAPOOL(ckernel::p_setrwc::CLR_NONE, ckernel::p_gpool::DIM_16X16, ckernel::ADDR_MOD_0, ckernel::p_gpool::INDEX_DIS, 4));
+        tmp.program(ckernel::instrn_buffer);
     }
     else
     {
-        ckernel_template tmp(1, num_fidelity_phases, TT_OP_GAPOOL(p_setrwc::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_3, p_gpool::INDEX_DIS, 0));
-        tmp.set_last_inner_loop_instr(TT_OP_GAPOOL(p_setrwc::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, 0));
-        tmp.set_last_outer_loop_instr(TT_OP_GAPOOL(p_setrwc::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, 0));
-        tmp.program(instrn_buffer);
+        ckernel::ckernel_template tmp(
+            1,
+            num_fidelity_phases,
+            TT_OP_GAPOOL(ckernel::p_setrwc::CLR_NONE, ckernel::p_gpool::DIM_16X16, ckernel::ADDR_MOD_3, ckernel::p_gpool::INDEX_DIS, 0));
+        tmp.set_last_inner_loop_instr(
+            TT_OP_GAPOOL(ckernel::p_setrwc::CLR_NONE, ckernel::p_gpool::DIM_16X16, ckernel::ADDR_MOD_0, ckernel::p_gpool::INDEX_DIS, 0));
+        tmp.set_last_outer_loop_instr(
+            TT_OP_GAPOOL(ckernel::p_setrwc::CLR_NONE, ckernel::p_gpool::DIM_16X16, ckernel::ADDR_MOD_0, ckernel::p_gpool::INDEX_DIS, 0));
+        tmp.program(ckernel::instrn_buffer);
     }
 }
 
-template <PoolType type, ReduceDim dim, int MATH_FIDELITY_DESC = 0>
+template <ckernel::PoolType type, ckernel::ReduceDim dim, int MATH_FIDELITY_DESC = 0>
 inline void _llk_math_reduce_init_(const std::uint32_t within_face_16x16_transpose = 0)
 { // within_face_16x16_transpose used for unpack, ignored by math
 
@@ -377,5 +385,5 @@ inline void _llk_math_reduce_init_(const std::uint32_t within_face_16x16_transpo
 
     TTI_SETC16(CLR_DVALID_SrcA_Disable_ADDR32, 0);
 
-    math::reset_counters(p_setrwc::SET_ABD_F);
+    ckernel::math::reset_counters(ckernel::p_setrwc::SET_ABD_F);
 }

--- a/tt_llk_blackhole/llk_lib/llk_math_reduce.h
+++ b/tt_llk_blackhole/llk_lib/llk_math_reduce.h
@@ -315,8 +315,8 @@ inline void _llk_math_reduce_(const uint dst_index, bool narrow_tile = false, co
 template <ckernel::PoolType type, int MATH_FIDELITY_DESC>
 inline void reduce_configure_addrmod()
 {
-    constexpr int NUM_FIDELITY_PHASES = get_math_num_fidelity_phases(MATH_FIDELITY_DESC);
-    constexpr int FIDELITY_INCREMENT  = get_math_fidelity_increment(MATH_FIDELITY_DESC);
+    constexpr int NUM_FIDELITY_PHASES = ckernel::math::get_math_num_fidelity_phases(MATH_FIDELITY_DESC);
+    constexpr int FIDELITY_INCREMENT  = ckernel::math::get_math_fidelity_increment(MATH_FIDELITY_DESC);
     constexpr bool HIGH_FIDELITY      = NUM_FIDELITY_PHASES > 0;
 
     ckernel::addr_mod_t {.srca = {.incr = 0}, .srcb = {.incr = 0}, .dest = {.incr = 0}, .fidelity = {.incr = 0, .clr = 1}}.set(ckernel::ADDR_MOD_0);
@@ -374,7 +374,7 @@ template <ckernel::PoolType type, ckernel::ReduceDim dim, int MATH_FIDELITY_DESC
 inline void _llk_math_reduce_init_(const std::uint32_t within_face_16x16_transpose = 0)
 { // within_face_16x16_transpose used for unpack, ignored by math
 
-    constexpr int MATH_FIDELITY_PHASES = get_math_num_fidelity_phases(MATH_FIDELITY_DESC);
+    constexpr int MATH_FIDELITY_PHASES = ckernel::math::get_math_num_fidelity_phases(MATH_FIDELITY_DESC);
     constexpr bool HIGH_FIDELITY       = MATH_FIDELITY_PHASES > 0;
 
     reduce_configure_addrmod<type, MATH_FIDELITY_DESC>();

--- a/tt_llk_blackhole/llk_lib/llk_math_transpose_dest.h
+++ b/tt_llk_blackhole/llk_lib/llk_math_transpose_dest.h
@@ -13,96 +13,94 @@
 #include "cmath_common.h"
 #include "llk_math_common.h"
 
-using namespace ckernel;
-
 // local function declarations
 inline void transpose_dest_configure_addrmod();
 
 inline void _llk_math_transpose_dest_(const std::uint32_t dst_index)
 {
-    math::set_dst_write_addr<DstTileLayout::Default, DstTileShape::Tile32x32>(dst_index);
+    ckernel::math::set_dst_write_addr<ckernel::DstTileLayout::Default, ckernel::DstTileShape::Tile32x32>(dst_index);
 
-    TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::WAIT_SFPU);
+    TTI_STALLWAIT(ckernel::p_stall::STALL_MATH, ckernel::p_stall::WAIT_SFPU);
 
-    ckernel_template::run(instrn_buffer);
+    ckernel::ckernel_template::run(ckernel::instrn_buffer);
 
     TTI_REPLAY(20, 5, 0, 0);
     TTI_REPLAY(26, 4, 0, 0);
 
-    TTI_SETRWC(p_setrwc::CLR_AB, 0, 0, 0, 0, p_setrwc::SET_AB);
+    TTI_SETRWC(ckernel::p_setrwc::CLR_AB, 0, 0, 0, 0, ckernel::p_setrwc::SET_AB);
 
-    math::clear_dst_reg_addr();
+    ckernel::math::clear_dst_reg_addr();
 }
 
 inline void transpose_dest_configure_addrmod()
 {
-    addr_mod_t {
+    ckernel::addr_mod_t {
         .srca = {.incr = 0},
         .srcb = {.incr = 0},
         .dest = {.incr = 16},
     }
-        .set(ADDR_MOD_0);
+        .set(ckernel::ADDR_MOD_0);
 
-    addr_mod_t {
+    ckernel::addr_mod_t {
         .srca = {.incr = 0},
         .srcb = {.incr = 0},
         .dest = {.incr = 0},
     }
         .set(ADDR_MOD_1);
 
-    addr_mod_t {
+    ckernel::addr_mod_t {
         .srca = {.incr = 0},
         .srcb = {.incr = 0},
         .dest = {.incr = -16},
     }
-        .set(ADDR_MOD_2);
+        .set(ckernel::ADDR_MOD_2);
 }
 
 inline void transpose_dest_configure_mop()
 {
-    load_replay_buf<16, 16, 0>(
+    ckernel::load_replay_buf<16, 16, 0>(
         []
         {
             // A
-            TTI_MOVD2B(0, p_movd2b::SRC_ZERO_OFFSET + 0, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 0 - 16);
-            TTI_MOVD2B(0, p_movd2b::SRC_ZERO_OFFSET + 4, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 4 - 16);
-            TTI_MOVD2B(0, p_movd2b::SRC_ZERO_OFFSET + 8, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 8 - 16);
-            TTI_MOVD2B(0, p_movd2b::SRC_ZERO_OFFSET + 12, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 12 - 16);
+            TTI_MOVD2B(0, ckernel::p_movd2b::SRC_ZERO_OFFSET + 0, ckernel::ADDR_MOD_1, ckernel::p_movd2b::MOV_4_ROWS, 0 - 16);
+            TTI_MOVD2B(0, ckernel::p_movd2b::SRC_ZERO_OFFSET + 4, ckernel::ADDR_MOD_1, ckernel::p_movd2b::MOV_4_ROWS, 4 - 16);
+            TTI_MOVD2B(0, ckernel::p_movd2b::SRC_ZERO_OFFSET + 8, ckernel::ADDR_MOD_1, ckernel::p_movd2b::MOV_4_ROWS, 8 - 16);
+            TTI_MOVD2B(0, ckernel::p_movd2b::SRC_ZERO_OFFSET + 12, ckernel::ADDR_MOD_1, ckernel::p_movd2b::MOV_4_ROWS, 12 - 16);
 
             // B
-            TTI_MOVD2B(0, p_movd2b::SRC_ROW16_OFFSET + 0, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 0);
-            TTI_MOVD2B(0, p_movd2b::SRC_ROW16_OFFSET + 4, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 4);
-            TTI_MOVD2B(0, p_movd2b::SRC_ROW16_OFFSET + 8, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 8);
-            TTI_MOVD2B(0, p_movd2b::SRC_ROW16_OFFSET + 12, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 12);
+            TTI_MOVD2B(0, ckernel::p_movd2b::SRC_ROW16_OFFSET + 0, ckernel::ADDR_MOD_1, ckernel::p_movd2b::MOV_4_ROWS, 0);
+            TTI_MOVD2B(0, ckernel::p_movd2b::SRC_ROW16_OFFSET + 4, ckernel::ADDR_MOD_1, ckernel::p_movd2b::MOV_4_ROWS, 4);
+            TTI_MOVD2B(0, ckernel::p_movd2b::SRC_ROW16_OFFSET + 8, ckernel::ADDR_MOD_1, ckernel::p_movd2b::MOV_4_ROWS, 8);
+            TTI_MOVD2B(0, ckernel::p_movd2b::SRC_ROW16_OFFSET + 12, ckernel::ADDR_MOD_1, ckernel::p_movd2b::MOV_4_ROWS, 12);
 
             // C
             TTI_TRNSPSRCB;
 
             // D
-            TTI_MOVD2B(0, p_movd2b::SRC_ZERO_OFFSET + 32, ADDR_MOD_2, p_movd2b::MOV_1_ROW, 0); // throwaway to decrement dst
+            TTI_MOVD2B(0, ckernel::p_movd2b::SRC_ZERO_OFFSET + 32, ckernel::ADDR_MOD_2, ckernel::p_movd2b::MOV_1_ROW, 0); // throwaway to decrement dst
 
             // E
-            TTI_MOVB2D(0, p_movd2b::SRC_ROW16_OFFSET + 0, ADDR_MOD_1, p_movb2d::MOV_4_ROWS, 0);
-            TTI_MOVB2D(0, p_movd2b::SRC_ROW16_OFFSET + 4, ADDR_MOD_1, p_movb2d::MOV_4_ROWS, 4);
-            TTI_MOVB2D(0, p_movd2b::SRC_ROW16_OFFSET + 8, ADDR_MOD_1, p_movb2d::MOV_4_ROWS, 8);
-            TTI_MOVB2D(0, p_movd2b::SRC_ROW16_OFFSET + 12, ADDR_MOD_0, p_movb2d::MOV_4_ROWS, 12);
+            TTI_MOVB2D(0, ckernel::p_movd2b::SRC_ROW16_OFFSET + 0, ckernel::ADDR_MOD_1, ckernel::p_movb2d::MOV_4_ROWS, 0);
+            TTI_MOVB2D(0, ckernel::p_movd2b::SRC_ROW16_OFFSET + 4, ckernel::ADDR_MOD_1, ckernel::p_movb2d::MOV_4_ROWS, 4);
+            TTI_MOVB2D(0, ckernel::p_movd2b::SRC_ROW16_OFFSET + 8, ckernel::ADDR_MOD_1, ckernel::p_movb2d::MOV_4_ROWS, 8);
+            TTI_MOVB2D(0, ckernel::p_movd2b::SRC_ROW16_OFFSET + 12, ckernel::ADDR_MOD_0, ckernel::p_movb2d::MOV_4_ROWS, 12);
 
             // F
-            TTI_MOVB2D(0, p_movd2b::SRC_ZERO_OFFSET + 0, ADDR_MOD_1, p_movb2d::MOV_4_ROWS, 0);
-            TTI_MOVB2D(0, p_movd2b::SRC_ZERO_OFFSET + 4, ADDR_MOD_1, p_movb2d::MOV_4_ROWS, 4);
+            TTI_MOVB2D(0, ckernel::p_movd2b::SRC_ZERO_OFFSET + 0, ckernel::ADDR_MOD_1, ckernel::p_movb2d::MOV_4_ROWS, 0);
+            TTI_MOVB2D(0, ckernel::p_movd2b::SRC_ZERO_OFFSET + 4, ckernel::ADDR_MOD_1, ckernel::p_movb2d::MOV_4_ROWS, 4);
         });
 
     uint AF = TT_OP_REPLAY(16, 16, 0, 0);
     uint BC = TT_OP_REPLAY(20, 5, 0, 0);
     uint E  = TT_OP_REPLAY(26, 4, 0, 0);
-    uint X  = TT_OP_MOVB2D(0, p_movd2b::SRC_ZERO_OFFSET + 8, ADDR_MOD_1, p_movb2d::MOV_4_ROWS, 8);
-    uint Y  = TT_OP_MOVB2D(0, p_movd2b::SRC_ZERO_OFFSET + 12, ADDR_MOD_0, p_movb2d::MOV_4_ROWS, 12);
+    uint X  = TT_OP_MOVB2D(0, ckernel::p_movd2b::SRC_ZERO_OFFSET + 8, ckernel::ADDR_MOD_1, ckernel::p_movb2d::MOV_4_ROWS, 8);
+    uint Y  = TT_OP_MOVB2D(0, ckernel::p_movd2b::SRC_ZERO_OFFSET + 12, ckernel::ADDR_MOD_0, ckernel::p_movb2d::MOV_4_ROWS, 12);
 
-    ckernel_template tmp(1, 2, E, BC);
+    ckernel::ckernel_template tmp(1, 2, E, BC);
     tmp.set_start_op(BC);
     tmp.set_last_outer_loop_instr(AF);
     tmp.set_end_ops(X, Y);
-    tmp.program(instrn_buffer);
+    tmp.program(ckernel::instrn_buffer);
 }
 
 inline void _llk_math_transpose_dest_init_()

--- a/tt_llk_blackhole/llk_lib/llk_pack.h
+++ b/tt_llk_blackhole/llk_lib/llk_pack.h
@@ -498,7 +498,7 @@ inline void _llk_pack_reconfig_data_format_(
     const bool partial_face        = false,
     const bool narrow_tile         = false)
 {
-    reconfig_packer_data_format<is_fp32_dest_acc_en>(pack_src_format, pack_dst_format, tile_size, face_r_dim, tile_c_dim);
+    ckernel::packer::reconfig_packer_data_format<is_fp32_dest_acc_en>(pack_src_format, pack_dst_format, tile_size, face_r_dim, tile_c_dim);
 
     if constexpr (is_tile_dim_reconfig_en)
     {
@@ -534,7 +534,7 @@ inline void _llk_pack_reduce_hw_configure_(
     const bool narrow_tile          = false,
     const std::uint32_t relu_config = 0)
 {
-    configure_pack<is_fp32_dest_acc_en, untilize, false>(
+    ckernel::packer::configure_pack<is_fp32_dest_acc_en, untilize, false>(
         pack_src_format, pack_dst_format, tile_size, face_r_dim, tile_c_dim, num_faces, partial_face, narrow_tile, relu_config);
 
     volatile uint tt_reg_ptr *cfg = ckernel::get_cfg_pointer();

--- a/tt_llk_blackhole/llk_lib/llk_pack.h
+++ b/tt_llk_blackhole/llk_lib/llk_pack.h
@@ -13,9 +13,6 @@
 #include "llk_defs.h"
 #include "llk_pack_common.h"
 
-using namespace ckernel;
-using namespace ckernel::packer;
-
 template <bool untilize = false, bool tilize = false>
 inline void _llk_pack_configure_addrmod_()
 {
@@ -24,119 +21,123 @@ inline void _llk_pack_configure_addrmod_()
         /*  Y src & Y dest inc by 1 to give strided increments:
             Rows: 0, 16, 1, 17, 2, 18, ........ 15, 31
         */
-        addr_mod_pack_t {.y_src = {.incr = 1}, .y_dst = {.incr = 1}, .z_src = {.incr = 0}, .z_dst = {.incr = 0}}.set(ADDR_MOD_0);
+        ckernel::addr_mod_pack_t {.y_src = {.incr = 1}, .y_dst = {.incr = 1}, .z_src = {.incr = 0}, .z_dst = {.incr = 0}}.set(ckernel::ADDR_MOD_0);
 
         /* Increment Faces by 2 to give next 2 faces:
             Rows: 32, 48, 33, 49, 34, 50........47, 63
         */
-        addr_mod_pack_t {.y_src = {.incr = 0, .clr = 1}, .y_dst = {.incr = 0, .clr = 1}, .z_src = {.incr = 1}, .z_dst = {.incr = 0}}.set(ADDR_MOD_1);
+        ckernel::addr_mod_pack_t {.y_src = {.incr = 0, .clr = 1}, .y_dst = {.incr = 0, .clr = 1}, .z_src = {.incr = 1}, .z_dst = {.incr = 0}}.set(
+            ckernel::ADDR_MOD_1);
 
-        addr_mod_pack_t {.y_src = {.incr = 0, .clr = 1}, .y_dst = {.incr = 0, .clr = 1}, .z_src = {.incr = 0, .clr = 1}, .z_dst = {.incr = 0, .clr = 1}}.set(
-            ADDR_MOD_2);
+        ckernel::addr_mod_pack_t {
+            .y_src = {.incr = 0, .clr = 1}, .y_dst = {.incr = 0, .clr = 1}, .z_src = {.incr = 0, .clr = 1}, .z_dst = {.incr = 0, .clr = 1}}
+            .set(ckernel::ADDR_MOD_2);
     }
     else if constexpr (tilize && !untilize)
     {
-        addr_mod_pack_t {.y_src = {.incr = 4}, .y_dst = {.incr = 2}, .z_src = {.incr = 0}, .z_dst = {.incr = 0}}.set(ADDR_MOD_0);
+        ckernel::addr_mod_pack_t {.y_src = {.incr = 4}, .y_dst = {.incr = 2}, .z_src = {.incr = 0}, .z_dst = {.incr = 0}}.set(ckernel::ADDR_MOD_0);
 
-        addr_mod_pack_t {.y_src = {.incr = 0, .clr = 1}, .y_dst = {.incr = 0, .clr = 1}, .z_src = {.incr = 0}, .z_dst = {.incr = 0}}.set(ADDR_MOD_1);
+        ckernel::addr_mod_pack_t {.y_src = {.incr = 0, .clr = 1}, .y_dst = {.incr = 0, .clr = 1}, .z_src = {.incr = 0}, .z_dst = {.incr = 0}}.set(
+            ckernel::ADDR_MOD_1);
 
         // Increment faces by 2 (jump 2 dest address 32)
-        addr_mod_pack_t {.y_src = {.incr = 0, .clr = 1}, .y_dst = {.incr = 0, .clr = 1}, .z_src = {.incr = 1}, .z_dst = {.incr = 0}}.set(ADDR_MOD_2);
+        ckernel::addr_mod_pack_t {.y_src = {.incr = 0, .clr = 1}, .y_dst = {.incr = 0, .clr = 1}, .z_src = {.incr = 1}, .z_dst = {.incr = 0}}.set(
+            ckernel::ADDR_MOD_2);
     }
     else
     {
-        addr_mod_pack_t {
+        ckernel::addr_mod_pack_t {
             .y_src = {.incr = 4},
             .y_dst = {.incr = 4},
         }
-            .set(ADDR_MOD_0);
+            .set(ckernel::ADDR_MOD_0);
 
-        addr_mod_pack_t {
+        ckernel::addr_mod_pack_t {
             .y_src = {.incr = 0, .clr = 1, .cr = 0},
             .y_dst = {.incr = 0, .clr = 1, .cr = 0},
             .z_src = {.incr = 0, .clr = 1},
             .z_dst = {.incr = 0, .clr = 0},
         }
-            .set(ADDR_MOD_1);
+            .set(ckernel::ADDR_MOD_1);
 
-        addr_mod_pack_t {
+        ckernel::addr_mod_pack_t {
             .y_src = {.incr = 0, .clr = 1, .cr = 0},
             .y_dst = {.incr = 4, .clr = 0, .cr = 0},
             .z_src = {.incr = 1, .clr = 0},
         }
-            .set(ADDR_MOD_2);
+            .set(ckernel::ADDR_MOD_2);
     }
 }
 
 template <
-    bool untilize                = false,
-    bool zero_output             = false,
-    DstTileFaceLayout FaceLayout = DstTileFaceLayout::RowMajor,
-    bool write_tile_header       = true,
-    bool tilize                  = false>
+    bool untilize                         = false,
+    bool zero_output                      = false,
+    ckernel::DstTileFaceLayout FaceLayout = ckernel::DstTileFaceLayout::RowMajor,
+    bool write_tile_header                = true,
+    bool tilize                           = false>
 inline void _llk_pack_mop_config_(
     const std::uint32_t pack_dst_format,
-    const std::uint32_t face_r_dim = FACE_R_DIM,
-    const std::uint32_t tile_c_dim = TILE_C_DIM,
+    const std::uint32_t face_r_dim = ckernel::FACE_R_DIM,
+    const std::uint32_t tile_c_dim = ckernel::TILE_C_DIM,
     const std::uint32_t num_faces  = 4,
     const bool partial_face        = false,
     const bool narrow_tile         = false)
 {
-    static_assert(FaceLayout == DstTileFaceLayout::RowMajor, "FaceLayout must be RowMajor");
+    static_assert(FaceLayout == ckernel::DstTileFaceLayout::RowMajor, "FaceLayout must be RowMajor");
 
     constexpr uint MEGAROW          = 1;
-    constexpr uint ZERO_OUTPUT_FLAG = zero_output ? p_pacr::P_ZERO_OUTPUT_ENABLED : p_pacr::P_ZERO_OUTPUT_DISABLED;
+    constexpr uint ZERO_OUTPUT_FLAG = zero_output ? ckernel::p_pacr::P_ZERO_OUTPUT_ENABLED : ckernel::p_pacr::P_ZERO_OUTPUT_DISABLED;
 
     if constexpr (untilize && !tilize)
     {
-        const uint PACK_INTF_SEL  = (tile_c_dim < TILE_C_DIM) ? p_pacr::SINGLE_INTF_ACTIVE : p_pacr::TWO_INTFS_ACTIVE;
+        const uint PACK_INTF_SEL  = (tile_c_dim < ckernel::TILE_C_DIM) ? ckernel::p_pacr::SINGLE_INTF_ACTIVE : ckernel::p_pacr::TWO_INTFS_ACTIVE;
         const uint MOP_INNER_LOOP = face_r_dim;
-        const uint MOP_OUTER_LOOP = (tile_c_dim < TILE_C_DIM) ? num_faces : (num_faces >> 1);
+        const uint MOP_OUTER_LOOP = (tile_c_dim < ckernel::TILE_C_DIM) ? num_faces : (num_faces >> 1);
 
         ckernel::ckernel_template tmp(
             MOP_OUTER_LOOP,
             MOP_INNER_LOOP,
             TT_OP_PACR(
-                p_pacr::CFG_CTXT_0,
-                p_pacr::NO_ROW_PAD_ZERO,
-                p_pacr::DST_ACCESS_STRIDED_MODE,
-                ADDR_MOD_0,
-                p_pacr::ADDR_CNT_CTXT_0,
+                ckernel::p_pacr::CFG_CTXT_0,
+                ckernel::p_pacr::NO_ROW_PAD_ZERO,
+                ckernel::p_pacr::DST_ACCESS_STRIDED_MODE,
+                ckernel::ADDR_MOD_0,
+                ckernel::p_pacr::ADDR_CNT_CTXT_0,
                 ZERO_OUTPUT_FLAG,
                 PACK_INTF_SEL,
                 0,
                 MEGAROW,
-                p_pacr::NO_CTXT_CTRL,
+                ckernel::p_pacr::NO_CTXT_CTRL,
                 0,
                 0));
 
         tmp.set_last_inner_loop_instr(TT_OP_PACR(
-            p_pacr::CFG_CTXT_0,
-            p_pacr::NO_ROW_PAD_ZERO,
-            p_pacr::DST_ACCESS_STRIDED_MODE,
-            ADDR_MOD_1,
-            p_pacr::ADDR_CNT_CTXT_0,
+            ckernel::p_pacr::CFG_CTXT_0,
+            ckernel::p_pacr::NO_ROW_PAD_ZERO,
+            ckernel::p_pacr::DST_ACCESS_STRIDED_MODE,
+            ckernel::ADDR_MOD_1,
+            ckernel::p_pacr::ADDR_CNT_CTXT_0,
             ZERO_OUTPUT_FLAG,
             PACK_INTF_SEL,
             0,
             MEGAROW,
-            p_pacr::NO_CTXT_CTRL,
+            ckernel::p_pacr::NO_CTXT_CTRL,
             0,
             0));
         tmp.set_last_outer_loop_instr(TT_OP_PACR(
-            p_pacr::CFG_CTXT_0,
-            p_pacr::NO_ROW_PAD_ZERO,
-            p_pacr::DST_ACCESS_STRIDED_MODE,
-            ADDR_MOD_2,
-            p_pacr::ADDR_CNT_CTXT_0,
+            ckernel::p_pacr::CFG_CTXT_0,
+            ckernel::p_pacr::NO_ROW_PAD_ZERO,
+            ckernel::p_pacr::DST_ACCESS_STRIDED_MODE,
+            ckernel::ADDR_MOD_2,
+            ckernel::p_pacr::ADDR_CNT_CTXT_0,
             ZERO_OUTPUT_FLAG,
             PACK_INTF_SEL,
             0,
             0,
-            p_pacr::NO_CTXT_CTRL,
+            ckernel::p_pacr::NO_CTXT_CTRL,
             0,
             1));
-        tmp.program(instrn_buffer);
+        tmp.program(ckernel::instrn_buffer);
     }
     else if constexpr (tilize && !untilize)
     {
@@ -149,7 +150,7 @@ inline void _llk_pack_mop_config_(
         const uint replay_buf_len = 15;
 
         // This replay buffer finishes 2 faces
-        load_replay_buf(
+        ckernel::load_replay_buf(
             0,
             replay_buf_len,
             false,
@@ -158,200 +159,200 @@ inline void _llk_pack_mop_config_(
             {
                 // Face 0 -> mask rows 1010
                 TTI_PACR(
-                    p_pacr::CFG_CTXT_0,
-                    p_pacr::NO_ROW_PAD_ZERO,
-                    p_pacr::DST_ACCESS_NORMAL_MODE,
-                    ADDR_MOD_0,
-                    p_pacr::ADDR_CNT_CTXT_0,
+                    ckernel::p_pacr::CFG_CTXT_0,
+                    ckernel::p_pacr::NO_ROW_PAD_ZERO,
+                    ckernel::p_pacr::DST_ACCESS_NORMAL_MODE,
+                    ckernel::ADDR_MOD_0,
+                    ckernel::p_pacr::ADDR_CNT_CTXT_0,
                     ZERO_OUTPUT_FLAG,
                     PACK_INTF_SEL_0,
                     0,
                     MEGAROW,
-                    p_pacr::NO_CTXT_CTRL,
+                    ckernel::p_pacr::NO_CTXT_CTRL,
                     0,
                     0);
                 TTI_PACR(
-                    p_pacr::CFG_CTXT_0,
-                    p_pacr::NO_ROW_PAD_ZERO,
-                    p_pacr::DST_ACCESS_NORMAL_MODE,
-                    ADDR_MOD_0,
-                    p_pacr::ADDR_CNT_CTXT_0,
+                    ckernel::p_pacr::CFG_CTXT_0,
+                    ckernel::p_pacr::NO_ROW_PAD_ZERO,
+                    ckernel::p_pacr::DST_ACCESS_NORMAL_MODE,
+                    ckernel::ADDR_MOD_0,
+                    ckernel::p_pacr::ADDR_CNT_CTXT_0,
                     ZERO_OUTPUT_FLAG,
                     PACK_INTF_SEL_0,
                     0,
                     MEGAROW,
-                    p_pacr::NO_CTXT_CTRL,
+                    ckernel::p_pacr::NO_CTXT_CTRL,
                     0,
                     0);
                 TTI_PACR(
-                    p_pacr::CFG_CTXT_0,
-                    p_pacr::NO_ROW_PAD_ZERO,
-                    p_pacr::DST_ACCESS_NORMAL_MODE,
-                    ADDR_MOD_0,
-                    p_pacr::ADDR_CNT_CTXT_0,
+                    ckernel::p_pacr::CFG_CTXT_0,
+                    ckernel::p_pacr::NO_ROW_PAD_ZERO,
+                    ckernel::p_pacr::DST_ACCESS_NORMAL_MODE,
+                    ckernel::ADDR_MOD_0,
+                    ckernel::p_pacr::ADDR_CNT_CTXT_0,
                     ZERO_OUTPUT_FLAG,
                     PACK_INTF_SEL_0,
                     0,
                     MEGAROW,
-                    p_pacr::NO_CTXT_CTRL,
+                    ckernel::p_pacr::NO_CTXT_CTRL,
                     0,
                     0);
                 TTI_PACR(
-                    p_pacr::CFG_CTXT_0,
-                    p_pacr::NO_ROW_PAD_ZERO,
-                    p_pacr::DST_ACCESS_NORMAL_MODE,
-                    ADDR_MOD_0,
-                    p_pacr::ADDR_CNT_CTXT_0,
+                    ckernel::p_pacr::CFG_CTXT_0,
+                    ckernel::p_pacr::NO_ROW_PAD_ZERO,
+                    ckernel::p_pacr::DST_ACCESS_NORMAL_MODE,
+                    ckernel::ADDR_MOD_0,
+                    ckernel::p_pacr::ADDR_CNT_CTXT_0,
                     ZERO_OUTPUT_FLAG,
                     PACK_INTF_SEL_0,
                     0,
                     MEGAROW,
-                    p_pacr::NO_CTXT_CTRL,
+                    ckernel::p_pacr::NO_CTXT_CTRL,
                     0,
                     0);
                 TTI_PACR(
-                    p_pacr::CFG_CTXT_0,
-                    p_pacr::NO_ROW_PAD_ZERO,
-                    p_pacr::DST_ACCESS_NORMAL_MODE,
-                    ADDR_MOD_0,
-                    p_pacr::ADDR_CNT_CTXT_0,
+                    ckernel::p_pacr::CFG_CTXT_0,
+                    ckernel::p_pacr::NO_ROW_PAD_ZERO,
+                    ckernel::p_pacr::DST_ACCESS_NORMAL_MODE,
+                    ckernel::ADDR_MOD_0,
+                    ckernel::p_pacr::ADDR_CNT_CTXT_0,
                     ZERO_OUTPUT_FLAG,
                     PACK_INTF_SEL_0,
                     0,
                     MEGAROW,
-                    p_pacr::NO_CTXT_CTRL,
+                    ckernel::p_pacr::NO_CTXT_CTRL,
                     0,
                     0);
                 TTI_PACR(
-                    p_pacr::CFG_CTXT_0,
-                    p_pacr::NO_ROW_PAD_ZERO,
-                    p_pacr::DST_ACCESS_NORMAL_MODE,
-                    ADDR_MOD_0,
-                    p_pacr::ADDR_CNT_CTXT_0,
+                    ckernel::p_pacr::CFG_CTXT_0,
+                    ckernel::p_pacr::NO_ROW_PAD_ZERO,
+                    ckernel::p_pacr::DST_ACCESS_NORMAL_MODE,
+                    ckernel::ADDR_MOD_0,
+                    ckernel::p_pacr::ADDR_CNT_CTXT_0,
                     ZERO_OUTPUT_FLAG,
                     PACK_INTF_SEL_0,
                     0,
                     MEGAROW,
-                    p_pacr::NO_CTXT_CTRL,
+                    ckernel::p_pacr::NO_CTXT_CTRL,
                     0,
                     0);
                 TTI_PACR(
-                    p_pacr::CFG_CTXT_0,
-                    p_pacr::NO_ROW_PAD_ZERO,
-                    p_pacr::DST_ACCESS_NORMAL_MODE,
-                    ADDR_MOD_0,
-                    p_pacr::ADDR_CNT_CTXT_0,
+                    ckernel::p_pacr::CFG_CTXT_0,
+                    ckernel::p_pacr::NO_ROW_PAD_ZERO,
+                    ckernel::p_pacr::DST_ACCESS_NORMAL_MODE,
+                    ckernel::ADDR_MOD_0,
+                    ckernel::p_pacr::ADDR_CNT_CTXT_0,
                     ZERO_OUTPUT_FLAG,
                     PACK_INTF_SEL_0,
                     0,
                     MEGAROW,
-                    p_pacr::NO_CTXT_CTRL,
+                    ckernel::p_pacr::NO_CTXT_CTRL,
                     0,
                     0);
                 TTI_PACR(
-                    p_pacr::CFG_CTXT_0,
-                    p_pacr::NO_ROW_PAD_ZERO,
-                    p_pacr::DST_ACCESS_NORMAL_MODE,
-                    ADDR_MOD_1,
-                    p_pacr::ADDR_CNT_CTXT_0,
+                    ckernel::p_pacr::CFG_CTXT_0,
+                    ckernel::p_pacr::NO_ROW_PAD_ZERO,
+                    ckernel::p_pacr::DST_ACCESS_NORMAL_MODE,
+                    ckernel::ADDR_MOD_1,
+                    ckernel::p_pacr::ADDR_CNT_CTXT_0,
                     ZERO_OUTPUT_FLAG,
                     PACK_INTF_SEL_0,
                     0,
                     MEGAROW,
-                    p_pacr::NO_CTXT_CTRL,
+                    ckernel::p_pacr::NO_CTXT_CTRL,
                     0,
                     0);
 
                 // Face 1 -> mask rows 0101
                 TTI_PACR(
-                    p_pacr::CFG_CTXT_0,
-                    p_pacr::NO_ROW_PAD_ZERO,
-                    p_pacr::DST_ACCESS_NORMAL_MODE,
-                    ADDR_MOD_0,
-                    p_pacr::ADDR_CNT_CTXT_0,
+                    ckernel::p_pacr::CFG_CTXT_0,
+                    ckernel::p_pacr::NO_ROW_PAD_ZERO,
+                    ckernel::p_pacr::DST_ACCESS_NORMAL_MODE,
+                    ckernel::ADDR_MOD_0,
+                    ckernel::p_pacr::ADDR_CNT_CTXT_0,
                     ZERO_OUTPUT_FLAG,
                     PACK_INTF_SEL_1,
                     0,
                     MEGAROW,
-                    p_pacr::NO_CTXT_CTRL,
+                    ckernel::p_pacr::NO_CTXT_CTRL,
                     0,
                     0);
                 TTI_PACR(
-                    p_pacr::CFG_CTXT_0,
-                    p_pacr::NO_ROW_PAD_ZERO,
-                    p_pacr::DST_ACCESS_NORMAL_MODE,
-                    ADDR_MOD_0,
-                    p_pacr::ADDR_CNT_CTXT_0,
+                    ckernel::p_pacr::CFG_CTXT_0,
+                    ckernel::p_pacr::NO_ROW_PAD_ZERO,
+                    ckernel::p_pacr::DST_ACCESS_NORMAL_MODE,
+                    ckernel::ADDR_MOD_0,
+                    ckernel::p_pacr::ADDR_CNT_CTXT_0,
                     ZERO_OUTPUT_FLAG,
                     PACK_INTF_SEL_1,
                     0,
                     MEGAROW,
-                    p_pacr::NO_CTXT_CTRL,
+                    ckernel::p_pacr::NO_CTXT_CTRL,
                     0,
                     0);
                 TTI_PACR(
-                    p_pacr::CFG_CTXT_0,
-                    p_pacr::NO_ROW_PAD_ZERO,
-                    p_pacr::DST_ACCESS_NORMAL_MODE,
-                    ADDR_MOD_0,
-                    p_pacr::ADDR_CNT_CTXT_0,
+                    ckernel::p_pacr::CFG_CTXT_0,
+                    ckernel::p_pacr::NO_ROW_PAD_ZERO,
+                    ckernel::p_pacr::DST_ACCESS_NORMAL_MODE,
+                    ckernel::ADDR_MOD_0,
+                    ckernel::p_pacr::ADDR_CNT_CTXT_0,
                     ZERO_OUTPUT_FLAG,
                     PACK_INTF_SEL_1,
                     0,
                     MEGAROW,
-                    p_pacr::NO_CTXT_CTRL,
+                    ckernel::p_pacr::NO_CTXT_CTRL,
                     0,
                     0);
                 TTI_PACR(
-                    p_pacr::CFG_CTXT_0,
-                    p_pacr::NO_ROW_PAD_ZERO,
-                    p_pacr::DST_ACCESS_NORMAL_MODE,
-                    ADDR_MOD_0,
-                    p_pacr::ADDR_CNT_CTXT_0,
+                    ckernel::p_pacr::CFG_CTXT_0,
+                    ckernel::p_pacr::NO_ROW_PAD_ZERO,
+                    ckernel::p_pacr::DST_ACCESS_NORMAL_MODE,
+                    ckernel::ADDR_MOD_0,
+                    ckernel::p_pacr::ADDR_CNT_CTXT_0,
                     ZERO_OUTPUT_FLAG,
                     PACK_INTF_SEL_1,
                     0,
                     MEGAROW,
-                    p_pacr::NO_CTXT_CTRL,
+                    ckernel::p_pacr::NO_CTXT_CTRL,
                     0,
                     0);
                 TTI_PACR(
-                    p_pacr::CFG_CTXT_0,
-                    p_pacr::NO_ROW_PAD_ZERO,
-                    p_pacr::DST_ACCESS_NORMAL_MODE,
-                    ADDR_MOD_0,
-                    p_pacr::ADDR_CNT_CTXT_0,
+                    ckernel::p_pacr::CFG_CTXT_0,
+                    ckernel::p_pacr::NO_ROW_PAD_ZERO,
+                    ckernel::p_pacr::DST_ACCESS_NORMAL_MODE,
+                    ckernel::ADDR_MOD_0,
+                    ckernel::p_pacr::ADDR_CNT_CTXT_0,
                     ZERO_OUTPUT_FLAG,
                     PACK_INTF_SEL_1,
                     0,
                     MEGAROW,
-                    p_pacr::NO_CTXT_CTRL,
+                    ckernel::p_pacr::NO_CTXT_CTRL,
                     0,
                     0);
                 TTI_PACR(
-                    p_pacr::CFG_CTXT_0,
-                    p_pacr::NO_ROW_PAD_ZERO,
-                    p_pacr::DST_ACCESS_NORMAL_MODE,
-                    ADDR_MOD_0,
-                    p_pacr::ADDR_CNT_CTXT_0,
+                    ckernel::p_pacr::CFG_CTXT_0,
+                    ckernel::p_pacr::NO_ROW_PAD_ZERO,
+                    ckernel::p_pacr::DST_ACCESS_NORMAL_MODE,
+                    ckernel::ADDR_MOD_0,
+                    ckernel::p_pacr::ADDR_CNT_CTXT_0,
                     ZERO_OUTPUT_FLAG,
                     PACK_INTF_SEL_1,
                     0,
                     MEGAROW,
-                    p_pacr::NO_CTXT_CTRL,
+                    ckernel::p_pacr::NO_CTXT_CTRL,
                     0,
                     0);
                 TTI_PACR(
-                    p_pacr::CFG_CTXT_0,
-                    p_pacr::NO_ROW_PAD_ZERO,
-                    p_pacr::DST_ACCESS_NORMAL_MODE,
-                    ADDR_MOD_0,
-                    p_pacr::ADDR_CNT_CTXT_0,
+                    ckernel::p_pacr::CFG_CTXT_0,
+                    ckernel::p_pacr::NO_ROW_PAD_ZERO,
+                    ckernel::p_pacr::DST_ACCESS_NORMAL_MODE,
+                    ckernel::ADDR_MOD_0,
+                    ckernel::p_pacr::ADDR_CNT_CTXT_0,
                     ZERO_OUTPUT_FLAG,
                     PACK_INTF_SEL_1,
                     0,
                     MEGAROW,
-                    p_pacr::NO_CTXT_CTRL,
+                    ckernel::p_pacr::NO_CTXT_CTRL,
                     0,
                     0);
                 // Last PACR instruction of the half-tile must go separately in the MOP. This is to be able to override it, to ensure that for the second half
@@ -363,51 +364,59 @@ inline void _llk_pack_mop_config_(
             MOP_INNER_LOOP,
             TT_OP_REPLAY(0, replay_buf_len, 0, 0),
             TT_OP_PACR(
-                p_pacr::CFG_CTXT_0,
-                p_pacr::NO_ROW_PAD_ZERO,
-                p_pacr::DST_ACCESS_NORMAL_MODE,
-                ADDR_MOD_2,
-                p_pacr::ADDR_CNT_CTXT_0,
+                ckernel::p_pacr::CFG_CTXT_0,
+                ckernel::p_pacr::NO_ROW_PAD_ZERO,
+                ckernel::p_pacr::DST_ACCESS_NORMAL_MODE,
+                ckernel::ADDR_MOD_2,
+                ckernel::p_pacr::ADDR_CNT_CTXT_0,
                 ZERO_OUTPUT_FLAG,
                 PACK_INTF_SEL_1,
                 0,
                 0,
-                p_pacr::NO_CTXT_CTRL,
+                ckernel::p_pacr::NO_CTXT_CTRL,
                 0,
                 0) // don't close tile
         );
 
         // Close the tile only when it is actually done.
         tmp.set_last_outer_loop_instr(TT_OP_PACR(
-            p_pacr::CFG_CTXT_0,
-            p_pacr::NO_ROW_PAD_ZERO,
-            p_pacr::DST_ACCESS_NORMAL_MODE,
-            ADDR_MOD_2,
-            p_pacr::ADDR_CNT_CTXT_0,
+            ckernel::p_pacr::CFG_CTXT_0,
+            ckernel::p_pacr::NO_ROW_PAD_ZERO,
+            ckernel::p_pacr::DST_ACCESS_NORMAL_MODE,
+            ckernel::ADDR_MOD_2,
+            ckernel::p_pacr::ADDR_CNT_CTXT_0,
             ZERO_OUTPUT_FLAG,
             PACK_INTF_SEL_1,
             0,
             0,
-            p_pacr::NO_CTXT_CTRL,
+            ckernel::p_pacr::NO_CTXT_CTRL,
             0,
             1));
 
         if constexpr (write_tile_header)
         {
             tmp.set_end_ops(
-                TT_OP_SETADCZW(p_setadc::PAC, 0, 2, 0, 0, 0b0100),                                                                 // ch0_z = 0, ch1_z = 2;
-                TT_OP_STOREIND(1, 0, p_ind::LD_16B, LO_16(0), p_ind::INC_NONE, p_gpr_pack::TILE_HEADER, p_gpr_pack::OUTPUT_ADDR)); // write tile header to L1
+                TT_OP_SETADCZW(ckernel::p_setadc::PAC, 0, 2, 0, 0, 0b0100), // ch0_z = 0, ch1_z = 2;
+                TT_OP_STOREIND(
+                    1,
+                    0,
+                    ckernel::p_ind::LD_16B,
+                    LO_16(0),
+                    ckernel::p_ind::INC_NONE,
+                    ckernel::p_gpr_pack::TILE_HEADER,
+                    ckernel::p_gpr_pack::OUTPUT_ADDR)); // write tile header to L1
         }
         else
         {
-            tmp.set_end_op(TT_OP_SETADCZW(p_setadc::PAC, 0, 2, 0, 0, 0b0100)); // ch0_z = 0, ch1_z = 2;
+            tmp.set_end_op(TT_OP_SETADCZW(ckernel::p_setadc::PAC, 0, 2, 0, 0, 0b0100)); // ch0_z = 0, ch1_z = 2;
         }
 
-        tmp.program(instrn_buffer);
+        tmp.program(ckernel::instrn_buffer);
     }
     else
     {
-        const uint PACK_INTF_SEL = face_r_dim == 1 ? p_pacr::SINGLE_INTF_ACTIVE : (face_r_dim == 2 ? p_pacr::TWO_INTFS_ACTIVE : p_pacr::ALL_INTF_ACTIVE);
+        const uint PACK_INTF_SEL =
+            face_r_dim == 1 ? ckernel::p_pacr::SINGLE_INTF_ACTIVE : (face_r_dim == 2 ? ckernel::p_pacr::TWO_INTFS_ACTIVE : ckernel::p_pacr::ALL_INTF_ACTIVE);
 
         const uint MOP_INNER_LOOP = (face_r_dim < 4) ? 1 : face_r_dim >> 2;
         const uint MOP_OUTER_LOOP = num_faces;
@@ -416,11 +425,11 @@ inline void _llk_pack_mop_config_(
             MOP_OUTER_LOOP,
             MOP_INNER_LOOP,
             TT_OP_PACR(
-                p_pacr::CFG_CTXT_0,
-                p_pacr::NO_ROW_PAD_ZERO,
-                p_pacr::DST_ACCESS_NORMAL_MODE,
-                ADDR_MOD_0,
-                p_pacr::ADDR_CNT_CTXT_0,
+                ckernel::p_pacr::CFG_CTXT_0,
+                ckernel::p_pacr::NO_ROW_PAD_ZERO,
+                ckernel::p_pacr::DST_ACCESS_NORMAL_MODE,
+                ckernel::ADDR_MOD_0,
+                ckernel::p_pacr::ADDR_CNT_CTXT_0,
                 ZERO_OUTPUT_FLAG,
                 PACK_INTF_SEL,
                 0,
@@ -429,11 +438,11 @@ inline void _llk_pack_mop_config_(
                 0,
                 0));
         tmp.set_last_inner_loop_instr(TT_OP_PACR(
-            p_pacr::CFG_CTXT_0,
-            p_pacr::NO_ROW_PAD_ZERO,
-            p_pacr::DST_ACCESS_NORMAL_MODE,
-            ADDR_MOD_2,
-            p_pacr::ADDR_CNT_CTXT_0,
+            ckernel::p_pacr::CFG_CTXT_0,
+            ckernel::p_pacr::NO_ROW_PAD_ZERO,
+            ckernel::p_pacr::DST_ACCESS_NORMAL_MODE,
+            ckernel::ADDR_MOD_2,
+            ckernel::p_pacr::ADDR_CNT_CTXT_0,
             ZERO_OUTPUT_FLAG,
             PACK_INTF_SEL,
             0,
@@ -442,11 +451,11 @@ inline void _llk_pack_mop_config_(
             0,
             0));
         tmp.set_last_outer_loop_instr(TT_OP_PACR(
-            p_pacr::CFG_CTXT_0,
-            p_pacr::NO_ROW_PAD_ZERO,
-            p_pacr::DST_ACCESS_NORMAL_MODE,
-            ADDR_MOD_1,
-            p_pacr::ADDR_CNT_CTXT_0,
+            ckernel::p_pacr::CFG_CTXT_0,
+            ckernel::p_pacr::NO_ROW_PAD_ZERO,
+            ckernel::p_pacr::DST_ACCESS_NORMAL_MODE,
+            ckernel::ADDR_MOD_1,
+            ckernel::p_pacr::ADDR_CNT_CTXT_0,
             ZERO_OUTPUT_FLAG,
             PACK_INTF_SEL,
             0,
@@ -456,33 +465,35 @@ inline void _llk_pack_mop_config_(
             1));
 
         // if (partial_face) {
-        //     tmp.set_start_op(TT_OP_PACR(p_pacr::CFG_CTXT_0, p_pacr::NO_ROW_PAD_ZERO, p_pacr::DST_ACCESS_NORMAL_MODE, ADDR_MOD_0, p_pacr::ADDR_CNT_CTXT_0,
-        //     ZERO_OUTPUT_FLAG, p_pacr::ALL_INTF_ACTIVE, 0, MEGAROW, 0, 0, 1)); // Don't close the tile, point to the next face
-        //     tmp.set_loop_op0(TT_OP_INCADCXY(p_setadc::PAC, 0, 0, 1, 0)); // Inc ch0_y+=1 (addr_mod_0 will increment by 15)
-        //     tmp.set_loop_op1(TT_OP_PACR(p_pacr::CFG_CTXT_0, p_pacr::NO_ROW_PAD_ZERO, p_pacr::DST_ACCESS_NORMAL_MODE, ADDR_MOD_1, p_pacr::ADDR_CNT_CTXT_0,
-        //     ZERO_OUTPUT_FLAG, p_pacr::ALL_INTF_ACTIVE, 0, MEGAROW, 0, 0, 1)); // Close the tile
+        //     tmp.set_start_op(TT_OP_PACR(ckernel::p_pacr::CFG_CTXT_0, ckernel::p_pacr::NO_ROW_PAD_ZERO, ckernel::p_pacr::DST_ACCESS_NORMAL_MODE,
+        //     ckernel::ADDR_MOD_0, ckernel::p_pacr::ADDR_CNT_CTXT_0, ZERO_OUTPUT_FLAG, ckernel::p_pacr::ALL_INTF_ACTIVE, 0, MEGAROW, 0, 0, 1)); // Don't close
+        //     the tile, point to the next face tmp.set_loop_op0(TT_OP_INCADCXY(ckernel::p_setadc::PAC, 0, 0, 1, 0)); // Inc ch0_y+=1 (addr_mod_0 will increment
+        //     by 15) tmp.set_loop_op1(TT_OP_PACR(ckernel::p_pacr::CFG_CTXT_0, ckernel::p_pacr::NO_ROW_PAD_ZERO, ckernel::p_pacr::DST_ACCESS_NORMAL_MODE,
+        //     ckernel::ADDR_MOD_1, ckernel::p_pacr::ADDR_CNT_CTXT_0, ZERO_OUTPUT_FLAG, ckernel::p_pacr::ALL_INTF_ACTIVE, 0, MEGAROW, 0, 0, 1)); // Close the
+        //     tile
         // }
         // Write header to l1
         if constexpr (write_tile_header)
         {
-            tmp.set_end_op(TT_OP_STOREIND(1, 0, p_ind::LD_16B, LO_16(0), p_ind::INC_NONE, p_gpr_pack::TILE_HEADER, p_gpr_pack::OUTPUT_ADDR));
+            tmp.set_end_op(TT_OP_STOREIND(
+                1, 0, ckernel::p_ind::LD_16B, LO_16(0), ckernel::p_ind::INC_NONE, ckernel::p_gpr_pack::TILE_HEADER, ckernel::p_gpr_pack::OUTPUT_ADDR));
         }
 
-        tmp.program(instrn_buffer);
+        tmp.program(ckernel::instrn_buffer);
     }
 }
 
 template <
-    bool is_fp32_dest_acc_en     = false,
-    bool is_tile_dim_reconfig_en = false,
-    DstTileFaceLayout FaceLayout = DstTileFaceLayout::RowMajor,
-    bool write_tile_header       = true>
+    bool is_fp32_dest_acc_en              = false,
+    bool is_tile_dim_reconfig_en          = false,
+    ckernel::DstTileFaceLayout FaceLayout = ckernel::DstTileFaceLayout::RowMajor,
+    bool write_tile_header                = true>
 inline void _llk_pack_reconfig_data_format_(
     const std::uint32_t pack_src_format,
     const std::uint32_t pack_dst_format,
     const std::uint32_t tile_size,
-    const std::uint32_t face_r_dim = FACE_R_DIM,
-    const std::uint32_t tile_c_dim = TILE_C_DIM,
+    const std::uint32_t face_r_dim = ckernel::FACE_R_DIM,
+    const std::uint32_t tile_c_dim = ckernel::TILE_C_DIM,
     const std::uint32_t num_faces  = 4,
     const bool partial_face        = false,
     const bool narrow_tile         = false)
@@ -500,24 +511,24 @@ inline void _llk_pack_hw_configure_(
     const std::uint32_t pack_src_format,
     const std::uint32_t pack_dst_format,
     const std::uint32_t tile_size,
-    const std::uint32_t face_r_dim  = FACE_R_DIM,
-    const std::uint32_t tile_c_dim  = TILE_C_DIM,
+    const std::uint32_t face_r_dim  = ckernel::FACE_R_DIM,
+    const std::uint32_t tile_c_dim  = ckernel::TILE_C_DIM,
     const std::uint32_t num_faces   = 4,
     const bool partial_face         = false,
     const bool narrow_tile          = false,
     const std::uint32_t relu_config = 0)
 {
-    configure_pack<is_fp32_dest_acc_en, untilize, tilize>(
+    ckernel::packer::configure_pack<is_fp32_dest_acc_en, untilize, tilize>(
         pack_src_format, pack_dst_format, tile_size, face_r_dim, tile_c_dim, num_faces, partial_face, narrow_tile, relu_config);
 }
 
-template <bool untilize = false, PoolType type, ReduceDim dim, bool is_fp32_dest_acc_en = false>
+template <bool untilize = false, ckernel::PoolType type, ckernel::ReduceDim dim, bool is_fp32_dest_acc_en = false>
 inline void _llk_pack_reduce_hw_configure_(
     const std::uint32_t pack_src_format,
     const std::uint32_t pack_dst_format,
     const std::uint32_t tile_size,
-    const std::uint32_t face_r_dim  = FACE_R_DIM,
-    const std::uint32_t tile_c_dim  = TILE_C_DIM,
+    const std::uint32_t face_r_dim  = ckernel::FACE_R_DIM,
+    const std::uint32_t tile_c_dim  = ckernel::TILE_C_DIM,
     const std::uint32_t num_faces   = 4,
     const bool partial_face         = false,
     const bool narrow_tile          = false,
@@ -526,11 +537,11 @@ inline void _llk_pack_reduce_hw_configure_(
     configure_pack<is_fp32_dest_acc_en, untilize, false>(
         pack_src_format, pack_dst_format, tile_size, face_r_dim, tile_c_dim, num_faces, partial_face, narrow_tile, relu_config);
 
-    volatile uint tt_reg_ptr *cfg = get_cfg_pointer();
+    volatile uint tt_reg_ptr *cfg = ckernel::get_cfg_pointer();
 
     ckernel::packer::pck_edge_offset_u pack_edge_offset = {.val = 0};
     pack_edge_offset.f.mask                             = 0x0;
-    if constexpr (dim == ReduceDim::REDUCE_ROW)
+    if constexpr (dim == ckernel::ReduceDim::REDUCE_ROW)
     {
         cfg[PCK_EDGE_OFFSET_SEC0_mask_ADDR32 + 1] = 0x0001;
         if constexpr (untilize)
@@ -549,7 +560,7 @@ inline void _llk_pack_reduce_hw_configure_(
         }
         cfg[PCK_EDGE_OFFSET_SEC0_mask_ADDR32 + 0] = pack_edge_offset.val;
     }
-    else if constexpr (dim == ReduceDim::REDUCE_SCALAR)
+    else if constexpr (dim == ckernel::ReduceDim::REDUCE_SCALAR)
     {
         pack_edge_offset.f.tile_row_set_select_pack0         = 1;
         cfg[PCK_EDGE_OFFSET_SEC0_mask_ADDR32 + 0]            = pack_edge_offset.val;
@@ -575,15 +586,15 @@ inline void _llk_pack_reduce_hw_configure_(
 }
 
 template <
-    bool untilize                = false,
-    bool zero_output             = false,
-    DstTileFaceLayout FaceLayout = DstTileFaceLayout::RowMajor,
-    bool write_tile_header       = true,
-    bool tilize                  = false>
+    bool untilize                         = false,
+    bool zero_output                      = false,
+    ckernel::DstTileFaceLayout FaceLayout = ckernel::DstTileFaceLayout::RowMajor,
+    bool write_tile_header                = true,
+    bool tilize                           = false>
 inline void _llk_pack_init_(
     const std::uint32_t pack_dst_format,
-    const std::uint32_t face_r_dim = FACE_R_DIM,
-    const std::uint32_t tile_c_dim = TILE_C_DIM,
+    const std::uint32_t face_r_dim = ckernel::FACE_R_DIM,
+    const std::uint32_t tile_c_dim = ckernel::TILE_C_DIM,
     const std::uint32_t num_faces  = 4,
     const bool partial_face        = false,
     const bool narrow_tile         = false)
@@ -594,33 +605,33 @@ inline void _llk_pack_init_(
         pack_dst_format, face_r_dim, tile_c_dim, num_faces, partial_face, narrow_tile);
 }
 
-template <DstSync Dst, bool untilize = false, bool is_fp32_dest_acc_en = false>
+template <ckernel::DstSync Dst, bool untilize = false, bool is_fp32_dest_acc_en = false>
 inline void _llk_pack_(const std::uint32_t tile_index, const std::uint32_t address)
 {
-    if constexpr (Dst == DstSync::SyncTile16)
+    if constexpr (Dst == ckernel::DstSync::SyncTile16)
     {
         constexpr uint32_t DEST_NUM_TILES_SHIFT = is_fp32_dest_acc_en ? (1) : (0);
-        constexpr uint32_t DEST_NUM_TILES       = DEST_NUM_TILES_FP16 >> DEST_NUM_TILES_SHIFT;
+        constexpr uint32_t DEST_NUM_TILES       = ckernel::DEST_NUM_TILES_FP16 >> DEST_NUM_TILES_SHIFT;
         // W-counter points to the next tile in dest
-        TT_SETADC(p_setadc::PAC, p_setadc::CH_0, p_setadc::SET_W, pack_sync_tile_dst_ptr);
+        TT_SETADC(ckernel::p_setadc::PAC, ckernel::p_setadc::CH_0, ckernel::p_setadc::SET_W, pack_sync_tile_dst_ptr);
         pack_sync_tile_dst_ptr += 1;
         pack_sync_tile_dst_ptr = pack_sync_tile_dst_ptr & (DEST_NUM_TILES - 1);
     }
-    else if constexpr (Dst == DstSync::SyncTile2)
+    else if constexpr (Dst == ckernel::DstSync::SyncTile2)
     {
-        TT_SETADC(p_setadc::PAC, p_setadc::CH_0, p_setadc::SET_W, pack_sync_tile_dst_ptr);
+        TT_SETADC(ckernel::p_setadc::PAC, ckernel::p_setadc::CH_0, ckernel::p_setadc::SET_W, pack_sync_tile_dst_ptr);
         pack_sync_tile_dst_ptr = 0;
     }
     else
     {
-        TT_SETADC(p_setadc::PAC, p_setadc::CH_0, p_setadc::SET_W, tile_index);
+        TT_SETADC(ckernel::p_setadc::PAC, ckernel::p_setadc::CH_0, ckernel::p_setadc::SET_W, tile_index);
     }
 
-    program_packer_destination(address);
+    ckernel::packer::program_packer_destination(address);
 
-    mop_run(1, 1);
+    ckernel::mop_run(1, 1);
 
-    TT_SETADCZW(p_setadc::PAC, 0, 0, 0, 0, 0b0101); // reset z counters
+    TT_SETADCZW(ckernel::p_setadc::PAC, 0, 0, 0, 0, 0b0101); // reset z counters
 }
 
 #include "llk_pack_untilize.h"

--- a/tt_llk_blackhole/llk_lib/llk_pack_untilize.h
+++ b/tt_llk_blackhole/llk_lib/llk_pack_untilize.h
@@ -13,42 +13,43 @@
 #include "llk_defs.h"
 #include "llk_pack_common.h"
 
-using namespace ckernel;
-using namespace ckernel::packer;
-
 template <bool diagonal = false>
 inline void _llk_pack_untilize_configure_addrmod_()
 {
     static_assert(!diagonal, "Diagonal not supported");
 
-    addr_mod_pack_t {
+    ckernel::addr_mod_pack_t {
         .y_src = {.incr = 0, .clr = 0},
     }
-        .set(ADDR_MOD_0);
+        .set(ckernel::ADDR_MOD_0);
 
-    // addr_mod_pack_t{
+    // ckernel::addr_mod_pack_t{
     //     .y_src = { .incr = 1, .clr = 0},
-    // }.set(ADDR_MOD_1);
+    // }.set(ckernel::ADDR_MOD_1);
 
-    addr_mod_pack_t {
+    ckernel::addr_mod_pack_t {
         .z_src = {.clr = 1},
     }
-        .set(ADDR_MOD_2);
+        .set(ckernel::ADDR_MOD_2);
 }
 
 template <std::uint32_t block_ct_dim, std::uint32_t full_ct_dim = block_ct_dim, bool diagonal = false>
 inline void _llk_pack_untilize_mop_config_(
-    const std::uint32_t face_r_dim = FACE_R_DIM, const std::uint32_t num_faces = 4, bool narrow_row = false, std::uint32_t row_num_datums = TILE_C_DIM)
+    const std::uint32_t face_r_dim = ckernel::FACE_R_DIM,
+    const std::uint32_t num_faces  = 4,
+    bool narrow_row                = false,
+    std::uint32_t row_num_datums   = ckernel::TILE_C_DIM)
 {
     constexpr uint MEGAROW          = 1;
-    constexpr uint ZERO_OUTPUT_FLAG = p_pacr::P_ZERO_OUTPUT_DISABLED;
+    constexpr uint ZERO_OUTPUT_FLAG = ckernel::p_pacr::P_ZERO_OUTPUT_DISABLED;
     constexpr uint MOP_INNER_LOOP   = block_ct_dim;
 
     // Loop until face_r_dim - 1.
     // Last row of face needs to be handled differently depending on num_faces, block_ct and full_ct.
     const uint MOP_OUTER_LOOP = face_r_dim - 1;
 
-    const uint PACK_INTF_SEL = (narrow_row) ? p_pacr::SINGLE_INTF_ACTIVE : ((num_faces > 1) ? p_pacr::TWO_INTFS_ACTIVE : p_pacr::SINGLE_INTF_ACTIVE);
+    const uint PACK_INTF_SEL =
+        (narrow_row) ? ckernel::p_pacr::SINGLE_INTF_ACTIVE : ((num_faces > 1) ? ckernel::p_pacr::TWO_INTFS_ACTIVE : ckernel::p_pacr::SINGLE_INTF_ACTIVE);
 
     bool outer_loop_valid = (MOP_OUTER_LOOP > 0) && (MOP_OUTER_LOOP < 128);
     bool inner_loop_valid = (MOP_INNER_LOOP > 0) && (MOP_INNER_LOOP < 128);
@@ -70,58 +71,58 @@ inline void _llk_pack_untilize_mop_config_(
             MOP_OUTER_LOOP,
             MOP_INNER_LOOP,
             TT_OP_PACR(
-                p_pacr::CFG_CTXT_0,
-                p_pacr::NO_ROW_PAD_ZERO,
-                p_pacr::DST_ACCESS_STRIDED_MODE,
-                ADDR_MOD_0,
-                p_pacr::ADDR_CNT_CTXT_0,
+                ckernel::p_pacr::CFG_CTXT_0,
+                ckernel::p_pacr::NO_ROW_PAD_ZERO,
+                ckernel::p_pacr::DST_ACCESS_STRIDED_MODE,
+                ckernel::ADDR_MOD_0,
+                ckernel::p_pacr::ADDR_CNT_CTXT_0,
                 0,
                 PACK_INTF_SEL,
                 0,
                 MEGAROW,
-                p_pacr::NO_CTXT_CTRL,
+                ckernel::p_pacr::NO_CTXT_CTRL,
                 0,
                 0),
-            TT_OP_INCADCZW(p_setadc::PAC, 0, 0, 1, 0) // w cnt points to the next tile
+            TT_OP_INCADCZW(ckernel::p_setadc::PAC, 0, 0, 1, 0) // w cnt points to the next tile
         );
 
         // reset ch0_w counters
-        tmp.set_start_op(TT_OP_SETADCZW(p_setadc::PAC, 0, 0, 0, 0, 0b0010));
+        tmp.set_start_op(TT_OP_SETADCZW(ckernel::p_setadc::PAC, 0, 0, 0, 0, 0b0010));
 
         if constexpr (block_ct_dim != full_ct_dim)
         {
             const std::uint32_t replay_buf_len = 4;
-            load_replay_buf(
+            ckernel::load_replay_buf(
                 ckernel::packer::replay_buf_offset,
                 replay_buf_len,
                 false,
                 []
                 {
                     // update l1 address
-                    TTI_ADDDMAREG(0, p_gpr_pack::OUTPUT_ADDR, p_gpr_pack::OUTPUT_ADDR, p_gpr_pack::OUTPUT_ADDR_OFFSET);
-                    TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::THCON);
-                    TTI_WRCFG(p_gpr_pack::OUTPUT_ADDR, 0, THCON_SEC0_REG1_L1_Dest_addr_ADDR32);
+                    TTI_ADDDMAREG(0, ckernel::p_gpr_pack::OUTPUT_ADDR, ckernel::p_gpr_pack::OUTPUT_ADDR, ckernel::p_gpr_pack::OUTPUT_ADDR_OFFSET);
+                    TTI_STALLWAIT(ckernel::p_stall::STALL_CFG, ckernel::p_stall::THCON);
+                    TTI_WRCFG(ckernel::p_gpr_pack::OUTPUT_ADDR, 0, THCON_SEC0_REG1_L1_Dest_addr_ADDR32);
                     TTI_NOP;
                 });
 
             tmp.set_end_ops(
-                TT_OP_INCADCXY(p_setadc::PAC, 0, 0, 1, 0),                             // inc ch0_y counters
+                TT_OP_INCADCXY(ckernel::p_setadc::PAC, 0, 0, 1, 0),                    // inc ch0_y counters
                 TT_OP_REPLAY(ckernel::packer::replay_buf_offset, replay_buf_len, 0, 0) // update row address
             );
         }
         else
         {
-            tmp.set_end_op(TT_OP_INCADCXY(p_setadc::PAC, 0, 0, 1, 0) // inc ch0_y counters
+            tmp.set_end_op(TT_OP_INCADCXY(ckernel::p_setadc::PAC, 0, 0, 1, 0) // inc ch0_y counters
             );
         }
-        tmp.program(instrn_buffer);
+        tmp.program(ckernel::instrn_buffer);
     }
     // If wanted MOP config is not valid, create a default one.
     // This is due to not being able to check if MOP config is valid before issuing in runtime.
     else
     {
         ckernel::ckernel_template tmp(1, 1);
-        tmp.program(instrn_buffer);
+        tmp.program(ckernel::instrn_buffer);
     }
 }
 
@@ -130,9 +131,12 @@ template <
     std::uint32_t full_ct_dim    = block_ct_dim,
     bool diagonal                = false,
     bool narrow_row              = false,
-    std::uint32_t row_num_datums = TILE_C_DIM>
+    std::uint32_t row_num_datums = ckernel::TILE_C_DIM>
 inline void _llk_pack_untilize_init_(
-    const std::uint32_t pack_src_format, const std::uint32_t pack_dst_format, const std::uint32_t face_r_dim = FACE_R_DIM, const std::uint32_t num_faces = 4)
+    const std::uint32_t pack_src_format,
+    const std::uint32_t pack_dst_format,
+    const std::uint32_t face_r_dim = ckernel::FACE_R_DIM,
+    const std::uint32_t num_faces  = 4)
 {
     static_assert(!diagonal, "Diagonal not supported");
     _llk_pack_untilize_configure_addrmod_<diagonal>();
@@ -141,14 +145,15 @@ inline void _llk_pack_untilize_init_(
 
     // Set CH0 Zstride = 2x16x16 faces, .z_src = {.incr = 1} jumps 2 faces
     uint x_stride       = (uint)(pack_src_format & 0x3) == (uint)DataFormat::Float32 ? 4 : (uint)(pack_src_format & 0x3) == (uint)DataFormat::Float16 ? 2 : 1;
-    uint y_stride       = FACE_C_DIM * x_stride;
+    uint y_stride       = ckernel::FACE_C_DIM * x_stride;
     const uint z_stride = 2 * face_r_dim * y_stride;
-    cfg_reg_rmw_tensix<PCK0_ADDR_CTRL_ZW_REG_0_Zstride_RMW>(z_stride);
+    ckernel::cfg_reg_rmw_tensix<PCK0_ADDR_CTRL_ZW_REG_0_Zstride_RMW>(z_stride);
 
     if (block_ct_dim != full_ct_dim)
     {
-        const std::uint32_t output_addr_offset = SCALE_DATUM_SIZE(pack_dst_format, full_ct_dim * ((num_faces > 1) ? (num_faces >> 1) : 1) * FACE_C_DIM);
-        TT_SETDMAREG(0, LOWER_HALFWORD(output_addr_offset / 16), 0, LO_16(p_gpr_pack::OUTPUT_ADDR_OFFSET)); // store 16B aligned row offset address
+        const std::uint32_t output_addr_offset =
+            ckernel::SCALE_DATUM_SIZE(pack_dst_format, full_ct_dim * ((num_faces > 1) ? (num_faces >> 1) : 1) * ckernel::FACE_C_DIM);
+        TT_SETDMAREG(0, LOWER_HALFWORD(output_addr_offset / 16), 0, LO_16(ckernel::p_gpr_pack::OUTPUT_ADDR_OFFSET)); // store 16B aligned row offset address
     }
 }
 
@@ -157,31 +162,32 @@ template <
     std::uint32_t full_ct_dim    = block_ct_dim,
     bool diagonal                = false,
     bool narrow_row              = false,
-    std::uint32_t row_num_datums = TILE_C_DIM>
+    std::uint32_t row_num_datums = ckernel::TILE_C_DIM>
 inline void _llk_pack_untilize_(
     const std::uint32_t address,
     const std::uint32_t pack_dst_format,
-    const std::uint32_t face_r_dim      = FACE_R_DIM,
+    const std::uint32_t face_r_dim      = ckernel::FACE_R_DIM,
     const std::uint32_t num_faces       = 4,
     const std::uint32_t tile_dst_offset = 0)
 {
     // program_packer_untilized_destination<block_ct_dim, full_ct_dim, diagonal>(address, pack_dst_format);
-    program_packer_destination(address);
+    ckernel::packer::program_packer_destination(address);
     const std::uint32_t num_faces_per_rdim_tile = (num_faces > 2) ? 2 : 1;
-    const uint PACK_INTF_SEL = (narrow_row) ? p_pacr::SINGLE_INTF_ACTIVE : ((num_faces > 1) ? p_pacr::TWO_INTFS_ACTIVE : p_pacr::SINGLE_INTF_ACTIVE);
+    const uint PACK_INTF_SEL =
+        (narrow_row) ? ckernel::p_pacr::SINGLE_INTF_ACTIVE : ((num_faces > 1) ? ckernel::p_pacr::TWO_INTFS_ACTIVE : ckernel::p_pacr::SINGLE_INTF_ACTIVE);
 
-    TT_SETADCZW(p_setadc::PAC, 0, 0, 0, 0, 0b0011); // reset ch0 zw counters
-    TT_SETADCXY(p_setadc::PAC, 0, 0, 0, 0, 0b0011); // reset ch0 xy counters
-    TT_SETADC(p_setadc::PAC, p_setadc::CH_0, p_setadc::SET_W, tile_dst_offset);
+    TT_SETADCZW(ckernel::p_setadc::PAC, 0, 0, 0, 0, 0b0011); // reset ch0 zw counters
+    TT_SETADCXY(ckernel::p_setadc::PAC, 0, 0, 0, 0, 0b0011); // reset ch0 xy counters
+    TT_SETADC(ckernel::p_setadc::PAC, ckernel::p_setadc::CH_0, ckernel::p_setadc::SET_W, tile_dst_offset);
 
     for (std::uint32_t face = 0; face < num_faces_per_rdim_tile; face++)
     {
-        ckernel::ckernel_template::run(instrn_buffer);
+        ckernel::ckernel_template::run(ckernel::instrn_buffer);
 
         //-----------------------------------------------------------------------
         // Handle last row of face, i.e. last outer_loop iteration of MOP.
         // Start OP is the same for all cases.
-        TTI_SETADCZW(p_setadc::PAC, 0, 0, 0, 0, 0b0010); // reset ch0 W counter
+        TTI_SETADCZW(ckernel::p_setadc::PAC, 0, 0, 0, 0, 0b0010); // reset ch0 W counter
 
         // Inner loop of MOP.
         for (std::uint32_t i = 0; i < block_ct_dim; i++)
@@ -190,54 +196,54 @@ inline void _llk_pack_untilize_(
             if ((face == num_faces_per_rdim_tile - 1) && (i == block_ct_dim - 1) && (block_ct_dim == full_ct_dim))
             {
                 TTI_PACR(
-                    p_pacr::CFG_CTXT_0,
-                    p_pacr::NO_ROW_PAD_ZERO,
-                    p_pacr::DST_ACCESS_STRIDED_MODE,
-                    ADDR_MOD_2,
-                    p_pacr::ADDR_CNT_CTXT_0,
-                    p_pacr::P_ZERO_OUTPUT_DISABLED,
+                    ckernel::p_pacr::CFG_CTXT_0,
+                    ckernel::p_pacr::NO_ROW_PAD_ZERO,
+                    ckernel::p_pacr::DST_ACCESS_STRIDED_MODE,
+                    ckernel::ADDR_MOD_2,
+                    ckernel::p_pacr::ADDR_CNT_CTXT_0,
+                    ckernel::p_pacr::P_ZERO_OUTPUT_DISABLED,
                     PACK_INTF_SEL,
                     0,
                     0 /*MEGAROW*/,
-                    p_pacr::NO_CTXT_CTRL,
+                    ckernel::p_pacr::NO_CTXT_CTRL,
                     0,
                     1);
             }
             else
             {
                 TTI_PACR(
-                    p_pacr::CFG_CTXT_0,
-                    p_pacr::NO_ROW_PAD_ZERO,
-                    p_pacr::DST_ACCESS_STRIDED_MODE,
-                    ADDR_MOD_0,
-                    p_pacr::ADDR_CNT_CTXT_0,
-                    p_pacr::P_ZERO_OUTPUT_DISABLED,
+                    ckernel::p_pacr::CFG_CTXT_0,
+                    ckernel::p_pacr::NO_ROW_PAD_ZERO,
+                    ckernel::p_pacr::DST_ACCESS_STRIDED_MODE,
+                    ckernel::ADDR_MOD_0,
+                    ckernel::p_pacr::ADDR_CNT_CTXT_0,
+                    ckernel::p_pacr::P_ZERO_OUTPUT_DISABLED,
                     PACK_INTF_SEL,
                     0,
                     1 /*MEGAROW*/,
-                    p_pacr::NO_CTXT_CTRL,
+                    ckernel::p_pacr::NO_CTXT_CTRL,
                     0,
                     0);
             }
 
-            TTI_INCADCZW(p_setadc::PAC, 0, 0, 1, 0); // w cnt points to the next tile
+            TTI_INCADCZW(ckernel::p_setadc::PAC, 0, 0, 1, 0); // w cnt points to the next tile
         }
 
         // End OP.
-        TTI_INCADCXY(p_setadc::PAC, 0, 0, 1, 0); // inc ch0_y counters
+        TTI_INCADCXY(ckernel::p_setadc::PAC, 0, 0, 1, 0); // inc ch0_y counters
         if (block_ct_dim != full_ct_dim)
         {
             // update l1 address
-            TTI_ADDDMAREG(0, p_gpr_pack::OUTPUT_ADDR, p_gpr_pack::OUTPUT_ADDR, p_gpr_pack::OUTPUT_ADDR_OFFSET);
-            TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::THCON);
-            TTI_WRCFG(p_gpr_pack::OUTPUT_ADDR, 0, THCON_SEC0_REG1_L1_Dest_addr_ADDR32);
+            TTI_ADDDMAREG(0, ckernel::p_gpr_pack::OUTPUT_ADDR, ckernel::p_gpr_pack::OUTPUT_ADDR, ckernel::p_gpr_pack::OUTPUT_ADDR_OFFSET);
+            TTI_STALLWAIT(ckernel::p_stall::STALL_CFG, ckernel::p_stall::THCON);
+            TTI_WRCFG(ckernel::p_gpr_pack::OUTPUT_ADDR, 0, THCON_SEC0_REG1_L1_Dest_addr_ADDR32);
             TTI_NOP;
         }
         //-----------------------------------------------------------------------
 
-        TTI_INCADCZW(p_setadc::PAC, 0, 0, 0, 1);         // z cnt increments by 2xface_r_dimxFACE_C_DIM
-        TTI_SETADCXY(p_setadc::PAC, 0, 0, 0, 0, 0b0010); // reset ch0_y counters
+        TTI_INCADCZW(ckernel::p_setadc::PAC, 0, 0, 0, 1);         // z cnt increments by 2xface_r_dimxFACE_C_DIM
+        TTI_SETADCXY(ckernel::p_setadc::PAC, 0, 0, 0, 0, 0b0010); // reset ch0_y counters
     }
 
-    TT_SETADCZW(p_setadc::PAC, 0, 0, 0, 0, 0b0101); // reset z counters
+    TT_SETADCZW(ckernel::p_setadc::PAC, 0, 0, 0, 0, 0b0101); // reset z counters
 }

--- a/tt_llk_blackhole/llk_lib/llk_unpack_A.h
+++ b/tt_llk_blackhole/llk_lib/llk_unpack_A.h
@@ -44,7 +44,7 @@ inline void _llk_unpack_A_mop_config_(
     static constexpr uint srcb_set_z_2           = TT_OP_NOP;
     static constexpr uint srcb_clear_z           = TT_OP_NOP;
     constexpr uint replay_buf_len                = 1;
-    load_replay_buf<0, 1>([] { TTI_NOP; });
+    ckernel::load_replay_buf<0, 1>([] { TTI_NOP; });
 #else
     static constexpr uint unpack_srca =
         TT_OP_UNPACR(ckernel::SrcA, 0b1 /*Z inc*/, 0, 0, 0, 1 /* Set OvrdThreadId*/, 1 /*Set Dvalid*/, ckernel::p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);

--- a/tt_llk_blackhole/llk_lib/llk_unpack_A.h
+++ b/tt_llk_blackhole/llk_lib/llk_unpack_A.h
@@ -13,25 +13,23 @@
 #include "ckernel_template.h"
 #include "cunpack_common.h"
 
-using namespace ckernel;
-using namespace ckernel::unpacker;
-
 #ifndef SKIP_UNP
 #define SKIP_UNP 0
 #endif
 
 template <
-    BroadcastType BType                          = BroadcastType::NONE,
-    bool acc_to_dest                             = false,
-    EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE,
-    bool unpack_to_dest                          = false>
+    ckernel::BroadcastType BType                          = ckernel::BroadcastType::NONE,
+    bool acc_to_dest                                      = false,
+    ckernel::EltwiseBinaryReuseDestType binary_reuse_dest = ckernel::EltwiseBinaryReuseDestType::NONE,
+    bool unpack_to_dest                                   = false>
 inline void _llk_unpack_A_mop_config_(
     const bool transpose_of_faces, const std::uint32_t num_faces, const std::uint32_t unpack_src_format, const std::uint32_t unpack_dst_format = 0)
 {
     static_assert(
-        !((BType != BroadcastType::NONE) && acc_to_dest && (binary_reuse_dest == EltwiseBinaryReuseDestType::DEST_TO_SRCB)), "Not supported configuration!");
+        !((BType != ckernel::BroadcastType::NONE) && acc_to_dest && (binary_reuse_dest == ckernel::EltwiseBinaryReuseDestType::DEST_TO_SRCB)),
+        "Not supported configuration!");
     static_assert(
-        (((BType == BroadcastType::NONE) && (!acc_to_dest) && (binary_reuse_dest == EltwiseBinaryReuseDestType::NONE)) || (!unpack_to_dest)),
+        (((BType == ckernel::BroadcastType::NONE) && (!acc_to_dest) && (binary_reuse_dest == ckernel::EltwiseBinaryReuseDestType::NONE)) || (!unpack_to_dest)),
         "Not supported configuration when unpacking to dest!");
 
 #if SKIP_UNP == 1
@@ -49,74 +47,77 @@ inline void _llk_unpack_A_mop_config_(
     load_replay_buf<0, 1>([] { TTI_NOP; });
 #else
     static constexpr uint unpack_srca =
-        TT_OP_UNPACR(SrcA, 0b1 /*Z inc*/, 0, 0, 0, 1 /* Set OvrdThreadId*/, 1 /*Set Dvalid*/, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
-    static constexpr uint unpack_srca_to_dest =
-        TT_OP_UNPACR(SrcA, 0b00010001 /*Z inc*/, 0, 0, 0, 1 /* Set OvrdThreadId*/, 0 /*Set Dvalid*/, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1); // ch0/ch1 z_inc
-    static constexpr uint unpack_srca_set_dvalid = TT_OP_UNPACR_NOP(SrcA, 0, 0, p_unpacr_nop::SET_DVALID, 0, 0, 0, 0, p_unpacr_nop::UNP_ZEROSRC);
+        TT_OP_UNPACR(ckernel::SrcA, 0b1 /*Z inc*/, 0, 0, 0, 1 /* Set OvrdThreadId*/, 1 /*Set Dvalid*/, ckernel::p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
+    static constexpr uint unpack_srca_to_dest = TT_OP_UNPACR(
+        ckernel::SrcA, 0b00010001 /*Z inc*/, 0, 0, 0, 1 /* Set OvrdThreadId*/, 0 /*Set Dvalid*/, ckernel::p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1); // ch0/ch1
+                                                                                                                                                     // z_inc
+    static constexpr uint unpack_srca_set_dvalid =
+        TT_OP_UNPACR_NOP(ckernel::SrcA, 0, 0, ckernel::p_unpacr_nop::SET_DVALID, 0, 0, 0, 0, ckernel::p_unpacr_nop::UNP_ZEROSRC);
     static constexpr uint unpack_srcb =
-        TT_OP_UNPACR(SrcB, 0b1 /*Z inc*/, 0, 0, 0, 1 /* Set OvrdThreadId*/, 1 /*Set Dvalid*/, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
+        TT_OP_UNPACR(ckernel::SrcB, 0b1 /*Z inc*/, 0, 0, 0, 1 /* Set OvrdThreadId*/, 1 /*Set Dvalid*/, ckernel::p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
     static constexpr uint unpack_srcb_inc_z_0 =
-        TT_OP_UNPACR(SrcB, 0b0 /*Z inc*/, 0, 0, 0, 1 /* Set OvrdThreadId*/, 1 /*Set Dvalid*/, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
-    static constexpr uint unpack_srcb_set_dvalid = TT_OP_UNPACR_NOP(SrcB, 0, 0, p_unpacr_nop::SET_DVALID, 0, 0, 0, 0, p_unpacr_nop::UNP_ZEROSRC);
-    static constexpr uint srca_set_z_1           = TT_OP_SETADCZW(p_setadc::UNP_A, 0, 0, 0, 1, 0b0001); // set srcA ch0_z = 1
-    static constexpr uint srcb_set_z_2           = TT_OP_SETADCZW(p_setadc::UNP_B, 0, 0, 0, 2, 0b0001); // set srcB ch0_z = 2
-    static constexpr uint srcb_clear_z           = TT_OP_SETADCZW(p_setadc::UNP_B, 0, 0, 0, 0, 0b0001); // set srcB ch0_z = 0
+        TT_OP_UNPACR(ckernel::SrcB, 0b0 /*Z inc*/, 0, 0, 0, 1 /* Set OvrdThreadId*/, 1 /*Set Dvalid*/, ckernel::p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
+    static constexpr uint unpack_srcb_set_dvalid =
+        TT_OP_UNPACR_NOP(ckernel::SrcB, 0, 0, ckernel::p_unpacr_nop::SET_DVALID, 0, 0, 0, 0, ckernel::p_unpacr_nop::UNP_ZEROSRC);
+    static constexpr uint srca_set_z_1 = TT_OP_SETADCZW(ckernel::p_setadc::UNP_A, 0, 0, 0, 1, 0b0001); // set srcA ch0_z = 1
+    static constexpr uint srcb_set_z_2 = TT_OP_SETADCZW(ckernel::p_setadc::UNP_B, 0, 0, 0, 2, 0b0001); // set srcB ch0_z = 2
+    static constexpr uint srcb_clear_z = TT_OP_SETADCZW(ckernel::p_setadc::UNP_B, 0, 0, 0, 0, 0b0001); // set srcB ch0_z = 0
 #endif
 
-    if (unpack_to_dest && is_32bit_input(unpack_src_format, unpack_dst_format))
+    if (unpack_to_dest && ckernel::unpacker::is_32bit_input(unpack_src_format, unpack_dst_format))
     {
         const uint32_t outerloop     = num_faces;
         constexpr uint32_t innerloop = 1;
-        ckernel_template tmp(outerloop, innerloop, unpack_srca_to_dest);
-        tmp.program(instrn_buffer);
+        ckernel::ckernel_template tmp(outerloop, innerloop, unpack_srca_to_dest);
+        tmp.program(ckernel::instrn_buffer);
     }
-    else if constexpr (BType == BroadcastType::COL)
+    else if constexpr (BType == ckernel::BroadcastType::COL)
     {
         if constexpr (acc_to_dest)
         {
             constexpr uint32_t innerloop = 1;
             constexpr uint32_t outerloop = 2; // TODO: add support for num_faces, add support for dest to srcB
-            ckernel_template tmp(outerloop, innerloop, unpack_srca_set_dvalid, unpack_srca_set_dvalid);
+            ckernel::ckernel_template tmp(outerloop, innerloop, unpack_srca_set_dvalid, unpack_srca_set_dvalid);
             tmp.set_start_op(unpack_srcb);
             tmp.set_end_op(srcb_set_z_2);
-            tmp.program(instrn_buffer);
+            tmp.program(ckernel::instrn_buffer);
         }
         else
         {
             constexpr uint32_t innerloop = 1;
             constexpr uint32_t outerloop = 1; // TODO: add support for num_faces, add support for dest to srcB
-            ckernel_template tmp(outerloop, innerloop, unpack_srcb, srcb_set_z_2);
+            ckernel::ckernel_template tmp(outerloop, innerloop, unpack_srcb, srcb_set_z_2);
             tmp.set_start_op(unpack_srca_set_dvalid);
             tmp.set_end_op(unpack_srcb);
-            tmp.program(instrn_buffer);
+            tmp.program(ckernel::instrn_buffer);
         }
     }
-    else if constexpr (BType == BroadcastType::ROW)
+    else if constexpr (BType == ckernel::BroadcastType::ROW)
     {
         constexpr uint32_t innerloop = 2;
         constexpr uint32_t outerloop = 2; // TODO: add support for num_faces
         if constexpr (acc_to_dest)
         {
-            ckernel_template tmp(outerloop, innerloop, unpack_srcb, unpack_srca_set_dvalid);
+            ckernel::ckernel_template tmp(outerloop, innerloop, unpack_srcb, unpack_srca_set_dvalid);
             tmp.set_end_op(srcb_clear_z);
-            tmp.program(instrn_buffer);
+            tmp.program(ckernel::instrn_buffer);
         }
         else
         {
-            ckernel_template tmp(outerloop, innerloop, unpack_srcb);
+            ckernel::ckernel_template tmp(outerloop, innerloop, unpack_srcb);
             tmp.set_end_op(srcb_clear_z);
-            tmp.program(instrn_buffer);
+            tmp.program(ckernel::instrn_buffer);
         }
     }
-    else if constexpr (BType == BroadcastType::SCALAR)
+    else if constexpr (BType == ckernel::BroadcastType::SCALAR)
     {
         static_assert((!acc_to_dest) && "accumulate into dest with broadcast scaler is not supported!");
         const uint32_t outerloop     = 1;
         constexpr uint32_t innerloop = 1;
-        ckernel_template tmp(outerloop, innerloop, unpack_srcb_inc_z_0);
+        ckernel::ckernel_template tmp(outerloop, innerloop, unpack_srcb_inc_z_0);
         // ELWADD used in datacopy due to broadcast bug, use zerosrca regardless of acc_to_dest
         tmp.set_start_op(unpack_srca_set_dvalid);
-        tmp.program(instrn_buffer);
+        tmp.program(ckernel::instrn_buffer);
     }
     else
     {
@@ -124,96 +125,96 @@ inline void _llk_unpack_A_mop_config_(
         {
 #if SKIP_UNP == 0
             constexpr uint replay_buf_len = 2;
-            load_replay_buf<0, replay_buf_len>(
+            ckernel::load_replay_buf<0, replay_buf_len>(
                 [num_faces]
                 {
-                    TTI_UNPACR_NOP(SrcB, 0, 0, p_unpacr_nop::SET_DVALID, 0, 0, 0, 0, p_unpacr_nop::UNP_ZEROSRC);
+                    TTI_UNPACR_NOP(ckernel::SrcB, 0, 0, ckernel::p_unpacr_nop::SET_DVALID, 0, 0, 0, 0, ckernel::p_unpacr_nop::UNP_ZEROSRC);
                     if (num_faces > 2)
                     {
-                        TTI_UNPACR(SrcA, 0b10, 0, 0, 0, 1, 1, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1); // inc srcA ch0_z+=2
+                        TTI_UNPACR(ckernel::SrcA, 0b10, 0, 0, 0, 1, 1, ckernel::p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1); // inc srcA ch0_z+=2
                     }
                     else
                     {
-                        TTI_UNPACR(SrcA, 0b01, 0, 0, 0, 1, 1, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1); // inc srcA ch0_z+=1
+                        TTI_UNPACR(ckernel::SrcA, 0b01, 0, 0, 0, 1, 1, ckernel::p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1); // inc srcA ch0_z+=1
                     }
                 });
 #endif
             const uint32_t outerloop = num_faces < 4 ? 1 : 2;
             const uint32_t innerloop = num_faces < 2 ? 1 : 2;
-            ckernel_template tmp(outerloop, innerloop, TT_OP_REPLAY(0, replay_buf_len, 0, 0)); // Unpack faces 0/2 && 1/3 to srcA
-                                                                                               // or 0/1 for 2 face tile
+            ckernel::ckernel_template tmp(outerloop, innerloop, TT_OP_REPLAY(0, replay_buf_len, 0, 0)); // Unpack faces 0/2 && 1/3 to srcA
+                                                                                                        // or 0/1 for 2 face tile
             if (num_faces > 2)
             {
                 tmp.set_end_op(srca_set_z_1);
             }
-            tmp.program(instrn_buffer);
+            tmp.program(ckernel::instrn_buffer);
         }
         else
         {
             if constexpr (acc_to_dest)
             {
                 static constexpr uint unpack_srca_reuse =
-                    (binary_reuse_dest == EltwiseBinaryReuseDestType::DEST_TO_SRCA) ? unpack_srca_set_dvalid : unpack_srca;
+                    (binary_reuse_dest == ckernel::EltwiseBinaryReuseDestType::DEST_TO_SRCA) ? unpack_srca_set_dvalid : unpack_srca;
 
                 static constexpr uint unpack_srcb_reuse =
-                    (binary_reuse_dest == EltwiseBinaryReuseDestType::DEST_TO_SRCB) ? unpack_srcb_set_dvalid : unpack_srcb;
+                    (binary_reuse_dest == ckernel::EltwiseBinaryReuseDestType::DEST_TO_SRCB) ? unpack_srcb_set_dvalid : unpack_srcb;
 
                 const uint32_t outerloop     = num_faces;
                 constexpr uint32_t innerloop = 1;
-                ckernel_template tmp(outerloop, innerloop, unpack_srca_reuse, unpack_srcb_reuse);
-                tmp.program(instrn_buffer);
+                ckernel::ckernel_template tmp(outerloop, innerloop, unpack_srca_reuse, unpack_srcb_reuse);
+                tmp.program(ckernel::instrn_buffer);
             }
             else
             {
                 const uint32_t outerloop     = num_faces;
                 constexpr uint32_t innerloop = 1;
-                ckernel_template tmp(outerloop, innerloop, unpack_srcb_set_dvalid);
+                ckernel::ckernel_template tmp(outerloop, innerloop, unpack_srcb_set_dvalid);
                 tmp.set_start_op(unpack_srca);
-                tmp.program(instrn_buffer);
+                tmp.program(ckernel::instrn_buffer);
             }
         }
     }
 }
 
-template <bool is_fp32_dest_acc_en = false, StochRndType stoch_rnd_mode = StochRndType::None, bool disable_src_zero_flag = false>
+template <bool is_fp32_dest_acc_en = false, ckernel::StochRndType stoch_rnd_mode = ckernel::StochRndType::None, bool disable_src_zero_flag = false>
 inline void _llk_unpack_A_hw_configure_(
     const std::uint32_t unpack_src_format,
     const std::uint32_t unpack_dst_format,
-    const std::uint32_t face_r_dim                  = FACE_R_DIM,
+    const std::uint32_t face_r_dim                  = ckernel::FACE_R_DIM,
     const std::uint32_t within_face_16x16_transpose = 0,
     const std::uint32_t num_faces                   = 4)
 {
     constexpr bool is_row_pool  = false;
-    constexpr bool stoch_rnd_en = (stoch_rnd_mode == StochRndType::All);
-    constexpr bool fpu_srnd_en  = stoch_rnd_en || (stoch_rnd_mode == StochRndType::Fpu);
-    constexpr bool pack_srnd_en = stoch_rnd_en || (stoch_rnd_mode == StochRndType::Pack);
-    configure_unpack_AB<is_row_pool, is_fp32_dest_acc_en, fpu_srnd_en, pack_srnd_en, disable_src_zero_flag>(
+    constexpr bool stoch_rnd_en = (stoch_rnd_mode == ckernel::StochRndType::All);
+    constexpr bool fpu_srnd_en  = stoch_rnd_en || (stoch_rnd_mode == ckernel::StochRndType::Fpu);
+    constexpr bool pack_srnd_en = stoch_rnd_en || (stoch_rnd_mode == ckernel::StochRndType::Pack);
+    ckernel::unpacker::configure_unpack_AB<is_row_pool, is_fp32_dest_acc_en, fpu_srnd_en, pack_srnd_en, disable_src_zero_flag>(
         unpack_src_format, unpack_src_format, unpack_dst_format, unpack_dst_format, face_r_dim, face_r_dim, within_face_16x16_transpose, num_faces, num_faces);
 }
 
 template <
-    BroadcastType BType                          = BroadcastType::NONE,
-    bool acc_to_dest                             = false,
-    EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE,
-    bool unpack_to_dest                          = false>
+    ckernel::BroadcastType BType                          = ckernel::BroadcastType::NONE,
+    bool acc_to_dest                                      = false,
+    ckernel::EltwiseBinaryReuseDestType binary_reuse_dest = ckernel::EltwiseBinaryReuseDestType::NONE,
+    bool unpack_to_dest                                   = false>
 inline void _llk_unpack_A_init_(
     const std::uint32_t transpose_of_faces          = 0,
     const std::uint32_t within_face_16x16_transpose = 0,
-    const std::uint32_t face_r_dim                  = FACE_R_DIM,
+    const std::uint32_t face_r_dim                  = ckernel::FACE_R_DIM,
     const std::uint32_t num_faces                   = 4,
     const std::uint32_t unpack_src_format           = 0,
     const std::uint32_t unpack_dst_format           = 0)
 {
-    constexpr std::uint32_t UNP_SEL = (BType == BroadcastType::NONE) ? p_setadc::UNP_A : p_setadc::UNP_B;
-    config_unpacker_x_end<UNP_SEL>(face_r_dim);
+    constexpr std::uint32_t UNP_SEL = (BType == ckernel::BroadcastType::NONE) ? ckernel::p_setadc::UNP_A : ckernel::p_setadc::UNP_B;
+    ckernel::unpacker::config_unpacker_x_end<UNP_SEL>(face_r_dim);
     _llk_unpack_A_mop_config_<BType, acc_to_dest, binary_reuse_dest, unpack_to_dest>(transpose_of_faces > 0, num_faces, unpack_src_format, unpack_dst_format);
 }
 
 template <
-    BroadcastType BType                          = BroadcastType::NONE,
-    bool acc_to_dest                             = false,
-    EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE,
-    bool unpack_to_dest                          = false>
+    ckernel::BroadcastType BType                          = ckernel::BroadcastType::NONE,
+    bool acc_to_dest                                      = false,
+    ckernel::EltwiseBinaryReuseDestType binary_reuse_dest = ckernel::EltwiseBinaryReuseDestType::NONE,
+    bool unpack_to_dest                                   = false>
 inline void _llk_unpack_A_(
     const std::uint32_t address, const bool transpose_of_faces = 0, const std::uint32_t unpack_src_format = 0, const std::uint32_t unpack_dst_format = 0)
 {
@@ -221,21 +222,21 @@ inline void _llk_unpack_A_(
     TTI_SETADCZW(0b011, 0, 0, 0, 0, 0b1111);
 
     // Program srcA and srcB base addresses
-    volatile uint tt_reg_ptr *cfg = get_cfg_pointer(); // get pointer to registers for current state ID
+    volatile uint tt_reg_ptr *cfg = ckernel::get_cfg_pointer(); // get pointer to registers for current state ID
 
     // Wait for free context
-    wait_for_next_context(2);
+    ckernel::unpacker::wait_for_next_context(2);
 
     // Get tile address
     if (0 == unp_cfg_context)
     {
-        if constexpr ((BType == BroadcastType::NONE) && (!acc_to_dest))
+        if constexpr ((BType == ckernel::BroadcastType::NONE) && (!acc_to_dest))
         {
             cfg[THCON_SEC0_REG3_Base_address_ADDR32] = address;
         }
         else
         {
-            if constexpr (binary_reuse_dest == EltwiseBinaryReuseDestType::DEST_TO_SRCB)
+            if constexpr (binary_reuse_dest == ckernel::EltwiseBinaryReuseDestType::DEST_TO_SRCB)
             {
                 cfg[THCON_SEC0_REG3_Base_address_ADDR32] = address;
             }
@@ -244,13 +245,13 @@ inline void _llk_unpack_A_(
     }
     else
     {
-        if constexpr ((BType == BroadcastType::NONE) && (!acc_to_dest))
+        if constexpr ((BType == ckernel::BroadcastType::NONE) && (!acc_to_dest))
         {
             cfg[THCON_SEC0_REG3_Base_cntx1_address_ADDR32] = address;
         }
         else
         {
-            if constexpr (binary_reuse_dest == EltwiseBinaryReuseDestType::DEST_TO_SRCB)
+            if constexpr (binary_reuse_dest == ckernel::EltwiseBinaryReuseDestType::DEST_TO_SRCB)
             {
                 cfg[THCON_SEC0_REG3_Base_cntx1_address_ADDR32] = address;
             }
@@ -259,36 +260,36 @@ inline void _llk_unpack_A_(
     }
 
     // Trisc::SEMPOST for context acquire
-    semaphore_post(semaphore::UNPACK_SYNC);
+    ckernel::semaphore_post(ckernel::semaphore::UNPACK_SYNC);
 
     if constexpr (unpack_to_dest)
     {
-        if (is_32bit_input(unpack_src_format, unpack_dst_format))
+        if (ckernel::unpacker::is_32bit_input(unpack_src_format, unpack_dst_format))
         {
-            set_dst_write_addr(unp_cfg_context, unpack_dst_format);
-            wait_for_dest_available();
+            ckernel::unpacker::set_dst_write_addr(unp_cfg_context, unpack_dst_format);
+            ckernel::unpacker::wait_for_dest_available();
         }
     }
 
     // Stall unpacker until pending CFG writes from Trisc have completed
-    TTI_STALLWAIT(p_stall::STALL_UNPACK, p_stall::TRISC_CFG);
+    TTI_STALLWAIT(ckernel::p_stall::STALL_UNPACK, ckernel::p_stall::TRISC_CFG);
 
     // Run MOP
-    ckernel::ckernel_template::run(instrn_buffer);
+    ckernel::ckernel_template::run(ckernel::instrn_buffer);
 
     // T6::SEMGET for context release
-    t6_semaphore_get(semaphore::UNPACK_SYNC);
+    ckernel::t6_semaphore_get(ckernel::semaphore::UNPACK_SYNC);
 
     if (unpack_to_dest)
     {
-        if (is_32bit_input(unpack_src_format, unpack_dst_format))
+        if (ckernel::unpacker::is_32bit_input(unpack_src_format, unpack_dst_format))
         {
-            unpack_to_dest_tile_done(unp_cfg_context);
+            ckernel::unpacker::unpack_to_dest_tile_done(unp_cfg_context);
         }
     }
 
     // Switch unpacker config context
-    switch_config_context(unp_cfg_context);
+    ckernel::unpacker::switch_config_context(unp_cfg_context);
 
 #ifdef PERF_DUMP
     first_unpack_recorded = true;

--- a/tt_llk_blackhole/llk_lib/llk_unpack_AB.h
+++ b/tt_llk_blackhole/llk_lib/llk_unpack_AB.h
@@ -13,26 +13,23 @@
 #include "ckernel_template.h"
 #include "cunpack_common.h"
 
-using namespace ckernel;
-using namespace ckernel::unpacker;
-
-template <BroadcastType BType = BroadcastType::NONE>
+template <ckernel::BroadcastType BType = ckernel::BroadcastType::NONE>
 inline void _llk_unpack_AB_mop_config_(const bool transpose_of_faces = false, const std::uint32_t num_faces = 4, const bool narrow_tile = false)
 {
 #if SKIP_UNP == 1
     static constexpr uint unpack_srca = TT_OP_NOP;
     static constexpr uint unpack_srcb = TT_OP_NOP;
 #else
-    static constexpr uint unpack_srca = TT_OP_UNPACR(SrcA, 0b1, 0, 0, 0, 1, 1, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
-    static constexpr uint unpack_srcb = TT_OP_UNPACR(SrcB, 0b1, 0, 0, 0, 1, 1, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
+    static constexpr uint unpack_srca = TT_OP_UNPACR(ckernel::SrcA, 0b1, 0, 0, 0, 1, 1, ckernel::p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
+    static constexpr uint unpack_srcb = TT_OP_UNPACR(ckernel::SrcB, 0b1, 0, 0, 0, 1, 1, ckernel::p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
 #endif
 
-    if constexpr (BType == BroadcastType::COL)
+    if constexpr (BType == ckernel::BroadcastType::COL)
     {
         static constexpr uint unpack_srcb_set_z = TT_OP_SETADCZW(0b010, 0, 0, 0, 2, 0b0001);
         const uint32_t outerloop                = num_faces < 4 ? 1 : 2;
         const uint32_t innerloop                = num_faces < 2 ? 1 : 2;
-        ckernel_template tmp(outerloop, innerloop, unpack_srca);
+        ckernel::ckernel_template tmp(outerloop, innerloop, unpack_srca);
         tmp.set_start_op(unpack_srcb);
         if (narrow_tile)
         {
@@ -42,92 +39,93 @@ inline void _llk_unpack_AB_mop_config_(const bool transpose_of_faces = false, co
         {
             tmp.set_end_op(unpack_srcb_set_z);
         }
-        tmp.program(instrn_buffer);
+        tmp.program(ckernel::instrn_buffer);
     }
-    else if constexpr (BType == BroadcastType::ROW)
+    else if constexpr (BType == ckernel::BroadcastType::ROW)
     {
         static constexpr uint unpack_srcb_clear_z  = TT_OP_SETADCZW(0b010, 0, 0, 0, 0, 0b0001);
-        static constexpr uint unpack_srcb_no_z_inc = TT_OP_UNPACR(SrcB, 0b0, 0, 0, 0, 1, 1, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
+        static constexpr uint unpack_srcb_no_z_inc = TT_OP_UNPACR(ckernel::SrcB, 0b0, 0, 0, 0, 1, 1, ckernel::p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
         const uint32_t outerloop                   = num_faces < 4 ? 1 : 2;
         const uint32_t innerloop                   = num_faces < 2 ? 1 : 2;
-        ckernel_template tmp(outerloop, innerloop, narrow_tile ? unpack_srcb_no_z_inc : unpack_srcb, unpack_srca);
+        ckernel::ckernel_template tmp(outerloop, innerloop, narrow_tile ? unpack_srcb_no_z_inc : unpack_srcb, unpack_srca);
         tmp.set_end_op(unpack_srcb_clear_z);
-        tmp.program(instrn_buffer);
+        tmp.program(ckernel::instrn_buffer);
     }
-    else if constexpr (BType == BroadcastType::SCALAR)
+    else if constexpr (BType == ckernel::BroadcastType::SCALAR)
     {
         const uint32_t outerloop = 1;
         const uint32_t innerloop = num_faces;
-        ckernel_template tmp(outerloop, innerloop, unpack_srca);
+        ckernel::ckernel_template tmp(outerloop, innerloop, unpack_srca);
         tmp.set_start_op(unpack_srcb);
-        tmp.program(instrn_buffer);
+        tmp.program(ckernel::instrn_buffer);
     }
     else
     {
         if (transpose_of_faces)
         {
-            static constexpr uint srca_set_z         = TT_OP_SETADCZW(0b001, 0, 0, 0, 1, 0b0001);                                         // set z to 1
-            static constexpr uint unpack_srca_skip_z = TT_OP_UNPACR(SrcA, 0b10, 0, 0, 0, 1, 1, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1); // inc z by 2
-            const uint32_t outerloop                 = num_faces < 4 ? 1 : 2;
-            const uint32_t innerloop                 = num_faces < 2 ? 1 : 2;
-            ckernel_template tmp(outerloop, innerloop, num_faces < 4 ? unpack_srca : unpack_srca_skip_z, unpack_srcb);
+            static constexpr uint srca_set_z = TT_OP_SETADCZW(0b001, 0, 0, 0, 1, 0b0001); // set z to 1
+            static constexpr uint unpack_srca_skip_z =
+                TT_OP_UNPACR(ckernel::SrcA, 0b10, 0, 0, 0, 1, 1, ckernel::p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1); // inc z by 2
+            const uint32_t outerloop = num_faces < 4 ? 1 : 2;
+            const uint32_t innerloop = num_faces < 2 ? 1 : 2;
+            ckernel::ckernel_template tmp(outerloop, innerloop, num_faces < 4 ? unpack_srca : unpack_srca_skip_z, unpack_srcb);
             tmp.set_end_op(srca_set_z);
-            tmp.program(instrn_buffer);
+            tmp.program(ckernel::instrn_buffer);
         }
         else
         {
             constexpr uint32_t outerloop = 1;
             const uint32_t innerloop     = num_faces;
-            ckernel_template tmp(outerloop, innerloop, unpack_srca, unpack_srcb);
-            tmp.program(instrn_buffer);
+            ckernel::ckernel_template tmp(outerloop, innerloop, unpack_srca, unpack_srcb);
+            tmp.program(ckernel::instrn_buffer);
         }
     }
 }
 
-template <bool is_fp32_dest_acc_en = false, StochRndType stoch_rnd_mode = StochRndType::None>
+template <bool is_fp32_dest_acc_en = false, ckernel::StochRndType stoch_rnd_mode = ckernel::StochRndType::None>
 inline void _llk_unpack_AB_hw_configure_(
     const std::uint32_t unpA_src_format,
     const std::uint32_t unpB_src_format,
     const std::uint32_t unpA_dst_format,
     const std::uint32_t unpB_dst_format,
-    const std::uint32_t face_r_dim                  = FACE_R_DIM,
+    const std::uint32_t face_r_dim                  = ckernel::FACE_R_DIM,
     const std::uint32_t within_face_16x16_transpose = 0,
     const std::uint32_t num_faces                   = 4)
 {
     constexpr bool is_row_pool  = false;
-    constexpr bool stoch_rnd_en = (stoch_rnd_mode == StochRndType::All);
-    constexpr bool fpu_srnd_en  = stoch_rnd_en || (stoch_rnd_mode == StochRndType::Fpu);
-    constexpr bool pack_srnd_en = stoch_rnd_en || (stoch_rnd_mode == StochRndType::Pack);
-    configure_unpack_AB<is_row_pool, is_fp32_dest_acc_en, fpu_srnd_en, pack_srnd_en>(
+    constexpr bool stoch_rnd_en = (stoch_rnd_mode == ckernel::StochRndType::All);
+    constexpr bool fpu_srnd_en  = stoch_rnd_en || (stoch_rnd_mode == ckernel::StochRndType::Fpu);
+    constexpr bool pack_srnd_en = stoch_rnd_en || (stoch_rnd_mode == ckernel::StochRndType::Pack);
+    ckernel::unpacker::configure_unpack_AB<is_row_pool, is_fp32_dest_acc_en, fpu_srnd_en, pack_srnd_en>(
         unpA_src_format, unpB_src_format, unpA_dst_format, unpB_dst_format, face_r_dim, face_r_dim, within_face_16x16_transpose, num_faces, num_faces);
 }
 
-template <BroadcastType BType = BroadcastType::NONE>
+template <ckernel::BroadcastType BType = ckernel::BroadcastType::NONE>
 inline void _llk_unpack_AB_init_(
-    const std::uint32_t face_r_dim  = FACE_R_DIM,
+    const std::uint32_t face_r_dim  = ckernel::FACE_R_DIM,
     const std::uint32_t num_faces   = 4,
     const bool narrow_tile          = false,
     const std::uint32_t transpose   = 0,
     const std::uint32_t acc_to_dest = 0)
 {
-    cfg_reg_rmw_tensix<THCON_SEC0_REG2_Haloize_mode_RMW>(transpose); // transpose within the face
+    ckernel::cfg_reg_rmw_tensix<THCON_SEC0_REG2_Haloize_mode_RMW>(transpose); // transpose within the face
 
-    constexpr std::uint32_t UNP_SEL = p_setadc::UNP_AB;
-    config_unpacker_x_end<UNP_SEL>(face_r_dim);
+    constexpr std::uint32_t UNP_SEL = ckernel::p_setadc::UNP_AB;
+    ckernel::unpacker::config_unpacker_x_end<UNP_SEL>(face_r_dim);
 
     _llk_unpack_AB_mop_config_<BType>(transpose > 0, num_faces, narrow_tile); // transpose of faces 0,2,1,3
 }
 
-template <BroadcastType BType = BroadcastType::NONE>
+template <ckernel::BroadcastType BType = ckernel::BroadcastType::NONE>
 inline void _llk_unpack_AB_(const std::uint32_t address_a, const std::uint32_t address_b, const bool transpose_of_faces = 0 /*not used*/)
 {
     TTI_SETADCZW(0b011, 0, 0, 0, 0, 0b1111); // reset counters
 
     // Program srcA and srcB base addresses
-    volatile uint tt_reg_ptr *cfg = get_cfg_pointer(); // get pointer to registers for current state ID
+    volatile uint tt_reg_ptr *cfg = ckernel::get_cfg_pointer(); // get pointer to registers for current state ID
 
     // Wait for free context
-    wait_for_next_context(2);
+    ckernel::unpacker::wait_for_next_context(2);
 
     // Get tile address
     if (0 == unp_cfg_context)
@@ -142,19 +140,19 @@ inline void _llk_unpack_AB_(const std::uint32_t address_a, const std::uint32_t a
     }
 
     // Trisc::SEMPOST for context acquire
-    semaphore_post(semaphore::UNPACK_SYNC);
+    ckernel::semaphore_post(ckernel::semaphore::UNPACK_SYNC);
 
     // Stall unpacker until pending CFG writes from Trisc have completed
-    TTI_STALLWAIT(p_stall::STALL_UNPACK, p_stall::TRISC_CFG);
+    TTI_STALLWAIT(ckernel::p_stall::STALL_UNPACK, ckernel::p_stall::TRISC_CFG);
 
     // Run MOP
-    ckernel::ckernel_template::run(instrn_buffer);
+    ckernel::ckernel_template::run(ckernel::instrn_buffer);
 
     // T6::SEMGET for context release
-    t6_semaphore_get(semaphore::UNPACK_SYNC);
+    ckernel::t6_semaphore_get(ckernel::semaphore::UNPACK_SYNC);
 
     // Switch unpacker config context
-    switch_config_context(unp_cfg_context);
+    ckernel::unpacker::switch_config_context(unp_cfg_context);
 
 #ifdef PERF_DUMP
     first_unpack_recorded = true;

--- a/tt_llk_blackhole/llk_lib/llk_unpack_AB_matmul.h
+++ b/tt_llk_blackhole/llk_lib/llk_unpack_AB_matmul.h
@@ -13,9 +13,6 @@
 #include "ckernel_template.h"
 #include "cunpack_common.h"
 
-using namespace ckernel;
-using namespace ckernel::unpacker;
-
 // transpose is unused, math is adjusted to take into account srca face layout when transpose=true
 template <std::uint32_t kernel_broadcast_a = 0, std::uint32_t kernel_broadcast_b = 0>
 inline void _llk_unpack_AB_matmul_mop_config_(
@@ -26,8 +23,8 @@ inline void _llk_unpack_AB_matmul_mop_config_(
     const bool unpA_partial_face,
     const bool unpB_partial_face)
 {
-    // in0/inA - loaded to SrcB
-    // in1/inB - loaded to SrcA
+    // in0/inA - loaded to ckernel::SrcB
+    // in1/inB - loaded to ckernel::SrcA
 
     const bool reuse_a                      = ct_dim >= rt_dim;
     const std::uint32_t replay_buf_prog_len = (reuse_a && unpA_partial_face) ? 18 : ((!reuse_a && unpB_partial_face) ? 18 : 12);
@@ -36,10 +33,10 @@ inline void _llk_unpack_AB_matmul_mop_config_(
     if (reuse_a)
     {
 #if SKIP_UNP == 1
-        load_replay_buf<0, 1>([] { TTI_NOP; });
+        ckernel::load_replay_buf<0, 1>([] { TTI_NOP; });
 #else
         static_assert(kernel_broadcast_b <= 1, "kernel_broadcast>1 on matmul input 1 is not supported with reuse enabled");
-        load_replay_buf(
+        ckernel::load_replay_buf(
             0,
             replay_buf_prog_len,
             false,
@@ -48,16 +45,53 @@ inline void _llk_unpack_AB_matmul_mop_config_(
             {
                 if (unpA_partial_face)
                 {
-                    TTI_UNPACR_NOP(SrcA, 0, 0, 0 /*Set Dvalid*/, 0, 0, 0, 0, p_unpacr_nop::UNP_ZEROSRC);
+                    TTI_UNPACR_NOP(ckernel::SrcA, 0, 0, 0 /*Set Dvalid*/, 0, 0, 0, 0, ckernel::p_unpacr_nop::UNP_ZEROSRC);
                     TTI_UNPACR(
-                        SrcA, 0b00010001, 0, 0, 0, 1 /*Set OvrdThreadId*/, 0 /*Set Dvalid*/, p_unpacr::RAREFYB_DISABLE, 0, 0 /* Set ContextIdInc */, 0, 0, 1);
+                        ckernel::SrcA,
+                        0b00010001,
+                        0,
+                        0,
+                        0,
+                        1 /*Set OvrdThreadId*/,
+                        0 /*Set Dvalid*/,
+                        ckernel::p_unpacr::RAREFYB_DISABLE,
+                        0,
+                        0 /* Set ContextIdInc */,
+                        0,
+                        0,
+                        1);
                     TTI_UNPACR(
-                        SrcA, 0b00010001, 0, 0, 0, 1 /*Set OvrdThreadId*/, 1 /*Set Dvalid*/, p_unpacr::RAREFYB_DISABLE, 0, 0 /* Set ContextIdInc */, 0, 0, 1);
-                    TTI_SETADCZW(p_setadc::UNP_A, 0, 0, 0, 0, 0b0101); // Set ch0_z=0, ch1_z=0
+                        ckernel::SrcA,
+                        0b00010001,
+                        0,
+                        0,
+                        0,
+                        1 /*Set OvrdThreadId*/,
+                        1 /*Set Dvalid*/,
+                        ckernel::p_unpacr::RAREFYB_DISABLE,
+                        0,
+                        0 /* Set ContextIdInc */,
+                        0,
+                        0,
+                        1);
+                    TTI_SETADCZW(ckernel::p_setadc::UNP_A, 0, 0, 0, 0, 0b0101); // Set ch0_z=0, ch1_z=0
                 }
                 else
                 {
-                    TTI_UNPACR(SrcA, 0, 0, 0, 0, 1 /*Set OvrdThreadId*/, 1 /*Set Dvalid*/, p_unpacr::RAREFYB_DISABLE, 0, 0 /* Set ContextIdInc */, 0, 0, 1);
+                    TTI_UNPACR(
+                        ckernel::SrcA,
+                        0,
+                        0,
+                        0,
+                        0,
+                        1 /*Set OvrdThreadId*/,
+                        1 /*Set Dvalid*/,
+                        ckernel::p_unpacr::RAREFYB_DISABLE,
+                        0,
+                        0 /* Set ContextIdInc */,
+                        0,
+                        0,
+                        1);
                 }
                 if constexpr (kernel_broadcast_b == 1)
                 {
@@ -68,26 +102,63 @@ inline void _llk_unpack_AB_matmul_mop_config_(
                 }
                 else
                 {
-                    TTI_RDCFG(p_gpr_unpack::TMP0, THCON_SEC0_REG3_Base_address_ADDR32);
-                    TTI_ADDDMAREG(0, p_gpr_unpack::TMP0, p_gpr_unpack::TMP0, p_gpr_unpack::TILE_SIZE_A);
-                    TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::THCON);
-                    TTI_WRCFG(p_gpr_unpack::TMP0, 0, THCON_SEC0_REG3_Base_address_ADDR32);
+                    TTI_RDCFG(ckernel::p_gpr_unpack::TMP0, THCON_SEC0_REG3_Base_address_ADDR32);
+                    TTI_ADDDMAREG(0, ckernel::p_gpr_unpack::TMP0, ckernel::p_gpr_unpack::TMP0, ckernel::p_gpr_unpack::TILE_SIZE_A);
+                    TTI_STALLWAIT(ckernel::p_stall::STALL_CFG, ckernel::p_stall::THCON);
+                    TTI_WRCFG(ckernel::p_gpr_unpack::TMP0, 0, THCON_SEC0_REG3_Base_address_ADDR32);
                 }
                 // Added to ensure WRCFG instruction has finished, since it takes 2 cycles.
                 TTI_NOP;
 
                 if (unpA_partial_face)
                 {
-                    TTI_UNPACR_NOP(SrcA, 0, 0, 0 /*Set Dvalid*/, 0, 0, 0, 0, p_unpacr_nop::UNP_ZEROSRC);
+                    TTI_UNPACR_NOP(ckernel::SrcA, 0, 0, 0 /*Set Dvalid*/, 0, 0, 0, 0, ckernel::p_unpacr_nop::UNP_ZEROSRC);
                     TTI_UNPACR(
-                        SrcA, 0b00010001, 0, 0, 0, 1 /*Set OvrdThreadId*/, 0 /*Set Dvalid*/, p_unpacr::RAREFYB_DISABLE, 0, 0 /* Set ContextIdInc */, 0, 0, 1);
+                        ckernel::SrcA,
+                        0b00010001,
+                        0,
+                        0,
+                        0,
+                        1 /*Set OvrdThreadId*/,
+                        0 /*Set Dvalid*/,
+                        ckernel::p_unpacr::RAREFYB_DISABLE,
+                        0,
+                        0 /* Set ContextIdInc */,
+                        0,
+                        0,
+                        1);
                     TTI_UNPACR(
-                        SrcA, 0b00010001, 0, 0, 0, 1 /*Set OvrdThreadId*/, 1 /*Set Dvalid*/, p_unpacr::RAREFYB_DISABLE, 0, 0 /* Set ContextIdInc */, 0, 0, 1);
-                    TTI_SETADCZW(p_setadc::UNP_A, 0, 0, 0, 0, 0b0101); // Set ch0_z=0, ch1_z=0
+                        ckernel::SrcA,
+                        0b00010001,
+                        0,
+                        0,
+                        0,
+                        1 /*Set OvrdThreadId*/,
+                        1 /*Set Dvalid*/,
+                        ckernel::p_unpacr::RAREFYB_DISABLE,
+                        0,
+                        0 /* Set ContextIdInc */,
+                        0,
+                        0,
+                        1);
+                    TTI_SETADCZW(ckernel::p_setadc::UNP_A, 0, 0, 0, 0, 0b0101); // Set ch0_z=0, ch1_z=0
                 }
                 else
                 {
-                    TTI_UNPACR(SrcA, 0, 0, 0, 0, 1 /*Set OvrdThreadId*/, 1 /*Set Dvalid*/, p_unpacr::RAREFYB_DISABLE, 0, 0 /* Set ContextIdInc */, 0, 0, 1);
+                    TTI_UNPACR(
+                        ckernel::SrcA,
+                        0,
+                        0,
+                        0,
+                        0,
+                        1 /*Set OvrdThreadId*/,
+                        1 /*Set Dvalid*/,
+                        ckernel::p_unpacr::RAREFYB_DISABLE,
+                        0,
+                        0 /* Set ContextIdInc */,
+                        0,
+                        0,
+                        1);
                 }
                 if constexpr (kernel_broadcast_b == 1)
                 {
@@ -98,10 +169,10 @@ inline void _llk_unpack_AB_matmul_mop_config_(
                 }
                 else
                 {
-                    TTI_RDCFG(p_gpr_unpack::TMP0, THCON_SEC0_REG3_Base_cntx1_address_ADDR32);
-                    TTI_ADDDMAREG(0, p_gpr_unpack::TMP0, p_gpr_unpack::TMP0, p_gpr_unpack::TILE_SIZE_A);
-                    TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::THCON);
-                    TTI_WRCFG(p_gpr_unpack::TMP0, 0, THCON_SEC0_REG3_Base_cntx1_address_ADDR32);
+                    TTI_RDCFG(ckernel::p_gpr_unpack::TMP0, THCON_SEC0_REG3_Base_cntx1_address_ADDR32);
+                    TTI_ADDDMAREG(0, ckernel::p_gpr_unpack::TMP0, ckernel::p_gpr_unpack::TMP0, ckernel::p_gpr_unpack::TILE_SIZE_A);
+                    TTI_STALLWAIT(ckernel::p_stall::STALL_CFG, ckernel::p_stall::THCON);
+                    TTI_WRCFG(ckernel::p_gpr_unpack::TMP0, 0, THCON_SEC0_REG3_Base_cntx1_address_ADDR32);
                 }
                 // Added to ensure WRCFG instruction has finished, since it takes 2 cycles.
                 TTI_NOP;
@@ -111,10 +182,10 @@ inline void _llk_unpack_AB_matmul_mop_config_(
     else
     {
 #if SKIP_UNP == 1
-        load_replay_buf<0, 1>([] { TTI_NOP; });
+        ckernel::load_replay_buf<0, 1>([] { TTI_NOP; });
 #else
         static_assert(kernel_broadcast_a <= 1, "kernel_broadcast>1 on matmul input 0 is not supported with reuse enabled");
-        load_replay_buf(
+        ckernel::load_replay_buf(
             0,
             replay_buf_prog_len,
             false,
@@ -123,16 +194,53 @@ inline void _llk_unpack_AB_matmul_mop_config_(
             {
                 if (unpB_partial_face)
                 {
-                    TTI_UNPACR_NOP(SrcB, 0, 0, 0 /*Set Dvalid*/, 0, 0, 0, 0, p_unpacr_nop::UNP_ZEROSRC);
+                    TTI_UNPACR_NOP(ckernel::SrcB, 0, 0, 0 /*Set Dvalid*/, 0, 0, 0, 0, ckernel::p_unpacr_nop::UNP_ZEROSRC);
                     TTI_UNPACR(
-                        SrcB, 0b00010001, 0, 0, 0, 1 /*Set OvrdThreadId*/, 0 /*Set Dvalid*/, p_unpacr::RAREFYB_DISABLE, 0, 0 /* Set ContextIdInc */, 0, 0, 1);
+                        ckernel::SrcB,
+                        0b00010001,
+                        0,
+                        0,
+                        0,
+                        1 /*Set OvrdThreadId*/,
+                        0 /*Set Dvalid*/,
+                        ckernel::p_unpacr::RAREFYB_DISABLE,
+                        0,
+                        0 /* Set ContextIdInc */,
+                        0,
+                        0,
+                        1);
                     TTI_UNPACR(
-                        SrcB, 0b00010001, 0, 0, 0, 1 /*Set OvrdThreadId*/, 1 /*Set Dvalid*/, p_unpacr::RAREFYB_DISABLE, 0, 0 /* Set ContextIdInc */, 0, 0, 1);
-                    TTI_SETADCZW(p_setadc::UNP_B, 0, 0, 0, 0, 0b0101); // Set ch0_z=0, ch1_z=0
+                        ckernel::SrcB,
+                        0b00010001,
+                        0,
+                        0,
+                        0,
+                        1 /*Set OvrdThreadId*/,
+                        1 /*Set Dvalid*/,
+                        ckernel::p_unpacr::RAREFYB_DISABLE,
+                        0,
+                        0 /* Set ContextIdInc */,
+                        0,
+                        0,
+                        1);
+                    TTI_SETADCZW(ckernel::p_setadc::UNP_B, 0, 0, 0, 0, 0b0101); // Set ch0_z=0, ch1_z=0
                 }
                 else
                 {
-                    TTI_UNPACR(SrcB, 0, 0, 0, 0, 1 /*Set OvrdThreadId*/, 1 /*Set Dvalid*/, p_unpacr::RAREFYB_DISABLE, 0, 0 /* Set ContextIdInc */, 0, 0, 1);
+                    TTI_UNPACR(
+                        ckernel::SrcB,
+                        0,
+                        0,
+                        0,
+                        0,
+                        1 /*Set OvrdThreadId*/,
+                        1 /*Set Dvalid*/,
+                        ckernel::p_unpacr::RAREFYB_DISABLE,
+                        0,
+                        0 /* Set ContextIdInc */,
+                        0,
+                        0,
+                        1);
                 }
                 if constexpr (kernel_broadcast_a == 1)
                 {
@@ -143,26 +251,63 @@ inline void _llk_unpack_AB_matmul_mop_config_(
                 }
                 else
                 {
-                    TTI_RDCFG(p_gpr_unpack::TMP0, THCON_SEC1_REG3_Base_address_ADDR32);
-                    TTI_ADDDMAREG(0, p_gpr_unpack::TMP0, p_gpr_unpack::TMP0, p_gpr_unpack::TMP_LO);
-                    TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::THCON);
-                    TTI_WRCFG(p_gpr_unpack::TMP0, 0, THCON_SEC1_REG3_Base_address_ADDR32);
+                    TTI_RDCFG(ckernel::p_gpr_unpack::TMP0, THCON_SEC1_REG3_Base_address_ADDR32);
+                    TTI_ADDDMAREG(0, ckernel::p_gpr_unpack::TMP0, ckernel::p_gpr_unpack::TMP0, ckernel::p_gpr_unpack::TMP_LO);
+                    TTI_STALLWAIT(ckernel::p_stall::STALL_CFG, ckernel::p_stall::THCON);
+                    TTI_WRCFG(ckernel::p_gpr_unpack::TMP0, 0, THCON_SEC1_REG3_Base_address_ADDR32);
                 }
                 // Added to ensure WRCFG instruction has finished, since it takes 2 cycles.
                 TTI_NOP;
 
                 if (unpB_partial_face)
                 {
-                    TTI_UNPACR_NOP(SrcB, 0, 0, 0 /*Set Dvalid*/, 0, 0, 0, 0, p_unpacr_nop::UNP_ZEROSRC);
+                    TTI_UNPACR_NOP(ckernel::SrcB, 0, 0, 0 /*Set Dvalid*/, 0, 0, 0, 0, ckernel::p_unpacr_nop::UNP_ZEROSRC);
                     TTI_UNPACR(
-                        SrcB, 0b00010001, 0, 0, 0, 1 /*Set OvrdThreadId*/, 0 /*Set Dvalid*/, p_unpacr::RAREFYB_DISABLE, 0, 0 /* Set ContextIdInc */, 0, 0, 1);
+                        ckernel::SrcB,
+                        0b00010001,
+                        0,
+                        0,
+                        0,
+                        1 /*Set OvrdThreadId*/,
+                        0 /*Set Dvalid*/,
+                        ckernel::p_unpacr::RAREFYB_DISABLE,
+                        0,
+                        0 /* Set ContextIdInc */,
+                        0,
+                        0,
+                        1);
                     TTI_UNPACR(
-                        SrcB, 0b00010001, 0, 0, 0, 1 /*Set OvrdThreadId*/, 1 /*Set Dvalid*/, p_unpacr::RAREFYB_DISABLE, 0, 0 /* Set ContextIdInc */, 0, 0, 1);
-                    TTI_SETADCZW(p_setadc::UNP_B, 0, 0, 0, 0, 0b0101); // Set ch0_z=0, ch1_z=0
+                        ckernel::SrcB,
+                        0b00010001,
+                        0,
+                        0,
+                        0,
+                        1 /*Set OvrdThreadId*/,
+                        1 /*Set Dvalid*/,
+                        ckernel::p_unpacr::RAREFYB_DISABLE,
+                        0,
+                        0 /* Set ContextIdInc */,
+                        0,
+                        0,
+                        1);
+                    TTI_SETADCZW(ckernel::p_setadc::UNP_B, 0, 0, 0, 0, 0b0101); // Set ch0_z=0, ch1_z=0
                 }
                 else
                 {
-                    TTI_UNPACR(SrcB, 0, 0, 0, 0, 1 /*Set OvrdThreadId*/, 1 /*Set Dvalid*/, p_unpacr::RAREFYB_DISABLE, 0, 0 /* Set ContextIdInc */, 0, 0, 1);
+                    TTI_UNPACR(
+                        ckernel::SrcB,
+                        0,
+                        0,
+                        0,
+                        0,
+                        1 /*Set OvrdThreadId*/,
+                        1 /*Set Dvalid*/,
+                        ckernel::p_unpacr::RAREFYB_DISABLE,
+                        0,
+                        0 /* Set ContextIdInc */,
+                        0,
+                        0,
+                        1);
                 }
                 if constexpr (kernel_broadcast_a == 1)
                 {
@@ -173,10 +318,10 @@ inline void _llk_unpack_AB_matmul_mop_config_(
                 }
                 else
                 {
-                    TTI_RDCFG(p_gpr_unpack::TMP0, THCON_SEC1_REG3_Base_cntx1_address_ADDR32);
-                    TTI_ADDDMAREG(0, p_gpr_unpack::TMP0, p_gpr_unpack::TMP0, p_gpr_unpack::TMP_LO);
-                    TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::THCON);
-                    TTI_WRCFG(p_gpr_unpack::TMP0, 0, THCON_SEC1_REG3_Base_cntx1_address_ADDR32);
+                    TTI_RDCFG(ckernel::p_gpr_unpack::TMP0, THCON_SEC1_REG3_Base_cntx1_address_ADDR32);
+                    TTI_ADDDMAREG(0, ckernel::p_gpr_unpack::TMP0, ckernel::p_gpr_unpack::TMP0, ckernel::p_gpr_unpack::TMP_LO);
+                    TTI_STALLWAIT(ckernel::p_stall::STALL_CFG, ckernel::p_stall::THCON);
+                    TTI_WRCFG(ckernel::p_gpr_unpack::TMP0, 0, THCON_SEC1_REG3_Base_cntx1_address_ADDR32);
                 }
                 // Added to ensure WRCFG instruction has finished, since it takes 2 cycles.
                 TTI_NOP;
@@ -184,7 +329,7 @@ inline void _llk_unpack_AB_matmul_mop_config_(
 #endif
     }
 
-    ckernel_unpack_template tmp = ckernel_unpack_template(
+    ckernel::ckernel_unpack_template tmp = ckernel::ckernel_unpack_template(
         false,                                     // src B
         false,                                     // halo - just used for 4 unpacks
         TT_OP_REPLAY(0, replay_buf_run_len, 0, 0), // runs when context is 0
@@ -195,17 +340,17 @@ inline void _llk_unpack_AB_matmul_mop_config_(
         0,
         0);
 
-    tmp.program(instrn_buffer);
+    tmp.program(ckernel::instrn_buffer);
 }
 
-template <bool is_fp32_dest_acc_en = false, StochRndType stoch_rnd_mode = StochRndType::None>
+template <bool is_fp32_dest_acc_en = false, ckernel::StochRndType stoch_rnd_mode = ckernel::StochRndType::None>
 inline void _llk_unpack_AB_matmul_hw_configure_(
     const std::uint32_t unpA_src_format,
     const std::uint32_t unpB_src_format,
     const std::uint32_t unpA_dst_format,
     const std::uint32_t unpB_dst_format,
-    const std::uint32_t unpA_face_r_dim             = FACE_R_DIM,
-    const std::uint32_t unpB_face_r_dim             = FACE_R_DIM,
+    const std::uint32_t unpA_face_r_dim             = ckernel::FACE_R_DIM,
+    const std::uint32_t unpB_face_r_dim             = ckernel::FACE_R_DIM,
     const std::uint32_t within_face_16x16_transpose = 0,
     const std::uint32_t unpA_num_faces              = 4,
     const std::uint32_t unpB_num_faces              = 4,
@@ -213,11 +358,11 @@ inline void _llk_unpack_AB_matmul_hw_configure_(
     const std::uint32_t unpB_tile_size              = 0)
 {
     constexpr bool is_row_pool  = false;
-    constexpr bool stoch_rnd_en = (stoch_rnd_mode == StochRndType::All);
-    constexpr bool fpu_srnd_en  = stoch_rnd_en || (stoch_rnd_mode == StochRndType::Fpu);
-    constexpr bool pack_srnd_en = stoch_rnd_en || (stoch_rnd_mode == StochRndType::Pack);
+    constexpr bool stoch_rnd_en = (stoch_rnd_mode == ckernel::StochRndType::All);
+    constexpr bool fpu_srnd_en  = stoch_rnd_en || (stoch_rnd_mode == ckernel::StochRndType::Fpu);
+    constexpr bool pack_srnd_en = stoch_rnd_en || (stoch_rnd_mode == ckernel::StochRndType::Pack);
 
-    configure_unpack_AB<is_row_pool, is_fp32_dest_acc_en, fpu_srnd_en, pack_srnd_en>(
+    ckernel::unpacker::configure_unpack_AB<is_row_pool, is_fp32_dest_acc_en, fpu_srnd_en, pack_srnd_en>(
         unpA_src_format,
         unpB_src_format,
         unpA_dst_format,
@@ -229,14 +374,14 @@ inline void _llk_unpack_AB_matmul_hw_configure_(
         unpB_num_faces);
 
     // Configure tile size in datums
-    const uint32_t unpA_x_end = unpA_num_faces * unpA_face_r_dim * FACE_C_DIM - 1;
-    const uint32_t unpB_x_end = unpB_num_faces * unpB_face_r_dim * FACE_C_DIM - 1;
-    TT_SETADCXX(p_setadc::UNP_A, unpA_x_end, 0x0);
-    TT_SETADCXX(p_setadc::UNP_B, unpB_x_end, 0x0);
+    const uint32_t unpA_x_end = unpA_num_faces * unpA_face_r_dim * ckernel::FACE_C_DIM - 1;
+    const uint32_t unpB_x_end = unpB_num_faces * unpB_face_r_dim * ckernel::FACE_C_DIM - 1;
+    TT_SETADCXX(ckernel::p_setadc::UNP_A, unpA_x_end, 0x0);
+    TT_SETADCXX(ckernel::p_setadc::UNP_B, unpB_x_end, 0x0);
 
-    regfile[p_gpr_unpack::TILE_SIZE_A] = unpA_tile_size;
-    regfile[p_gpr_unpack::TILE_SIZE_B] = unpB_tile_size;
-    sync_regfile_write(p_gpr_unpack::TILE_SIZE_B);
+    ckernel::regfile[ckernel::p_gpr_unpack::TILE_SIZE_A] = unpA_tile_size;
+    ckernel::regfile[ckernel::p_gpr_unpack::TILE_SIZE_B] = unpB_tile_size;
+    ckernel::sync_regfile_write(ckernel::p_gpr_unpack::TILE_SIZE_B);
 }
 
 template <std::uint32_t kernel_broadcast_a = 0, std::uint32_t kernel_broadcast_b = 0>
@@ -245,8 +390,8 @@ __attribute__((always_inline)) inline void _llk_unpack_AB_matmul_init_(
     const std::uint32_t ct_dim          = 1,
     const std::uint32_t rt_dim          = 1,
     const std::uint32_t kt_dim          = 1,
-    const std::uint32_t unpA_face_r_dim = FACE_R_DIM,
-    const std::uint32_t unpB_face_r_dim = FACE_R_DIM,
+    const std::uint32_t unpA_face_r_dim = ckernel::FACE_R_DIM,
+    const std::uint32_t unpB_face_r_dim = ckernel::FACE_R_DIM,
     const std::uint32_t unpA_num_faces  = 4,
     const std::uint32_t unpB_num_faces  = 4,
     const bool unpA_partial_face        = false,
@@ -258,7 +403,7 @@ __attribute__((always_inline)) inline void _llk_unpack_AB_matmul_init_(
     // on WH, the unpacker performs both transpose of faces as well as transpose each face.
     // the former is configured in mop, the latter is configured in cfg register in hw_configure
     // in large matmul, datacopy will disable the transpose of faces, so we need it turn it back on for matmul.
-    cfg_reg_rmw_tensix<THCON_SEC0_REG2_Haloize_mode_RMW>(transpose);
+    ckernel::cfg_reg_rmw_tensix<THCON_SEC0_REG2_Haloize_mode_RMW>(transpose);
 
     TTI_SETADCZW(0b011, 0, 0, 0, 0, 0b1111);
 
@@ -266,29 +411,29 @@ __attribute__((always_inline)) inline void _llk_unpack_AB_matmul_init_(
     {
         // Do face by face unpacking. Need to program correct face dim
         // to compute address of the next face
-        config_unpacker_x_end<p_setadc::UNP_A>(unpA_face_r_dim);
+        ckernel::unpacker::config_unpacker_x_end<ckernel::p_setadc::UNP_A>(unpA_face_r_dim);
     }
     else
     {
-        const uint32_t unpA_x_end = unpA_num_faces * unpA_face_r_dim * FACE_C_DIM - 1;
-        TT_SETADCXX(p_setadc::UNP_A, unpA_x_end, 0x0);
+        const uint32_t unpA_x_end = unpA_num_faces * unpA_face_r_dim * ckernel::FACE_C_DIM - 1;
+        TT_SETADCXX(ckernel::p_setadc::UNP_A, unpA_x_end, 0x0);
     }
 
     if (unpB_partial_face)
     {
         // Do face by face unpacking. Need to program correct face dim
         // to compute address of the next face
-        config_unpacker_x_end<p_setadc::UNP_B>(unpB_face_r_dim);
+        ckernel::unpacker::config_unpacker_x_end<ckernel::p_setadc::UNP_B>(unpB_face_r_dim);
     }
     else
     {
         // Do full tile unpacking. No need to program face dim
         // as address counter pointing to the face is not incremented
-        const uint32_t unpB_x_end = unpB_num_faces * unpB_face_r_dim * FACE_C_DIM - 1;
-        TT_SETADCXX(p_setadc::UNP_B, unpB_x_end, 0x0);
+        const uint32_t unpB_x_end = unpB_num_faces * unpB_face_r_dim * ckernel::FACE_C_DIM - 1;
+        TT_SETADCXX(ckernel::p_setadc::UNP_B, unpB_x_end, 0x0);
     }
 
-    TT_SETDMAREG(0, LOWER_HALFWORD(kt_dim), 0, LO_16(p_gpr_unpack::KT_DIM)); // store kt_dim to gpr for scaling tile size
+    TT_SETDMAREG(0, LOWER_HALFWORD(kt_dim), 0, LO_16(ckernel::p_gpr_unpack::KT_DIM)); // store kt_dim to gpr for scaling tile size
 
     _llk_unpack_AB_matmul_mop_config_<kernel_broadcast_a, kernel_broadcast_b>(transpose != 0, ct_dim, rt_dim, kt_dim, unpA_partial_face, unpB_partial_face);
 }
@@ -301,8 +446,8 @@ inline void _llk_unpack_AB_matmul_(
     const std::uint32_t tile_index_b,
     const std::uint32_t tile_size_a,
     const std::uint32_t tile_size_b,
-    const std::uint32_t unpA_face_r_dim = FACE_R_DIM,
-    const std::uint32_t unpB_face_r_dim = FACE_R_DIM,
+    const std::uint32_t unpA_face_r_dim = ckernel::FACE_R_DIM,
+    const std::uint32_t unpB_face_r_dim = ckernel::FACE_R_DIM,
     const bool unpA_partial_face        = false,
     const bool unpB_partial_face        = false,
     std::uint32_t ct_dim                = 1,
@@ -312,14 +457,14 @@ inline void _llk_unpack_AB_matmul_(
     // In0/InA -> srcB (supports partial face)
     // In1/InB -> srcA
 
-    volatile uint *cfg = get_cfg_pointer(); // get pointer to registers for current state ID
+    volatile uint *cfg = ckernel::get_cfg_pointer(); // get pointer to registers for current state ID
 
     const bool reuse_a        = ct_dim >= rt_dim;
     const std::uint32_t t_dim = reuse_a ? rt_dim : ct_dim;
 
     if (!reuse_a)
     {
-        TTI_MULDMAREG(0, p_gpr_unpack::TMP_LO, p_gpr_unpack::TILE_SIZE_B, p_gpr_unpack::KT_DIM);
+        TTI_MULDMAREG(0, ckernel::p_gpr_unpack::TMP_LO, ckernel::p_gpr_unpack::TILE_SIZE_B, ckernel::p_gpr_unpack::KT_DIM);
     }
 
     for (uint t = 0; t < t_dim; t++)
@@ -339,7 +484,7 @@ inline void _llk_unpack_AB_matmul_(
         std::uint32_t address_b = base_address_b + offset_address_b;
 
         // Wait for free context
-        wait_for_next_context(2);
+        ckernel::unpacker::wait_for_next_context(2);
 
         // Program unpacker 1 base address
         if (0 == unp_cfg_context)
@@ -353,10 +498,10 @@ inline void _llk_unpack_AB_matmul_(
             cfg[THCON_SEC1_REG3_Base_cntx1_address_ADDR32] = address_a;
         }
 
-        semaphore_post(semaphore::UNPACK_SYNC); // Trisc::SEMPOST for context acquire
+        ckernel::semaphore_post(ckernel::semaphore::UNPACK_SYNC); // Trisc::SEMPOST for context acquire
 
         // Stall unpacker until pending CFG writes from Trisc have completed
-        TTI_STALLWAIT(p_stall::STALL_UNPACK, p_stall::TRISC_CFG);
+        TTI_STALLWAIT(ckernel::p_stall::STALL_UNPACK, ckernel::p_stall::TRISC_CFG);
 
         if (reuse_a)
         {
@@ -365,17 +510,54 @@ inline void _llk_unpack_AB_matmul_(
 #else
             if (unpB_partial_face)
             {
-                TTI_UNPACR_NOP(SrcB, 0, 0, 0 /*Set Dvalid*/, 0, 0, 0, 0, p_unpacr_nop::UNP_ZEROSRC);
+                TTI_UNPACR_NOP(ckernel::SrcB, 0, 0, 0 /*Set Dvalid*/, 0, 0, 0, 0, ckernel::p_unpacr_nop::UNP_ZEROSRC);
                 // Do face by face unpacking
                 TTI_UNPACR(
-                    SrcB, 0b00010001, 0, 0, 0, 1 /*Set OvrdThreadId*/, 0 /*Set Dvalid*/, p_unpacr::RAREFYB_DISABLE, 0, 0 /* Set ContextIdInc */, 0, 0, 1);
+                    ckernel::SrcB,
+                    0b00010001,
+                    0,
+                    0,
+                    0,
+                    1 /*Set OvrdThreadId*/,
+                    0 /*Set Dvalid*/,
+                    ckernel::p_unpacr::RAREFYB_DISABLE,
+                    0,
+                    0 /* Set ContextIdInc */,
+                    0,
+                    0,
+                    1);
                 TTI_UNPACR(
-                    SrcB, 0b00010001, 0, 0, 0, 1 /*Set OvrdThreadId*/, 1 /*Set Dvalid*/, p_unpacr::RAREFYB_DISABLE, 0, 0 /* Set ContextIdInc */, 0, 0, 1);
-                TTI_SETADCZW(p_setadc::UNP_B, 0, 0, 0, 0, 0b0101); // Set ch0_z=0, ch1_z=0
+                    ckernel::SrcB,
+                    0b00010001,
+                    0,
+                    0,
+                    0,
+                    1 /*Set OvrdThreadId*/,
+                    1 /*Set Dvalid*/,
+                    ckernel::p_unpacr::RAREFYB_DISABLE,
+                    0,
+                    0 /* Set ContextIdInc */,
+                    0,
+                    0,
+                    1);
+                TTI_SETADCZW(ckernel::p_setadc::UNP_B, 0, 0, 0, 0, 0b0101); // Set ch0_z=0, ch1_z=0
             }
             else
             {
-                TTI_UNPACR(SrcB, 0, 0, 0, 0, 1 /*Set OvrdThreadId*/, 1 /*Set Dvalid*/, p_unpacr::RAREFYB_DISABLE, 0, 0 /* Set ContextIdInc */, 0, 0, 1);
+                TTI_UNPACR(
+                    ckernel::SrcB,
+                    0,
+                    0,
+                    0,
+                    0,
+                    1 /*Set OvrdThreadId*/,
+                    1 /*Set Dvalid*/,
+                    ckernel::p_unpacr::RAREFYB_DISABLE,
+                    0,
+                    0 /* Set ContextIdInc */,
+                    0,
+                    0,
+                    1);
             }
 #endif
         }
@@ -387,16 +569,53 @@ inline void _llk_unpack_AB_matmul_(
             if (unpA_partial_face)
             {
                 // Do face by face unpacking
-                TTI_UNPACR_NOP(SrcA, 0, 0, 0 /*Set Dvalid*/, 0, 0, 0, 0, p_unpacr_nop::UNP_ZEROSRC);
+                TTI_UNPACR_NOP(ckernel::SrcA, 0, 0, 0 /*Set Dvalid*/, 0, 0, 0, 0, ckernel::p_unpacr_nop::UNP_ZEROSRC);
                 TTI_UNPACR(
-                    SrcA, 0b00010001, 0, 0, 0, 1 /*Set OvrdThreadId*/, 0 /*Set Dvalid*/, p_unpacr::RAREFYB_DISABLE, 0, 0 /* Set ContextIdInc */, 0, 0, 1);
+                    ckernel::SrcA,
+                    0b00010001,
+                    0,
+                    0,
+                    0,
+                    1 /*Set OvrdThreadId*/,
+                    0 /*Set Dvalid*/,
+                    ckernel::p_unpacr::RAREFYB_DISABLE,
+                    0,
+                    0 /* Set ContextIdInc */,
+                    0,
+                    0,
+                    1);
                 TTI_UNPACR(
-                    SrcA, 0b00010001, 0, 0, 0, 1 /*Set OvrdThreadId*/, 1 /*Set Dvalid*/, p_unpacr::RAREFYB_DISABLE, 0, 0 /* Set ContextIdInc */, 0, 0, 1);
-                TTI_SETADCZW(p_setadc::UNP_A, 0, 0, 0, 0, 0b0101); // Set ch0_z=0, ch1_z=0
+                    ckernel::SrcA,
+                    0b00010001,
+                    0,
+                    0,
+                    0,
+                    1 /*Set OvrdThreadId*/,
+                    1 /*Set Dvalid*/,
+                    ckernel::p_unpacr::RAREFYB_DISABLE,
+                    0,
+                    0 /* Set ContextIdInc */,
+                    0,
+                    0,
+                    1);
+                TTI_SETADCZW(ckernel::p_setadc::UNP_A, 0, 0, 0, 0, 0b0101); // Set ch0_z=0, ch1_z=0
             }
             else
             {
-                TTI_UNPACR(SrcA, 0, 0, 0, 0, 1 /*Set OvrdThreadId*/, 1 /*Set Dvalid*/, p_unpacr::RAREFYB_DISABLE, 0, 0 /* Set ContextIdInc */, 0, 0, 1);
+                TTI_UNPACR(
+                    ckernel::SrcA,
+                    0,
+                    0,
+                    0,
+                    0,
+                    1 /*Set OvrdThreadId*/,
+                    1 /*Set Dvalid*/,
+                    ckernel::p_unpacr::RAREFYB_DISABLE,
+                    0,
+                    0 /* Set ContextIdInc */,
+                    0,
+                    0,
+                    1);
             }
 #endif
         }
@@ -404,10 +623,10 @@ inline void _llk_unpack_AB_matmul_(
         TT_MOP(0, (reuse_a ? ct_dim : rt_dim) - 1, unp_cfg_context == 0 ? 0 : 0xff); // Run the MOP
 
         // T6::SEMGET for context release
-        t6_semaphore_get(semaphore::UNPACK_SYNC);
+        ckernel::t6_semaphore_get(ckernel::semaphore::UNPACK_SYNC);
 
         // Switch unpacker config context
-        switch_config_context(unp_cfg_context);
+        ckernel::unpacker::switch_config_context(unp_cfg_context);
     }
 
 #ifdef PERF_DUMP

--- a/tt_llk_blackhole/llk_lib/llk_unpack_common.h
+++ b/tt_llk_blackhole/llk_lib/llk_unpack_common.h
@@ -16,20 +16,24 @@
 #include "ckernel_perf_api.h"
 #endif
 
-using namespace ckernel;
-using namespace ckernel::unpacker;
-
 void _llk_zero_buffer_(const std::uint32_t base_address, const std::uint32_t size)
 {
-    TT_SETDMAREG(0, 0, 0, LO_16(p_gpr_unpack::OPERAND_OFFSET_ADDR));
-    TT_SETDMAREG(0, 0, 0, HI_16(p_gpr_unpack::OPERAND_OFFSET_ADDR));
+    TT_SETDMAREG(0, 0, 0, LO_16(ckernel::p_gpr_unpack::OPERAND_OFFSET_ADDR));
+    TT_SETDMAREG(0, 0, 0, HI_16(ckernel::p_gpr_unpack::OPERAND_OFFSET_ADDR));
 
-    TT_SETDMAREG(0, LOWER_HALFWORD(base_address), 0, LO_16(p_gpr_unpack::p_gpr_unpack::OPERAND_BASE_ADDR));
-    TT_SETDMAREG(0, UPPER_HALFWORD(base_address), 0, HI_16(p_gpr_unpack::p_gpr_unpack::OPERAND_BASE_ADDR));
+    TT_SETDMAREG(0, LOWER_HALFWORD(base_address), 0, LO_16(ckernel::p_gpr_unpack::p_gpr_unpack::OPERAND_BASE_ADDR));
+    TT_SETDMAREG(0, UPPER_HALFWORD(base_address), 0, HI_16(ckernel::p_gpr_unpack::p_gpr_unpack::OPERAND_BASE_ADDR));
 
     for (std::uint32_t i = 0; i < size; i++)
     {
-        TTI_STOREIND(1, 0, p_ind::LD_16B, LO_16(p_gpr_unpack::OPERAND_OFFSET_ADDR), p_ind::INC_16B, p_gpr_unpack::ZERO_0, p_gpr_unpack::OPERAND_BASE_ADDR);
+        TTI_STOREIND(
+            1,
+            0,
+            ckernel::p_ind::LD_16B,
+            LO_16(ckernel::p_gpr_unpack::OPERAND_OFFSET_ADDR),
+            ckernel::p_ind::INC_16B,
+            ckernel::p_gpr_unpack::ZERO_0,
+            ckernel::p_gpr_unpack::OPERAND_BASE_ADDR);
     }
 }
 
@@ -40,14 +44,14 @@ inline void _llk_unpack_get_tile_(std::uint32_t address, std::uint32_t *p_tile)
 
     if constexpr (mail2math)
     {
-        mailbox_write(ThreadId::MathThreadId, byte_address);
-        semaphore_post(semaphore::UNPACK_OPERAND_SYNC);
+        ckernel::mailbox_write(ckernel::ThreadId::MathThreadId, byte_address);
+        ckernel::semaphore_post(ckernel::semaphore::UNPACK_OPERAND_SYNC);
     }
 
     if constexpr (mail2pack)
     {
-        mailbox_write(ThreadId::PackThreadId, byte_address);
-        semaphore_post(semaphore::UNPACK_OPERAND_SYNC);
+        ckernel::mailbox_write(ckernel::ThreadId::PackThreadId, byte_address);
+        ckernel::semaphore_post(ckernel::semaphore::UNPACK_OPERAND_SYNC);
     }
 
     *p_tile = byte_address;
@@ -56,82 +60,82 @@ inline void _llk_unpack_get_tile_(std::uint32_t address, std::uint32_t *p_tile)
 template <bool mail2math = true, bool mail2pack = true>
 inline void _llk_unpack_release_tile_()
 {
-    while (semaphore_read(semaphore::UNPACK_OPERAND_SYNC) > 0)
+    while (ckernel::semaphore_read(ckernel::semaphore::UNPACK_OPERAND_SYNC) > 0)
         ;
 }
 
 inline void _llk_unpack_debug_dump_(std::uint8_t *data, std::uint32_t byte_size)
 {
-    debug_dump(data, byte_size);
+    ckernel::debug_dump(data, byte_size);
 }
 
 inline void _llk_unpack_debug_dump_seek_(std::uint8_t offset)
 {
-    debug_dump_seek(offset);
+    ckernel::debug_dump_seek(offset);
 }
 
-inline void _llk_unpack_config_tile_dim_srca_impl_(const std::uint32_t face_r_dim = FACE_R_DIM, const std::uint32_t num_faces = 4)
+inline void _llk_unpack_config_tile_dim_srca_impl_(const std::uint32_t face_r_dim = ckernel::FACE_R_DIM, const std::uint32_t num_faces = 4)
 {
-    cfg_reg_rmw_tensix<THCON_SEC0_REG0_TileDescriptor_ADDR32 + 1, 16, 0xffff0000>(num_faces);
-    config_unpacker_0_face_dim<true, p_setadc::UNP_A>(face_r_dim);
+    ckernel::cfg_reg_rmw_tensix<THCON_SEC0_REG0_TileDescriptor_ADDR32 + 1, 16, 0xffff0000>(num_faces);
+    ckernel::unpacker::config_unpacker_0_face_dim<true, ckernel::p_setadc::UNP_A>(face_r_dim);
 }
 
-inline void _llk_unpack_config_tile_dim_srcb_impl_(const std::uint32_t face_r_dim = FACE_R_DIM, const std::uint32_t num_faces = 4)
+inline void _llk_unpack_config_tile_dim_srcb_impl_(const std::uint32_t face_r_dim = ckernel::FACE_R_DIM, const std::uint32_t num_faces = 4)
 {
-    const uint face_dim = face_r_dim * FACE_C_DIM;
-    cfg_reg_rmw_tensix<THCON_SEC1_REG0_TileDescriptor_ADDR32, 16, 0xffff0000>(face_dim);
-    cfg_reg_rmw_tensix<THCON_SEC1_REG0_TileDescriptor_ADDR32 + 1, 16, 0xffff0000>(num_faces);
+    const uint face_dim = face_r_dim * ckernel::FACE_C_DIM;
+    ckernel::cfg_reg_rmw_tensix<THCON_SEC1_REG0_TileDescriptor_ADDR32, 16, 0xffff0000>(face_dim);
+    ckernel::cfg_reg_rmw_tensix<THCON_SEC1_REG0_TileDescriptor_ADDR32 + 1, 16, 0xffff0000>(num_faces);
 }
 
 template <bool to_from_int8 = false, bool is_fp32_dest_acc_en = false>
 inline void _llk_unpack_reconfig_data_format_srca_impl_(
     const std::uint32_t unpack_src_format, const std::uint32_t unpack_dst_format, const std::uint32_t tile_size)
 {
-    TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::UNPACK0);
+    TTI_STALLWAIT(ckernel::p_stall::STALL_CFG, ckernel::p_stall::UNPACK0);
     if constexpr (to_from_int8)
     {
         static_assert(is_fp32_dest_acc_en, "Reconfiguring unpack to/from Int8 formats requires FP32 Dest mode enabled");
-        cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG0_SrcAUnsigned_RMW>(((uint)unpack_src_format == (uint)DataFormat::UInt8) ? 1 : 0);
+        ckernel::cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG0_SrcAUnsigned_RMW>(((uint)unpack_src_format == (uint)DataFormat::UInt8) ? 1 : 0);
     }
-    cfg_reg_rmw_tensix<THCON_SEC0_REG0_TileDescriptor_ADDR32, 0, 0x0f>(unpack_src_format);
-    cfg_reg_rmw_tensix<THCON_SEC0_REG2_Out_data_format_RMW>(unpack_dst_format);
-    TT_SETDMAREG(0, LOWER_HALFWORD(tile_size), 0, LO_16(p_gpr_unpack::TILE_SIZE_A)); // update gpr which holds tile size A
+    ckernel::cfg_reg_rmw_tensix<THCON_SEC0_REG0_TileDescriptor_ADDR32, 0, 0x0f>(unpack_src_format);
+    ckernel::cfg_reg_rmw_tensix<THCON_SEC0_REG2_Out_data_format_RMW>(unpack_dst_format);
+    TT_SETDMAREG(0, LOWER_HALFWORD(tile_size), 0, LO_16(ckernel::p_gpr_unpack::TILE_SIZE_A)); // update gpr which holds tile size A
 }
 
 template <bool to_from_int8 = false, bool is_fp32_dest_acc_en = false>
 inline void _llk_unpack_reconfig_data_format_srcb_impl_(
     const std::uint32_t unpack_src_format, const std::uint32_t unpack_dst_format, const std::uint32_t tile_size)
 {
-    TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::UNPACK1);
+    TTI_STALLWAIT(ckernel::p_stall::STALL_CFG, ckernel::p_stall::UNPACK1);
     if constexpr (to_from_int8)
     {
         static_assert(is_fp32_dest_acc_en, "Reconfiguring unpack to/from Int8 formats requires FP32 Dest mode enabled");
-        cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG0_SrcBUnsigned_RMW>(((uint)unpack_src_format == (uint)DataFormat::UInt8) ? 1 : 0);
+        ckernel::cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG0_SrcBUnsigned_RMW>(((uint)unpack_src_format == (uint)DataFormat::UInt8) ? 1 : 0);
     }
-    cfg_reg_rmw_tensix<THCON_SEC1_REG0_TileDescriptor_ADDR32, 0, 0x0f>(unpack_src_format);
-    cfg_reg_rmw_tensix<THCON_SEC1_REG2_Out_data_format_RMW>(unpack_dst_format);
-    TT_SETDMAREG(0, LOWER_HALFWORD(tile_size), 0, LO_16(p_gpr_unpack::TILE_SIZE_B)); // update gpr which holds tile size B
+    ckernel::cfg_reg_rmw_tensix<THCON_SEC1_REG0_TileDescriptor_ADDR32, 0, 0x0f>(unpack_src_format);
+    ckernel::cfg_reg_rmw_tensix<THCON_SEC1_REG2_Out_data_format_RMW>(unpack_dst_format);
+    TT_SETDMAREG(0, LOWER_HALFWORD(tile_size), 0, LO_16(ckernel::p_gpr_unpack::TILE_SIZE_B)); // update gpr which holds tile size B
 }
 
 inline void _llk_unpack_dbg_feature_disable_()
 {
-    reg_write(RISCV_DEBUG_REG_DBG_FEATURE_DISABLE, 1 << 11); // Set debug feature disable bit 11
-                                                             // workaround for bug tenstorrent/budabackend#1372
+    ckernel::reg_write(RISCV_DEBUG_REG_DBG_FEATURE_DISABLE, 1 << 11); // Set debug feature disable bit 11
+                                                                      // workaround for bug tenstorrent/budabackend#1372
 }
 
 inline void _llk_unpack_clear_dbg_feature_disable_()
 {
-    reg_write(RISCV_DEBUG_REG_DBG_FEATURE_DISABLE, 0); // Unset debug feature disable
+    ckernel::reg_write(RISCV_DEBUG_REG_DBG_FEATURE_DISABLE, 0); // Unset debug feature disable
 }
 
 inline void _llk_enable_int8_fpu_math_()
 {
-    enable_int8_fpu_math();
+    ckernel::unpacker::enable_int8_fpu_math();
 }
 
 inline void _llk_unpack_set_srcb_dummy_valid_()
 {
-    TTI_STALLWAIT(p_stall::STALL_UNPACK, p_stall::UNPACK);
-    TTI_UNPACR_NOP(SrcB, 0, 0, p_unpacr_nop::SET_DVALID, 0, 0, 0, 0, p_unpacr_nop::UNP_ZEROSRC);
-    TTI_UNPACR_NOP(SrcA, 0, 0, p_unpacr_nop::SET_DVALID, 0, 0, 0, 0, p_unpacr_nop::UNP_ZEROSRC);
+    TTI_STALLWAIT(ckernel::p_stall::STALL_UNPACK, ckernel::p_stall::UNPACK);
+    TTI_UNPACR_NOP(ckernel::SrcB, 0, 0, ckernel::p_unpacr_nop::SET_DVALID, 0, 0, 0, 0, ckernel::p_unpacr_nop::UNP_ZEROSRC);
+    TTI_UNPACR_NOP(ckernel::SrcA, 0, 0, ckernel::p_unpacr_nop::SET_DVALID, 0, 0, 0, 0, ckernel::p_unpacr_nop::UNP_ZEROSRC);
 }

--- a/tt_llk_blackhole/llk_lib/llk_unpack_reduce.h
+++ b/tt_llk_blackhole/llk_lib/llk_unpack_reduce.h
@@ -19,16 +19,16 @@ inline void _llk_unpack_reduce_mop_config_()
 #if SKIP_UNP == 1
     static constexpr uint unpack_srca = TT_OP_NOP;
 #else
-    static constexpr uint unpack_srca = TT_OP_UNPACR(SrcA, 0b1, 0, 0, 0, 1, 1, ckernel::p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
+    static constexpr uint unpack_srca = TT_OP_UNPACR(ckernel::SrcA, 0b1, 0, 0, 0, 1, 1, ckernel::p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
 #endif
     static constexpr uint unpack_zerosrca =
         TT_OP_UNPACR_NOP(ckernel::p_unpacr_nop::UNP0, 0, 0, 0, 0, 0, 0, ckernel::p_unpacr_nop::CLR_SRC_0, ckernel::p_unpacr_nop::CLR_SRC);
 #if SKIP_UNP == 1
     static constexpr uint unpack_srcb = TT_OP_NOP;
 #else
-    static constexpr uint unpack_srcb = TT_OP_UNPACR(SrcB, 0b0, 0, 0, 0, 1, 1, ckernel::p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
+    static constexpr uint unpack_srcb = TT_OP_UNPACR(ckernel::SrcB, 0b0, 0, 0, 0, 1, 1, ckernel::p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
 #endif
-    ckernel_unpack_template tmp = ckernel_unpack_template(
+    ckernel::ckernel_unpack_template tmp = ckernel::ckernel_unpack_template(
         true, // src B
         true, // halo - just used for 4 unpacks
         unpack_zerosrca,
@@ -38,7 +38,7 @@ inline void _llk_unpack_reduce_mop_config_()
         0,
         unpack_srcb,
         0);
-    tmp.program(instrn_buffer);
+    tmp.program(ckernel::instrn_buffer);
 }
 
 template <bool is_fp32_dest_acc_en = false, ckernel::StochRndType stoch_rnd_mode = ckernel::StochRndType::None>
@@ -47,8 +47,8 @@ inline void _llk_unpack_reduce_hw_configure_(
     const std::uint32_t unpB_src_format,
     const std::uint32_t unpA_dst_format,
     const std::uint32_t unpB_dst_format,
-    const std::uint32_t unpA_face_r_dim             = FACE_R_DIM,
-    const std::uint32_t unpB_face_r_dim             = FACE_R_DIM,
+    const std::uint32_t unpA_face_r_dim             = ckernel::FACE_R_DIM,
+    const std::uint32_t unpB_face_r_dim             = ckernel::FACE_R_DIM,
     const std::uint32_t within_face_16x16_transpose = 0,
     const std::uint32_t unpA_num_faces              = 4,
     const std::uint32_t unpB_num_faces              = 4)
@@ -58,7 +58,7 @@ inline void _llk_unpack_reduce_hw_configure_(
     constexpr bool fpu_srnd_en  = stoch_rnd_en || (stoch_rnd_mode == ckernel::StochRndType::Fpu);
     constexpr bool pack_srnd_en = stoch_rnd_en || (stoch_rnd_mode == ckernel::StochRndType::Pack);
 
-    configure_unpack_AB<is_row_pool, is_fp32_dest_acc_en, fpu_srnd_en, pack_srnd_en>(
+    ckernel::unpacker::configure_unpack_AB<is_row_pool, is_fp32_dest_acc_en, fpu_srnd_en, pack_srnd_en>(
         unpA_src_format,
         unpB_src_format,
         unpA_dst_format,
@@ -75,9 +75,10 @@ inline void _llk_unpack_reduce_init_(const std::uint32_t within_face_16x16_trans
 {
     // REDUCE_ROW requires transpose itself; additionaly, within_face_16x16_transpose flag could require transpose;
     // if we have the flag set with REDUCE_ROW, we don't need to do anything
-    cfg_reg_rmw_tensix<THCON_SEC0_REG2_Haloize_mode_RMW>(ckernel::ReduceDim::REDUCE_ROW == dim ? !within_face_16x16_transpose : within_face_16x16_transpose);
+    ckernel::cfg_reg_rmw_tensix<THCON_SEC0_REG2_Haloize_mode_RMW>(
+        ckernel::ReduceDim::REDUCE_ROW == dim ? !within_face_16x16_transpose : within_face_16x16_transpose);
 
-    TTI_SETADCXX(0b11, FACE_R_DIM * FACE_C_DIM - 1, 0x0);
+    TTI_SETADCXX(0b11, ckernel::FACE_R_DIM * ckernel::FACE_C_DIM - 1, 0x0);
 
     _llk_unpack_reduce_mop_config_<type, dim>();
 }
@@ -89,7 +90,7 @@ inline void _llk_unpack_reduce_(const std::uint32_t address)
     TTI_SETADCZW(0b011, 0, 0, 0, 0, 0b1111);
 
     // Program srcA and srcB base addresses
-    volatile uint tt_reg_ptr *cfg = get_cfg_pointer(); // get pointer to registers for current state ID
+    volatile uint tt_reg_ptr *cfg = ckernel::get_cfg_pointer(); // get pointer to registers for current state ID
 
     // Wait for free context
     ckernel::unpacker::wait_for_next_context(2);
@@ -105,13 +106,13 @@ inline void _llk_unpack_reduce_(const std::uint32_t address)
     }
 
     // Trisc::SEMPOST for context acquire
-    semaphore_post(semaphore::UNPACK_SYNC);
+    ckernel::semaphore_post(ckernel::semaphore::UNPACK_SYNC);
 
     // Load only 16 datums into srcB
-    TTI_SETADCXX(p_setadc::UNP1, FACE_C_DIM - 1, 0x0);
+    TTI_SETADCXX(ckernel::p_setadc::UNP1, ckernel::FACE_C_DIM - 1, 0x0);
 
     // Stall unpacker until pending CFG writes from Trisc have completed
-    TTI_STALLWAIT(p_stall::STALL_UNPACK, p_stall::TRISC_CFG);
+    TTI_STALLWAIT(ckernel::p_stall::STALL_UNPACK, ckernel::p_stall::TRISC_CFG);
 
     // Run MOP
     mop_run(0, 4);
@@ -120,10 +121,10 @@ inline void _llk_unpack_reduce_(const std::uint32_t address)
     TTI_SETADCXX(p_setadc::UNP1, FACE_R_DIM * FACE_C_DIM - 1, 0x0);
 
     // T6::SEMGET for context release
-    t6_semaphore_get(semaphore::UNPACK_SYNC);
+    ckernel::t6_semaphore_get(ckernel::semaphore::UNPACK_SYNC);
 
     // Switch unpacker config context
-    switch_config_context(unp_cfg_context);
+    ckernel::unpacker::switch_config_context(unp_cfg_context);
 
 #ifdef PERF_DUMP
     first_unpack_recorded = true;

--- a/tt_llk_blackhole/llk_lib/llk_unpack_tilize.h
+++ b/tt_llk_blackhole/llk_lib/llk_unpack_tilize.h
@@ -13,9 +13,6 @@
 #include "ckernel_template.h"
 #include "cunpack_common.h"
 
-using namespace ckernel;
-using namespace ckernel::unpacker;
-
 inline void _llk_unpack_tilize_mop_config_(const bool narrow_tile = false)
 {
 #if SKIP_UNP == 1
@@ -24,31 +21,32 @@ inline void _llk_unpack_tilize_mop_config_(const bool narrow_tile = false)
     static constexpr uint unpack_srcb_set_dvalid = TT_OP_NOP;
 #else
     static constexpr uint unpack_srca =
-        TT_OP_UNPACR(SrcA, 0b1 /*Z inc*/, 0, 0, 0, 1 /* Set OvrdThreadId*/, 1 /*Set Dvalid*/, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
-    static constexpr uint unpack_srcb_set_dvalid = TT_OP_UNPACR_NOP(SrcB, 0, 0, p_unpacr_nop::SET_DVALID, 0, 0, 0, 0, p_unpacr_nop::UNP_ZEROSRC);
+        TT_OP_UNPACR(ckernel::SrcA, 0b1 /*Z inc*/, 0, 0, 0, 1 /* Set OvrdThreadId*/, 1 /*Set Dvalid*/, ckernel::p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
+    static constexpr uint unpack_srcb_set_dvalid =
+        TT_OP_UNPACR_NOP(ckernel::SrcB, 0, 0, ckernel::p_unpacr_nop::SET_DVALID, 0, 0, 0, 0, ckernel::p_unpacr_nop::UNP_ZEROSRC);
 #endif
 
     const uint32_t outerloop     = 1;
     constexpr uint32_t innerloop = 1;
-    ckernel_template tmp(outerloop, innerloop, unpack_srcb_set_dvalid);
+    ckernel::ckernel_template tmp(outerloop, innerloop, unpack_srcb_set_dvalid);
     tmp.set_start_op(unpack_srca);
-    tmp.program(instrn_buffer);
+    tmp.program(ckernel::instrn_buffer);
 }
 
-template <bool is_fp32_dest_acc_en = false, StochRndType stoch_rnd_mode = StochRndType::None>
+template <bool is_fp32_dest_acc_en = false, ckernel::StochRndType stoch_rnd_mode = ckernel::StochRndType::None>
 inline void _llk_unpack_tilize_hw_configure_(
     const std::uint32_t unpack_src_format,
     const std::uint32_t unpack_dst_format,
-    const std::uint32_t face_r_dim                  = FACE_R_DIM,
+    const std::uint32_t face_r_dim                  = ckernel::FACE_R_DIM,
     const std::uint32_t within_face_16x16_transpose = 0,
     const std::uint32_t num_faces                   = 4)
 {
     constexpr bool is_row_pool  = false;
-    constexpr bool stoch_rnd_en = (stoch_rnd_mode == StochRndType::All);
-    constexpr bool fpu_srnd_en  = stoch_rnd_en || (stoch_rnd_mode == StochRndType::Fpu);
-    constexpr bool pack_srnd_en = stoch_rnd_en || (stoch_rnd_mode == StochRndType::Pack);
+    constexpr bool stoch_rnd_en = (stoch_rnd_mode == ckernel::StochRndType::All);
+    constexpr bool fpu_srnd_en  = stoch_rnd_en || (stoch_rnd_mode == ckernel::StochRndType::Fpu);
+    constexpr bool pack_srnd_en = stoch_rnd_en || (stoch_rnd_mode == ckernel::StochRndType::Pack);
 
-    configure_unpack_AB<is_row_pool, is_fp32_dest_acc_en, fpu_srnd_en, pack_srnd_en>(
+    ckernel::unpacker::configure_unpack_AB<is_row_pool, is_fp32_dest_acc_en, fpu_srnd_en, pack_srnd_en>(
         unpack_src_format, unpack_src_format, unpack_dst_format, unpack_dst_format, face_r_dim, face_r_dim, within_face_16x16_transpose, num_faces, num_faces);
 }
 
@@ -56,41 +54,41 @@ inline void _llk_unpack_tilize_init_(
     const std::uint32_t unpack_src_format = 0,
     const std::uint32_t unpack_dst_format = 0,
     const std::uint32_t ct_dim            = 0,
-    const std::uint32_t face_r_dim        = FACE_R_DIM,
+    const std::uint32_t face_r_dim        = ckernel::FACE_R_DIM,
     const bool narrow_tile                = false)
 {
-    cfg_reg_rmw_tensix<THCON_SEC0_REG2_Haloize_mode_RMW>(0);
+    ckernel::cfg_reg_rmw_tensix<THCON_SEC0_REG2_Haloize_mode_RMW>(0);
 
-    const std::uint32_t block_c_dim = ct_dim * (narrow_tile ? FACE_C_DIM : TILE_C_DIM);
+    const std::uint32_t block_c_dim = ct_dim * (narrow_tile ? ckernel::FACE_C_DIM : ckernel::TILE_C_DIM);
 
     // Set face dim
-    TT_SETADCXX(p_setadc::UNP_A, face_r_dim * FACE_C_DIM - 1, 0x0);
+    TT_SETADCXX(ckernel::p_setadc::UNP_A, face_r_dim * ckernel::FACE_C_DIM - 1, 0x0);
 
     // Override default settings to enable tilize mode
-    unpack_config_u config   = {0};
-    config.f.out_data_format = unpack_dst_format;
-    config.f.throttle_mode   = 2;
-    config.f.tileize_mode    = 1;
-    config.f.shift_amount    = (SCALE_DATUM_SIZE(unpack_src_format, block_c_dim)) >> 4;
+    ckernel::unpacker::unpack_config_u config = {0};
+    config.f.out_data_format                  = unpack_dst_format;
+    config.f.throttle_mode                    = 2;
+    config.f.tileize_mode                     = 1;
+    config.f.shift_amount                     = (ckernel::SCALE_DATUM_SIZE(unpack_src_format, block_c_dim)) >> 4;
 
-    TT_SETDMAREG(0, LOWER_HALFWORD(config.val[0]), 0, LO_16(p_gpr_unpack::TMP0));
-    TT_SETDMAREG(0, UPPER_HALFWORD(config.val[0]), 0, HI_16(p_gpr_unpack::TMP0));
-    TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::THCON);
-    TTI_WRCFG(p_gpr_unpack::TMP0, p_cfg::WRCFG_32b, THCON_SEC0_REG2_Out_data_format_ADDR32);
-    // TTI_REG2FLOP(1,0,0,0,THCON_SEC0_REG5_Tile_x_dim_cntx0_ADDR32-THCON_CFGREG_BASE_ADDR32, p_gpr_unpack::FACE_DIM_1x16); //GPR preloaded with  16 | (16 <<
-    // 16)
+    TT_SETDMAREG(0, LOWER_HALFWORD(config.val[0]), 0, LO_16(ckernel::p_gpr_unpack::TMP0));
+    TT_SETDMAREG(0, UPPER_HALFWORD(config.val[0]), 0, HI_16(ckernel::p_gpr_unpack::TMP0));
+    TTI_STALLWAIT(ckernel::p_stall::STALL_CFG, ckernel::p_stall::THCON);
+    TTI_WRCFG(ckernel::p_gpr_unpack::TMP0, ckernel::p_cfg::WRCFG_32b, THCON_SEC0_REG2_Out_data_format_ADDR32);
+    // TTI_REG2FLOP(1,0,0,0,THCON_SEC0_REG5_Tile_x_dim_cntx0_ADDR32-THCON_CFGREG_BASE_ADDR32, ckernel::p_gpr_unpack::FACE_DIM_1x16); //GPR preloaded with  16 |
+    // (16 << 16)
 
     // below is the configuration for 64-row unpack for srca
     const uint Tile_x_dim = 1024;
     const uint Tile_z_dim = 1;
-    cfg_reg_rmw_tensix<THCON_SEC0_REG5_Tile_x_dim_cntx0_ADDR32, 0, 0xffffffff>(Tile_x_dim | (Tile_x_dim << 16));
+    ckernel::cfg_reg_rmw_tensix<THCON_SEC0_REG5_Tile_x_dim_cntx0_ADDR32, 0, 0xffffffff>(Tile_x_dim | (Tile_x_dim << 16));
     // Force x-dim to 1024
-    cfg_reg_rmw_tensix<THCON_SEC0_REG0_TileDescriptor_ADDR32, 0, 0xffff0000>(0 | (Tile_x_dim << 16));
+    ckernel::cfg_reg_rmw_tensix<THCON_SEC0_REG0_TileDescriptor_ADDR32, 0, 0xffff0000>(0 | (Tile_x_dim << 16));
     // Force z-dim to 1 as X dim is set to cover the entire tile, so no need to iterate over faces.
-    cfg_reg_rmw_tensix<THCON_SEC0_REG0_TileDescriptor_ADDR32 + 1, 0, 0xffff0000>(0 | (Tile_z_dim << 16));
+    ckernel::cfg_reg_rmw_tensix<THCON_SEC0_REG0_TileDescriptor_ADDR32 + 1, 0, 0xffff0000>(0 | (Tile_z_dim << 16));
 
     // Force x-end for Unpackers to 1024
-    TTI_SETADCXX(p_setadc::UNP0, 1023, 0x0);
+    TTI_SETADCXX(ckernel::p_setadc::UNP0, 1023, 0x0);
 
     _llk_unpack_tilize_mop_config_(narrow_tile);
 }
@@ -100,20 +98,21 @@ inline void _llk_unpack_tilize_(
     const std::uint32_t tile_index,
     std::uint32_t unpack_src_format = 0,
     std::uint32_t block_ct_dim      = 0,
-    const std::uint32_t face_r_dim  = FACE_R_DIM,
+    const std::uint32_t face_r_dim  = ckernel::FACE_R_DIM,
     const std::uint32_t num_faces   = 4,
     const bool narrow_tile          = false)
 {
-    volatile uint tt_reg_ptr *cfg = get_cfg_pointer(); // get pointer to registers for current state ID
+    volatile uint tt_reg_ptr *cfg = ckernel::get_cfg_pointer(); // get pointer to registers for current state ID
 
-    std::uint32_t top_face_offset_address = SCALE_DATUM_SIZE(unpack_src_format, tile_index) << (narrow_tile ? 0 : 1);
+    std::uint32_t top_face_offset_address = ckernel::SCALE_DATUM_SIZE(unpack_src_format, tile_index) << (narrow_tile ? 0 : 1);
     // Each iteration unpacks 2 face_r_dimx16 faces (1st 0,1 2nd 2,3 unless tile is <=16x32)
     // For narrow tile we unpack 1 face in each iteration
     // Offset address is in 16B words
     // Datum count = tile_index*face_r_dim (/16 to get word count)
 
-    const std::uint32_t block_c_dim_16B   = block_ct_dim * (narrow_tile ? FACE_C_DIM / 16 : TILE_C_DIM / 16);
-    std::uint32_t bot_face_offset_address = SCALE_DATUM_SIZE(unpack_src_format, face_r_dim * block_c_dim_16B); //*N rows / 16 to get 16B word aligned address
+    const std::uint32_t block_c_dim_16B = block_ct_dim * (narrow_tile ? ckernel::FACE_C_DIM / 16 : ckernel::TILE_C_DIM / 16);
+    std::uint32_t bot_face_offset_address =
+        ckernel::SCALE_DATUM_SIZE(unpack_src_format, face_r_dim * block_c_dim_16B); //*N rows / 16 to get 16B word aligned address
 
     // Program srcA and srcB base addresses
     // FIXME MT: This should be revisited for narrow tiles
@@ -125,7 +124,7 @@ inline void _llk_unpack_tilize_(
     TTI_SETADCZW(0b001, 0, 0, 0, 0, 0b1111);
 
     // Wait for free context
-    wait_for_next_context(2);
+    ckernel::unpacker::wait_for_next_context(2);
 
     // Get tile address
     if (0 == unp_cfg_context)
@@ -138,19 +137,19 @@ inline void _llk_unpack_tilize_(
     }
 
     // Trisc::SEMPOST for context acquire
-    semaphore_post(semaphore::UNPACK_SYNC);
+    ckernel::semaphore_post(ckernel::semaphore::UNPACK_SYNC);
 
     // Stall unpacker until pending CFG writes from Trisc have completed
-    TTI_STALLWAIT(p_stall::STALL_UNPACK, p_stall::TRISC_CFG);
+    TTI_STALLWAIT(ckernel::p_stall::STALL_UNPACK, ckernel::p_stall::TRISC_CFG);
 
     // Run MOP
-    ckernel::ckernel_template::run(instrn_buffer);
+    ckernel::ckernel_template::run(ckernel::instrn_buffer);
 
     // T6::SEMGET for context release
-    t6_semaphore_get(semaphore::UNPACK_SYNC);
+    ckernel::t6_semaphore_get(ckernel::semaphore::UNPACK_SYNC);
 
     // Switch unpacker config context
-    switch_config_context(unp_cfg_context);
+    ckernel::unpacker::switch_config_context(unp_cfg_context);
 
 #ifdef PERF_DUMP
     first_unpack_recorded = true;

--- a/tt_llk_blackhole/llk_lib/llk_unpack_untilize.h
+++ b/tt_llk_blackhole/llk_lib/llk_unpack_untilize.h
@@ -13,9 +13,6 @@
 #include "ckernel_template.h"
 #include "cunpack_common.h"
 
-using namespace ckernel;
-using namespace ckernel::unpacker;
-
 #ifndef SKIP_UNP
 #define SKIP_UNP (0)
 #endif
@@ -23,7 +20,7 @@ using namespace ckernel::unpacker;
 inline void _llk_unpack_untilize_mop_config_()
 {
     constexpr uint replay_buf_len = (SKIP_UNP == 1) ? 1 : 6;
-    load_replay_buf(
+    ckernel::load_replay_buf(
         0,
         replay_buf_len,
         false,
@@ -34,12 +31,12 @@ inline void _llk_unpack_untilize_mop_config_()
             TTI_NOP;
 #else
             TTI_DMANOP; // WRCFG that sets offset in previous loop needs additional cycle to complete
-            TTI_UNPACR(SrcA, 0b01000001 /*CH1_Y+=1, CH0_Z+=1*/, 0, 0, 0, 1, 0, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
-            TTI_UNPACR(SrcA, 0b01000001 /*CH1_Y+=1, CH0_Z+=1*/, 0, 0, 0, 1, 0, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
-            TTI_ADDDMAREG(0, p_gpr_unpack::TILE_OFFSET, p_gpr_unpack::TILE_OFFSET, p_gpr_unpack::TILE_SIZE);
+            TTI_UNPACR(ckernel::SrcA, 0b01000001 /*CH1_Y+=1, CH0_Z+=1*/, 0, 0, 0, 1, 0, ckernel::p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
+            TTI_UNPACR(ckernel::SrcA, 0b01000001 /*CH1_Y+=1, CH0_Z+=1*/, 0, 0, 0, 1, 0, ckernel::p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
+            TTI_ADDDMAREG(0, ckernel::p_gpr_unpack::TILE_OFFSET, ckernel::p_gpr_unpack::TILE_OFFSET, ckernel::p_gpr_unpack::TILE_SIZE);
             // Need to stall WRCFG on the addition from ADDDMAREG
-            TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::THCON);
-            // Resets SrcA Z counter CR, which should point to initial Z counter value
+            TTI_STALLWAIT(ckernel::p_stall::STALL_CFG, ckernel::p_stall::THCON);
+            // Resets ckernel::SrcA Z counter CR, which should point to initial Z counter value
             TTI_ADDRCRZW(0b001, 0, 0, 0, 0, 0b0001 /*CH0_Z*/);
 #endif
         });
@@ -48,11 +45,13 @@ inline void _llk_unpack_untilize_mop_config_()
     static constexpr uint load_offset_addr_cntx0 = TT_OP_NOP;
     static constexpr uint load_offset_addr_cntx1 = TT_OP_NOP;
 #else
-    static constexpr uint load_offset_addr_cntx0 = TT_OP_WRCFG(p_gpr_unpack::TILE_OFFSET, p_cfg::WRCFG_32b, THCON_SEC0_REG7_Offset_address_ADDR32);
-    static constexpr uint load_offset_addr_cntx1 = TT_OP_WRCFG(p_gpr_unpack::TILE_OFFSET, p_cfg::WRCFG_32b, THCON_SEC0_REG7_Offset_cntx1_address_ADDR32);
+    static constexpr uint load_offset_addr_cntx0 =
+        TT_OP_WRCFG(ckernel::p_gpr_unpack::TILE_OFFSET, ckernel::p_cfg::WRCFG_32b, THCON_SEC0_REG7_Offset_address_ADDR32);
+    static constexpr uint load_offset_addr_cntx1 =
+        TT_OP_WRCFG(ckernel::p_gpr_unpack::TILE_OFFSET, ckernel::p_cfg::WRCFG_32b, THCON_SEC0_REG7_Offset_cntx1_address_ADDR32);
 #endif
 
-    ckernel_unpack_template tmp = ckernel_unpack_template(
+    ckernel::ckernel_unpack_template tmp = ckernel::ckernel_unpack_template(
         true,  // src B
         false, // halo - just used for 4 unpacks
         TT_OP_REPLAY(0, replay_buf_len, 0, 0),
@@ -62,45 +61,49 @@ inline void _llk_unpack_untilize_mop_config_()
         TT_OP_REPLAY(0, replay_buf_len, 0, 0),
         load_offset_addr_cntx0,
         load_offset_addr_cntx1);
-    tmp.program(instrn_buffer);
+    tmp.program(ckernel::instrn_buffer);
 }
 
-template <bool is_fp32_dest_acc_en = false, StochRndType stoch_rnd_mode = StochRndType::None>
+template <bool is_fp32_dest_acc_en = false, ckernel::StochRndType stoch_rnd_mode = ckernel::StochRndType::None>
 inline void _llk_unpack_untilize_hw_configure_(
     const std::uint32_t unpack_src_format,
     const std::uint32_t unpack_dst_format,
-    const std::uint32_t face_r_dim                  = FACE_R_DIM,
+    const std::uint32_t face_r_dim                  = ckernel::FACE_R_DIM,
     const std::uint32_t within_face_16x16_transpose = 0,
     const std::uint32_t num_faces                   = 4)
 {
     constexpr bool is_row_pool  = false;
-    constexpr bool stoch_rnd_en = (stoch_rnd_mode == StochRndType::All);
-    constexpr bool fpu_srnd_en  = stoch_rnd_en || (stoch_rnd_mode == StochRndType::Fpu);
-    constexpr bool pack_srnd_en = stoch_rnd_en || (stoch_rnd_mode == StochRndType::Pack);
-    configure_unpack_AB<is_row_pool, is_fp32_dest_acc_en, fpu_srnd_en, pack_srnd_en>(
+    constexpr bool stoch_rnd_en = (stoch_rnd_mode == ckernel::StochRndType::All);
+    constexpr bool fpu_srnd_en  = stoch_rnd_en || (stoch_rnd_mode == ckernel::StochRndType::Fpu);
+    constexpr bool pack_srnd_en = stoch_rnd_en || (stoch_rnd_mode == ckernel::StochRndType::Pack);
+    ckernel::unpacker::configure_unpack_AB<is_row_pool, is_fp32_dest_acc_en, fpu_srnd_en, pack_srnd_en>(
         unpack_src_format, unpack_src_format, unpack_dst_format, unpack_dst_format, face_r_dim, face_r_dim, within_face_16x16_transpose, num_faces, num_faces);
 }
 
 inline void _llk_unpack_untilize_init_(
-    const std::uint32_t unpack_dst_format, const std::uint32_t tile_size, const std::uint32_t face_r_dim = FACE_R_DIM, const std::uint32_t num_faces = 4)
+    const std::uint32_t unpack_dst_format,
+    const std::uint32_t tile_size,
+    const std::uint32_t face_r_dim = ckernel::FACE_R_DIM,
+    const std::uint32_t num_faces  = 4)
 {
     const std::uint32_t unpA_ch1_x_stride = (unpack_dst_format & 0x3) == (std::uint32_t)DataFormat::Float32   ? 4
                                             : (unpack_dst_format & 0x3) == (std::uint32_t)DataFormat::Float16 ? 2
                                                                                                               : 1;
-    const std::uint32_t unpA_ch1_y_stride = FACE_R_DIM * unpA_ch1_x_stride;
+    const std::uint32_t unpA_ch1_y_stride = ckernel::FACE_R_DIM * unpA_ch1_x_stride;
 
-    TT_SETADCXX(p_setadc::UNP_A, face_r_dim * FACE_C_DIM - 1, 0x0);
+    TT_SETADCXX(ckernel::p_setadc::UNP_A, face_r_dim * ckernel::FACE_C_DIM - 1, 0x0);
 
     // Get pointer to registers for current state ID
-    TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::UNPACK);
-    cfg_reg_rmw_tensix<UNP0_ADDR_CTRL_XY_REG_1_Ystride_ADDR32, UNP0_ADDR_CTRL_XY_REG_0_Ystride_SHAMT, UNP0_ADDR_CTRL_XY_REG_1_Ystride_MASK>(unpA_ch1_y_stride);
-    cfg_reg_rmw_tensix<THCON_SEC0_REG0_TileDescriptor_ADDR32 + 1, 0, 0xFFFF>(FACE_C_DIM);
-    // TTI_REG2FLOP(1,0,0,0,THCON_SEC0_REG5_Tile_x_dim_cntx0_ADDR32-THCON_CFGREG_BASE_ADDR32, p_gpr_unpack::FACE_DIM_1x16); //GPR preloaded with  16 | (16 <<
-    // 16)
-    TTI_WRCFG(p_gpr_unpack::FACE_DIM_1x16, p_cfg::WRCFG_32b, THCON_SEC0_REG5_Tile_x_dim_cntx0_ADDR32); // GPR preloaded with  16 | (16 << 16)
+    TTI_STALLWAIT(ckernel::p_stall::STALL_CFG, ckernel::p_stall::UNPACK);
+    ckernel::cfg_reg_rmw_tensix<UNP0_ADDR_CTRL_XY_REG_1_Ystride_ADDR32, UNP0_ADDR_CTRL_XY_REG_0_Ystride_SHAMT, UNP0_ADDR_CTRL_XY_REG_1_Ystride_MASK>(
+        unpA_ch1_y_stride);
+    ckernel::cfg_reg_rmw_tensix<THCON_SEC0_REG0_TileDescriptor_ADDR32 + 1, 0, 0xFFFF>(ckernel::FACE_C_DIM);
+    // TTI_REG2FLOP(1,0,0,0,THCON_SEC0_REG5_Tile_x_dim_cntx0_ADDR32-THCON_CFGREG_BASE_ADDR32, ckernel::ckernel::p_gpr_unpack::FACE_DIM_1x16); //GPR preloaded
+    // with  16 | (16 << 16)
+    TTI_WRCFG(ckernel::p_gpr_unpack::FACE_DIM_1x16, ckernel::p_cfg::WRCFG_32b, THCON_SEC0_REG5_Tile_x_dim_cntx0_ADDR32); // GPR preloaded with  16 | (16 << 16)
 
-    TT_SETDMAREG(0, LOWER_HALFWORD(tile_size), 0, LO_16(p_gpr_unpack::TILE_SIZE));
-    TT_SETDMAREG(0, UPPER_HALFWORD(tile_size), 0, HI_16(p_gpr_unpack::TILE_SIZE));
+    TT_SETDMAREG(0, LOWER_HALFWORD(tile_size), 0, LO_16(ckernel::p_gpr_unpack::TILE_SIZE));
+    TT_SETDMAREG(0, UPPER_HALFWORD(tile_size), 0, HI_16(ckernel::p_gpr_unpack::TILE_SIZE));
 
     _llk_unpack_untilize_mop_config_();
 }
@@ -111,22 +114,22 @@ inline void _llk_unpack_untilize_pass_(const std::uint32_t base_address, const s
     std::uint32_t rem_blocks_in_row = block_tile_cols;
 
     // Program srcA and srcB base addresses
-    volatile uint tt_reg_ptr *cfg = get_cfg_pointer(); // get pointer to registers for current state ID
+    volatile uint tt_reg_ptr *cfg = ckernel::get_cfg_pointer(); // get pointer to registers for current state ID
 
     TTI_SETADCXY(0b001, 0, 0, 0, 0, 0b0010); // Clear l1 addr y cnt
     if constexpr (first_pass)
     {
         // Select top faces in the 1st pass
-        TT_SETADC(p_setadc::UNP0, p_setadc::CH_0, p_setadc::SET_Z, 0);
+        TT_SETADC(ckernel::p_setadc::UNP0, ckernel::p_setadc::CH_0, ckernel::p_setadc::SET_Z, 0);
     }
     else
     {
         // Select bottom faces in the 2nd pass
-        TT_SETADC(p_setadc::UNP0, p_setadc::CH_0, p_setadc::SET_Z, 2);
+        TT_SETADC(ckernel::p_setadc::UNP0, ckernel::p_setadc::CH_0, ckernel::p_setadc::SET_Z, 2);
     }
 
     // Wait for free context
-    wait_for_next_context(2);
+    ckernel::unpacker::wait_for_next_context(2);
 
     // Get tile address
     if (0 == unp_cfg_context)
@@ -139,27 +142,27 @@ inline void _llk_unpack_untilize_pass_(const std::uint32_t base_address, const s
     }
 
     // Trisc::SEMPOST for context acquire
-    semaphore_post(semaphore::UNPACK_SYNC);
+    ckernel::semaphore_post(ckernel::semaphore::UNPACK_SYNC);
 
     // Stall unpacker until pending CFG writes from Trisc have completed
-    TTI_STALLWAIT(p_stall::STALL_UNPACK, p_stall::TRISC_CFG);
+    TTI_STALLWAIT(ckernel::p_stall::STALL_UNPACK, ckernel::p_stall::TRISC_CFG);
 
     std::uint32_t face_2xr_cnt = 0;
-    for (std::uint32_t r = 0; r < FACE_HEIGHT; r++)
+    for (std::uint32_t r = 0; r < ckernel::FACE_HEIGHT; r++)
     {
         rem_blocks_in_row = block_tile_cols; // reset remaining blocks in row
 
         do
         {
-            if ((face_2xr_cnt + rem_blocks_in_row) >= (FACE_HEIGHT / 2))
+            if ((face_2xr_cnt + rem_blocks_in_row) >= (ckernel::FACE_HEIGHT / 2))
             {
                 // Run MOP
                 TT_MOP(0, 8 - face_2xr_cnt - 1, unp_cfg_context == 0 ? 0 : 0xff); // Run the MOP
 #if SKIP_UNP == 1
                 TTI_NOP;
 #else
-                TTI_UNPACR(SrcA, 0b0, 0, 0, 0, 1, 1, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1); // set data valid
-                TTI_UNPACR_NOP(SrcB, 0, 0, p_unpacr_nop::SET_DVALID, 0, 0, 0, 0, p_unpacr_nop::UNP_ZEROSRC);
+                TTI_UNPACR(ckernel::SrcA, 0b0, 0, 0, 0, 1, 1, ckernel::p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1); // set data valid
+                TTI_UNPACR_NOP(ckernel::SrcB, 0, 0, ckernel::p_unpacr_nop::SET_DVALID, 0, 0, 0, 0, ckernel::p_unpacr_nop::UNP_ZEROSRC);
 #endif
                 TTI_SETADCXY(0b001, 0, 0, 0, 0, 0b1000); // Clear srcA addr y cnt
                 rem_blocks_in_row -= (8 - face_2xr_cnt);
@@ -171,31 +174,31 @@ inline void _llk_unpack_untilize_pass_(const std::uint32_t base_address, const s
                 face_2xr_cnt += rem_blocks_in_row;
                 rem_blocks_in_row = 0;
                 // if (face_2xr_cnt==FACE_HEIGHT/2) {
-                //   TTI_UNPACR(SrcA, 0b0, 0, 0, 0, 0, 1, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1); //set data valid
+                //   TTI_UNPACR(ckernel::SrcA, 0b0, 0, 0, 0, 0, 1, ckernel::p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1); //set data valid
                 //   TTI_SETADCXY(0b001, 0, 0, 0, 0, 0b1000); // Clear srcA addr y cnt
                 //   face_2xr_cnt = 0;
                 //}
             }
         } while (rem_blocks_in_row > 0);
 
-        TTI_MULDMAREG(0, p_gpr_unpack::TILE_OFFSET, p_gpr_unpack::TILE_OFFSET, p_gpr::ZERO); // TILE_OFFSET=TILE_OFFSET*0
-        TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::THCON);
+        TTI_MULDMAREG(0, ckernel::p_gpr_unpack::TILE_OFFSET, ckernel::p_gpr_unpack::TILE_OFFSET, ckernel::p_gpr::ZERO); // TILE_OFFSET=TILE_OFFSET*0
+        TTI_STALLWAIT(ckernel::p_stall::STALL_CFG, ckernel::p_stall::THCON);
         if (0 == unp_cfg_context)
         {
-            TTI_WRCFG(p_gpr::ZERO, p_cfg::WRCFG_32b, THCON_SEC0_REG7_Offset_address_ADDR32);
+            TTI_WRCFG(ckernel::p_gpr::ZERO, ckernel::p_cfg::WRCFG_32b, THCON_SEC0_REG7_Offset_address_ADDR32);
         }
         else
         {
-            TTI_WRCFG(p_gpr::ZERO, p_cfg::WRCFG_32b, THCON_SEC0_REG7_Offset_cntx1_address_ADDR32);
+            TTI_WRCFG(ckernel::p_gpr::ZERO, ckernel::p_cfg::WRCFG_32b, THCON_SEC0_REG7_Offset_cntx1_address_ADDR32);
         }
         TTI_INCADCXY(0b001, 0, 0, 1, 0); // inc l1 addr y cnt
     }
 
     // T6::SEMGET for context release
-    t6_semaphore_get(semaphore::UNPACK_SYNC);
+    ckernel::t6_semaphore_get(ckernel::semaphore::UNPACK_SYNC);
 
     // Switch unpacker config context
-    switch_config_context(unp_cfg_context);
+    ckernel::unpacker::switch_config_context(unp_cfg_context);
 
 #ifdef PERF_DUMP
     first_unpack_recorded = true;


### PR DESCRIPTION
### Ticket
#20 

### Problem description
At present, we have a situation where we have a namespace polution (we're leaking namespaces via header files).

### What's changed
This pull request aims at removing using namespace declarations in Blackhole header files.

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14133298878) CI passes (if applicable)
