### PR TITLE
fix: add parameter for configuring dest accumulation

### DIFF
--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_recip.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_recip.h
@@ -49,7 +49,7 @@ sfpi_inline sfpi::vFloat _sfpu_reciprocal_(const sfpi::vFloat in)
     return setexp(result, new_exp);
 }
 
-template <bool APPROXIMATION_MODE, int ITERATIONS>
+template <bool APPROXIMATION_MODE, int ITERATIONS, bool is_fp32_dest_acc_en = true>
 inline void _calculate_reciprocal_(const int iterations)
 {
 #pragma GCC unroll 8
@@ -65,7 +65,7 @@ inline void _calculate_reciprocal_(const int iterations)
         }
         v_endif;
 
-        if constexpr (APPROXIMATION_MODE)
+        if constexpr (is_fp32_dest_acc_en || APPROXIMATION_MODE)
         {
             sfpi::dst_reg[0] = out;
         }


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/19766

### Problem description
Reciprocal operation in Blackhole doesn't have support for `is_fp32_dest_acc_en`, which causes precision difference compared to WH and BH output.

### What's changed
This PR introduced the missing template parameter. tt-metal counterpart of this change can be found [here](https://github.com/tenstorrent/tt-metal/compare/main...refs/heads/fvranicTT/add-dest-acc-config-to-reciprocal).

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14206569426) CI passes (if applicable)
