### PR TITLE
Throttle MM Perf

### DIFF
--- a/tt_llk_blackhole/common/inc/cmath_common.h
+++ b/tt_llk_blackhole/common/inc/cmath_common.h
@@ -37,12 +37,8 @@ constexpr uint DstTileSizeLog2[3] = {
     4  // 16x16 tile shape
 };
 
-#ifdef MM_THROTTLE
-constexpr uint replay_buf_offset = MM_THROTTLE > 3 ? 8 : 16; // split replay buffer usage between fpu/sfpu
-#else
 constexpr uint replay_buf_offset = 16; // split replay buffer usage between fpu/sfpu
                                        // first 16 for sfpu, next 16 for fpu
-#endif
 
 inline void reset_counters(const uint setrwc)
 {

--- a/tt_llk_blackhole/common/inc/cmath_common.h
+++ b/tt_llk_blackhole/common/inc/cmath_common.h
@@ -37,8 +37,8 @@ constexpr uint DstTileSizeLog2[3] = {
     4  // 16x16 tile shape
 };
 
-#ifdef THROTTLE_MM
-constexpr uint replay_buf_offset = THROTTLE_MM > 3 ? 8 : 16; // split replay buffer usage between fpu/sfpu
+#ifdef MM_THROTTLE
+constexpr uint replay_buf_offset = MM_THROTTLE > 3 ? 8 : 16; // split replay buffer usage between fpu/sfpu
 #else
 constexpr uint replay_buf_offset = 16; // split replay buffer usage between fpu/sfpu
                                        // first 16 for sfpu, next 16 for fpu

--- a/tt_llk_blackhole/common/inc/cmath_common.h
+++ b/tt_llk_blackhole/common/inc/cmath_common.h
@@ -37,8 +37,13 @@ constexpr uint DstTileSizeLog2[3] = {
     4  // 16x16 tile shape
 };
 
-constexpr uint replay_buf_offset = 16; // split replay buffer usage between fpu/sfpu
+#ifdef MM_ADD_NOPS
+constexpr uint replay_buf_offset = 8; // split replay buffer usage between fpu/sfpu
                                        // fist 16 for sfpu, next 16 for fpu
+#else
+constexpr uint replay_buf_offset = 16; // split replay buffer usage between fpu/sfpu
+                                        // fist 16 for sfpu, next 16 for fpu
+#endif
 
 inline void reset_counters(const uint setrwc)
 {

--- a/tt_llk_blackhole/common/inc/cmath_common.h
+++ b/tt_llk_blackhole/common/inc/cmath_common.h
@@ -39,10 +39,10 @@ constexpr uint DstTileSizeLog2[3] = {
 
 #ifdef MM_ADD_NOPS
 constexpr uint replay_buf_offset = 8; // split replay buffer usage between fpu/sfpu
-                                       // fist 16 for sfpu, next 16 for fpu
+                                      // first 8 for sfpu, next 24 for fpu
 #else
 constexpr uint replay_buf_offset = 16; // split replay buffer usage between fpu/sfpu
-                                        // fist 16 for sfpu, next 16 for fpu
+                                       // first 16 for sfpu, next 16 for fpu
 #endif
 
 inline void reset_counters(const uint setrwc)

--- a/tt_llk_blackhole/common/inc/cmath_common.h
+++ b/tt_llk_blackhole/common/inc/cmath_common.h
@@ -37,9 +37,8 @@ constexpr uint DstTileSizeLog2[3] = {
     4  // 16x16 tile shape
 };
 
-#ifdef MM_ADD_NOPS
-constexpr uint replay_buf_offset = 8; // split replay buffer usage between fpu/sfpu
-                                      // first 8 for sfpu, next 24 for fpu
+#ifdef THROTTLE_MM
+constexpr uint replay_buf_offset = THROTTLE_MM > 3 ? 8 : 16; // split replay buffer usage between fpu/sfpu
 #else
 constexpr uint replay_buf_offset = 16; // split replay buffer usage between fpu/sfpu
                                        // first 16 for sfpu, next 16 for fpu

--- a/tt_llk_blackhole/llk_lib/llk_math_matmul.h
+++ b/tt_llk_blackhole/llk_lib/llk_math_matmul.h
@@ -16,8 +16,8 @@
 #define HF 0
 #endif
 
-#ifndef THROTTLE_MM
-#define THROTTLE_MM 0
+#ifndef MM_THROTTLE
+#define MM_THROTTLE 0
 #endif
 
 using namespace ckernel;
@@ -425,6 +425,18 @@ inline void matmul_configure_mop(
     tmp.program(instrn_buffer);
 }
 
+/*
+ * Programming of the MOP for the case we limit matmul compute throughput
+ * Done by inserting NOP instructions between MVMUL instructions of matmul kernel
+ *
+ * Valid range of THROTTLE_LEVEL is {1,2,3,4,5}
+ * Each value corresponds to level of throttling as:
+ * Level 1: throttle to 73% of max
+ * Level 2: throttle to 67% of max
+ * Level 3: throttle to 50% of max
+ * Level 4: throttle to 40% of max
+ * Level 5: throttle to 33% of max
+ */
 template <int NUM_FIDELITY_PHASES, DstTileFaceLayout FaceLayout = DstTileFaceLayout::ColMajor, int THROTTLE_LEVEL>
 inline void matmul_configure_mop_throttled(
     bool transpose,
@@ -672,13 +684,13 @@ inline void _llk_math_matmul_init_(
     const std::uint32_t rt_dim         = 1,
     const std::uint32_t kt_dim         = 1)
 {
-    matmul_configure_addrmod<MATH_FIDELITY_DESC, FaceLayout, THROTTLE_MM>(
+    matmul_configure_addrmod<MATH_FIDELITY_DESC, FaceLayout, MM_THROTTLE>(
         transpose, ct_dim, rt_dim, kt_dim, in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face);
 
     constexpr int MATH_FIDELITY_PHASES = get_math_num_fidelity_phases(MATH_FIDELITY_DESC);
-    if constexpr (THROTTLE_MM > 0)
+    if constexpr (MM_THROTTLE > 0)
     {
-        matmul_configure_mop_throttled<MATH_FIDELITY_PHASES, FaceLayout, THROTTLE_MM>(
+        matmul_configure_mop_throttled<MATH_FIDELITY_PHASES, FaceLayout, MM_THROTTLE>(
             transpose > 0, ct_dim, rt_dim, kt_dim, in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face);
     }
     else

--- a/tt_llk_blackhole/llk_lib/llk_math_matmul.h
+++ b/tt_llk_blackhole/llk_lib/llk_math_matmul.h
@@ -296,8 +296,13 @@ inline void matmul_configure_mop(
     const bool is_in0_32x16 = (in0_tile_r_dim > FACE_R_DIM) && (in0_tile_c_dim <= FACE_C_DIM);
     const bool is_in1_16x32 = (in1_tile_r_dim <= FACE_R_DIM) && (in1_tile_c_dim > FACE_C_DIM);
 
-    const std::uint32_t replay_buf_len =
-        (is_in0_16x32 && is_in1_32x16) ? 4 : ((is_in0_16x32 || is_in1_32x16 || is_in0_32x16 || is_in1_16x32) ? (partial_face ? 4 : 8) : 16);
+#ifdef MM_ADD_NOPS
+    const std::uint32_t replay_buf_len = (is_in0_16x32 && is_in1_32x16) ? 4 :
+                                         ((is_in0_16x32 || is_in1_32x16 || is_in0_32x16 || is_in1_16x32) ? (partial_face ? 4 : 8) : 21);
+#else    
+    const std::uint32_t replay_buf_len = (is_in0_16x32 && is_in1_32x16) ? 4 :
+                                         ((is_in0_16x32 || is_in1_32x16 || is_in0_32x16 || is_in1_16x32) ? (partial_face ? 4 : 8) : 16);
+#endif
 
     load_replay_buf(
         ckernel::math::replay_buf_offset,
@@ -352,10 +357,17 @@ inline void matmul_configure_mop(
                 TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B0A0 // srca=srca, srcb+=8,  dest+=8
                 TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0); // B0A0 // srca+=16/32, srcb=0, dest+=8  // srca+=32 if transposed
                 TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B0A1 // srca=srca, srcb+=8,  dest+=8  // A1 -> A2 if transposed
+                #ifdef MM_ADD_NOPS
+                TTI_NOP;
+                #endif
                 TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_2, 0); // B0A1 // srca=0,    srcb=32,  dest+=8  // A1 -> A2 if transposed
 
                 TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B2A0 // srca=srca, srcb+=8,  dest+=8
                 TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0); // B2A0 // srca+=16/32, srcb=0, dest+=8 // srca+=32 if transposed
+                #ifdef MM_ADD_NOPS
+                TTI_NOP;
+                #endif
+
                 TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B2A1 // srca=srca, srcb+=8,  dest+=8 // A1 -> A2 if transposed
                 if (!is_in1_16x32)
                 {
@@ -363,13 +375,23 @@ inline void matmul_configure_mop(
                     TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_4, 0); // B2A1 // srca=32/16,srcb=16,  dest=0 (addr_mod_4) // A1 -> A2 && srca=16 if transposed
 
                     TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B1A2 // srca=srca, srcb+=8,  dest+=8 // A2 -> A1 if transposed
+                    #ifdef MM_ADD_NOPS
+                    TTI_NOP;
+                    #endif
+
                     TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0); // B1A2 // srca+=16,  srcb=16,  dest+=8 // A2 -> A1 if transposed
                     TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B1A3 // srca=srca, srcb+=8,  dest+=8
                     TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_2, 0); // B1A3 // srca=32,   srcb=48,  dest+=8
+                    #ifdef MM_ADD_NOPS
+                    TTI_NOP;
+                    #endif
 
                     TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B3A2 // srca=srca, srcb+=8,  dest+=8 // A2 -> A1 if transposed
                     TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0); // B3A2 // srca+=16,  srcb=0,   dest+=8 // A2 -> A1 if transposed
                     TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B3A3 // srca=srca, srcb+=8,  dest+=8
+                    #ifdef MM_ADD_NOPS
+                    TTI_NOP;
+                    #endif
                 }
             }
 

--- a/tt_llk_blackhole/llk_lib/llk_math_matmul.h
+++ b/tt_llk_blackhole/llk_lib/llk_math_matmul.h
@@ -672,13 +672,13 @@ inline void _llk_math_matmul_init_(
     const std::uint32_t rt_dim         = 1,
     const std::uint32_t kt_dim         = 1)
 {
-    matmul_configure_addrmod<MATH_FIDELITY_DESC, FaceLayout, THROTTLE_LEVEL>(
+    matmul_configure_addrmod<MATH_FIDELITY_DESC, FaceLayout, THROTTLE_MM>(
         transpose, ct_dim, rt_dim, kt_dim, in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face);
 
     constexpr int MATH_FIDELITY_PHASES = get_math_num_fidelity_phases(MATH_FIDELITY_DESC);
-    if constexpr (THROTTLE_LEVEL > 0)
+    if constexpr (THROTTLE_MM > 0)
     {
-        matmul_configure_mop_throttled<MATH_FIDELITY_PHASES, FaceLayout, THROTTLE_LEVEL>(
+        matmul_configure_mop_throttled<MATH_FIDELITY_PHASES, FaceLayout, THROTTLE_MM>(
             transpose > 0, ct_dim, rt_dim, kt_dim, in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face);
     }
     else

--- a/tt_llk_blackhole/llk_lib/llk_math_matmul.h
+++ b/tt_llk_blackhole/llk_lib/llk_math_matmul.h
@@ -22,7 +22,7 @@
 
 using namespace ckernel;
 
-template <int MATH_FIDELITY_DESC, DstTileFaceLayout FaceLayout = DstTileFaceLayout::ColMajor>
+template <int MATH_FIDELITY_DESC, DstTileFaceLayout FaceLayout = DstTileFaceLayout::ColMajor, int NUM_NOPS>
 inline void matmul_configure_addrmod(
     const bool transpose,
     const std::uint32_t ct_dim,
@@ -66,6 +66,17 @@ inline void matmul_configure_addrmod(
         .fidelity = {.incr = FIDELITY_INCREMENT, .clr = 0},
     }
         .set(ADDR_MOD_5);
+
+    if constexpr (NUM_NOPS) {
+        // reset all, including fidelity
+        addr_mod_t {
+            .srca     = {.incr = 0, .clr = 1, .cr = 1},
+            .srcb     = {.incr = 0, .clr = 1, .cr = 1},
+            .dest     = {.incr = 0, .clr = 1, .cr = 1},
+            .fidelity = {.incr = 0, .clr = 1},
+        }
+        .set(ADDR_MOD_6);
+    }
 
     if ((is_in0_16x32 && (!is_in1_32x16)) || is_in0_32x16)
     {
@@ -270,7 +281,7 @@ inline void matmul_configure_addrmod(
     }
 }
 
-template <int NUM_FIDELITY_PHASES, DstTileFaceLayout FaceLayout = DstTileFaceLayout::ColMajor, int ADD_NOPS = 0>
+template <int NUM_FIDELITY_PHASES, DstTileFaceLayout FaceLayout = DstTileFaceLayout::ColMajor>
 inline void matmul_configure_mop(
     bool transpose,
     const std::uint32_t ct_dim,
@@ -300,8 +311,8 @@ inline void matmul_configure_mop(
     const bool is_in0_32x16 = (in0_tile_r_dim > FACE_R_DIM) && (in0_tile_c_dim <= FACE_C_DIM);
     const bool is_in1_16x32 = (in1_tile_r_dim <= FACE_R_DIM) && (in1_tile_c_dim > FACE_C_DIM);
 
-    const std::uint32_t replay_buf_len = (is_in0_16x32 && is_in1_32x16) ? 4 :
-                                        ((is_in0_16x32 || is_in1_32x16 || is_in0_32x16 || is_in1_16x32) ? (partial_face ? 4 : 8) : (16 + 5*ADD_NOPS)); // up to 31 needed
+    const std::uint32_t replay_buf_len =
+        (is_in0_16x32 && is_in1_32x16) ? 4 : ((is_in0_16x32 || is_in1_32x16 || is_in0_32x16 || is_in1_16x32) ? (partial_face ? 4 : 8) : 16);
 
     load_replay_buf(
         ckernel::math::replay_buf_offset,
@@ -356,29 +367,10 @@ inline void matmul_configure_mop(
                 TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B0A0 // srca=srca, srcb+=8,  dest+=8
                 TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0); // B0A0 // srca+=16/32, srcb=0, dest+=8  // srca+=32 if transposed
                 TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B0A1 // srca=srca, srcb+=8,  dest+=8  // A1 -> A2 if transposed
-                if constexpr (ADD_NOPS) {
-                    TTI_NOP;
-                    if constexpr (ADD_NOPS > 1) {
-                        TTI_NOP;
-                        if constexpr (ADD_NOPS > 2) {
-                            TTI_NOP;
-                        }
-                    }
-                }
                 TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_2, 0); // B0A1 // srca=0,    srcb=32,  dest+=8  // A1 -> A2 if transposed
 
                 TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B2A0 // srca=srca, srcb+=8,  dest+=8
                 TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0); // B2A0 // srca+=16/32, srcb=0, dest+=8 // srca+=32 if transposed
-                if constexpr (ADD_NOPS) {
-                    TTI_NOP;
-                    if constexpr (ADD_NOPS > 1) {
-                        TTI_NOP;
-                        if constexpr (ADD_NOPS > 2) {
-                            TTI_NOP;
-                        }
-                    }
-                }
-
                 TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B2A1 // srca=srca, srcb+=8,  dest+=8 // A1 -> A2 if transposed
                 if (!is_in1_16x32)
                 {
@@ -386,41 +378,13 @@ inline void matmul_configure_mop(
                     TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_4, 0); // B2A1 // srca=32/16,srcb=16,  dest=0 (addr_mod_4) // A1 -> A2 && srca=16 if transposed
 
                     TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B1A2 // srca=srca, srcb+=8,  dest+=8 // A2 -> A1 if transposed
-                    if constexpr (ADD_NOPS) {
-                        TTI_NOP;
-                        if constexpr (ADD_NOPS > 1) {
-                            TTI_NOP;
-                            if constexpr (ADD_NOPS > 2) {
-                                TTI_NOP;
-                            }
-                        }
-                    }
-
                     TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0); // B1A2 // srca+=16,  srcb=16,  dest+=8 // A2 -> A1 if transposed
                     TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B1A3 // srca=srca, srcb+=8,  dest+=8
                     TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_2, 0); // B1A3 // srca=32,   srcb=48,  dest+=8
-                    if constexpr (ADD_NOPS) {
-                        TTI_NOP;
-                        if constexpr (ADD_NOPS > 1) {
-                            TTI_NOP;
-                            if constexpr (ADD_NOPS > 2) {
-                                TTI_NOP;
-                            }
-                        }
-                    }
 
                     TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B3A2 // srca=srca, srcb+=8,  dest+=8 // A2 -> A1 if transposed
                     TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0); // B3A2 // srca+=16,  srcb=0,   dest+=8 // A2 -> A1 if transposed
                     TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B3A3 // srca=srca, srcb+=8,  dest+=8
-                    if constexpr (ADD_NOPS) {
-                        TTI_NOP;
-                        if constexpr (ADD_NOPS > 1) {
-                            TTI_NOP;
-                            if constexpr (ADD_NOPS > 2) {
-                                TTI_NOP;
-                            }
-                        }
-                    }
                 }
             }
 
@@ -460,6 +424,154 @@ inline void matmul_configure_mop(
     tmp.program(instrn_buffer);
 }
 
+template <int NUM_FIDELITY_PHASES, DstTileFaceLayout FaceLayout = DstTileFaceLayout::ColMajor, int NUM_NOPS>
+inline void matmul_configure_mop_throttled(
+    bool transpose,
+    const std::uint32_t ct_dim,
+    const std::uint32_t rt_dim,
+    const std::uint32_t kt_dim,
+    const std::uint32_t in0_tile_r_dim = TILE_R_DIM,
+    const std::uint32_t in0_tile_c_dim = TILE_C_DIM,
+    const std::uint32_t in1_tile_r_dim = TILE_R_DIM,
+    const std::uint32_t in1_tile_c_dim = TILE_C_DIM,
+    const bool partial_face            = false)
+{
+    // in0 - loaded to SrcB
+    // in1 - loaded to SrcA
+    // Unpacker will always load faces in f0,f1,f2,f3 order
+    // if in1 is transposed then faces 1&2 need to be swapped during read
+    // by changing address increment amount via addr_mods
+    // Col major layout in dest only impacs destination address increment
+    // if col major layout faces are ordered as f0,f2,f1,f3
+
+    constexpr bool high_fidelity = NUM_FIDELITY_PHASES > 0;
+    static_assert((NUM_NOPS > 0) && (NUM_NOPS <= 3), "MM throttling only enabled for NUM_NOPS={1,2,3}");
+
+    const bool reuse_a        = ct_dim >= rt_dim;
+    const std::uint32_t t_dim = reuse_a ? rt_dim : ct_dim;
+
+    const bool is_in0_16x32 = (in0_tile_r_dim <= FACE_R_DIM) && (in0_tile_c_dim > FACE_C_DIM);
+    const bool is_in1_32x16 = (in1_tile_r_dim > FACE_R_DIM) && (in1_tile_c_dim <= FACE_C_DIM);
+    const bool is_in0_32x16 = (in0_tile_r_dim > FACE_R_DIM) && (in0_tile_c_dim <= FACE_C_DIM);
+    const bool is_in1_16x32 = (in1_tile_r_dim <= FACE_R_DIM) && (in1_tile_c_dim > FACE_C_DIM);
+
+    const std::uint32_t replay_buf_len = (is_in0_16x32 && is_in1_32x16) ? 4 :
+                                        ((is_in0_16x32 || is_in1_32x16 || is_in0_32x16 || is_in1_16x32) ? (partial_face ? 4 : 8) : (7 + NUM_NOPS*4));
+
+    load_replay_buf(
+        ckernel::math::replay_buf_offset,
+        replay_buf_len,
+        false,
+        // Lambda function to load reply buffer
+        [high_fidelity, reuse_a, partial_face, is_in1_32x16, is_in0_16x32, is_in0_32x16, is_in1_16x32, t_dim]
+        {
+            if (is_in1_32x16)
+            {
+                if (is_in0_16x32)
+                {
+                    // FIXME
+                }
+                else
+                {
+                    // FIXME
+                }
+            }
+            else if (is_in0_16x32 || is_in0_32x16)
+            {
+                if (partial_face)
+                {
+                    // FIXME
+                }
+                else
+                {
+                    // FIXME
+                }
+            }
+            else
+            {
+                TTI_NOP;
+                TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B0A0 // srca=srca, srcb+=8,  dest+=8
+                if constexpr (NUM_NOPS > 1) {
+                    TTI_NOP;
+                    if constexpr (NUM_NOPS > 2) {
+                        TTI_NOP;
+                    }
+                }
+                TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0); // B0A0 // srca+=16/32, srcb=0, dest+=8  // srca+=32 if transposed
+                
+                TTI_NOP;
+                TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B0A1 // srca=srca, srcb+=8,  dest+=8  // A1 -> A2 if transposed
+                if constexpr (NUM_NOPS > 1) {
+                    TTI_NOP;
+                    if constexpr (NUM_NOPS > 2) {
+                        TTI_NOP;
+                    }
+                }
+                TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_2, 0); // B0A1 // srca=0,    srcb=32,  dest+=8  // A1 -> A2 if transposed
+
+                TTI_NOP;
+                TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B2A0 // srca=srca, srcb+=8,  dest+=8
+                if constexpr (NUM_NOPS > 1) {
+                    TTI_NOP;
+                    if constexpr (NUM_NOPS > 2) {
+                        TTI_NOP;
+                    }
+                }
+                TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0); // B2A0 // srca+=16/32, srcb=0, dest+=8 // srca+=32 if transposed
+                
+                TTI_NOP;
+                TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B2A1 // srca=srca, srcb+=8,  dest+=8 // A1 -> A2 if transposed
+                if constexpr (NUM_NOPS > 1) {
+                    TTI_NOP;
+                    if constexpr (NUM_NOPS > 2) {
+                        TTI_NOP;
+                    }
+                }        
+            }
+        });
+
+    constexpr uint outer_loops = high_fidelity ? NUM_FIDELITY_PHASES : 1;
+    const uint inner_loops = (!is_in1_16x32) ? 2 : 1;
+    ckernel_template tmp(outer_loops, inner_loops, TT_OP_REPLAY(ckernel::math::replay_buf_offset, replay_buf_len, 0, 0), TT_OP_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_4, 0));
+    if (is_in1_16x32) {
+        // FIXME
+    }
+
+    if (is_in1_32x16) {
+        if (is_in0_16x32) {
+            // FIXME
+        } else {
+            // FIXME
+        }    
+    } else if (is_in0_16x32 || is_in0_32x16) {
+        if (partial_face) {
+            // FIXME
+        } else {
+            // FIXME
+        }
+    } else {
+        if (!is_in1_16x32) {
+            if constexpr (high_fidelity) {
+                tmp.set_last_inner_loop_instr(TT_OP_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_5, 0)); // B3A3 or B3A2 // reset srca/srcb/dest, increment phase (addr_mod_5)
+                if (reuse_a) {
+                    tmp.set_last_outer_loop_instr(TT_OP_MVMUL(p_setrwc::CLR_A, 0, ADDR_MOD_6, 0)); // B3A3 or B3A2 // reset srca/srcb/dest/phase (addr_mod_6), clear src A
+                } else {
+                    tmp.set_last_outer_loop_instr(TT_OP_MVMUL(p_setrwc::CLR_B, 0, ADDR_MOD_6, 0)); // B3A3 or B3A2 // reset srca/srcb/dest/phase (addr_mod_6), clear src B
+                }
+            } else {
+                if (reuse_a) {
+                    tmp.set_last_outer_loop_instr(TT_OP_MVMUL(p_setrwc::CLR_A, 0, ADDR_MOD_5, 0)); // B3A3 or B3A2 // reset srca/srcb/dest, increment phase (addr_mod_5), clear src A
+                } else {
+                    tmp.set_last_outer_loop_instr(TT_OP_MVMUL(p_setrwc::CLR_B, 0, ADDR_MOD_5, 0)); // B3A3 or B2A1 // reset srca/srcb/dest, increment phase (addr_mod_5), clear src B
+                }
+            }
+        } else {
+            // FIXME
+        }
+    }
+    tmp.program(instrn_buffer);
+}
+
 template <int MATH_FIDELITY_DESC, DstTileFaceLayout FaceLayout = DstTileFaceLayout::ColMajor>
 inline void _llk_math_matmul_init_(
     const std::uint32_t in0_tile_r_dim = TILE_R_DIM,
@@ -472,12 +584,15 @@ inline void _llk_math_matmul_init_(
     const std::uint32_t rt_dim         = 1,
     const std::uint32_t kt_dim         = 1)
 {
-    matmul_configure_addrmod<MATH_FIDELITY_DESC, FaceLayout>(
+    matmul_configure_addrmod<MATH_FIDELITY_DESC, FaceLayout, MM_ADD_NOPS>(
         transpose, ct_dim, rt_dim, kt_dim, in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face);
 
     constexpr int MATH_FIDELITY_PHASES = get_math_num_fidelity_phases(MATH_FIDELITY_DESC);
-    matmul_configure_mop<MATH_FIDELITY_PHASES, FaceLayout, MM_ADD_NOPS>(
-        transpose > 0, ct_dim, rt_dim, kt_dim, in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face);
+    if constexpr (MM_ADD_NOPS > 0) {
+        matmul_configure_mop_throttled<MATH_FIDELITY_PHASES, FaceLayout, MM_ADD_NOPS>(transpose>0, ct_dim, rt_dim, kt_dim, in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face);
+    } else {
+        matmul_configure_mop<MATH_FIDELITY_PHASES, FaceLayout>(transpose>0, ct_dim, rt_dim, kt_dim, in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face);
+    }
     math::reset_counters(p_setrwc::SET_ABD_F);
 }
 

--- a/tt_llk_blackhole/llk_lib/llk_math_matmul.h
+++ b/tt_llk_blackhole/llk_lib/llk_math_matmul.h
@@ -577,48 +577,23 @@ inline void matmul_configure_mop_throttled(
 
     if (!is_in1_32x16 && !is_in1_16x32 && !is_in0_32x16 && !is_in0_16x32)
     {
-        if constexpr (high_fidelity)
+        if constexpr (high_fidelity && THROTTLE_LEVEL > 3)
         {
-            if constexpr (THROTTLE_LEVEL > 3)
-            {
-                tmp.set_last_inner_loop_instr(
-                    TT_OP_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_4, 0)); // B2A1 // srca=32/16,srcb=16,  dest=0 (addr_mod_4) // A1 -> A2 && srca=16 if transposed
-                tmp.set_last_outer_loop_instr(
-                    TT_OP_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_5, 0)); // B3A3 or B3A2 // reset srca/srcb/dest, increment phase (addr_mod_5)
-            }
-            else
-            {
-                tmp.set_last_inner_loop_instr(
-                    TT_OP_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_5, 0)); // B3A3 or B3A2 // reset srca/srcb/dest, increment phase (addr_mod_5)
-                if (reuse_a)
-                {
-                    tmp.set_last_outer_loop_instr(
-                        TT_OP_MVMUL(p_setrwc::CLR_A, 0, ADDR_MOD_6, 0)); // B3A3 or B3A2 // reset srca/srcb/dest/phase (addr_mod_6), clear src A
-                }
-                else
-                {
-                    tmp.set_last_outer_loop_instr(
-                        TT_OP_MVMUL(p_setrwc::CLR_B, 0, ADDR_MOD_6, 0)); // B3A3 or B3A2 // reset srca/srcb/dest/phase (addr_mod_6), clear src B
-                }
-            }
+            tmp.set_last_inner_loop_instr(TT_OP_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_4, 0));
+            tmp.set_last_outer_loop_instr(TT_OP_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_5, 0));
+        }
+        else if constexpr (high_fidelity)
+        {
+            tmp.set_last_inner_loop_instr(TT_OP_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_5, 0));
+            tmp.set_last_outer_loop_instr(TT_OP_MVMUL(reuse_a ? p_setrwc::CLR_A : p_setrwc::CLR_B, 0, ADDR_MOD_6, 0));
         }
         else
         {
             if constexpr (THROTTLE_LEVEL > 3)
             {
-                tmp.set_last_inner_loop_instr(
-                    TT_OP_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_4, 0)); // B2A1 // srca=32/16,srcb=16,  dest=0 (addr_mod_4) // A1 -> A2 && srca=16 if transposed
+                tmp.set_last_inner_loop_instr(TT_OP_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_4, 0));
             }
