### PR TITLE
[Test Infra] Ensure Tensix Operations Complete Before Reading Results from L1 & Wait for Tensix Completion to Expose Hangs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ compile_commands.json
 .vscode/
 *.log
 *.csv
+*.whl

--- a/tests/python_tests/helpers/__init__.py
+++ b/tests/python_tests/helpers/__init__.py
@@ -36,7 +36,7 @@ from .device import (
     run_elf_files,
     write_stimuli_to_l1,
     get_result_from_device,
-    assert_tensix_operations_finished,
+    wait_for_tensix_operations_finished,
 )
 from .param_config import (
     generate_format_combinations,

--- a/tests/python_tests/helpers/format_arg_mapping.py
+++ b/tests/python_tests/helpers/format_arg_mapping.py
@@ -133,3 +133,9 @@ class TileCount(Enum):
     Two = 2
     Three = 3
     Four = 4
+
+
+class Mailbox(Enum):
+    Unpacker = 0x19FFC
+    Math = 0x19FF8
+    Packer = 0x19FF4

--- a/tests/python_tests/pytest.ini
+++ b/tests/python_tests/pytest.ini
@@ -1,6 +1,8 @@
 [pytest]
 filterwarnings =
     ignore::UserWarning
+    ignore::DeprecationWarning
+    ignore::FutureWarning
 addopts = -v --tb=no
 python_files = test_*.py
 python_functions = test

--- a/tests/python_tests/test_eltwise_unary_datacopy.py
+++ b/tests/python_tests/test_eltwise_unary_datacopy.py
@@ -81,15 +81,13 @@ def test_unary_datacopy(testname, formats, dest_acc):
     run_shell_command(f"cd .. && {make_cmd}")
     run_elf_files(testname)
 
-    # JUST PASS formats
+    wait_for_tensix_operations_finished()
     res_from_L1 = collect_results(
         formats
     )  # Bug patchup in (unpack.py): passing formats struct to check unpack_src with pack_dst and distinguish when input and output formats have different exponent widths then reading from L1 changes
 
-    run_shell_command("cd .. && make clean")
-
     assert len(res_from_L1) == len(golden)
-    assert_tensix_operations_finished()
+    run_shell_command("cd .. && make clean")
 
     if formats.pack_dst in format_dict:
         atol = 0.05

--- a/tests/python_tests/test_eltwise_unary_sfpu.py
+++ b/tests/python_tests/test_eltwise_unary_sfpu.py
@@ -76,14 +76,12 @@ def test_eltwise_unary_sfpu(testname, formats, dest_acc, approx_mode, mathop):  
     run_shell_command(f"cd .. && {make_cmd}")
     run_elf_files(testname)
 
+    wait_for_tensix_operations_finished()
     res_from_L1 = collect_results(
         formats, sfpu=True
     )  # Bug patchup in (unpack.py): passing formats struct to check unpack_src with pack_dst and distinguish when input and output formats have different exponent widths then reading from L1 changes
-
-    run_shell_command("cd .. && make clean")
-
     assert len(res_from_L1) == len(golden)
-    assert_tensix_operations_finished()
+    run_shell_command("cd .. && make clean")
 
     golden_tensor = torch.tensor(
         golden,

--- a/tests/python_tests/test_fill_dest.py
+++ b/tests/python_tests/test_fill_dest.py
@@ -79,8 +79,8 @@ def test_fill_dest(testname, formats, dest_acc):
 
     run_shell_command("cd .. && make clean")
 
+    wait_for_tensix_operations_finished()
     res_from_L1 = []
-
     for address in pack_addresses:
         res_from_L1.append(
             collect_results(formats, address)
@@ -88,7 +88,6 @@ def test_fill_dest(testname, formats, dest_acc):
     res_from_L1 = flatten_list(res_from_L1)
 
     assert len(res_from_L1) == len(golden)
-    assert_tensix_operations_finished()
 
     golden_tensor = torch.tensor(
         golden,

--- a/tests/python_tests/test_matmul.py
+++ b/tests/python_tests/test_matmul.py
@@ -69,13 +69,12 @@ def test_matmul(testname, formats, dest_acc, math_fidelity):
 
     run_elf_files(testname)
 
+    wait_for_tensix_operations_finished()
     res_from_L1 = collect_results(
         formats
     )  # Bug patchup in (unpack.py): passing formats struct to check unpack_src with pack_dst and distinguish when input and output formats have different exponent widths then reading from L1 changes
-    run_shell_command("cd .. && make clean")
-
     assert len(res_from_L1) == len(golden_tensor)
-    assert_tensix_operations_finished()
+    run_shell_command("cd .. && make clean")
 
     res_tensor = torch.tensor(
         res_from_L1,

--- a/tests/python_tests/test_multiple_tiles_eltwise.py
+++ b/tests/python_tests/test_multiple_tiles_eltwise.py
@@ -106,10 +106,9 @@ def test_multiple_tiles(testname, formats, dest_acc, mathop, math_fidelity, tile
     run_shell_command(f"cd .. && {make_cmd}")
 
     run_elf_files(testname)
+    wait_for_tensix_operations_finished()
 
     run_shell_command("cd .. && make clean")
-
-    assert_tensix_operations_finished()
 
     # check resluts from multiple tiles
     res_from_L1 = []

--- a/tests/python_tests/test_pack_untilize.py
+++ b/tests/python_tests/test_pack_untilize.py
@@ -48,14 +48,13 @@ def test_pack_untilize(testname, formats):
     run_shell_command(f"cd .. && {make_cmd}")
 
     run_elf_files(testname)
+    wait_for_tensix_operations_finished()
 
     res_from_L1 = collect_results(
         formats
     )  # Bug patchup in (unpack.py): passing formats struct to check unpack_src with pack_dst and distinguish when input and output formats have different exponent widths then reading from L1 changes
-    run_shell_command("cd .. && make clean")
-
     assert len(res_from_L1) == len(golden_tensor)
-    assert_tensix_operations_finished()
+    run_shell_command("cd .. && make clean")
 
     res_tensor = torch.tensor(
         res_from_L1,

--- a/tests/python_tests/test_reduce.py
+++ b/tests/python_tests/test_reduce.py
@@ -110,15 +110,13 @@ def test_reduce(testname, formats, dest_acc, reduce_dim, pool_type):
     run_shell_command(f"cd .. && {make_cmd}")
 
     run_elf_files(testname)
+    wait_for_tensix_operations_finished()
 
     res_from_L1 = collect_results(
         formats
     )  # Bug patchup in (unpack.py): passing formats struct to check unpack_src with pack_dst and distinguish when input and output formats have different exponent widths then reading from L1 changes
-
-    run_shell_command("cd .. && make clean")
-
     assert len(res_from_L1) == len(golden_tensor)
-    assert_tensix_operations_finished()
+    run_shell_command("cd .. && make clean")
 
     res_tensor = torch.tensor(
         res_from_L1,

--- a/tests/python_tests/test_sfpu_binary.py
+++ b/tests/python_tests/test_sfpu_binary.py
@@ -71,6 +71,7 @@ def test_all(testname, formats, dest_acc, mathop):
     run_shell_command(f"cd .. && {make_cmd}")
 
     run_elf_files(testname)
+    wait_for_tensix_operations_finished()
 
     res_from_L1 = collect_results(
         formats
@@ -79,8 +80,6 @@ def test_all(testname, formats, dest_acc, mathop):
     assert len(res_from_L1) == len(golden)
 
     run_shell_command("cd .. && make clean")
-
-    assert_tensix_operations_finished()
 
     if formats.pack_dst in [
         DataFormat.Float16_b,

--- a/tests/python_tests/test_tilize_calculate_untilize_L1.py
+++ b/tests/python_tests/test_tilize_calculate_untilize_L1.py
@@ -95,12 +95,14 @@ def test_tilize_calculate_untilize_L1(
     run_shell_command(f"cd .. && {make_cmd}")
 
     run_elf_files(testname)
+    wait_for_tensix_operations_finished()
 
     res_from_L1 = collect_results(
         formats, 0x1E000
     )  # Bug patchup in (unpack.py): passing formats struct to check unpack_src with pack_dst and distinguish when input and output formats have different exponent widths then reading from L1 changes
     assert len(res_from_L1) == len(golden_tensor)
-    assert_tensix_operations_finished()
+
+    run_shell_command("cd .. && make clean")
 
     res_tensor = torch.tensor(
         res_from_L1,

--- a/tests/python_tests/test_unpack_tilize.py
+++ b/tests/python_tests/test_unpack_tilize.py
@@ -38,15 +38,13 @@ def test_unpack_tilize(testname, formats):
     run_shell_command(f"cd .. && {make_cmd}")
 
     run_elf_files(testname)
+    wait_for_tensix_operations_finished()
 
     res_from_L1 = collect_results(
         formats
     )  # Bug patchup in (unpack.py): passing formats struct to check unpack_src with pack_dst and distinguish when input and output formats have different exponent widths then reading from L1 changes
-
-    run_shell_command("cd .. && make clean")
-
     assert len(res_from_L1) == len(golden_tensor)
-    assert_tensix_operations_finished()
+    run_shell_command("cd .. && make clean")
 
     res_tensor = torch.tensor(
         res_from_L1,

--- a/tests/python_tests/test_unpack_untilize.py
+++ b/tests/python_tests/test_unpack_untilize.py
@@ -41,15 +41,12 @@ def test_unpack_untilze(testname, formats):
     run_shell_command(f"cd .. && {make_cmd}")
 
     run_elf_files(testname)
-
+    wait_for_tensix_operations_finished()
     res_from_L1 = collect_results(
         formats
     )  # Bug patchup in (unpack.py): passing formats struct to check unpack_src with pack_dst and distinguish when input and output formats have different exponent widths then reading from L1 changes
-
-    run_shell_command("cd .. && make clean")
-
     assert len(res_from_L1) == len(golden_tensor)
-    assert_tensix_operations_finished()
+    run_shell_command("cd .. && make clean")
 
     res_tensor = torch.tensor(
         res_from_L1,


### PR DESCRIPTION
### Problem description
Previously, we were reading from L1 before verifying if our Tensix operations completed. This could have resulted in reading invalid data from L1, leading to misinterpretation of test failures as functional issues, when in fact the problem might have been a synchronization issue or a hang.
### What's changed
To address this, we’ve updated the flow to ensure that TRISC calls are fully completed before we read the results from L1. Additionally, we replaced our assertion calls with wait calls that pause execution until the Tensix operation finishes. This change improves our ability to distinguish between actual test failures (due to incorrect results) and potential hangs, as the test will now wait for the operation to complete instead of failing immediately on an assertion, which previously didn’t provide visibility into how long the assertion had been false.

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update