### PR TITLE
build: switch IRD base image to metaillium-dev

### DIFF
--- a/.github/Dockerfile.ird
+++ b/.github/Dockerfile.ird
@@ -1,4 +1,4 @@
-FROM ghcr.io/tenstorrent/tt-metal/tt-metalium/ubuntu-22.04-amd64:latest
+FROM ghcr.io/tenstorrent/tt-metal/tt-metalium/ubuntu-22.04-dev-amd64:latest
 SHELL ["/bin/bash", "-c"]
 
 # Set environment variables


### PR DESCRIPTION
### Ticket
None

### Problem description
There's compile issue when building tt-metal using our tt-llk IRD image:
```
In file included from /localdev/fvranic/tt-metal/tt_metal/common/metal_soc_descriptor.cpp:5:
In file included from /localdev/fvranic/tt-metal/tt_metal/api/tt-metalium/metal_soc_descriptor.h:14:
In file included from /localdev/fvranic/tt-metal/tt_metal/third_party/umd/device/api/umd/device/tt_cluster_descriptor.h:19:
In file included from /localdev/fvranic/tt-metal/tt_metal/third_party/umd/device/api/umd/device/chip/chip.h:9:
/localdev/fvranic/tt-metal/tt_metal/third_party/umd/device/api/umd/device/lock_manager.h:8:10: fatal error: 'boost/interprocess/sync/named_mutex.hpp' file not found
    8 | #include <boost/interprocess/sync/named_mutex.hpp>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
[355/1675] Building CXX object tt_metal/common/CMakeFiles/common.dir/core_coord.cpp.o
ninja: build stopped: subcommand failed.
```
It turns out this issue isn't visible when using dev image (in fact it is [masked](https://tenstorrent.slack.com/archives/C06JU0GUNGY/p1743698301695239?thread_ts=1743687502.988899&cid=C06JU0GUNGY), but that problem is in someone else's yard).
For us it doesn't matter much, since we will be able to build metal until issue in UMD gets resolved.

### What's changed
This PR switches base IRD image to metallium-dev, as the non-dev one is now deprecated.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