-            if (reuse_a)
-            {
-                tmp.set_last_outer_loop_instr(
-                    TT_OP_MVMUL(p_setrwc::CLR_A, 0, ADDR_MOD_5, 0)); // B3A3 or B3A2 // reset srca/srcb/dest, increment phase (addr_mod_5), clear src A
-            }
-            else
-            {
-                tmp.set_last_outer_loop_instr(
-                    TT_OP_MVMUL(p_setrwc::CLR_B, 0, ADDR_MOD_5, 0)); // B3A3 or B2A1 // reset srca/srcb/dest, increment phase (addr_mod_5), clear src B
-            }
+            tmp.set_last_outer_loop_instr(TT_OP_MVMUL(reuse_a ? p_setrwc::CLR_A : p_setrwc::CLR_B, 0, ADDR_MOD_5, 0));
         }
     }
 

--- a/tt_llk_blackhole/llk_lib/llk_math_matmul.h
+++ b/tt_llk_blackhole/llk_lib/llk_math_matmul.h
@@ -16,13 +16,13 @@
 #define HF 0
 #endif
 
-#ifndef MM_ADD_NOPS
-#define MM_ADD_NOPS 0
+#ifndef THROTTLE_MM
+#define THROTTLE_MM 0
 #endif
 
 using namespace ckernel;
 
