### PR TITLE
[Test Infra] Added flexibility for dynamic byte count calculation for reading datums of different sizes

### DIFF
--- a/tests/python_tests/helpers/__init__.py
+++ b/tests/python_tests/helpers/__init__.py
@@ -5,7 +5,7 @@ from .format_config import FormatConfig, DataFormat, create_formats_for_testing
 from .stimuli_generator import flatten_list, generate_stimuli
 from .format_arg_mapping import (
     format_dict,
-    format_sizes,
+    format_num_bytes,
     ApproximationMode,
     MathOperation,
     ReduceDimension,
@@ -24,11 +24,11 @@ from .unpack import (
 )
 from .utils import (
     run_shell_command,
-    calculate_read_words_count,
     compare_pcc,
     format_kernel_list,
     print_faces,
     get_chip_architecture,
+    calculate_read_byte_count,
 )
 from .device import (
     collect_results,

--- a/tests/python_tests/helpers/__init__.py
+++ b/tests/python_tests/helpers/__init__.py
@@ -5,7 +5,6 @@ from .format_config import FormatConfig, DataFormat, create_formats_for_testing
 from .stimuli_generator import flatten_list, generate_stimuli
 from .format_arg_mapping import (
     format_dict,
-    format_num_bytes,
     ApproximationMode,
     MathOperation,
     ReduceDimension,

--- a/tests/python_tests/helpers/device.py
+++ b/tests/python_tests/helpers/device.py
@@ -15,6 +15,8 @@ import inspect
 import time
 from helpers.param_config import *
 
+MAX_READ_BYTE_SIZE_16BIT = 2048
+
 
 def collect_results(
     formats: FormatConfig,
@@ -105,7 +107,6 @@ def get_result_from_device(
     read_data_bytes: bytes,
     core_loc: str = "0,0",
     sfpu: bool = False,
-    num_tiles: int = 1,
 ):
     # Dictionary of format to unpacking function mappings
     unpackers = {
@@ -120,14 +121,6 @@ def get_result_from_device(
         unpack_func = unpack_bfp16 if sfpu else unpack_bfp8_b
     else:
         unpack_func = unpackers.get(formats.pack_dst)
-
-    if formats.pack_dst in [
-        DataFormat.Float16_b,
-        DataFormat.Float16,
-    ]:  # and num_tiles > 1:
-        read_data_bytes = read_data_bytes[
-            :2048
-        ]  # truncating tensor size so that we only read one tile at a time
 
     if unpack_func:
         num_args = len(inspect.signature(unpack_func).parameters)

--- a/tests/python_tests/helpers/format_arg_mapping.py
+++ b/tests/python_tests/helpers/format_arg_mapping.py
@@ -68,12 +68,12 @@ pack_dst_dict = {
     DataFormat.Int32: "PACK_DST_INT32",
 }
 
-format_sizes = {
-    DataFormat.Float32: 1024,
-    DataFormat.Float16: 512,
-    DataFormat.Float16_b: 512,
-    DataFormat.Bfp8_b: 272,
-    DataFormat.Int32: 1024,
+format_num_bytes = {
+    DataFormat.Float32: 4,
+    DataFormat.Float16: 2,
+    DataFormat.Float16_b: 2,
+    DataFormat.Bfp8_b: 1,
+    DataFormat.Int32: 4,
 }
 
 

--- a/tests/python_tests/helpers/format_arg_mapping.py
+++ b/tests/python_tests/helpers/format_arg_mapping.py
@@ -5,6 +5,7 @@ import torch
 from enum import Enum
 from .format_config import DataFormat
 
+
 format_dict = {
     DataFormat.Float32: torch.float32,
     DataFormat.Float16: torch.float16,
@@ -66,14 +67,6 @@ pack_dst_dict = {
     DataFormat.Float16_b: "PACK_DST_FLOAT16_B",
     DataFormat.Bfp8_b: "PACK_DST_BFP8_B",
     DataFormat.Int32: "PACK_DST_INT32",
-}
-
-format_num_bytes = {
-    DataFormat.Float32: 4,
-    DataFormat.Float16: 2,
-    DataFormat.Float16_b: 2,
-    DataFormat.Bfp8_b: 1,
-    DataFormat.Int32: 4,
 }
 
 

--- a/tests/python_tests/helpers/format_config.py
+++ b/tests/python_tests/helpers/format_config.py
@@ -6,20 +6,40 @@ from enum import Enum
 from typing import List, Optional, Tuple
 
 
-class DataFormat(Enum):
+class DataFormatInfo:
     """
-    An enumeration class that holds all the data formats supported by the LLKs.
-    Used to avoid hardcoding the format strings in the test scripts using strings. This avoid typos and future errors.
-    DataFormat(Enum) class instances can be compared via unique values.
-    When you have a set of related constants and you want to leverage the benefits of enumeration (unique members, comparisons, introspection, etc.).
-    It's a good choice for things like state machines, categories, or settings where values should not be changed or duplicated.
+    A helper class that encapsulates metadata for a data format.
+
+    Attributes:
+        name (str): A human-readable name for the data format.
+        byte_size (int): The size in bytes of one unit of the data format.
     """
 
-    Float16 = "Float16"
-    Float16_b = "Float16_b"
-    Bfp8_b = "Bfp8_b"
-    Float32 = "Float32"
-    Int32 = "Int32"
+    def __init__(self, name: str, byte_size: int):
+        self.name = name
+        self.byte_size = byte_size
+
+
+class DataFormat(Enum):
+    """
+    An enumeration of data formats supported by the LLKs.
+    Holds format name and byte size, and is extendable.
+    """
+
+    Float16 = DataFormatInfo("Float16", 2)
+    Float16_b = DataFormatInfo("Float16_b", 2)
+    Bfp8_b = DataFormatInfo("Bfp8_b", 1)
+    Float32 = DataFormatInfo("Float32", 4)
+    Int32 = DataFormatInfo("Int32", 4)
+
+    @property
+    def size(self) -> int:
+        """Returns the byte size of the data format."""
+        return self.value.byte_size
+
+    def __str__(self) -> str:
+        """Returns the string representation of the data format."""
+        return self.value.name
 
 
 @dataclass

--- a/tests/python_tests/helpers/param_config.py
+++ b/tests/python_tests/helpers/param_config.py
@@ -228,11 +228,11 @@ def generate_param_ids(included_params, all_params: List[tuple]) -> List[str]:
 
         # Start with the FormatConfig information
         result = [
-            f"unpack_src={format_config.unpack_A_src.value}, {format_config.unpack_B_src.value}",
-            f"unpack_dst={format_config.unpack_A_dst.value}, {format_config.unpack_B_dst.value}",
-            f"math={format_config.math.value}",
-            f"pack_src={format_config.pack_src.value}",
-            f"pack_dst={format_config.pack_dst.value}",
+            f"unpack_src={format_config.unpack_A_src.name}, {format_config.unpack_B_src.name}",
+            f"unpack_dst={format_config.unpack_A_dst.name}, {format_config.unpack_B_dst.name}",
+            f"math={format_config.math.name}",
+            f"pack_src={format_config.pack_src.name}",
+            f"pack_dst={format_config.pack_dst.name}",
         ]
         if params[0]:
             result.append(f"dest_acc={params[0].name}")

--- a/tests/python_tests/helpers/unpack.py
+++ b/tests/python_tests/helpers/unpack.py
@@ -11,11 +11,8 @@ def unpack_fp16(packed_list, unpack_src, pack_dst):
     def bytes_to_float16(byte_list):
         return struct.unpack("<e", bytes(byte_list))[0]
 
-    limited_packed_list = packed_list[:2048]
-
     return [
-        bytes_to_float16(limited_packed_list[i : i + 2])
-        for i in range(0, len(limited_packed_list), 2)
+        bytes_to_float16(packed_list[i : i + 2]) for i in range(0, len(packed_list), 2)
     ]
 
 
@@ -25,10 +22,8 @@ def unpack_bfp16(packed_list, unpack_src, pack_dst):
         unpacked_value = struct.unpack("<f", bytes_data)[0]
         return unpacked_value
 
-    limited_packed_list = packed_list[:2048]
     return [
-        bytes_to_bfloat16(limited_packed_list[i : i + 2])
-        for i in range(0, len(limited_packed_list), 2)
+        bytes_to_bfloat16(packed_list[i : i + 2]) for i in range(0, len(packed_list), 2)
     ]
 
 

--- a/tests/python_tests/helpers/utils.py
+++ b/tests/python_tests/helpers/utils.py
@@ -5,7 +5,6 @@ import os
 import torch
 import numpy as np
 import subprocess
-from .format_arg_mapping import format_num_bytes
 from .format_config import DataFormat, FormatConfig
 
 torch.set_printoptions(linewidth=500, sci_mode=False, precision=2, threshold=10000)
@@ -48,20 +47,10 @@ def run_shell_command(command: str):
 
 
 def calculate_read_byte_count(format: FormatConfig, array_size: int, sfpu=False) -> int:
-    num_elements_per_word = (
-        4 // format_num_bytes[format.pack_dst]
-    )  # num_bytes_per_word/num_element_bytes
-    print(f"\nnum_elements_per_word: {num_elements_per_word}")
-    num_words = (
-        array_size // num_elements_per_word
-    )  # num_elements // num_elements_per_word
-    print(f"\nnum_words: {num_words}")
-    num_bytes = num_words * 4  # num_words * num_bytes_per_word
-    print(f"\nnum_bytes: {num_bytes}")
+    total_bytes = array_size * format.pack_dst.size
     if format.pack_dst == DataFormat.Bfp8_b:
-        num_blocks = num_words // 4
-        num_bytes += num_blocks  # note: in bfp8_b each block is represented by an extra byte in order to represent the exponent
-    return int(num_bytes)
+        total_bytes += total_bytes // 16
+    return total_bytes
 
 
 def reverse_endian_chunk(input_list, chunk_size=4):

--- a/tests/python_tests/test_eltwise_unary_datacopy.py
+++ b/tests/python_tests/test_eltwise_unary_datacopy.py
@@ -84,7 +84,7 @@ def test_unary_datacopy(testname, formats, dest_acc):
 
     wait_for_tensix_operations_finished()
     res_from_L1 = collect_results(
-        formats, len(src_A)
+        formats, tensor_size=len(src_A)
     )  # Bug patchup in (unpack.py): passing formats struct to check unpack_src with pack_dst and distinguish when input and output formats have different exponent widths then reading from L1 changes
 
     assert len(res_from_L1) == len(golden)

--- a/tests/python_tests/test_eltwise_unary_datacopy.py
+++ b/tests/python_tests/test_eltwise_unary_datacopy.py
@@ -84,7 +84,7 @@ def test_unary_datacopy(testname, formats, dest_acc):
 
     wait_for_tensix_operations_finished()
     res_from_L1 = collect_results(
-        formats
+        formats, len(src_A)
     )  # Bug patchup in (unpack.py): passing formats struct to check unpack_src with pack_dst and distinguish when input and output formats have different exponent widths then reading from L1 changes
 
     assert len(res_from_L1) == len(golden)

--- a/tests/python_tests/test_eltwise_unary_sfpu.py
+++ b/tests/python_tests/test_eltwise_unary_sfpu.py
@@ -78,7 +78,7 @@ def test_eltwise_unary_sfpu(testname, formats, dest_acc, approx_mode, mathop):  
 
     wait_for_tensix_operations_finished()
     res_from_L1 = collect_results(
-        formats, sfpu=True
+        formats, len(src_A), sfpu=True
     )  # Bug patchup in (unpack.py): passing formats struct to check unpack_src with pack_dst and distinguish when input and output formats have different exponent widths then reading from L1 changes
     res_from_L1 = res_from_L1[
         :256

--- a/tests/python_tests/test_eltwise_unary_sfpu.py
+++ b/tests/python_tests/test_eltwise_unary_sfpu.py
@@ -78,7 +78,7 @@ def test_eltwise_unary_sfpu(testname, formats, dest_acc, approx_mode, mathop):  
 
     wait_for_tensix_operations_finished()
     res_from_L1 = collect_results(
-        formats, len(src_A), sfpu=True
+        formats, tensor_size=len(src_A)
     )  # Bug patchup in (unpack.py): passing formats struct to check unpack_src with pack_dst and distinguish when input and output formats have different exponent widths then reading from L1 changes
     res_from_L1 = res_from_L1[
         :256

--- a/tests/python_tests/test_fill_dest.py
+++ b/tests/python_tests/test_fill_dest.py
@@ -81,7 +81,7 @@ def test_fill_dest(testname, formats, dest_acc):
     res_from_L1 = []
     for address in pack_addresses:
         res_from_L1.append(
-            collect_results(formats, len(src_A), address)
+            collect_results(formats, tensor_size=len(src_A), address=address)
         )  # Bug patchup in (unpack.py): passing formats struct to check unpack_src with pack_dst and distinguish when input and output formats have different exponent widths then reading from L1 changes
     res_from_L1 = flatten_list(res_from_L1)
 

--- a/tests/python_tests/test_fill_dest.py
+++ b/tests/python_tests/test_fill_dest.py
@@ -81,7 +81,7 @@ def test_fill_dest(testname, formats, dest_acc):
     res_from_L1 = []
     for address in pack_addresses:
         res_from_L1.append(
-            collect_results(formats, address)
+            collect_results(formats, len(src_A), address)
         )  # Bug patchup in (unpack.py): passing formats struct to check unpack_src with pack_dst and distinguish when input and output formats have different exponent widths then reading from L1 changes
     res_from_L1 = flatten_list(res_from_L1)
 

--- a/tests/python_tests/test_matmul.py
+++ b/tests/python_tests/test_matmul.py
@@ -73,7 +73,7 @@ def test_matmul(testname, formats, dest_acc, math_fidelity):
 
     wait_for_tensix_operations_finished()
     res_from_L1 = collect_results(
-        formats
+        formats, len(src_A)
     )  # Bug patchup in (unpack.py): passing formats struct to check unpack_src with pack_dst and distinguish when input and output formats have different exponent widths then reading from L1 changes
     assert len(res_from_L1) == len(golden_tensor)
 

--- a/tests/python_tests/test_matmul.py
+++ b/tests/python_tests/test_matmul.py
@@ -73,7 +73,7 @@ def test_matmul(testname, formats, dest_acc, math_fidelity):
 
     wait_for_tensix_operations_finished()
     res_from_L1 = collect_results(
-        formats, len(src_A)
+        formats, tensor_size=len(src_A)
     )  # Bug patchup in (unpack.py): passing formats struct to check unpack_src with pack_dst and distinguish when input and output formats have different exponent widths then reading from L1 changes
     assert len(res_from_L1) == len(golden_tensor)
 

--- a/tests/python_tests/test_multiple_tiles_eltwise.py
+++ b/tests/python_tests/test_multiple_tiles_eltwise.py
@@ -45,7 +45,8 @@ def generate_golden(op, operand1, operand2, data_format, math_fidelity):
 
 full_sweep = False
 all_format_combos = generate_format_combinations(
-    [DataFormat.Float16_b, DataFormat.Float16, DataFormat.Bfp8_b], all_same=True
+    [DataFormat.Float16_b, DataFormat.Float16],
+    all_same=True,  # , DataFormat.Bfp8_b], all_same=True
 )  # Generate format combinations with all formats being the same (flag set to True), refer to `param_config.py` for more details.
 all_params = generate_params(
     ["multiple_tiles_eltwise_test"],
@@ -112,7 +113,11 @@ def test_multiple_tiles(testname, formats, dest_acc, mathop, math_fidelity, tile
     res_from_L1 = []
 
     for address in pack_addresses:
-        res_from_L1.append(collect_results(formats, len(src_A), address))
+        res_from_L1.append(
+            collect_results(
+                formats, tensor_size=len(src_A) // len(pack_addresses), address=address
+            )
+        )
 
     res_from_L1 = flatten_list(res_from_L1)
 

--- a/tests/python_tests/test_multiple_tiles_eltwise.py
+++ b/tests/python_tests/test_multiple_tiles_eltwise.py
@@ -112,7 +112,7 @@ def test_multiple_tiles(testname, formats, dest_acc, mathop, math_fidelity, tile
     res_from_L1 = []
 
     for address in pack_addresses:
-        res_from_L1.append(collect_results(formats, address))
+        res_from_L1.append(collect_results(formats, len(src_A), address))
 
     res_from_L1 = flatten_list(res_from_L1)
 

--- a/tests/python_tests/test_pack_untilize.py
+++ b/tests/python_tests/test_pack_untilize.py
@@ -51,7 +51,7 @@ def test_pack_untilize(testname, formats):
     wait_for_tensix_operations_finished()
 
     res_from_L1 = collect_results(
-        formats, len(src_A)
+        formats, tensor_size=len(src_A)
     )  # Bug patchup in (unpack.py): passing formats struct to check unpack_src with pack_dst and distinguish when input and output formats have different exponent widths then reading from L1 changes
     assert len(res_from_L1) == len(golden_tensor)
 

--- a/tests/python_tests/test_pack_untilize.py
+++ b/tests/python_tests/test_pack_untilize.py
@@ -51,7 +51,7 @@ def test_pack_untilize(testname, formats):
     wait_for_tensix_operations_finished()
 
     res_from_L1 = collect_results(
-        formats
+        formats, len(src_A)
     )  # Bug patchup in (unpack.py): passing formats struct to check unpack_src with pack_dst and distinguish when input and output formats have different exponent widths then reading from L1 changes
     assert len(res_from_L1) == len(golden_tensor)
 

--- a/tests/python_tests/test_reduce.py
+++ b/tests/python_tests/test_reduce.py
@@ -111,7 +111,7 @@ def test_reduce(testname, formats, dest_acc, reduce_dim, pool_type):
     wait_for_tensix_operations_finished()
 
     res_from_L1 = collect_results(
-        formats, len(src_A)
+        formats, tensor_size=len(src_A)
     )  # Bug patchup in (unpack.py): passing formats struct to check unpack_src with pack_dst and distinguish when input and output formats have different exponent widths then reading from L1 changes
     assert len(res_from_L1) == len(golden_tensor)
 

--- a/tests/python_tests/test_reduce.py
+++ b/tests/python_tests/test_reduce.py
@@ -111,7 +111,7 @@ def test_reduce(testname, formats, dest_acc, reduce_dim, pool_type):
     wait_for_tensix_operations_finished()
 
     res_from_L1 = collect_results(
-        formats
+        formats, len(src_A)
     )  # Bug patchup in (unpack.py): passing formats struct to check unpack_src with pack_dst and distinguish when input and output formats have different exponent widths then reading from L1 changes
     assert len(res_from_L1) == len(golden_tensor)
 

--- a/tests/python_tests/test_sfpu_binary.py
+++ b/tests/python_tests/test_sfpu_binary.py
@@ -74,7 +74,7 @@ def test_all(testname, formats, dest_acc, mathop):
     wait_for_tensix_operations_finished()
 
     res_from_L1 = collect_results(
-        formats
+        formats, len(src_A)
     )  # Bug patchup in (unpack.py): passing formats struct to check its unpack_src with pack_dst and distinguish when input and output formats have different exponent widths then reading from L1 changes
 
     assert len(res_from_L1) == len(golden)

--- a/tests/python_tests/test_sfpu_binary.py
+++ b/tests/python_tests/test_sfpu_binary.py
@@ -74,7 +74,7 @@ def test_all(testname, formats, dest_acc, mathop):
     wait_for_tensix_operations_finished()
 
     res_from_L1 = collect_results(
-        formats, len(src_A)
+        formats, tensor_size=len(src_A)
     )  # Bug patchup in (unpack.py): passing formats struct to check its unpack_src with pack_dst and distinguish when input and output formats have different exponent widths then reading from L1 changes
 
     assert len(res_from_L1) == len(golden)

--- a/tests/python_tests/test_tilize_calculate_untilize_L1.py
+++ b/tests/python_tests/test_tilize_calculate_untilize_L1.py
@@ -98,7 +98,7 @@ def test_tilize_calculate_untilize_L1(
     wait_for_tensix_operations_finished()
 
     res_from_L1 = collect_results(
-        formats, 0x1E000
+        formats, len(src_A), 0x1E000
     )  # Bug patchup in (unpack.py): passing formats struct to check unpack_src with pack_dst and distinguish when input and output formats have different exponent widths then reading from L1 changes
     assert len(res_from_L1) == len(golden_tensor)
 

--- a/tests/python_tests/test_tilize_calculate_untilize_L1.py
+++ b/tests/python_tests/test_tilize_calculate_untilize_L1.py
@@ -83,6 +83,7 @@ def test_tilize_calculate_untilize_L1(
         src_A, src_B, formats.unpack_A_src, formats.unpack_B_src, "0,0", tile_cnt
     )
 
+    buffer_dest_address = 0x1E000  # Since this test calls LLK pipeline twise, unpacker will read at address in L1 that packer packed to, this address is able to be reaused for two LLK calls
     test_config = {
         "formats": formats,
         "testname": testname,
@@ -98,7 +99,7 @@ def test_tilize_calculate_untilize_L1(
     wait_for_tensix_operations_finished()
 
     res_from_L1 = collect_results(
-        formats, len(src_A), 0x1E000
+        formats, tensor_size=len(src_A), address=buffer_dest_address
     )  # Bug patchup in (unpack.py): passing formats struct to check unpack_src with pack_dst and distinguish when input and output formats have different exponent widths then reading from L1 changes
     assert len(res_from_L1) == len(golden_tensor)
 

--- a/tests/python_tests/test_unpack_tilize.py
+++ b/tests/python_tests/test_unpack_tilize.py
@@ -41,7 +41,7 @@ def test_unpack_tilize(testname, formats):
     wait_for_tensix_operations_finished()
 
     res_from_L1 = collect_results(
-        formats, len(src_A)
+        formats, tensor_size=len(src_A)
     )  # Bug patchup in (unpack.py): passing formats struct to check unpack_src with pack_dst and distinguish when input and output formats have different exponent widths then reading from L1 changes
     assert len(res_from_L1) == len(golden_tensor)
 

--- a/tests/python_tests/test_unpack_tilize.py
+++ b/tests/python_tests/test_unpack_tilize.py
@@ -41,7 +41,7 @@ def test_unpack_tilize(testname, formats):
     wait_for_tensix_operations_finished()
 
     res_from_L1 = collect_results(
-        formats
+        formats, len(src_A)
     )  # Bug patchup in (unpack.py): passing formats struct to check unpack_src with pack_dst and distinguish when input and output formats have different exponent widths then reading from L1 changes
     assert len(res_from_L1) == len(golden_tensor)
 

--- a/tests/python_tests/test_unpack_untilize.py
+++ b/tests/python_tests/test_unpack_untilize.py
@@ -43,7 +43,7 @@ def test_unpack_untilze(testname, formats):
     run_elf_files(testname)
     wait_for_tensix_operations_finished()
     res_from_L1 = collect_results(
-        formats
+        formats, len(src_A)
     )  # Bug patchup in (unpack.py): passing formats struct to check unpack_src with pack_dst and distinguish when input and output formats have different exponent widths then reading from L1 changes
     assert len(res_from_L1) == len(golden_tensor)
 

--- a/tests/python_tests/test_unpack_untilize.py
+++ b/tests/python_tests/test_unpack_untilize.py
@@ -43,7 +43,7 @@ def test_unpack_untilze(testname, formats):
     run_elf_files(testname)
     wait_for_tensix_operations_finished()
     res_from_L1 = collect_results(
-        formats, len(src_A)
+        formats, tensor_size=len(src_A)
     )  # Bug patchup in (unpack.py): passing formats struct to check unpack_src with pack_dst and distinguish when input and output formats have different exponent widths then reading from L1 changes
     assert len(res_from_L1) == len(golden_tensor)
 


### PR DESCRIPTION
### Problem description
<!-- Provide context for the problem. -->
Instead of reading words from device to extract our result vector, we instead call read_from_device which reads the data in bytes. Previously this was set to read a fixed number or words and then a fixed number of bytes (maximum amount of bytes because it was set to read bytes for 32bit datums). 
However, we want to be able to be flexible with our stimuli generation for testing, which means input tensors will be of different sizes and different formats, thus the number of bytes we read should be flexible to these changes, instead of fixed. 

### What's changed
<!-- Describe the approach used to solve the problem.
Summarize the changes made and its impact. -->
Now we read the exact number of bytes necessary, we take into account the size of our output vector and the size of our datum, defined by `format_num_bytes` map. This calculation is done in `utils.py::calculate_read_byte_count` and the result is passed into exalens' `read_from_device` function called in `device.py`.
### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
