### PR TITLE
LLK tilize support for Int32/UInt32 inputs

### DIFF
--- a/tt_llk_wormhole_b0/common/inc/cmath_common.h
+++ b/tt_llk_wormhole_b0/common/inc/cmath_common.h
@@ -232,6 +232,10 @@ inline constexpr bool is_32bit_input(const std::uint32_t src_format, const std::
 {
     const uint input_df  = src_format & 0xF;
     const uint output_df = dst_format & 0xF;
+    if (src_format == (uint32_t)DataFormat::UInt32)
+    {
+        return true;
+    }
     return ((input_df == (uint)DataFormat::Int32) || (input_df == (uint)DataFormat::Float32)) &&
            ((output_df == (uint)DataFormat::Int32) || (output_df == (uint)DataFormat::Float32));
 }

--- a/tt_llk_wormhole_b0/common/inc/cmath_common.h
+++ b/tt_llk_wormhole_b0/common/inc/cmath_common.h
@@ -232,10 +232,7 @@ inline constexpr bool is_32bit_input(const std::uint32_t src_format, const std::
 {
     const uint input_df  = src_format & 0xF;
     const uint output_df = dst_format & 0xF;
-    if (src_format == (uint32_t)DataFormat::UInt32)
-    {
-        return true;
-    }
+
     return ((input_df == (uint)DataFormat::Int32) || (input_df == (uint)DataFormat::Float32)) &&
            ((output_df == (uint)DataFormat::Int32) || (output_df == (uint)DataFormat::Float32));
 }

--- a/tt_llk_wormhole_b0/common/inc/cpack_common.h
+++ b/tt_llk_wormhole_b0/common/inc/cpack_common.h
@@ -249,7 +249,8 @@ inline void set_packer_config(const uint pack_src_format, const uint pack_dst_fo
     dest_rd_ctrl_u dest_rd_ctrl;
     dest_rd_ctrl.val                              = 0;
     dest_rd_ctrl.f.PCK_DEST_RD_CTRL_Read_32b_data = ((pack_src_format & 0xF) == (uint)DataFormat::Int8) | (pack_src_format == (uint)DataFormat::Int32) |
-                                                    (pack_src_format == (uint)DataFormat::Float32) | (is_fp32_dest_acc_en ? 1 : 0);
+                                                    (pack_src_format == (uint)DataFormat::UInt32) | (pack_src_format == (uint)DataFormat::Float32) |
+                                                    (is_fp32_dest_acc_en ? 1 : 0);
     if (pack_dst_format == (uint)DataFormat::UInt8)
     {
         dest_rd_ctrl.f.PCK_DEST_RD_CTRL_Read_unsigned = 1;
@@ -362,7 +363,8 @@ inline void reconfig_packer_data_format(const uint pack_src_format, const uint p
     dest_rd_ctrl_u dest_rd_ctrl;
     dest_rd_ctrl.val                              = 0;
     dest_rd_ctrl.f.PCK_DEST_RD_CTRL_Read_32b_data = ((pack_src_format & 0xF) == (uint)DataFormat::Int8) | (pack_src_format == (uint)DataFormat::Int32) |
-                                                    (pack_src_format == (uint)DataFormat::Float32) | (is_fp32_dest_acc_en ? 1 : 0);
+                                                    (pack_src_format == (uint)DataFormat::UInt32) | (pack_src_format == (uint)DataFormat::Float32) |
+                                                    (is_fp32_dest_acc_en ? 1 : 0);
     if (pack_dst_format == (uint)DataFormat::UInt8)
     {
         dest_rd_ctrl.f.PCK_DEST_RD_CTRL_Read_unsigned = 1;

--- a/tt_llk_wormhole_b0/llk_lib/llk_unpack_tilize.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_unpack_tilize.h
@@ -16,24 +16,36 @@
 using namespace ckernel;
 using namespace ckernel::unpacker;
 
-inline void _llk_unpack_tilize_mop_config_(const bool narrow_tile = false)
+inline void _llk_unpack_tilize_mop_config_(const bool narrow_tile = false, const bool unpack_to_dest = false)
 {
 #if SKIP_UNP == 1
     static constexpr uint unpack_srca            = TT_OP_NOP;
+    static constexpr uint unpack_srca_to_dest    = TT_OP_NOP;
     static constexpr uint unpack_srcb_zerosrc    = TT_OP_NOP;
     static constexpr uint unpack_srcb_set_dvalid = TT_OP_NOP;
 #else
     static constexpr uint unpack_srca =
         TT_OP_UNPACR(SrcA, 0b1 /*Z inc*/, 0, 0, 0, 1 /* Set OvrdThreadId*/, 1 /*Set Dvalid*/, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
+    static constexpr uint unpack_srca_to_dest =
+        TT_OP_UNPACR(SrcA, 0b00010001 /*CH0/CH1 Z inc*/, 0, 0, 0, 1 /* Set OvrdThreadId*/, 0, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
     static constexpr uint unpack_srcb_zerosrc    = TT_OP_UNPACR_NOP(SrcB, p_unpacr_nop::UNP_ZEROSRC);
     static constexpr uint unpack_srcb_set_dvalid = TT_OP_UNPACR_NOP(SrcB, p_unpacr_nop::UNP_SET_DVALID); // WA for tenstorrent/budabackend#1230
 #endif
 
     const uint32_t outerloop     = narrow_tile ? 1 : 2;
     constexpr uint32_t innerloop = 1;
-    ckernel_template tmp(outerloop, innerloop, unpack_srcb_zerosrc, unpack_srcb_set_dvalid);
-    tmp.set_start_op(unpack_srca);
-    tmp.program(instrn_buffer);
+
+    if (unpack_to_dest)
+    {
+        ckernel_template tmp(outerloop, innerloop, unpack_srca_to_dest);
+        tmp.program(instrn_buffer);
+    }
+    else
+    {
+        ckernel_template tmp(outerloop, innerloop, unpack_srcb_zerosrc, unpack_srcb_set_dvalid);
+        tmp.set_start_op(unpack_srca);
+        tmp.program(instrn_buffer);
+    }
 }
 
 template <bool is_fp32_dest_acc_en = false, StochRndType stoch_rnd_mode = StochRndType::None>
@@ -62,6 +74,10 @@ inline void _llk_unpack_tilize_init_(
 {
     cfg_reg_rmw_tensix<THCON_SEC0_REG2_Haloize_mode_RMW>(0);
 
+    // In case of 32-bit integer numbers, we have to unpack into dest register
+    const bool unpack_to_dest = (unpack_src_format == static_cast<std::underlying_type_t<DataFormat>>(DataFormat::UInt32)) ||
+                                (unpack_src_format == static_cast<std::underlying_type_t<DataFormat>>(DataFormat::Int32));
+
     const std::uint32_t block_c_dim = ct_dim * (narrow_tile ? FACE_C_DIM : TILE_C_DIM);
 
     // Set face dim
@@ -80,7 +96,110 @@ inline void _llk_unpack_tilize_init_(
     TTI_REG2FLOP(
         1, 0, 0, 0, THCON_SEC0_REG5_Tile_x_dim_cntx0_ADDR32 - THCON_CFGREG_BASE_ADDR32, p_gpr_unpack::FACE_DIM_1x16); // GPR preloaded with  16 | (16 << 16)
 
-    _llk_unpack_tilize_mop_config_(narrow_tile);
+    _llk_unpack_tilize_mop_config_(narrow_tile, unpack_to_dest);
+}
+
+// Internal function to implement unpacking to source register
+inline void unpack_tilize_impl(
+    const std::uint32_t base_address, std::uint32_t num_loops, std::uint32_t top_face_offset_address, std::uint32_t bot_face_offset_address)
+{
+    volatile uint tt_reg_ptr* cfg = get_cfg_pointer(); // get pointer to registers for current state ID
+
+    for (std::uint32_t n = 0; n < num_loops; n++)
+    {
+        std::uint32_t address = base_address + top_face_offset_address + ((n == 1) ? bot_face_offset_address : 0);
+
+        // Clear z/w start counters
+        TTI_SETADCZW(0b001, 0, 0, 0, 0, 0b1111);
+
+        // Wait for free context
+        wait_for_next_context(2);
+
+        // Get tile address
+        if (0 == unp_cfg_context)
+        {
+            cfg[THCON_SEC0_REG3_Base_address_ADDR32] = address;
+        }
+        else
+        {
+            cfg[THCON_SEC0_REG3_Base_cntx1_address_ADDR32] = address;
+        }
+
+        // Trisc::SEMPOST for context acquire
+        semaphore_post(semaphore::UNPACK_SYNC);
+
+        // Stall unpacker until pending CFG writes from Trisc have completed
+        TTI_STALLWAIT(p_stall::STALL_UNPACK, p_stall::TRISC_CFG);
+
+        // Run MOP
+        ckernel::ckernel_template::run(instrn_buffer);
+
+        // T6::SEMGET for context release
+        t6_semaphore_get(semaphore::UNPACK_SYNC);
+
+        // Switch unpacker config context
+        switch_config_context(unp_cfg_context);
+    }
+}
+
+// Internal function to implement unpacking to destination register
+inline void unpack_tilize_to_dest_impl(
+    const std::uint32_t base_address,
+    std::uint32_t unpack_src_format,
+    std::uint32_t num_loops,
+    std::uint32_t top_face_offset_address,
+    std::uint32_t bot_face_offset_address)
+{
+    volatile uint tt_reg_ptr *cfg = get_cfg_pointer(); // get pointer to registers for current state ID
+
+    // Unpack to dest register
+    set_dst_write_addr(unp_cfg_context, unpack_src_format);
+    wait_for_dest_available();
+
+    // Trisc::SEMPOST for context acquire
+    semaphore_post(semaphore::UNPACK_SYNC);
+    std::uint32_t address = base_address + top_face_offset_address;
+
+    // Clear z/w start counters
+    TTI_SETADCZW(0b001, 0, 0, 0, 0, 0b1111);
+
+    // Get tile address
+    cfg[THCON_SEC0_REG3_Base_address_ADDR32] = address;
+
+    // Stall unpacker until pending CFG writes from Trisc have completed
+    TTI_STALLWAIT(p_stall::STALL_UNPACK, p_stall::TRISC_CFG);
+
+    // Unpack top faces
+    ckernel::ckernel_template::run(instrn_buffer);
+
+    // Unpack bottom faces if needed
+    if (num_loops > 1)
+    {
+        // Needed to stall counter reconfiguration until unpacker finishes previous instruction
+        TTI_STALLWAIT(p_stall::STALL_TDMA, p_stall::UNPACK);
+
+        // Don't clear the CH1 W counter - needed for multiple tiles
+        TTI_SETADCZW(0b001, 0, 0, 0, 0, 0b1011);
+
+        // Increment address to point to bottom faces in L1
+        address += bot_face_offset_address;
+
+        // Stall write to cfg until unpacker finishes
+        TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::UNPACK);
+
+        // Get tile address
+        cfg[THCON_SEC0_REG3_Base_address_ADDR32] = address;
+
+        // Stall unpacker until pending CFG writes from Trisc have completed
+        TTI_STALLWAIT(p_stall::STALL_UNPACK, p_stall::TRISC_CFG);
+
+        // Unpack bottom faces
+        ckernel::ckernel_template::run(instrn_buffer);
+    }
+
+    // T6::SEMGET for context release
+    t6_semaphore_get(semaphore::UNPACK_SYNC);
+    unpack_to_dest_tile_done(unp_cfg_context);
 }
 
 inline void _llk_unpack_tilize_(
@@ -90,10 +209,11 @@ inline void _llk_unpack_tilize_(
     std::uint32_t block_ct_dim      = 0,
     const std::uint32_t face_r_dim  = FACE_R_DIM,
     const std::uint32_t num_faces   = 4,
-    const bool narrow_tile          = false,
-    const bool is_32bit_integer     = false)
+    const bool narrow_tile          = false)
 {
-    volatile uint tt_reg_ptr* cfg = get_cfg_pointer(); // get pointer to registers for current state ID
+    // In case of 32-bit integer numbers, we have to unpack into dest register
+    const bool unpack_to_dest = (unpack_src_format == static_cast<std::underlying_type_t<DataFormat>>(DataFormat::UInt32)) ||
+                                (unpack_src_format == static_cast<std::underlying_type_t<DataFormat>>(DataFormat::Int32));
 
     std::uint32_t top_face_offset_address = SCALE_DATUM_SIZE(unpack_src_format, tile_index) << (narrow_tile ? 0 : 1);
     // Each iteration unpacks 2 face_r_dimx16 faces (1st 0,1 2nd 2,3 unless tile is <=16x32)
@@ -107,93 +227,13 @@ inline void _llk_unpack_tilize_(
     // Program srcA and srcB base addresses
     std::uint32_t num_loops = narrow_tile ? 2 : num_faces / 2;
 
-    if (!is_32bit_integer)
+    if (!unpack_to_dest)
     {
-        for (std::uint32_t n = 0; n < num_loops; n++)
-        {
-            std::uint32_t address = base_address + top_face_offset_address + ((n == 1) ? bot_face_offset_address : 0);
-
-            // Clear z/w start counters
-            TTI_SETADCZW(0b001, 0, 0, 0, 0, 0b1111);
-
-            // Wait for free context
-            wait_for_next_context(2);
-
-            // Get tile address
-            if (0 == unp_cfg_context)
-            {
-                cfg[THCON_SEC0_REG3_Base_address_ADDR32] = address;
-            }
-            else
-            {
-                cfg[THCON_SEC0_REG3_Base_cntx1_address_ADDR32] = address;
-            }
-
-            // Trisc::SEMPOST for context acquire
-            semaphore_post(semaphore::UNPACK_SYNC);
-
-            // Stall unpacker until pending CFG writes from Trisc have completed
-            TTI_STALLWAIT(p_stall::STALL_UNPACK, p_stall::TRISC_CFG);
-
-            // Run MOP
-            ckernel::ckernel_template::run(instrn_buffer);
-
-            // T6::SEMGET for context release
-            t6_semaphore_get(semaphore::UNPACK_SYNC);
-
-            // Switch unpacker config context
-            switch_config_context(unp_cfg_context);
-        }
+        unpack_tilize_impl(base_address, num_loops, top_face_offset_address, bot_face_offset_address);
     }
     else
     {
-        // Unpack to dest register
-        set_dst_write_addr(unp_cfg_context, unpack_src_format);
-        wait_for_dest_available();
-
-        // Trisc::SEMPOST for context acquire
-        semaphore_post(semaphore::UNPACK_SYNC);
-        std::uint32_t address = base_address + top_face_offset_address;
-
-        // Unroll loop to save cycles
-        // Clear z/w start counters
-        TTI_SETADCZW(0b001, 0, 0, 0, 0, 0b1111);
-
-        // Get tile address
-        cfg[THCON_SEC0_REG3_Base_address_ADDR32] = address;
-
-        // Stall unpacker until pending CFG writes from Trisc have completed
-        TTI_STALLWAIT(p_stall::STALL_UNPACK, p_stall::TRISC_CFG);
-
-        // Unpack top faces
-        TTI_UNPACR(SrcA, 0b00010001 /*CH0/CH1 Z inc*/, 0, 0, 0, 1 /* Set OvrdThreadId*/, 0, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
-        TTI_UNPACR(SrcA, 0b00010001 /*CH0/CH1 Z inc*/, 0, 0, 0, 1 /* Set OvrdThreadId*/, 0, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
-
-        if (num_loops > 1)
-        {
-            // Needed to stall counter reconfiguration until unpacker finishes previous instruction
-            TTI_STALLWAIT(p_stall::STALL_TDMA, p_stall::UNPACK);
-
-            // Don't clear the CH1 W counter - needed for multiple tiles
-            TTI_SETADCZW(0b001, 0, 0, 0, 0, 0b1011);
-
-            // Increment address to point to bottom faces in L1
-            address += bot_face_offset_address;
-
-            // Get tile address
-            cfg[THCON_SEC0_REG3_Base_address_ADDR32] = address;
-
-            // Stall unpacker until pending CFG writes from Trisc have completed
-            TTI_STALLWAIT(p_stall::STALL_UNPACK, p_stall::TRISC_CFG);
-
-            // Unpack bottom faces
-            TTI_UNPACR(SrcA, 0b00010001 /*CH0/CH1 Z inc*/, 0, 0, 0, 1 /* Set OvrdThreadId*/, 0, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
-            TTI_UNPACR(SrcA, 0b00010001 /*CH0/CH1 Z inc*/, 0, 0, 0, 1 /* Set OvrdThreadId*/, 0, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
-        }
-
-        // T6::SEMGET for context release
-        t6_semaphore_get(semaphore::UNPACK_SYNC);
-        unpack_to_dest_tile_done(unp_cfg_context);
+        unpack_tilize_to_dest_impl(base_address, unpack_src_format, num_loops, top_face_offset_address, bot_face_offset_address);
     }
 
 #ifdef PERF_DUMP

--- a/tt_llk_wormhole_b0/llk_lib/llk_unpack_tilize.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_unpack_tilize.h
@@ -150,7 +150,7 @@ inline void unpack_tilize_to_dest_impl(
     std::uint32_t top_face_offset_address,
     std::uint32_t bot_face_offset_address)
 {
-    volatile uint tt_reg_ptr *cfg = get_cfg_pointer(); // get pointer to registers for current state ID
+    volatile uint tt_reg_ptr* cfg = get_cfg_pointer(); // get pointer to registers for current state ID
 
     // Unpack to dest register
     set_dst_write_addr(unp_cfg_context, unpack_src_format);


### PR DESCRIPTION
### Ticket
[#16860](https://github.com/tenstorrent/tt-metal/issues/16860)
### Problem description
Int32/UInt32 tilize support was missing on both WH and BH.

### What's changed
In order to tilize 32-bit inputs without losing accuracy, the data cannot be unpacked to Source A/Source B registers - the provided solution unpacks tilized 32-bit integers directly into the destination register. 

### Type of change
- [x] New feature (non-breaking change which adds functionality)