-template <int MATH_FIDELITY_DESC, DstTileFaceLayout FaceLayout = DstTileFaceLayout::ColMajor, int NUM_NOPS>
+template <int MATH_FIDELITY_DESC, DstTileFaceLayout FaceLayout = DstTileFaceLayout::ColMajor, int THROTTLE_LEVEL>
 inline void matmul_configure_addrmod(
     const bool transpose,
     const std::uint32_t ct_dim,
@@ -67,7 +67,8 @@ inline void matmul_configure_addrmod(
     }
         .set(ADDR_MOD_5);
 
-    if constexpr (NUM_NOPS) {
+    if constexpr (THROTTLE_LEVEL)
+    {
         // reset all, including fidelity
         addr_mod_t {
             .srca     = {.incr = 0, .clr = 1, .cr = 1},
@@ -75,7 +76,7 @@ inline void matmul_configure_addrmod(
             .dest     = {.incr = 0, .clr = 1, .cr = 1},
             .fidelity = {.incr = 0, .clr = 1},
         }
-        .set(ADDR_MOD_6);
+            .set(ADDR_MOD_6);
     }
 
     if ((is_in0_16x32 && (!is_in1_32x16)) || is_in0_32x16)
@@ -424,7 +425,7 @@ inline void matmul_configure_mop(
     tmp.program(instrn_buffer);
 }
 
-template <int NUM_FIDELITY_PHASES, DstTileFaceLayout FaceLayout = DstTileFaceLayout::ColMajor, int NUM_NOPS>
+template <int NUM_FIDELITY_PHASES, DstTileFaceLayout FaceLayout = DstTileFaceLayout::ColMajor, int THROTTLE_LEVEL>
 inline void matmul_configure_mop_throttled(
     bool transpose,
     const std::uint32_t ct_dim,
@@ -445,7 +446,7 @@ inline void matmul_configure_mop_throttled(
     // if col major layout faces are ordered as f0,f2,f1,f3
 
     constexpr bool high_fidelity = NUM_FIDELITY_PHASES > 0;
-    static_assert((NUM_NOPS > 0) && (NUM_NOPS <= 3), "MM throttling only enabled for NUM_NOPS={1,2,3}");
+    static_assert((THROTTLE_LEVEL > 0) && (THROTTLE_LEVEL <= 5), "MM throttling only enabled for THROTTLE_LEVEL={1,2,3,4,5}");
 
     const bool reuse_a        = ct_dim >= rt_dim;
     const std::uint32_t t_dim = reuse_a ? rt_dim : ct_dim;
@@ -455,8 +456,10 @@ inline void matmul_configure_mop_throttled(
     const bool is_in0_32x16 = (in0_tile_r_dim > FACE_R_DIM) && (in0_tile_c_dim <= FACE_C_DIM);
     const bool is_in1_16x32 = (in1_tile_r_dim <= FACE_R_DIM) && (in1_tile_c_dim > FACE_C_DIM);
 
-    const std::uint32_t replay_buf_len = (is_in0_16x32 && is_in1_32x16) ? 4 :
-                                        ((is_in0_16x32 || is_in1_32x16 || is_in0_32x16 || is_in1_16x32) ? (partial_face ? 4 : 8) : (7 + NUM_NOPS*4));
+    constexpr std::uint32_t replay_buff_len_throttle = (THROTTLE_LEVEL == 1) ? 10 : (3 + THROTTLE_LEVEL * 4);
+    const std::uint32_t replay_buf_len =
+        (is_in0_16x32 && is_in1_32x16) ? 4
+                                       : ((is_in0_16x32 || is_in1_32x16 || is_in0_32x16 || is_in1_16x32) ? (partial_face ? 4 : 8) : replay_buff_len_throttle);
 
     load_replay_buf(
         ckernel::math::replay_buf_offset,
@@ -489,83 +492,168 @@ inline void matmul_configure_mop_throttled(
             }
             else
             {
-                TTI_NOP;
-                TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B0A0 // srca=srca, srcb+=8,  dest+=8
-                if constexpr (NUM_NOPS > 1) {
+                if constexpr (THROTTLE_LEVEL == 1)
+                {
                     TTI_NOP;
-                    if constexpr (NUM_NOPS > 2) {
-                        TTI_NOP;
-                    }
+                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B0A0 // srca=srca, srcb+=8,  dest+=8
+                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0); // B0A0 // srca+=16/32, srcb=0, dest+=8  // srca+=32 if transposed
+                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B0A1 // srca=srca, srcb+=8,  dest+=8  // A1 -> A2 if transposed
+                    TTI_NOP;
+                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_2, 0); // B0A1 // srca=0,    srcb=32,  dest+=8  // A1 -> A2 if transposed
+                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B2A0 // srca=srca, srcb+=8,  dest+=8
+                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0); // B2A0 // srca+=16/32, srcb=0, dest+=8 // srca+=32 if transposed
+                    TTI_NOP;
+                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B2A1 // srca=srca, srcb+=8,  dest+=8 // A1 -> A2 if transposed
                 }
-                TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0); // B0A0 // srca+=16/32, srcb=0, dest+=8  // srca+=32 if transposed
-                
-                TTI_NOP;
-                TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B0A1 // srca=srca, srcb+=8,  dest+=8  // A1 -> A2 if transposed
-                if constexpr (NUM_NOPS > 1) {
+                else if constexpr (THROTTLE_LEVEL == 2)
+                {
                     TTI_NOP;
-                    if constexpr (NUM_NOPS > 2) {
-                        TTI_NOP;
-                    }
+                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B0A0 // srca=srca, srcb+=8,  dest+=8
+                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0); // B0A0 // srca+=16/32, srcb=0, dest+=8  // srca+=32 if transposed
+                    TTI_NOP;
+                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B0A1 // srca=srca, srcb+=8,  dest+=8  // A1 -> A2 if transposed
+                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_2, 0); // B0A1 // srca=0,    srcb=32,  dest+=8  // A1 -> A2 if transposed
+                    TTI_NOP;
+                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B2A0 // srca=srca, srcb+=8,  dest+=8
+                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0); // B2A0 // srca+=16/32, srcb=0, dest+=8 // srca+=32 if transposed
+                    TTI_NOP;
+                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B2A1 // srca=srca, srcb+=8,  dest+=8 // A1 -> A2 if transposed
                 }
-                TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_2, 0); // B0A1 // srca=0,    srcb=32,  dest+=8  // A1 -> A2 if transposed
-
-                TTI_NOP;
-                TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B2A0 // srca=srca, srcb+=8,  dest+=8
-                if constexpr (NUM_NOPS > 1) {
+                else if constexpr (THROTTLE_LEVEL == 3)
+                {
                     TTI_NOP;
-                    if constexpr (NUM_NOPS > 2) {
-                        TTI_NOP;
-                    }
+                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B0A0 // srca=srca, srcb+=8,  dest+=8
+                    TTI_NOP;
+                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0); // B0A0 // srca+=16/32, srcb=0, dest+=8  // srca+=32 if transposed
+                    TTI_NOP;
+                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B0A1 // srca=srca, srcb+=8,  dest+=8  // A1 -> A2 if transposed
+                    TTI_NOP;
+                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_2, 0); // B0A1 // srca=0,    srcb=32,  dest+=8  // A1 -> A2 if transposed
+                    TTI_NOP;
+                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B2A0 // srca=srca, srcb+=8,  dest+=8
+                    TTI_NOP;
+                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0); // B2A0 // srca+=16/32, srcb=0, dest+=8 // srca+=32 if transposed
+                    TTI_NOP;
+                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B2A1 // srca=srca, srcb+=8,  dest+=8 // A1 -> A2 if transposed
+                    TTI_NOP;
                 }
-                TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0); // B2A0 // srca+=16/32, srcb=0, dest+=8 // srca+=32 if transposed
-                
-                TTI_NOP;
-                TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B2A1 // srca=srca, srcb+=8,  dest+=8 // A1 -> A2 if transposed
-                if constexpr (NUM_NOPS > 1) {
+                else if constexpr (THROTTLE_LEVEL == 4)
+                {
                     TTI_NOP;
-                    if constexpr (NUM_NOPS > 2) {
-                        TTI_NOP;
-                    }
-                }        
+                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B0A0 // srca=srca, srcb+=8,  dest+=8
+                    TTI_NOP;
+                    TTI_NOP;
+                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0); // B0A0 // srca+=16/32, srcb=0, dest+=8  // srca+=32 if transposed
+                    TTI_NOP;
+                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B0A1 // srca=srca, srcb+=8,  dest+=8  // A1 -> A2 if transposed
+                    TTI_NOP;
+                    TTI_NOP;
+                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_2, 0); // B0A1 // srca=0,    srcb=32,  dest+=8  // A1 -> A2 if transposed
+                    TTI_NOP;
+                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B2A0 // srca=srca, srcb+=8,  dest+=8
+                    TTI_NOP;
+                    TTI_NOP;
+                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0); // B2A0 // srca+=16/32, srcb=0, dest+=8 // srca+=32 if transposed
+                    TTI_NOP;
+                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B2A1 // srca=srca, srcb+=8,  dest+=8 // A1 -> A2 if transposed
+                    TTI_NOP;
+                    TTI_NOP;
+                }
+                else if constexpr (THROTTLE_LEVEL == 5)
+                {
+                    TTI_NOP;
+                    TTI_NOP;
+                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B0A0 // srca=srca, srcb+=8,  dest+=8
+                    TTI_NOP;
+                    TTI_NOP;
+                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0); // B0A0 // srca+=16/32, srcb=0, dest+=8  // srca+=32 if transposed
+                    TTI_NOP;
+                    TTI_NOP;
+                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B0A1 // srca=srca, srcb+=8,  dest+=8  // A1 -> A2 if transposed
+                    TTI_NOP;
+                    TTI_NOP;
+                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_2, 0); // B0A1 // srca=0,    srcb=32,  dest+=8  // A1 -> A2 if transposed
+                    TTI_NOP;
+                    TTI_NOP;
+                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B2A0 // srca=srca, srcb+=8,  dest+=8
+                    TTI_NOP;
+                    TTI_NOP;
+                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0); // B2A0 // srca+=16/32, srcb=0, dest+=8 // srca+=32 if transposed
+                    TTI_NOP;
+                    TTI_NOP;
+                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B2A1 // srca=srca, srcb+=8,  dest+=8 // A1 -> A2 if transposed
+                    TTI_NOP;
+                    TTI_NOP;
+                }
             }
         });
 
     constexpr uint outer_loops = high_fidelity ? NUM_FIDELITY_PHASES : 1;
