### PR TITLE
build: skip pr-comment step on forks due to permission issues

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -32,6 +32,8 @@ jobs:
   pr-comment:
     name: Post comment on PR
     runs-on: ubuntu-latest
+    # This job will only run if the PR is not from a fork (can't post comments to forks)
+    if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Check if comment already exists
         id: check-comment


### PR DESCRIPTION
### Ticket
None

### Problem description
It seems like GitHub Actions don't allow posting a comment on pull requests coming from forks, due to permission issues. Alternative can be seen as risky in terms of security (running PRs with elevated permissions), hence I'm going to disable bot from posting comments on PRs coming from forks.

### What's changed
Added conditional check if PR is coming from fork or not, allowing pr-comment action to run only for PRs coming from internal users.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