-    const uint inner_loops = (!is_in1_16x32) ? 2 : 1;
-    ckernel_template tmp(outer_loops, inner_loops, TT_OP_REPLAY(ckernel::math::replay_buf_offset, replay_buf_len, 0, 0), TT_OP_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_4, 0));
-    if (is_in1_16x32) {
+    const uint inner_loops     = (!is_in1_16x32) ? 2 : 1;
+    ckernel_template tmp(
+        outer_loops, inner_loops, TT_OP_REPLAY(ckernel::math::replay_buf_offset, replay_buf_len, 0, 0), TT_OP_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_4, 0));
+    if (is_in1_16x32)
+    {
         // FIXME
     }
 
-    if (is_in1_32x16) {
-        if (is_in0_16x32) {
-            // FIXME
-        } else {
-            // FIXME
-        }    
-    } else if (is_in0_16x32 || is_in0_32x16) {
-        if (partial_face) {
-            // FIXME
-        } else {
+    if (is_in1_32x16)
+    {
+        if (is_in0_16x32)
+        {
             // FIXME
         }
-    } else {
-        if (!is_in1_16x32) {
-            if constexpr (high_fidelity) {
-                tmp.set_last_inner_loop_instr(TT_OP_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_5, 0)); // B3A3 or B3A2 // reset srca/srcb/dest, increment phase (addr_mod_5)
-                if (reuse_a) {
-                    tmp.set_last_outer_loop_instr(TT_OP_MVMUL(p_setrwc::CLR_A, 0, ADDR_MOD_6, 0)); // B3A3 or B3A2 // reset srca/srcb/dest/phase (addr_mod_6), clear src A
-                } else {
-                    tmp.set_last_outer_loop_instr(TT_OP_MVMUL(p_setrwc::CLR_B, 0, ADDR_MOD_6, 0)); // B3A3 or B3A2 // reset srca/srcb/dest/phase (addr_mod_6), clear src B
+        else
+        {
+            // FIXME
+        }
+    }
+    else if (is_in0_16x32 || is_in0_32x16)
+    {
+        if (partial_face)
+        {
+            // FIXME
+        }
+        else
+        {
+            // FIXME
+        }
+    }
+    else
+    {
+        if (!is_in1_16x32)
+        {
+            if constexpr (high_fidelity)
+            {
+                tmp.set_last_inner_loop_instr(
+                    TT_OP_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_5, 0)); // B3A3 or B3A2 // reset srca/srcb/dest, increment phase (addr_mod_5)
+                if (reuse_a)
+                {
+                    tmp.set_last_outer_loop_instr(
+                        TT_OP_MVMUL(p_setrwc::CLR_A, 0, ADDR_MOD_6, 0)); // B3A3 or B3A2 // reset srca/srcb/dest/phase (addr_mod_6), clear src A
                 }
-            } else {
-                if (reuse_a) {
-                    tmp.set_last_outer_loop_instr(TT_OP_MVMUL(p_setrwc::CLR_A, 0, ADDR_MOD_5, 0)); // B3A3 or B3A2 // reset srca/srcb/dest, increment phase (addr_mod_5), clear src A
-                } else {
-                    tmp.set_last_outer_loop_instr(TT_OP_MVMUL(p_setrwc::CLR_B, 0, ADDR_MOD_5, 0)); // B3A3 or B2A1 // reset srca/srcb/dest, increment phase (addr_mod_5), clear src B
+                else
+                {
+                    tmp.set_last_outer_loop_instr(
+                        TT_OP_MVMUL(p_setrwc::CLR_B, 0, ADDR_MOD_6, 0)); // B3A3 or B3A2 // reset srca/srcb/dest/phase (addr_mod_6), clear src B
                 }
             }
-        } else {
+            else
+            {
+                if (reuse_a)
+                {
+                    tmp.set_last_outer_loop_instr(
+                        TT_OP_MVMUL(p_setrwc::CLR_A, 0, ADDR_MOD_5, 0)); // B3A3 or B3A2 // reset srca/srcb/dest, increment phase (addr_mod_5), clear src A
+                }
+                else
+                {
+                    tmp.set_last_outer_loop_instr(
+                        TT_OP_MVMUL(p_setrwc::CLR_B, 0, ADDR_MOD_5, 0)); // B3A3 or B2A1 // reset srca/srcb/dest, increment phase (addr_mod_5), clear src B
+                }
+            }
+        }
+        else
+        {
             // FIXME
         }
     }
@@ -584,14 +672,19 @@ inline void _llk_math_matmul_init_(
     const std::uint32_t rt_dim         = 1,
     const std::uint32_t kt_dim         = 1)
 {
-    matmul_configure_addrmod<MATH_FIDELITY_DESC, FaceLayout, MM_ADD_NOPS>(
+    matmul_configure_addrmod<MATH_FIDELITY_DESC, FaceLayout, THROTTLE_LEVEL>(
         transpose, ct_dim, rt_dim, kt_dim, in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face);
 
     constexpr int MATH_FIDELITY_PHASES = get_math_num_fidelity_phases(MATH_FIDELITY_DESC);
-    if constexpr (MM_ADD_NOPS > 0) {
-        matmul_configure_mop_throttled<MATH_FIDELITY_PHASES, FaceLayout, MM_ADD_NOPS>(transpose>0, ct_dim, rt_dim, kt_dim, in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face);
-    } else {
-        matmul_configure_mop<MATH_FIDELITY_PHASES, FaceLayout>(transpose>0, ct_dim, rt_dim, kt_dim, in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face);
+    if constexpr (THROTTLE_LEVEL > 0)
+    {
+        matmul_configure_mop_throttled<MATH_FIDELITY_PHASES, FaceLayout, THROTTLE_LEVEL>(
+            transpose > 0, ct_dim, rt_dim, kt_dim, in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face);
+    }
+    else
+    {
+        matmul_configure_mop<MATH_FIDELITY_PHASES, FaceLayout>(
+            transpose > 0, ct_dim, rt_dim, kt_dim, in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face);
     }
     math::reset_counters(p_setrwc::SET_ABD_F);
 }

--- a/tt_llk_blackhole/llk_lib/llk_math_matmul.h
+++ b/tt_llk_blackhole/llk_lib/llk_math_matmul.h
@@ -421,6 +421,90 @@ inline void matmul_configure_mop(
     tmp.program(instrn_buffer);
 }
 
+template <int Level>
+void run_throttled_sequence();
+
+template <>
+void run_throttled_sequence<1>()
+{
+    TTI_NOP;
+    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0);
+    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0);
+    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0);
+    TTI_NOP;
+    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_2, 0);
+    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0);
+    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0);
+    TTI_NOP;
+    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0);
+}
+
+template <>
+void run_throttled_sequence<2>()
+{
+    TTI_NOP;
+    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0);
+    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0);
+    TTI_NOP;
+    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0);
+    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_2, 0);
+    TTI_NOP;
+    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0);
+    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0);
+    TTI_NOP;
+    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0);
+}
+
+template <>
+void run_throttled_sequence<3>()
+{
+    TTI_NOP;
+    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0);
+    TTI_NOP;
+    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0);
+    TTI_NOP;
+    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0);
+    TTI_NOP;
+    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_2, 0);
+    TTI_NOP;
+    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0);
+    TTI_NOP;
+    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0);
+    TTI_NOP;
+    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0);
+    TTI_NOP;
+}
+
+template <>
+void run_throttled_sequence<4>()
+{
+    TTI_NOP;
+    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0);
+    TTI_NOP;
+    TTI_NOP;
+    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0);
+    TTI_NOP;
+    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0);
+    TTI_NOP;
+    TTI_NOP;
+}
+
+template <>
+void run_throttled_sequence<5>()
+{
+    TTI_NOP;
+    TTI_NOP;
+    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0);
+    TTI_NOP;
+    TTI_NOP;
+    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0);
+    TTI_NOP;
+    TTI_NOP;
+    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0);
+    TTI_NOP;
+    TTI_NOP;
+}
+
 /*
  * Programming of the MOP for the case we limit matmul compute throughput
  * Done by inserting NOP instructions between MVMUL instructions of matmul kernel
@@ -474,103 +558,11 @@ inline void matmul_configure_mop_throttled(
         replay_buf_len,
         false,
         // Lambda function to load reply buffer
-        [high_fidelity, reuse_a, partial_face, is_in1_32x16, is_in0_16x32, is_in0_32x16, is_in1_16x32, t_dim]
+        [is_in1_32x16, is_in1_16x32, is_in0_32x16, is_in0_16x32]
         {
-            if (is_in1_32x16)
+            if (!is_in1_32x16 && !is_in1_16x32 && !is_in0_32x16 && !is_in0_16x32)
             {
-                if (is_in0_16x32)
-                {
-                    // FIXME
-                }
-                else
-                {
-                    // FIXME
-                }
-            }
-            else if (is_in0_16x32 || is_in0_32x16)
-            {
-                if (partial_face)
-                {
-                    // FIXME
-                }
-                else
-                {
-                    // FIXME
-                }
-            }
-            else
-            {
-                if constexpr (THROTTLE_LEVEL == 1)
-                {
-                    TTI_NOP;
-                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B0A0 // srca=srca, srcb+=8,  dest+=8
-                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0); // B0A0 // srca+=16/32, srcb=0, dest+=8  // srca+=32 if transposed
-                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B0A1 // srca=srca, srcb+=8,  dest+=8  // A1 -> A2 if transposed
-                    TTI_NOP;
-                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_2, 0); // B0A1 // srca=0,    srcb=32,  dest+=8  // A1 -> A2 if transposed
-                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B2A0 // srca=srca, srcb+=8,  dest+=8
-                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0); // B2A0 // srca+=16/32, srcb=0, dest+=8 // srca+=32 if transposed
-                    TTI_NOP;
-                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B2A1 // srca=srca, srcb+=8,  dest+=8 // A1 -> A2 if transposed
-                }
-                else if constexpr (THROTTLE_LEVEL == 2)
-                {
-                    TTI_NOP;
-                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B0A0 // srca=srca, srcb+=8,  dest+=8
-                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0); // B0A0 // srca+=16/32, srcb=0, dest+=8  // srca+=32 if transposed
-                    TTI_NOP;
-                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B0A1 // srca=srca, srcb+=8,  dest+=8  // A1 -> A2 if transposed
-                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_2, 0); // B0A1 // srca=0,    srcb=32,  dest+=8  // A1 -> A2 if transposed
-                    TTI_NOP;
-                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B2A0 // srca=srca, srcb+=8,  dest+=8
-                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0); // B2A0 // srca+=16/32, srcb=0, dest+=8 // srca+=32 if transposed
-                    TTI_NOP;
-                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B2A1 // srca=srca, srcb+=8,  dest+=8 // A1 -> A2 if transposed
-                }
-                else if constexpr (THROTTLE_LEVEL == 3)
-                {
-                    TTI_NOP;
-                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B0A0 // srca=srca, srcb+=8,  dest+=8
-                    TTI_NOP;
-                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0); // B0A0 // srca+=16/32, srcb=0, dest+=8  // srca+=32 if transposed
-                    TTI_NOP;
-                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B0A1 // srca=srca, srcb+=8,  dest+=8  // A1 -> A2 if transposed
-                    TTI_NOP;
-                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_2, 0); // B0A1 // srca=0,    srcb=32,  dest+=8  // A1 -> A2 if transposed
-                    TTI_NOP;
-                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B2A0 // srca=srca, srcb+=8,  dest+=8
-                    TTI_NOP;
-                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0); // B2A0 // srca+=16/32, srcb=0, dest+=8 // srca+=32 if transposed
-                    TTI_NOP;
-                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B2A1 // srca=srca, srcb+=8,  dest+=8 // A1 -> A2 if transposed
-                    TTI_NOP;
-                }
-                else if constexpr (THROTTLE_LEVEL == 4)
-                {
-                    TTI_NOP;
-                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B0A0 // srca=srca, srcb+=8,  dest+=8
-                    TTI_NOP;
-                    TTI_NOP;
-                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0); // B0A0 // srca+=16/32, srcb=0, dest+=8  // srca+=32 if transposed
-                    TTI_NOP;
-                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B0A1 // srca=srca, srcb+=8,  dest+=8  // A1 -> A2 if transposed
-                    TTI_NOP;
-                    TTI_NOP;
-                }
-                else if constexpr (THROTTLE_LEVEL == 5)
-                {
-                    TTI_NOP;
-                    TTI_NOP;
-                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B0A0 // srca=srca, srcb+=8,  dest+=8
-                    TTI_NOP;
-                    TTI_NOP;
-                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0); // B0A0 // srca+=16/32, srcb=0, dest+=8  // srca+=32 if transposed
-                    TTI_NOP;
-                    TTI_NOP;
-                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B0A1 // srca=srca, srcb+=8,  dest+=8  // A1 -> A2 if transposed
-                    TTI_NOP;
-                    TTI_NOP;
-                }
+                run_throttled_sequence<THROTTLE_LEVEL>();
             }
         });
 
@@ -582,86 +574,54 @@ inline void matmul_configure_mop_throttled(
         inner_loops,
         TT_OP_REPLAY(ckernel::math::replay_buf_offset, replay_buf_len, 0, 0),
         TT_OP_MVMUL(p_setrwc::CLR_NONE, 0, addr_mod_inner_loop, 0));
-    if (is_in1_16x32)
-    {
-        // FIXME
-    }
 
-    if (is_in1_32x16)
+    if (!is_in1_32x16 && !is_in1_16x32 && !is_in0_32x16 && !is_in0_16x32)
     {
-        if (is_in0_16x32)
+        if constexpr (high_fidelity)
         {
-            // FIXME
-        }
-        else
-        {
-            // FIXME
-        }
-    }
-    else if (is_in0_16x32 || is_in0_32x16)
-    {
-        if (partial_face)
-        {
-            // FIXME
-        }
-        else
-        {
-            // FIXME
-        }
-    }
-    else
-    {
-        if (!is_in1_16x32)
-        {
-            if constexpr (high_fidelity)
+            if constexpr (THROTTLE_LEVEL > 3)
             {
-                if constexpr (THROTTLE_LEVEL > 3)
-                {
-                    tmp.set_last_inner_loop_instr(TT_OP_MVMUL(
-                        p_setrwc::CLR_NONE, 0, ADDR_MOD_4, 0)); // B2A1 // srca=32/16,srcb=16,  dest=0 (addr_mod_4) // A1 -> A2 && srca=16 if transposed
-                    tmp.set_last_outer_loop_instr(
-                        TT_OP_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_5, 0)); // B3A3 or B3A2 // reset srca/srcb/dest, increment phase (addr_mod_5)
-                }
-                else
-                {
-                    tmp.set_last_inner_loop_instr(
-                        TT_OP_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_5, 0)); // B3A3 or B3A2 // reset srca/srcb/dest, increment phase (addr_mod_5)
-                    if (reuse_a)
-                    {
-                        tmp.set_last_outer_loop_instr(
-                            TT_OP_MVMUL(p_setrwc::CLR_A, 0, ADDR_MOD_6, 0)); // B3A3 or B3A2 // reset srca/srcb/dest/phase (addr_mod_6), clear src A
-                    }
-                    else
-                    {
-                        tmp.set_last_outer_loop_instr(
-                            TT_OP_MVMUL(p_setrwc::CLR_B, 0, ADDR_MOD_6, 0)); // B3A3 or B3A2 // reset srca/srcb/dest/phase (addr_mod_6), clear src B
-                    }
-                }
+                tmp.set_last_inner_loop_instr(
+                    TT_OP_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_4, 0)); // B2A1 // srca=32/16,srcb=16,  dest=0 (addr_mod_4) // A1 -> A2 && srca=16 if transposed
+                tmp.set_last_outer_loop_instr(
+                    TT_OP_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_5, 0)); // B3A3 or B3A2 // reset srca/srcb/dest, increment phase (addr_mod_5)
             }
             else
             {
-                if constexpr (THROTTLE_LEVEL > 3)
-                {
-                    tmp.set_last_inner_loop_instr(TT_OP_MVMUL(
-                        p_setrwc::CLR_NONE, 0, ADDR_MOD_4, 0)); // B2A1 // srca=32/16,srcb=16,  dest=0 (addr_mod_4) // A1 -> A2 && srca=16 if transposed
-                }
+                tmp.set_last_inner_loop_instr(
+                    TT_OP_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_5, 0)); // B3A3 or B3A2 // reset srca/srcb/dest, increment phase (addr_mod_5)
                 if (reuse_a)
                 {
                     tmp.set_last_outer_loop_instr(
-                        TT_OP_MVMUL(p_setrwc::CLR_A, 0, ADDR_MOD_5, 0)); // B3A3 or B3A2 // reset srca/srcb/dest, increment phase (addr_mod_5), clear src A
+                        TT_OP_MVMUL(p_setrwc::CLR_A, 0, ADDR_MOD_6, 0)); // B3A3 or B3A2 // reset srca/srcb/dest/phase (addr_mod_6), clear src A
                 }
                 else
                 {
                     tmp.set_last_outer_loop_instr(
-                        TT_OP_MVMUL(p_setrwc::CLR_B, 0, ADDR_MOD_5, 0)); // B3A3 or B2A1 // reset srca/srcb/dest, increment phase (addr_mod_5), clear src B
+                        TT_OP_MVMUL(p_setrwc::CLR_B, 0, ADDR_MOD_6, 0)); // B3A3 or B3A2 // reset srca/srcb/dest/phase (addr_mod_6), clear src B
                 }
             }
         }
         else
         {
-            // FIXME
+            if constexpr (THROTTLE_LEVEL > 3)
+            {
+                tmp.set_last_inner_loop_instr(
+                    TT_OP_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_4, 0)); // B2A1 // srca=32/16,srcb=16,  dest=0 (addr_mod_4) // A1 -> A2 && srca=16 if transposed
+            }
+            if (reuse_a)
+            {
+                tmp.set_last_outer_loop_instr(
+                    TT_OP_MVMUL(p_setrwc::CLR_A, 0, ADDR_MOD_5, 0)); // B3A3 or B3A2 // reset srca/srcb/dest, increment phase (addr_mod_5), clear src A
+            }
+            else
+            {
+                tmp.set_last_outer_loop_instr(
+                    TT_OP_MVMUL(p_setrwc::CLR_B, 0, ADDR_MOD_5, 0)); // B3A3 or B2A1 // reset srca/srcb/dest, increment phase (addr_mod_5), clear src B
+            }
         }
     }
+
     tmp.program(instrn_buffer);
 }
 

--- a/tt_llk_blackhole/llk_lib/llk_math_matmul.h
+++ b/tt_llk_blackhole/llk_lib/llk_math_matmul.h
@@ -574,11 +574,14 @@ inline void matmul_configure_mop_throttled(
             }
         });
 
-    constexpr uint outer_loops = (THROTTLE_LEVEL > 3) ? 2 : (high_fidelity ? NUM_FIDELITY_PHASES : 1);
-    const uint inner_loops     = (!is_in1_16x32) ? 2 : 1;
+    constexpr uint outer_loops            = (THROTTLE_LEVEL > 3) ? 2 : (high_fidelity ? NUM_FIDELITY_PHASES : 1);
+    const uint inner_loops                = (!is_in1_16x32) ? 2 : 1;
     constexpr uint8_t addr_mod_inner_loop = (THROTTLE_LEVEL > 3) ? ADDR_MOD_2 : ADDR_MOD_4;
     ckernel_template tmp(
-        outer_loops, inner_loops, TT_OP_REPLAY(ckernel::math::replay_buf_offset, replay_buf_len, 0, 0), TT_OP_MVMUL(p_setrwc::CLR_NONE, 0, addr_mod_inner_loop, 0));
+        outer_loops,
+        inner_loops,
+        TT_OP_REPLAY(ckernel::math::replay_buf_offset, replay_buf_len, 0, 0),
+        TT_OP_MVMUL(p_setrwc::CLR_NONE, 0, addr_mod_inner_loop, 0));
     if (is_in1_16x32)
     {
         // FIXME
@@ -614,8 +617,8 @@ inline void matmul_configure_mop_throttled(
             {
                 if constexpr (THROTTLE_LEVEL > 3)
                 {
-                    tmp.set_last_inner_loop_instr(
-                        TT_OP_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_4, 0)); // B2A1 // srca=32/16,srcb=16,  dest=0 (addr_mod_4) // A1 -> A2 && srca=16 if transposed
+                    tmp.set_last_inner_loop_instr(TT_OP_MVMUL(
+                        p_setrwc::CLR_NONE, 0, ADDR_MOD_4, 0)); // B2A1 // srca=32/16,srcb=16,  dest=0 (addr_mod_4) // A1 -> A2 && srca=16 if transposed
                     tmp.set_last_outer_loop_instr(
                         TT_OP_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_5, 0)); // B3A3 or B3A2 // reset srca/srcb/dest, increment phase (addr_mod_5)
                 }
@@ -639,8 +642,8 @@ inline void matmul_configure_mop_throttled(
             {
                 if constexpr (THROTTLE_LEVEL > 3)
                 {
-                    tmp.set_last_inner_loop_instr(
-                        TT_OP_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_4, 0)); // B2A1 // srca=32/16,srcb=16,  dest=0 (addr_mod_4) // A1 -> A2 && srca=16 if transposed
+                    tmp.set_last_inner_loop_instr(TT_OP_MVMUL(
+                        p_setrwc::CLR_NONE, 0, ADDR_MOD_4, 0)); // B2A1 // srca=32/16,srcb=16,  dest=0 (addr_mod_4) // A1 -> A2 && srca=16 if transposed
                 }
                 if (reuse_a)
                 {
@@ -695,11 +698,11 @@ template <int MATH_FIDELITY_DESC, DstTileFaceLayout FaceLayout = DstTileFaceLayo
 inline void _llk_math_matmul_(
     uint dst_index, const bool transpose = false, const std::uint32_t ct_dim = 1, const std::uint32_t rt_dim = 1, const std::uint32_t kt_dim = 1)
 {
-    const bool reuse_a          = ct_dim >= rt_dim;
-    const std::uint32_t t_dim   = reuse_a ? rt_dim : ct_dim;
-    const std::uint32_t rut_dim = reuse_a ? ct_dim : rt_dim; // reuse-dim
+    const bool reuse_a                = ct_dim >= rt_dim;
+    const std::uint32_t t_dim         = reuse_a ? rt_dim : ct_dim;
+    const std::uint32_t rut_dim       = reuse_a ? ct_dim : rt_dim; // reuse-dim
     constexpr int NUM_FIDELITY_PHASES = get_math_num_fidelity_phases(MATH_FIDELITY_DESC);
-    constexpr bool high_fidelity = NUM_FIDELITY_PHASES > 0;
+    constexpr bool high_fidelity      = NUM_FIDELITY_PHASES > 0;
 
     for (uint t = 0; t < t_dim; t++)
     {

--- a/tt_llk_wormhole_b0/common/inc/cmath_common.h
+++ b/tt_llk_wormhole_b0/common/inc/cmath_common.h
@@ -37,12 +37,8 @@ constexpr uint DstTileSizeLog2[3] = {
     4  // 16x16 tile shape
 };
 
-#ifdef MM_THROTTLE
-constexpr uint replay_buf_offset = MM_THROTTLE > 3 ? 8 : 16; // split replay buffer usage between fpu/sfpu
-#else
 constexpr uint replay_buf_offset = 16; // split replay buffer usage between fpu/sfpu
                                        // first 16 for sfpu, next 16 for fpu
-#endif
 
 inline void reset_counters(const uint setrwc)
 {

--- a/tt_llk_wormhole_b0/common/inc/cmath_common.h
+++ b/tt_llk_wormhole_b0/common/inc/cmath_common.h
@@ -37,8 +37,8 @@ constexpr uint DstTileSizeLog2[3] = {
     4  // 16x16 tile shape
 };
 
-#ifdef THROTTLE_MM
-constexpr uint replay_buf_offset = THROTTLE_MM > 3 ? 8 : 16; // split replay buffer usage between fpu/sfpu
+#ifdef MM_THROTTLE
+constexpr uint replay_buf_offset = MM_THROTTLE > 3 ? 8 : 16; // split replay buffer usage between fpu/sfpu
 #else
 constexpr uint replay_buf_offset = 16; // split replay buffer usage between fpu/sfpu
                                        // first 16 for sfpu, next 16 for fpu

--- a/tt_llk_wormhole_b0/common/inc/cmath_common.h
+++ b/tt_llk_wormhole_b0/common/inc/cmath_common.h
@@ -37,8 +37,13 @@ constexpr uint DstTileSizeLog2[3] = {
     4  // 16x16 tile shape
 };
 
+#ifdef MM_ADD_NOPS
+constexpr uint replay_buf_offset = 8; // split replay buffer usage between fpu/sfpu
+                                      // first 8 for sfpu, next 24 for fpu
+#else
 constexpr uint replay_buf_offset = 16; // split replay buffer usage between fpu/sfpu
-                                       // fist 16 for sfpu, next 16 for fpu
+                                       // first 16 for sfpu, next 16 for fpu
+#endif
 
 inline void reset_counters(const uint setrwc)
 {

--- a/tt_llk_wormhole_b0/common/inc/cmath_common.h
+++ b/tt_llk_wormhole_b0/common/inc/cmath_common.h
@@ -37,9 +37,8 @@ constexpr uint DstTileSizeLog2[3] = {
     4  // 16x16 tile shape
 };
 
-#ifdef MM_ADD_NOPS
-constexpr uint replay_buf_offset = 8; // split replay buffer usage between fpu/sfpu
-                                      // first 8 for sfpu, next 24 for fpu
+#ifdef THROTTLE_MM
+constexpr uint replay_buf_offset = THROTTLE_MM > 3 ? 8 : 16; // split replay buffer usage between fpu/sfpu
 #else
 constexpr uint replay_buf_offset = 16; // split replay buffer usage between fpu/sfpu
                                        // first 16 for sfpu, next 16 for fpu

--- a/tt_llk_wormhole_b0/llk_lib/llk_math_matmul.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_math_matmul.h
@@ -16,10 +16,6 @@
 #define HF 0
 #endif
 
-#ifndef MM_THROTTLE
-#define MM_THROTTLE 0
-#endif
-
 using namespace ckernel;
 
 template <int MATH_FIDELITY_DESC, DstTileFaceLayout FaceLayout = DstTileFaceLayout::ColMajor, int THROTTLE_LEVEL>
@@ -511,7 +507,7 @@ inline void matmul_configure_mop_throttled(
     const bool is_in0_32x16 = (in0_tile_r_dim > FACE_R_DIM) && (in0_tile_c_dim <= FACE_C_DIM);
     const bool is_in1_16x32 = (in1_tile_r_dim <= FACE_R_DIM) && (in1_tile_c_dim > FACE_C_DIM);
 
-    constexpr std::uint32_t replay_buff_len_throttle = (THROTTLE_LEVEL == 1) ? 10 : (3 + THROTTLE_LEVEL * 4);
+    constexpr std::uint32_t replay_buff_len_throttle = (THROTTLE_LEVEL > 3) ? (1 + THROTTLE_LEVEL * 2) : ((THROTTLE_LEVEL > 1) ? (3 + THROTTLE_LEVEL * 4) : 10);
     const std::uint32_t replay_buf_len =
         (is_in0_16x32 && is_in1_32x16) ? 4
                                        : ((is_in0_16x32 || is_in1_32x16 || is_in0_32x16 || is_in1_16x32) ? (partial_face ? 4 : 8) : replay_buff_len_throttle);
@@ -598,16 +594,6 @@ inline void matmul_configure_mop_throttled(
             TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B0A1 // srca=srca, srcb+=8,  dest+=8  // A1 -> A2 if transposed
             TTI_NOP;
             TTI_NOP;
-            TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_2, 0); // B0A1 // srca=0,    srcb=32,  dest+=8  // A1 -> A2 if transposed
-            TTI_NOP;
-            TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B2A0 // srca=srca, srcb+=8,  dest+=8
-            TTI_NOP;
-            TTI_NOP;
-            TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0); // B2A0 // srca+=16/32, srcb=0, dest+=8 // srca+=32 if transposed
-            TTI_NOP;
-            TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_3, 0); // B2A1 // srca=srca, srcb+=8,  dest+=8,  bias=1 // A1 -> A2 if transposed
-            TTI_NOP;
-            TTI_NOP;
         }
         else if constexpr (THROTTLE_LEVEL == 5)
         {
@@ -622,25 +608,13 @@ inline void matmul_configure_mop_throttled(
             TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B0A1 // srca=srca, srcb+=8,  dest+=8  // A1 -> A2 if transposed
             TTI_NOP;
             TTI_NOP;
-            TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_2, 0); // B0A1 // srca=0,    srcb=32,  dest+=8  // A1 -> A2 if transposed
-            TTI_NOP;
-            TTI_NOP;
-            TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B2A0 // srca=srca, srcb+=8,  dest+=8
-            TTI_NOP;
-            TTI_NOP;
-            TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0); // B2A0 // srca+=16/32, srcb=0, dest+=8 // srca+=32 if transposed
-            TTI_NOP;
-            TTI_NOP;
-            TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_3, 0); // B2A1 // srca=srca, srcb+=8,  dest+=8,  bias=1 // A1 -> A2 if transposed
-            TTI_NOP;
-            TTI_NOP;
         }
     }
-
-    constexpr uint outer_loops = high_fidelity ? NUM_FIDELITY_PHASES : 1;
+    constexpr uint outer_loops = (THROTTLE_LEVEL > 3) ? 2 : (high_fidelity ? NUM_FIDELITY_PHASES : 1);
     const uint inner_loops     = (!is_in1_16x32) ? 2 : 1;
+    constexpr uint8_t addr_mod_inner_loop = (THROTTLE_LEVEL > 3) ? ADDR_MOD_2 : ADDR_MOD_0;
     ckernel_template tmp(
-        outer_loops, inner_loops, TT_OP_REPLAY(ckernel::math::replay_buf_offset, replay_buf_len, 0, 0), TT_OP_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0));
+        outer_loops, inner_loops, TT_OP_REPLAY(ckernel::math::replay_buf_offset, replay_buf_len, 0, 0), TT_OP_MVMUL(p_setrwc::CLR_NONE, 0, addr_mod_inner_loop, 0));
     if (is_in1_16x32)
     {
         // FIXME
@@ -674,28 +648,43 @@ inline void matmul_configure_mop_throttled(
         {
             if constexpr (high_fidelity)
             {
-                tmp.set_last_inner_loop_instr(
-                    TT_OP_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0)); // B3A3 or B3A2 // reset srca/srcb/dest, increment phase (addr_mod_5)
-                if (t_dim > 1)
+                if constexpr (THROTTLE_LEVEL > 3)
                 {
-                    tmp.set_last_outer_loop_instr(TT_OP_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_2, 0)); // B3A3 or B3A2 // reset srca/srcb/dest/phase (addr_mod_6)
+                    tmp.set_last_inner_loop_instr(
+                        TT_OP_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0)); // B2A1 // srca=32/16,srcb=16,  dest=0 (addr_mod_4) // A1 -> A2 && srca=16 if transposed
+                    tmp.set_last_outer_loop_instr(
+                        TT_OP_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0)); // B3A3 or B3A2 // reset srca/srcb/dest, increment phase (addr_mod_5)
                 }
                 else
                 {
-                    if (reuse_a)
+                    tmp.set_last_inner_loop_instr(
+                        TT_OP_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0)); // B3A3 or B3A2 // reset srca/srcb/dest, increment phase (addr_mod_5)
+                    if (t_dim > 1)
                     {
-                        tmp.set_last_outer_loop_instr(
-                            TT_OP_MVMUL(p_setrwc::CLR_A, 0, ADDR_MOD_2, 0)); // B3A3 or B3A2 // reset srca/srcb/dest/phase (addr_mod_6), clear src A
+                        tmp.set_last_outer_loop_instr(TT_OP_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_2, 0)); // B3A3 or B3A2 // reset srca/srcb/dest/phase (addr_mod_6)
                     }
                     else
                     {
-                        tmp.set_last_outer_loop_instr(
-                            TT_OP_MVMUL(p_setrwc::CLR_B, 0, ADDR_MOD_2, 0)); // B3A3 or B3A2 // reset srca/srcb/dest/phase (addr_mod_6), clear src B
+                        if (reuse_a)
+                        {
+                            tmp.set_last_outer_loop_instr(
+                                TT_OP_MVMUL(p_setrwc::CLR_A, 0, ADDR_MOD_2, 0)); // B3A3 or B3A2 // reset srca/srcb/dest/phase (addr_mod_6), clear src A
+                        }
+                        else
+                        {
+                            tmp.set_last_outer_loop_instr(
+                                TT_OP_MVMUL(p_setrwc::CLR_B, 0, ADDR_MOD_2, 0)); // B3A3 or B3A2 // reset srca/srcb/dest/phase (addr_mod_6), clear src B
+                        }
                     }
                 }
             }
             else
             {
+                if constexpr (THROTTLE_LEVEL > 3)
+                {
+                    tmp.set_last_inner_loop_instr(
+                        TT_OP_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0)); // B2A1 // srca=32/16,srcb=16,  dest=0 (addr_mod_4) // A1 -> A2 && srca=16 if transposed
+                }
                 if (reuse_a)
                 {
                     if (t_dim > 1)
@@ -733,7 +722,7 @@ inline void matmul_configure_mop_throttled(
     tmp.program(instrn_buffer);
 }
 
-template <int MATH_FIDELITY_DESC, DstTileFaceLayout FaceLayout = DstTileFaceLayout::ColMajor>
+template <int MATH_FIDELITY_DESC, DstTileFaceLayout FaceLayout = DstTileFaceLayout::ColMajor, int THROTTLE_LEVEL = 0>
 inline void _llk_math_matmul_init_(
     const std::uint32_t in0_tile_r_dim = TILE_R_DIM,
     const std::uint32_t in0_tile_c_dim = TILE_C_DIM,
@@ -745,7 +734,7 @@ inline void _llk_math_matmul_init_(
     const std::uint32_t rt_dim         = 1,
     const std::uint32_t kt_dim         = 1)
 {
-    matmul_configure_addrmod<MATH_FIDELITY_DESC, FaceLayout, MM_THROTTLE>(
+    matmul_configure_addrmod<MATH_FIDELITY_DESC, FaceLayout, THROTTLE_LEVEL>(
         transpose, ct_dim, rt_dim, kt_dim, in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face);
     const bool reuse_a        = ct_dim >= rt_dim;
     const std::uint32_t t_dim = reuse_a ? rt_dim : ct_dim;
@@ -766,9 +755,9 @@ inline void _llk_math_matmul_init_(
     }
 
     constexpr int MATH_FIDELITY_PHASES = get_math_num_fidelity_phases(MATH_FIDELITY_DESC);
-    if constexpr (MM_THROTTLE > 0)
+    if constexpr (THROTTLE_LEVEL > 0)
     {
-        matmul_configure_mop_throttled<MATH_FIDELITY_PHASES, FaceLayout, MM_THROTTLE>(
+        matmul_configure_mop_throttled<MATH_FIDELITY_PHASES, FaceLayout, THROTTLE_LEVEL>(
             transpose > 0, ct_dim, rt_dim, kt_dim, in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face);
     }
     else
@@ -779,13 +768,15 @@ inline void _llk_math_matmul_init_(
     math::reset_counters(p_setrwc::SET_ABD_F);
 }
 
-template <int MATH_FIDELITY_DESC, DstTileFaceLayout FaceLayout = DstTileFaceLayout::ColMajor>
+template <int MATH_FIDELITY_DESC, DstTileFaceLayout FaceLayout = DstTileFaceLayout::ColMajor, int THROTTLE_LEVEL = 0>
 inline void _llk_math_matmul_(
     uint dst_index, const bool transpose = false, const std::uint32_t ct_dim = 1, const std::uint32_t rt_dim = 1, const std::uint32_t kt_dim = 1)
 {
     const bool reuse_a          = ct_dim >= rt_dim;
     const std::uint32_t t_dim   = reuse_a ? rt_dim : ct_dim;
     const std::uint32_t rut_dim = reuse_a ? ct_dim : rt_dim; // reuse-dim
+    constexpr int NUM_FIDELITY_PHASES = get_math_num_fidelity_phases(MATH_FIDELITY_DESC);
+    constexpr bool high_fidelity = NUM_FIDELITY_PHASES > 0;
 
     for (uint t = 0; t < t_dim; t++)
     {
@@ -795,7 +786,25 @@ inline void _llk_math_matmul_(
 
             if (t_dim == 1)
             {
-                ckernel_template::run(instrn_buffer);
+                if constexpr (THROTTLE_LEVEL > 3 && high_fidelity)
+                {
+                    for (uint phase = 0; phase < NUM_FIDELITY_PHASES; phase++)
+                    {
+                        ckernel_template::run(instrn_buffer);
+                    }
+                    if (reuse_a)
+                    {
+                        TTI_SETRWC(p_setrwc::CLR_A, 0, 0, 0, 0, p_setrwc::SET_ABD_F);
+                    }
+                    else
+                    {
+                        TTI_SETRWC(p_setrwc::CLR_B, 0, 0, 0, 0, p_setrwc::SET_ABD_F);
+                    }
+                }
+                else
+                {
+                    ckernel_template::run(instrn_buffer);
+                }
 
                 // Done with reuse. Clear srcA or srcB valid
                 if (rut == (rut_dim - 1))
@@ -812,7 +821,18 @@ inline void _llk_math_matmul_(
             }
             else
             {
-                ckernel_template::run(instrn_buffer);
+                if constexpr (THROTTLE_LEVEL > 3 && high_fidelity)
+                {
+                    for (uint phase = 0; phase < NUM_FIDELITY_PHASES; phase++)
+                    {
+                        ckernel_template::run(instrn_buffer);
+                    }
+                    TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_ABD_F);
+                }
+                else
+                {
+                    ckernel_template::run(instrn_buffer);
+                }
 
                 if ((t + 1) < t_dim)
                 {
@@ -846,7 +866,18 @@ inline void _llk_math_matmul_(
 
                     math::set_dst_write_addr<DstTileLayout::Default, DstTileShape::Tile32x32>(
                         dst_index + (reuse_a ? ct_dim * (t + 1) + rut : t + 1 + rut * ct_dim));
-                    ckernel_template::run(instrn_buffer);
+                    if constexpr (THROTTLE_LEVEL > 3 && high_fidelity)
+                    {
+                        for (uint phase = 0; phase < NUM_FIDELITY_PHASES; phase++)
+                        {
+                            ckernel_template::run(instrn_buffer);
+                        }
+                        TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_ABD_F);
+                    }
+                    else
+                    {
+                        ckernel_template::run(instrn_buffer);
+                    }
                 }
 
                 if (reuse_a)

--- a/tt_llk_wormhole_b0/llk_lib/llk_math_matmul.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_math_matmul.h
@@ -610,11 +610,14 @@ inline void matmul_configure_mop_throttled(
             TTI_NOP;
         }
     }
-    constexpr uint outer_loops = (THROTTLE_LEVEL > 3) ? 2 : (high_fidelity ? NUM_FIDELITY_PHASES : 1);
-    const uint inner_loops     = (!is_in1_16x32) ? 2 : 1;
+    constexpr uint outer_loops            = (THROTTLE_LEVEL > 3) ? 2 : (high_fidelity ? NUM_FIDELITY_PHASES : 1);
+    const uint inner_loops                = (!is_in1_16x32) ? 2 : 1;
     constexpr uint8_t addr_mod_inner_loop = (THROTTLE_LEVEL > 3) ? ADDR_MOD_2 : ADDR_MOD_0;
     ckernel_template tmp(
-        outer_loops, inner_loops, TT_OP_REPLAY(ckernel::math::replay_buf_offset, replay_buf_len, 0, 0), TT_OP_MVMUL(p_setrwc::CLR_NONE, 0, addr_mod_inner_loop, 0));
+        outer_loops,
+        inner_loops,
+        TT_OP_REPLAY(ckernel::math::replay_buf_offset, replay_buf_len, 0, 0),
+        TT_OP_MVMUL(p_setrwc::CLR_NONE, 0, addr_mod_inner_loop, 0));
     if (is_in1_16x32)
     {
         // FIXME
@@ -650,8 +653,8 @@ inline void matmul_configure_mop_throttled(
             {
                 if constexpr (THROTTLE_LEVEL > 3)
                 {
-                    tmp.set_last_inner_loop_instr(
-                        TT_OP_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0)); // B2A1 // srca=32/16,srcb=16,  dest=0 (addr_mod_4) // A1 -> A2 && srca=16 if transposed
+                    tmp.set_last_inner_loop_instr(TT_OP_MVMUL(
+                        p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0)); // B2A1 // srca=32/16,srcb=16,  dest=0 (addr_mod_4) // A1 -> A2 && srca=16 if transposed
                     tmp.set_last_outer_loop_instr(
                         TT_OP_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0)); // B3A3 or B3A2 // reset srca/srcb/dest, increment phase (addr_mod_5)
                 }
@@ -661,7 +664,8 @@ inline void matmul_configure_mop_throttled(
                         TT_OP_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0)); // B3A3 or B3A2 // reset srca/srcb/dest, increment phase (addr_mod_5)
                     if (t_dim > 1)
                     {
-                        tmp.set_last_outer_loop_instr(TT_OP_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_2, 0)); // B3A3 or B3A2 // reset srca/srcb/dest/phase (addr_mod_6)
+                        tmp.set_last_outer_loop_instr(
+                            TT_OP_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_2, 0)); // B3A3 or B3A2 // reset srca/srcb/dest/phase (addr_mod_6)
                     }
                     else
                     {
@@ -682,8 +686,8 @@ inline void matmul_configure_mop_throttled(
             {
                 if constexpr (THROTTLE_LEVEL > 3)
                 {
-                    tmp.set_last_inner_loop_instr(
-                        TT_OP_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0)); // B2A1 // srca=32/16,srcb=16,  dest=0 (addr_mod_4) // A1 -> A2 && srca=16 if transposed
+                    tmp.set_last_inner_loop_instr(TT_OP_MVMUL(
+                        p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0)); // B2A1 // srca=32/16,srcb=16,  dest=0 (addr_mod_4) // A1 -> A2 && srca=16 if transposed
                 }
                 if (reuse_a)
                 {
@@ -772,11 +776,11 @@ template <int MATH_FIDELITY_DESC, DstTileFaceLayout FaceLayout = DstTileFaceLayo
 inline void _llk_math_matmul_(
     uint dst_index, const bool transpose = false, const std::uint32_t ct_dim = 1, const std::uint32_t rt_dim = 1, const std::uint32_t kt_dim = 1)
 {
-    const bool reuse_a          = ct_dim >= rt_dim;
-    const std::uint32_t t_dim   = reuse_a ? rt_dim : ct_dim;
-    const std::uint32_t rut_dim = reuse_a ? ct_dim : rt_dim; // reuse-dim
+    const bool reuse_a                = ct_dim >= rt_dim;
+    const std::uint32_t t_dim         = reuse_a ? rt_dim : ct_dim;
+    const std::uint32_t rut_dim       = reuse_a ? ct_dim : rt_dim; // reuse-dim
     constexpr int NUM_FIDELITY_PHASES = get_math_num_fidelity_phases(MATH_FIDELITY_DESC);
-    constexpr bool high_fidelity = NUM_FIDELITY_PHASES > 0;
+    constexpr bool high_fidelity      = NUM_FIDELITY_PHASES > 0;
 
     for (uint t = 0; t < t_dim; t++)
     {

--- a/tt_llk_wormhole_b0/llk_lib/llk_math_matmul.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_math_matmul.h
@@ -16,6 +16,10 @@
 #define HF 0
 #endif
 
+#ifndef MM_ADD_NOPS
+#define MM_ADD_NOPS 0
+#endif
+
 using namespace ckernel;
 
 template <int MATH_FIDELITY_DESC, DstTileFaceLayout FaceLayout = DstTileFaceLayout::ColMajor>
@@ -451,6 +455,123 @@ inline void matmul_configure_mop(
     tmp.program(instrn_buffer);
 }
 
+template <int NUM_FIDELITY_PHASES, DstTileFaceLayout FaceLayout=DstTileFaceLayout::ColMajor, int NUM_NOPS>
+inline void matmul_configure_mop_throttled(bool transpose, const std::uint32_t ct_dim, const std::uint32_t rt_dim, const std::uint32_t kt_dim, const std::uint32_t in0_tile_r_dim = TILE_R_DIM, const std::uint32_t in0_tile_c_dim = TILE_C_DIM, const std::uint32_t in1_tile_r_dim = TILE_R_DIM, const std::uint32_t in1_tile_c_dim = TILE_C_DIM, const bool partial_face = false) {
+
+    // in0 - loaded to SrcB
+    // in1 - loaded to SrcA
+    // Unpacker will always load faces in f0,f1,f2,f3 order
+    // if in1 is transposed then faces 1&2 need to be swapped during read
+    // by changing address increment amount via addr_mods
+    // Col major layout in dest only impacs destination address increment
+    // if col major layout faces are ordered as f0,f2,f1,f3
+
+    constexpr bool high_fidelity = NUM_FIDELITY_PHASES > 0;
+    static_assert(!high_fidelity, "MM Throttling shouldn't be invoked with HF math!");
+    static_assert((NUM_NOPS > 0) && (NUM_NOPS < 3), "MM Throttling must be enabled for NUM_NOPS=1 and NUM_NOPS=2");
+
+    const bool reuse_a = ct_dim>=rt_dim;
+    const std::uint32_t t_dim = reuse_a ? rt_dim : ct_dim;
+
+    const bool is_in0_16x32 = (in0_tile_r_dim <=FACE_R_DIM) && (in0_tile_c_dim > FACE_C_DIM);
+    const bool is_in1_32x16 = (in1_tile_r_dim > FACE_R_DIM) && (in1_tile_c_dim <= FACE_C_DIM);
+    const bool is_in0_32x16 = (in0_tile_r_dim > FACE_R_DIM) && (in0_tile_c_dim <= FACE_C_DIM);
+    const bool is_in1_16x32 = (in1_tile_r_dim <= FACE_R_DIM) && (in1_tile_c_dim > FACE_C_DIM);
+
+    const std::uint32_t replay_buf_len = (is_in0_16x32 && is_in1_32x16) ? 4 :
+                                         ((is_in0_16x32 || is_in1_32x16 || is_in0_32x16 || is_in1_16x32) ? (partial_face ? 4 : 8) : 
+                                         (NUM_NOPS == 2) ? 15 : 11);
+
+    TT_REPLAY(ckernel::math::replay_buf_offset, replay_buf_len, 0, 1);
+
+    if (is_in1_32x16) {
+        if (is_in0_16x32) {
+            // FIXME
+        } else {
+            // FIXME
+        }    
+    } else if (is_in0_16x32 || is_in0_32x16) {
+        if (partial_face) {
+            // FIXME
+        } else {
+            // FIXME
+        }
+    } else {
+        TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B0A0 // srca=srca, srcb+=8,  dest+=8
+        TTI_NOP;
+        if constexpr (NUM_NOPS > 1) {
+            TTI_NOP;
+        }
+        TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0); // B0A0 // srca+=16/32, srcb=0, dest+=8  // srca+=32 if transposed
+
+        TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B0A1 // srca=srca, srcb+=8,  dest+=8  // A1 -> A2 if transposed
+        TTI_NOP;
+        if constexpr (NUM_NOPS > 1) {
+            TTI_NOP;
+        }
+        TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_2, 0); // B0A1 // srca=0,    srcb=32,  dest+=8  // A1 -> A2 if transposed
+
+        TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B2A0 // srca=srca, srcb+=8,  dest+=8
+        TTI_NOP;
+        if constexpr (NUM_NOPS > 1) {
+            TTI_NOP;
+        }
+        TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0); // B2A0 // srca+=16/32, srcb=0, dest+=8 // srca+=32 if transposed
+        
+        TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_3, 0); // B2A1 // srca=srca, srcb+=8,  dest+=8,  bias=1 // A1 -> A2 if transposed
+        TTI_NOP;
+        if constexpr (NUM_NOPS > 1) {
+            TTI_NOP;
+        }
+    }
+
+    constexpr uint outer_loops = 1;
+    const uint inner_loops = (!is_in1_16x32) ? 2 : 1;
+    ckernel_template tmp(outer_loops, inner_loops, TT_OP_REPLAY(ckernel::math::replay_buf_offset, replay_buf_len, 0, 0), TT_OP_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0));
+    if (is_in1_16x32) {
+        // FIXME
+    }
+
+    if (is_in1_32x16) {
+        if (is_in0_16x32) {
+            // FIXME
+        } else {
+            // FIXME
+        }    
+    } else if (is_in0_16x32 || is_in0_32x16) {
+        if (partial_face) {
+            // FIXME
+        } else {
+            // FIXME
+        }
+    } else {
+        if (!is_in1_16x32) {
+            if (reuse_a) {
+                if (t_dim>1) {
+                    tmp.set_last_inner_loop_instr(TT_OP_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0)); // B3A3 or B3A2 // reset srca/srcb/dest, increment phase (addr_mod_5)
+                    tmp.set_last_outer_loop_instr(TT_OP_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0)); // B3A3 or B3A2 // reset srca/srcb/dest, increment phase (addr_mod_5)
+                } else {
+                    tmp.set_last_inner_loop_instr(TT_OP_MVMUL(p_setrwc::CLR_A, 0, ADDR_MOD_1, 0)); // B3A3 or B3A2 // reset srca/srcb/dest, increment phase (addr_mod_5), clear src A
+                    tmp.set_last_outer_loop_instr(TT_OP_MVMUL(p_setrwc::CLR_A, 0, ADDR_MOD_1, 0)); // B3A3 or B3A2 // reset srca/srcb/dest, increment phase (addr_mod_5), clear src A
+                }
+            } else {
+                if (t_dim>1) {
+                    tmp.set_last_inner_loop_instr(TT_OP_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0)); // B3A3 or B2A1 // reset srca/srcb/dest, increment phase (addr_mod_5)
+                    tmp.set_last_outer_loop_instr(TT_OP_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0)); // B3A3 or B2A1 // reset srca/srcb/dest, increment phase (addr_mod_5)
+                } else {
+                    tmp.set_last_inner_loop_instr(TT_OP_MVMUL(p_setrwc::CLR_B, 0, ADDR_MOD_1, 0)); // B3A3 or B2A1 // reset srca/srcb/dest, increment phase (addr_mod_5), clear src A
+                    tmp.set_last_outer_loop_instr(TT_OP_MVMUL(p_setrwc::CLR_B, 0, ADDR_MOD_1, 0)); // B3A3 or B2A1 // reset srca/srcb/dest, increment phase (addr_mod_5), clear src A
+                }
+            }
+        } else {
+            // FIXME
+        }
+
+    }
+
+    tmp.program(instrn_buffer);
+}
+
 template <int MATH_FIDELITY_DESC, DstTileFaceLayout FaceLayout = DstTileFaceLayout::ColMajor>
 inline void _llk_math_matmul_init_(
     const std::uint32_t in0_tile_r_dim = TILE_R_DIM,
@@ -484,8 +605,12 @@ inline void _llk_math_matmul_init_(
     }
 
     constexpr int MATH_FIDELITY_PHASES = get_math_num_fidelity_phases(MATH_FIDELITY_DESC);
-    matmul_configure_mop<MATH_FIDELITY_PHASES, FaceLayout>(
-        transpose > 0, ct_dim, rt_dim, kt_dim, in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face);
+    if constexpr ((MM_ADD_NOPS > 1) && (MATH_FIDELITY_PHASES == 0)) {
+        // Only enable throttling for lo-fi math
+        matmul_configure_mop_throttled<MATH_FIDELITY_PHASES, FaceLayout, MM_ADD_NOPS>(transpose>0, ct_dim, rt_dim, kt_dim, in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face);
+    } else {
+        matmul_configure_mop<MATH_FIDELITY_PHASES, FaceLayout>(transpose>0, ct_dim, rt_dim, kt_dim, in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face);
+    }
     math::reset_counters(p_setrwc::SET_ABD_F);
 }
 

--- a/tt_llk_wormhole_b0/llk_lib/llk_math_matmul.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_math_matmul.h
@@ -464,88 +464,128 @@ inline void matmul_configure_mop(
     tmp.program(instrn_buffer);
 }
 
-template <int Level>
-void run_throttled_sequence();
-
-template <>
-void run_throttled_sequence<1>()
+template <int THROTTLE_LEVEL, bool HIGH_FIDELITY>
+void run_throttled_sequence(const std::uint32_t t_dim, const bool reuse_a)
 {
-    TTI_NOP;
-    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0);
-    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0);
-    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0);
-    TTI_NOP;
-    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_2, 0);
-    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0);
-    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0);
-    TTI_NOP;
-    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_3, 0);
-}
-
-template <>
-void run_throttled_sequence<2>()
-{
-    TTI_NOP;
-    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0);
-    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0);
-    TTI_NOP;
-    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0);
-    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_2, 0);
-    TTI_NOP;
-    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0);
-    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0);
-    TTI_NOP;
-    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_3, 0);
-}
-
-template <>
-void run_throttled_sequence<3>()
-{
-    TTI_NOP;
-    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0);
-    TTI_NOP;
-    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0);
-    TTI_NOP;
-    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0);
-    TTI_NOP;
-    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_2, 0);
-    TTI_NOP;
-    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0);
-    TTI_NOP;
-    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0);
-    TTI_NOP;
-    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_3, 0);
-    TTI_NOP;
-}
-
-template <>
-void run_throttled_sequence<4>()
-{
-    TTI_NOP;
-    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0);
-    TTI_NOP;
-    TTI_NOP;
-    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0);
-    TTI_NOP;
-    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0);
-    TTI_NOP;
-    TTI_NOP;
-}
-
-template <>
-void run_throttled_sequence<5>()
-{
-    TTI_NOP;
-    TTI_NOP;
-    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0);
-    TTI_NOP;
-    TTI_NOP;
-    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0);
-    TTI_NOP;
-    TTI_NOP;
-    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0);
-    TTI_NOP;
-    TTI_NOP;
+    if constexpr (THROTTLE_LEVEL == 1)
+    {
+        TTI_NOP;
+        TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0);
+        TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0);
+        TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0);
+        TTI_NOP;
+        TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_2, 0);
+        TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0);
+        TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0);
+        TTI_NOP;
+        TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_3, 0);
+    }
+    else if constexpr (THROTTLE_LEVEL == 2)
+    {
+        TTI_NOP;
+        TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0);
+        TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0);
+        TTI_NOP;
+        TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0);
+        TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_2, 0);
+        TTI_NOP;
+        TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0);
+        TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0);
+        TTI_NOP;
+        TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_3, 0);
+    }
+    else if constexpr (THROTTLE_LEVEL == 3)
+    {
+        TTI_NOP;
+        TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0);
+        TTI_NOP;
+        TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0);
+        TTI_NOP;
+        TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0);
+        TTI_NOP;
+        TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_2, 0);
+        TTI_NOP;
+        TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0);
+        TTI_NOP;
+        TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0);
+        TTI_NOP;
+        TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_3, 0);
+        TTI_NOP;
+    }
+    else if constexpr (THROTTLE_LEVEL == 4)
+    {
+        TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_3, 0);
+        TTI_NOP;
+        TTI_NOP;
+        TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0);
+        TTI_NOP;
+        TTI_NOP;
+        TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0);
+        TTI_NOP;
+        TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0);
+        TTI_NOP;
+        TTI_NOP;
+        TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_2, 0);
+        TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_3, 0);
+        TTI_NOP;
+        TTI_NOP;
+        if constexpr (HIGH_FIDELITY)
+        {
+            TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0);
+        }
+        else
+        {
+            if (t_dim > 1)
+            {
+                TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0);
+            }
+            else if (reuse_a)
+            {
+                TTI_MVMUL(p_setrwc::CLR_A, 0, ADDR_MOD_1, 0);
+            }
+            else
+            {
+                TTI_MVMUL(p_setrwc::CLR_B, 0, ADDR_MOD_1, 0);
+            }
+        }
+    }
+    else if constexpr (THROTTLE_LEVEL == 5)
+    {
+        TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_3, 0);
+        TTI_NOP;
+        TTI_NOP;
+        TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0);
+        TTI_NOP;
+        TTI_NOP;
+        TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0);
+        TTI_NOP;
+        TTI_NOP;
+        TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0);
+        TTI_NOP;
+        TTI_NOP;
+        TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_2, 0);
+        TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_3, 0);
+        TTI_NOP;
+        if constexpr (HIGH_FIDELITY)
+        {
+            TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0);
+        }
+        else
+        {
+            if (t_dim > 1)
+            {
+                TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0);
+            }
+            else if (reuse_a)
+            {
+                TTI_MVMUL(p_setrwc::CLR_A, 0, ADDR_MOD_1, 0);
+            }
+            else
+            {
+                TTI_MVMUL(p_setrwc::CLR_B, 0, ADDR_MOD_1, 0);
+            }
+        }
+    }
 }
 
 /*
@@ -591,7 +631,7 @@ inline void matmul_configure_mop_throttled(
     const bool is_in0_32x16 = (in0_tile_r_dim > FACE_R_DIM) && (in0_tile_c_dim <= FACE_C_DIM);
     const bool is_in1_16x32 = (in1_tile_r_dim <= FACE_R_DIM) && (in1_tile_c_dim > FACE_C_DIM);
 
-    constexpr std::uint32_t replay_buff_len_throttle = (THROTTLE_LEVEL > 3) ? (1 + THROTTLE_LEVEL * 2) : ((THROTTLE_LEVEL > 1) ? (3 + THROTTLE_LEVEL * 4) : 10);
+    constexpr std::uint32_t replay_buff_len_throttle = (THROTTLE_LEVEL > 3) ? (16) : ((THROTTLE_LEVEL > 1) ? (3 + THROTTLE_LEVEL * 4) : 10);
     const std::uint32_t replay_buf_len =
         (is_in0_16x32 && is_in1_32x16) ? 4
                                        : ((is_in0_16x32 || is_in1_32x16 || is_in0_32x16 || is_in1_16x32) ? (partial_face ? 4 : 8) : replay_buff_len_throttle);
@@ -599,82 +639,47 @@ inline void matmul_configure_mop_throttled(
     TT_REPLAY(ckernel::math::replay_buf_offset, replay_buf_len, 0, 1);
     if (!is_in1_32x16 && !is_in1_16x32 && !is_in0_32x16 && !is_in0_16x32)
     {
-        run_throttled_sequence<THROTTLE_LEVEL>();
+        run_throttled_sequence<THROTTLE_LEVEL, high_fidelity>(t_dim, reuse_a);
     }
 
-    constexpr uint outer_loops            = (THROTTLE_LEVEL > 3) ? 2 : (high_fidelity ? NUM_FIDELITY_PHASES : 1);
-    const uint inner_loops                = (!is_in1_16x32) ? 2 : 1;
-    constexpr uint8_t addr_mod_inner_loop = (THROTTLE_LEVEL > 3) ? ADDR_MOD_2 : ADDR_MOD_0;
-    ckernel_template tmp(
-        outer_loops,
-        inner_loops,
-        TT_OP_REPLAY(ckernel::math::replay_buf_offset, replay_buf_len, 0, 0),
-        TT_OP_MVMUL(p_setrwc::CLR_NONE, 0, addr_mod_inner_loop, 0));
+    constexpr uint outer_loops        = (THROTTLE_LEVEL > 3) ? 2 : (high_fidelity ? NUM_FIDELITY_PHASES : 1);
+    const uint inner_loops            = (!is_in1_16x32) ? 2 : 1;
+    constexpr uint loop_instruction_0 = (THROTTLE_LEVEL == 5)   ? TT_OP_REPLAY(ckernel::math::replay_buf_offset + 1, 8, 0, 0)
+                                        : (THROTTLE_LEVEL == 4) ? TT_OP_REPLAY(ckernel::math::replay_buf_offset + 2, 6, 0, 0)
+                                                                : TT_OP_REPLAY(ckernel::math::replay_buf_offset, replay_buff_len_throttle, 0, 0);
+    constexpr uint loop_instruction_1 = (THROTTLE_LEVEL == 5)   ? TT_OP_REPLAY(ckernel::math::replay_buf_offset + 9, 4, 0, 0)
+                                        : (THROTTLE_LEVEL == 4) ? TT_OP_REPLAY(ckernel::math::replay_buf_offset + 8, 4, 0, 0)
+                                                                : TT_OP_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0);
+    ckernel_template tmp(outer_loops, inner_loops, loop_instruction_0, loop_instruction_1);
 
-    if constexpr (high_fidelity)
+    if constexpr (THROTTLE_LEVEL == 5)
     {
-        if constexpr (THROTTLE_LEVEL > 3)
-        {
-            tmp.set_last_inner_loop_instr(
-                TT_OP_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0)); // B2A1 // srca=32/16,srcb=16,  dest=0 (addr_mod_4) // A1 -> A2 && srca=16 if transposed
-            tmp.set_last_outer_loop_instr(
-                TT_OP_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0)); // B3A3 or B3A2 // reset srca/srcb/dest, increment phase (addr_mod_5)
-        }
-        else
-        {
-            tmp.set_last_inner_loop_instr(
-                TT_OP_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0)); // B3A3 or B3A2 // reset srca/srcb/dest, increment phase (addr_mod_5)
-            if (t_dim > 1)
-            {
-                tmp.set_last_outer_loop_instr(TT_OP_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_2, 0)); // B3A3 or B3A2 // reset srca/srcb/dest/phase (addr_mod_6)
-            }
-            else
-            {
-                if (reuse_a)
-                {
-                    tmp.set_last_outer_loop_instr(
-                        TT_OP_MVMUL(p_setrwc::CLR_A, 0, ADDR_MOD_2, 0)); // B3A3 or B3A2 // reset srca/srcb/dest/phase (addr_mod_6), clear src A
-                }
-                else
-                {
-                    tmp.set_last_outer_loop_instr(
-                        TT_OP_MVMUL(p_setrwc::CLR_B, 0, ADDR_MOD_2, 0)); // B3A3 or B3A2 // reset srca/srcb/dest/phase (addr_mod_6), clear src B
-                }
-            }
-        }
+        tmp.set_last_inner_loop_instr(TT_OP_REPLAY(ckernel::math::replay_buf_offset, 4, 0, 0));
+        tmp.set_last_outer_loop_instr(TT_OP_REPLAY(ckernel::math::replay_buf_offset + 13, 3, 0, 0));
+    }
+    else if constexpr (THROTTLE_LEVEL == 4)
+    {
+        tmp.set_last_inner_loop_instr(TT_OP_REPLAY(ckernel::math::replay_buf_offset, 4, 0, 0));
+        tmp.set_last_outer_loop_instr(TT_OP_REPLAY(ckernel::math::replay_buf_offset + 12, 4, 0, 0));
     }
     else
     {
-        if constexpr (THROTTLE_LEVEL > 3)
+        if constexpr (high_fidelity)
         {
-            tmp.set_last_inner_loop_instr(
-                TT_OP_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0)); // B2A1 // srca=32/16,srcb=16,  dest=0 (addr_mod_4) // A1 -> A2 && srca=16 if transposed
+            tmp.set_last_inner_loop_instr(TT_OP_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0));
         }
-        if (reuse_a)
+
+        if (t_dim > 1)
         {
-            if (t_dim > 1)
-            {
-                tmp.set_last_outer_loop_instr(
-                    TT_OP_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0)); // B3A3 or B3A2 // reset srca/srcb/dest, increment phase (addr_mod_5)
-            }
-            else
-            {
-                tmp.set_last_outer_loop_instr(
-                    TT_OP_MVMUL(p_setrwc::CLR_A, 0, ADDR_MOD_1, 0)); // B3A3 or B3A2 // reset srca/srcb/dest, increment phase (addr_mod_5), clear src A
-            }
+            tmp.set_last_outer_loop_instr(TT_OP_MVMUL(p_setrwc::CLR_NONE, 0, high_fidelity ? ADDR_MOD_2 : ADDR_MOD_1, 0));
+        }
+        else if (reuse_a)
+        {
+            tmp.set_last_outer_loop_instr(TT_OP_MVMUL(p_setrwc::CLR_A, 0, high_fidelity ? ADDR_MOD_2 : ADDR_MOD_1, 0));
         }
         else
         {
-            if (t_dim > 1)
-            {
-                tmp.set_last_outer_loop_instr(
-                    TT_OP_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0)); // B3A3 or B2A1 // reset srca/srcb/dest, increment phase (addr_mod_5)
-            }
-            else
-            {
-                tmp.set_last_outer_loop_instr(
-                    TT_OP_MVMUL(p_setrwc::CLR_B, 0, ADDR_MOD_1, 0)); // B3A3 or B2A1 // reset srca/srcb/dest, increment phase (addr_mod_5), clear src B
-            }
+            tmp.set_last_outer_loop_instr(TT_OP_MVMUL(p_setrwc::CLR_B, 0, high_fidelity ? ADDR_MOD_2 : ADDR_MOD_1, 0));
         }
     }
 

--- a/tt_llk_wormhole_b0/llk_lib/llk_math_matmul.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_math_matmul.h
@@ -605,7 +605,7 @@ inline void _llk_math_matmul_init_(
     }
 
     constexpr int MATH_FIDELITY_PHASES = get_math_num_fidelity_phases(MATH_FIDELITY_DESC);
-    if constexpr ((MM_ADD_NOPS > 1) && (MATH_FIDELITY_PHASES == 0)) {
+    if constexpr ((MM_ADD_NOPS > 0) && (MATH_FIDELITY_PHASES == 0)) {
         // Only enable throttling for lo-fi math
         matmul_configure_mop_throttled<MATH_FIDELITY_PHASES, FaceLayout, MM_ADD_NOPS>(transpose>0, ct_dim, rt_dim, kt_dim, in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face);
     } else {


### PR DESCRIPTION
### Problem description
Power draw during matmul workload can be lowered by adding NOPs into the llk. Here we have enabled the throttling of MM workloads by this method, to various degrees.

### What's changed
This feature can be enabled by setting env variable `TT_MM_THROTTLE_PERF=1, 2, 3, 4, 5`.
Value of 1 produces 73% intensity MM, 2 produces 67% intensity MM, 3 produces 50% intensity MM, 4 produces 40% intensity MM, 5 produces 33% intensity MM.
This currently only works for full tile MM (32x32), but should work for all math fidelities.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14930410415) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14930412458) CI passes (if applicable)
- [x] [device perf regression](https://github.com/tenstorrent/tt-metal/actions/runs/14930414687)
- [x] [frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/14930416394)