### PR TITLE
Fix PCK_DEST_RD_CTRL config based on 32 vs 16 bit Dest for int8

### DIFF
--- a/tt_llk_blackhole/common/inc/cpack_common.h
+++ b/tt_llk_blackhole/common/inc/cpack_common.h
@@ -261,10 +261,10 @@ inline void set_packer_config(const uint pack_src_format, const uint pack_dst_fo
     // cfg[THCON_SEC0_REG1_Row_start_section_size_ADDR32+3]=config.val[3];
 
     dest_rd_ctrl_u dest_rd_ctrl;
-    dest_rd_ctrl.val                              = 0;
-    dest_rd_ctrl.f.PCK_DEST_RD_CTRL_Read_32b_data = (pack_output_src_format == (uint)DataFormat::Int32) | (pack_output_src_format == (uint)DataFormat::Float32) |
-                                                    (is_fp32_dest_acc_en ? 1 : 0);
-    dest_rd_ctrl.f.PCK_DEST_RD_CTRL_Read_int8     = !is_fp32_dest_acc_en && (pack_output_src_format == (uint)DataFormat::Int8);
+    dest_rd_ctrl.val = 0;
+    dest_rd_ctrl.f.PCK_DEST_RD_CTRL_Read_32b_data =
+        (pack_output_src_format == (uint)DataFormat::Int32) | (pack_output_src_format == (uint)DataFormat::Float32) | (is_fp32_dest_acc_en ? 1 : 0);
+    dest_rd_ctrl.f.PCK_DEST_RD_CTRL_Read_int8 = !is_fp32_dest_acc_en && (pack_output_src_format == (uint)DataFormat::Int8);
     if (pack_dst_format == (uint)DataFormat::UInt8)
     {
         dest_rd_ctrl.f.PCK_DEST_RD_CTRL_Read_unsigned = 1;
@@ -304,10 +304,10 @@ inline void reconfig_packer_data_format(
     TTI_WRCFG(p_gpr_pack::TMP_LO, p_cfg::WRCFG_32b, THCON_SEC0_REG1_Row_start_section_size_ADDR32 + 2);
 
     dest_rd_ctrl_u dest_rd_ctrl;
-    dest_rd_ctrl.val                              = 0;
-    dest_rd_ctrl.f.PCK_DEST_RD_CTRL_Read_32b_data = (pack_output_src_format == (uint)DataFormat::Int32) | (pack_output_src_format == (uint)DataFormat::Float32) |
-                                                    (is_fp32_dest_acc_en ? 1 : 0);
-    dest_rd_ctrl.f.PCK_DEST_RD_CTRL_Read_int8     = !is_fp32_dest_acc_en && (pack_output_src_format == (uint)DataFormat::Int8);
+    dest_rd_ctrl.val = 0;
+    dest_rd_ctrl.f.PCK_DEST_RD_CTRL_Read_32b_data =
+        (pack_output_src_format == (uint)DataFormat::Int32) | (pack_output_src_format == (uint)DataFormat::Float32) | (is_fp32_dest_acc_en ? 1 : 0);
+    dest_rd_ctrl.f.PCK_DEST_RD_CTRL_Read_int8 = !is_fp32_dest_acc_en && (pack_output_src_format == (uint)DataFormat::Int8);
     if (pack_dst_format == (uint)DataFormat::UInt8)
     {
         dest_rd_ctrl.f.PCK_DEST_RD_CTRL_Read_unsigned = 1;

--- a/tt_llk_blackhole/common/inc/cpack_common.h
+++ b/tt_llk_blackhole/common/inc/cpack_common.h
@@ -262,8 +262,9 @@ inline void set_packer_config(const uint pack_src_format, const uint pack_dst_fo
 
     dest_rd_ctrl_u dest_rd_ctrl;
     dest_rd_ctrl.val                              = 0;
-    dest_rd_ctrl.f.PCK_DEST_RD_CTRL_Read_32b_data = (pack_output_src_format == (uint)DataFormat::Int8) | (pack_output_src_format == (uint)DataFormat::Int32) |
-                                                    (pack_output_src_format == (uint)DataFormat::Float32) | (is_fp32_dest_acc_en ? 1 : 0);
+    dest_rd_ctrl.f.PCK_DEST_RD_CTRL_Read_32b_data = (pack_output_src_format == (uint)DataFormat::Int32) | (pack_output_src_format == (uint)DataFormat::Float32) |
+                                                    (is_fp32_dest_acc_en ? 1 : 0);
+    dest_rd_ctrl.f.PCK_DEST_RD_CTRL_Read_int8     = !is_fp32_dest_acc_en && (pack_output_src_format == (uint)DataFormat::Int8);
     if (pack_dst_format == (uint)DataFormat::UInt8)
     {
         dest_rd_ctrl.f.PCK_DEST_RD_CTRL_Read_unsigned = 1;
@@ -304,8 +305,9 @@ inline void reconfig_packer_data_format(
 
     dest_rd_ctrl_u dest_rd_ctrl;
     dest_rd_ctrl.val                              = 0;
-    dest_rd_ctrl.f.PCK_DEST_RD_CTRL_Read_32b_data = (pack_output_src_format == (uint)DataFormat::Int8) | (pack_src_format == (uint)DataFormat::Int32) |
-                                                    (pack_src_format == (uint)DataFormat::Float32) | (is_fp32_dest_acc_en ? 1 : 0);
+    dest_rd_ctrl.f.PCK_DEST_RD_CTRL_Read_32b_data = (pack_output_src_format == (uint)DataFormat::Int32) | (pack_output_src_format == (uint)DataFormat::Float32) |
+                                                    (is_fp32_dest_acc_en ? 1 : 0);
+    dest_rd_ctrl.f.PCK_DEST_RD_CTRL_Read_int8     = !is_fp32_dest_acc_en && (pack_output_src_format == (uint)DataFormat::Int8);
     if (pack_dst_format == (uint)DataFormat::UInt8)
     {
         dest_rd_ctrl.f.PCK_DEST_RD_CTRL_Read_unsigned = 1;

--- a/tt_llk_blackhole/common/inc/cpack_common.h
+++ b/tt_llk_blackhole/common/inc/cpack_common.h
@@ -6,6 +6,7 @@
 
 #include <array>
 #include <cstdint>
+#include <type_traits>
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
@@ -14,6 +15,8 @@
 
 namespace ckernel::packer
 {
+using DataFormatType = std::underlying_type_t<DataFormat>;
+
 constexpr uint replay_buf_offset = 16; // split replay buffer usage between fpu/sfpu
                                        // fist 16 for sfpu, next 16 for fpu
 constexpr uint32_t NUM_PACKERS = 1;    // Number of packers
@@ -164,7 +167,9 @@ inline void set_packer_strides(const uint pack_src_format, const uint pack_dst_f
     // Get pointer to registers for current state ID
     volatile uint tt_reg_ptr* cfg = get_cfg_pointer();
 
-    uint x_stride = (uint)(pack_src_format & 0x3) == (uint)DataFormat::Float32 ? 4 : (uint)(pack_src_format & 0x3) == (uint)DataFormat::Float16 ? 2 : 1;
+    uint x_stride = (uint)(pack_src_format & 0x3) == static_cast<DataFormatType>(DataFormat::Float32)   ? 4
+                    : (uint)(pack_src_format & 0x3) == static_cast<DataFormatType>(DataFormat::Float16) ? 2
+                                                                                                        : 1;
     uint y_stride = FACE_C_DIM * x_stride;
     uint w_stride = TILE_NUM_FACES * FACE_C_DIM * FACE_R_DIM * x_stride;
 
@@ -211,7 +216,7 @@ inline void set_packer_config(const uint pack_src_format, const uint pack_dst_fo
     }
 
     config.f.exp_section_size =
-        ((pack_output_dst_format == (uint)DataFormat::Lf8) || (pack_output_dst_format == (uint)DataFormat::Int8))
+        ((pack_output_dst_format == static_cast<DataFormatType>(DataFormat::Lf8)) || (pack_output_dst_format == static_cast<DataFormatType>(DataFormat::Int8)))
             ? 0
             : (partial_face ? 1 : num_faces); // set to num_faces as exp section size is not used for non-bfp formats except for lf8/int8
 
@@ -262,16 +267,23 @@ inline void set_packer_config(const uint pack_src_format, const uint pack_dst_fo
 
     dest_rd_ctrl_u dest_rd_ctrl;
     dest_rd_ctrl.val = 0;
-    dest_rd_ctrl.f.PCK_DEST_RD_CTRL_Read_32b_data =
-        (pack_output_src_format == (uint)DataFormat::Int32) | (pack_output_src_format == (uint)DataFormat::Float32) | (is_fp32_dest_acc_en ? 1 : 0);
-    dest_rd_ctrl.f.PCK_DEST_RD_CTRL_Read_int8 = !is_fp32_dest_acc_en && (pack_output_src_format == (uint)DataFormat::Int8);
-    if (pack_dst_format == (uint)DataFormat::UInt8)
+
+    bool is_32b_format = pack_output_src_format == static_cast<DataFormatType>(DataFormat::Int32) ||
+                         pack_output_src_format == static_cast<DataFormatType>(DataFormat::UInt32) ||
+                         pack_output_src_format == static_cast<DataFormatType>(DataFormat::Float32);
+    bool is_int8_format =
+        pack_output_src_format == static_cast<DataFormatType>(DataFormat::Int8) || pack_output_src_format == static_cast<DataFormatType>(DataFormat::UInt8);
+
+    dest_rd_ctrl.f.PCK_DEST_RD_CTRL_Read_32b_data = is_32b_format || is_fp32_dest_acc_en;
+    dest_rd_ctrl.f.PCK_DEST_RD_CTRL_Read_int8     = !(is_fp32_dest_acc_en || is_32b_format) && is_int8_format;
+
+    if (pack_dst_format == static_cast<DataFormatType>(DataFormat::UInt8))
     {
         dest_rd_ctrl.f.PCK_DEST_RD_CTRL_Read_unsigned = 1;
     }
 
     // Round to 10 bit mantissa from fp32 dest
-    if (is_fp32_dest_acc_en && (pack_output_src_format == (uint)DataFormat::Float16))
+    if (is_fp32_dest_acc_en && (pack_output_src_format == static_cast<DataFormatType>(DataFormat::Float16)))
     {
         dest_rd_ctrl.f.PCK_DEST_RD_CTRL_Round_10b_mant = 1;
     }
@@ -305,15 +317,22 @@ inline void reconfig_packer_data_format(
 
     dest_rd_ctrl_u dest_rd_ctrl;
     dest_rd_ctrl.val = 0;
-    dest_rd_ctrl.f.PCK_DEST_RD_CTRL_Read_32b_data =
-        (pack_output_src_format == (uint)DataFormat::Int32) | (pack_output_src_format == (uint)DataFormat::Float32) | (is_fp32_dest_acc_en ? 1 : 0);
-    dest_rd_ctrl.f.PCK_DEST_RD_CTRL_Read_int8 = !is_fp32_dest_acc_en && (pack_output_src_format == (uint)DataFormat::Int8);
-    if (pack_dst_format == (uint)DataFormat::UInt8)
+
+    bool is_32b_format = pack_output_src_format == static_cast<DataFormatType>(DataFormat::Int32) ||
+                         pack_output_src_format == static_cast<DataFormatType>(DataFormat::UInt32) ||
+                         pack_output_src_format == static_cast<DataFormatType>(DataFormat::Float32);
+    bool is_int8_format =
+        pack_output_src_format == static_cast<DataFormatType>(DataFormat::Int8) || pack_output_src_format == static_cast<DataFormatType>(DataFormat::UInt8);
+
+    dest_rd_ctrl.f.PCK_DEST_RD_CTRL_Read_32b_data = is_32b_format || is_fp32_dest_acc_en;
+    dest_rd_ctrl.f.PCK_DEST_RD_CTRL_Read_int8     = !(is_fp32_dest_acc_en || is_32b_format) && is_int8_format;
+
+    if (pack_dst_format == static_cast<DataFormatType>(DataFormat::UInt8))
     {
         dest_rd_ctrl.f.PCK_DEST_RD_CTRL_Read_unsigned = 1;
     }
     // Round to 10 bit mantissa from fp32 dest
-    if (is_fp32_dest_acc_en && (pack_output_src_format == (uint)DataFormat::Float16))
+    if (is_fp32_dest_acc_en && (pack_output_src_format == static_cast<DataFormatType>(DataFormat::Float16)))
     {
         dest_rd_ctrl.f.PCK_DEST_RD_CTRL_Round_10b_mant = 1;
     }
@@ -326,7 +345,8 @@ inline void reconfig_packer_data_format(
     {
         TTI_WRCFG(p_gpr_pack::EXP0_SEC_SIZE_BFP, p_cfg::WRCFG_32b, THCON_SEC0_REG1_Row_start_section_size_ADDR32);
     }
-    else if ((pack_output_dst_format == (uint)DataFormat::Lf8) || (pack_output_dst_format == (uint)DataFormat::Int8))
+    else if (
+        (pack_output_dst_format == static_cast<DataFormatType>(DataFormat::Lf8)) || (pack_output_dst_format == static_cast<DataFormatType>(DataFormat::Int8)))
     {
         TTI_WRCFG(p_gpr::ZERO, p_cfg::WRCFG_32b, THCON_SEC0_REG1_Row_start_section_size_ADDR32);
     }
@@ -380,7 +400,7 @@ inline void configure_pack(
     t6_mutex_acquire(mutex::REG_RMW);
 
     // Set Fp8 E4M3 mode for packer
-    if ((pack_dst_format & 0x1F) == (uint)DataFormat::Fp8_e4m3)
+    if ((pack_dst_format & 0x1F) == static_cast<DataFormatType>(DataFormat::Fp8_e4m3))
     {
         cfg_reg_rmw_tensix<THCON_SEC0_REG1_Pac_LF8_4b_exp_RMW>(1);
     }

--- a/tt_llk_wormhole_b0/common/inc/cpack_common.h
+++ b/tt_llk_wormhole_b0/common/inc/cpack_common.h
@@ -6,6 +6,7 @@
 
 #include <array>
 #include <cstdint>
+#include <type_traits>
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
@@ -14,6 +15,8 @@
 
 namespace ckernel::packer
 {
+using DataFormatType = std::underlying_type_t<DataFormat>;
+
 constexpr uint32_t PACK_CNT    = 4;
 constexpr uint32_t NUM_PACKERS = 4; // Number of packers
 
@@ -161,7 +164,9 @@ inline void set_packer_strides(const uint pack_src_format, const uint pack_dst_f
     // Get pointer to registers for current state ID
     volatile uint tt_reg_ptr* cfg = get_cfg_pointer();
 
-    uint x_stride = (uint)(pack_src_format & 0x3) == (uint)DataFormat::Float32 ? 4 : (uint)(pack_src_format & 0x3) == (uint)DataFormat::Float16 ? 2 : 1;
+    uint x_stride = (uint)(pack_src_format & 0x3) == static_cast<DataFormatType>(DataFormat::Float32)   ? 4
+                    : (uint)(pack_src_format & 0x3) == static_cast<DataFormatType>(DataFormat::Float16) ? 2
+                                                                                                        : 1;
     uint y_stride = FACE_R_DIM * x_stride;
     uint z_stride = PACK_CNT * FACE_C_DIM * y_stride;
     uint w_stride = z_stride;
@@ -190,7 +195,7 @@ inline void set_packer_config(const uint pack_src_format, const uint pack_dst_fo
     }
 
     config.f.exp_section_size =
-        ((pack_dst_format == (uint)DataFormat::Lf8) || ((pack_dst_format & 0xF) == (uint)DataFormat::Int8))
+        ((pack_dst_format == static_cast<DataFormatType>(DataFormat::Lf8)) || ((pack_dst_format & 0xF) == static_cast<DataFormatType>(DataFormat::Int8)))
             ? 0
             : (partial_face ? 1 : num_faces); // set to num_faces as exp section size is not used for non-bfp formats except for lf8/int8
 
@@ -247,17 +252,23 @@ inline void set_packer_config(const uint pack_src_format, const uint pack_dst_fo
     cfg[THCON_SEC1_REG8_Row_start_section_size_ADDR32 + 3] = config.val[3];
 
     dest_rd_ctrl_u dest_rd_ctrl;
-    dest_rd_ctrl.val                              = 0;
-    dest_rd_ctrl.f.PCK_DEST_RD_CTRL_Read_32b_data = (pack_src_format == (uint)DataFormat::Int32) | (pack_src_format == (uint)DataFormat::UInt32) |
-                                                    (pack_src_format == (uint)DataFormat::Float32) | (is_fp32_dest_acc_en ? 1 : 0);
-    dest_rd_ctrl.f.PCK_DEST_RD_CTRL_Read_int8 = !is_fp32_dest_acc_en && ((pack_src_format & 0xF) == (uint)DataFormat::Int8);
-    if (pack_dst_format == (uint)DataFormat::UInt8)
+    dest_rd_ctrl.val = 0;
+
+    bool is_32b_format = pack_src_format == static_cast<DataFormatType>(DataFormat::Int32) ||
+                         pack_src_format == static_cast<DataFormatType>(DataFormat::UInt32) ||
+                         pack_src_format == static_cast<DataFormatType>(DataFormat::Float32);
+    bool is_int8_format = pack_src_format == static_cast<DataFormatType>(DataFormat::Int8) || pack_src_format == static_cast<DataFormatType>(DataFormat::UInt8);
+
+    dest_rd_ctrl.f.PCK_DEST_RD_CTRL_Read_32b_data = is_32b_format || is_fp32_dest_acc_en;
+    dest_rd_ctrl.f.PCK_DEST_RD_CTRL_Read_int8     = !(is_fp32_dest_acc_en || is_32b_format) && is_int8_format;
+
+    if (pack_dst_format == static_cast<DataFormatType>(DataFormat::UInt8))
     {
         dest_rd_ctrl.f.PCK_DEST_RD_CTRL_Read_unsigned = 1;
     }
 
     // Round to 10 bit mantissa from fp32 dest
-    if (is_fp32_dest_acc_en && (pack_src_format == (uint)DataFormat::Float16))
+    if (is_fp32_dest_acc_en && (pack_src_format == static_cast<DataFormatType>(DataFormat::Float16)))
     {
         dest_rd_ctrl.f.PCK_DEST_RD_CTRL_Round_10b_mant = 1;
     }
@@ -267,7 +278,8 @@ inline void set_packer_config(const uint pack_src_format, const uint pack_dst_fo
     {
         // Override exp section size for packers 1,2,3
         // Tile header + exp size + datum size
-        if ((uint)(pack_dst_format & 0x1F) == (uint)DataFormat::Bfp8 || (uint)(pack_dst_format & 0x1F) == (uint)DataFormat::Bfp8_b)
+        if ((uint)(pack_dst_format & 0x1F) == static_cast<DataFormatType>(DataFormat::Bfp8) ||
+            (uint)(pack_dst_format & 0x1F) == static_cast<DataFormatType>(DataFormat::Bfp8_b))
         {
             config.f.exp_section_size                              = 1 + ((num_faces > 2) ? 2 : 0) + 16;
             cfg[THCON_SEC0_REG8_Row_start_section_size_ADDR32 + 0] = config.val[0];
@@ -276,7 +288,9 @@ inline void set_packer_config(const uint pack_src_format, const uint pack_dst_fo
             config.f.exp_section_size                              = 1 + 0 + 48;
             cfg[THCON_SEC1_REG8_Row_start_section_size_ADDR32 + 0] = config.val[0];
         }
-        else if ((uint)(pack_dst_format & 0x1F) == (uint)DataFormat::Bfp4 || (uint)(pack_dst_format & 0x1F) == (uint)DataFormat::Bfp4_b)
+        else if (
+            (uint)(pack_dst_format & 0x1F) == static_cast<DataFormatType>(DataFormat::Bfp4) ||
+            (uint)(pack_dst_format & 0x1F) == static_cast<DataFormatType>(DataFormat::Bfp4_b))
         {
             config.f.exp_section_size                              = 1 + ((num_faces > 2) ? 2 : 0) + 8;
             cfg[THCON_SEC0_REG8_Row_start_section_size_ADDR32 + 0] = config.val[0];
@@ -285,7 +299,9 @@ inline void set_packer_config(const uint pack_src_format, const uint pack_dst_fo
             config.f.exp_section_size                              = 1 + 0 + 24;
             cfg[THCON_SEC1_REG8_Row_start_section_size_ADDR32 + 0] = config.val[0];
         }
-        else if ((uint)(pack_dst_format & 0x1F) == (uint)DataFormat::Bfp2 || (uint)(pack_dst_format & 0x1F) == (uint)DataFormat::Bfp2_b)
+        else if (
+            (uint)(pack_dst_format & 0x1F) == static_cast<DataFormatType>(DataFormat::Bfp2) ||
+            (uint)(pack_dst_format & 0x1F) == static_cast<DataFormatType>(DataFormat::Bfp2_b))
         {
             config.f.exp_section_size                              = 1 + ((num_faces > 2) ? 2 : 0) + 4;
             cfg[THCON_SEC0_REG8_Row_start_section_size_ADDR32 + 0] = config.val[0];
@@ -318,10 +334,11 @@ inline void set_packer_l1_offset(const uint pack_dst_format, const uint face_r_d
 {
     const uint face_dim = face_r_dim * FACE_C_DIM;
 
-    uint32_t l1_offset_1 = IS_BFP_FORMAT(pack_dst_format) ? 1
-                                                          : (((uint8_t)(pack_dst_format & 0x3) == (uint8_t)DataFormat::Float32)   ? (face_dim / 16) * 4
-                                                             : ((uint8_t)(pack_dst_format & 0x3) == (uint8_t)DataFormat::Float16) ? (face_dim / 16) * 2
-                                                                                                                                  : (face_dim / 16));
+    uint32_t l1_offset_1 = IS_BFP_FORMAT(pack_dst_format)
+                               ? 1
+                               : (((uint8_t)(pack_dst_format & 0x3) == static_cast<DataFormatType>(DataFormat::Float32))   ? (face_dim / 16) * 4
+                                  : ((uint8_t)(pack_dst_format & 0x3) == static_cast<DataFormatType>(DataFormat::Float16)) ? (face_dim / 16) * 2
+                                                                                                                           : (face_dim / 16));
     uint32_t l1_offset_2 = 2 * l1_offset_1;
     uint32_t l1_offset_3 = 3 * l1_offset_1;
 
@@ -361,16 +378,22 @@ inline void reconfig_packer_data_format(const uint pack_src_format, const uint p
     TTI_REG2FLOP(2, 0, 0, 0, THCON_SEC1_REG8_Row_start_section_size_ADDR32 + 2 - THCON_CFGREG_BASE_ADDR32, p_gpr_pack::TMP_LO);
 
     dest_rd_ctrl_u dest_rd_ctrl;
-    dest_rd_ctrl.val                              = 0;
-    dest_rd_ctrl.f.PCK_DEST_RD_CTRL_Read_32b_data = (pack_src_format == (uint)DataFormat::Int32) | (pack_src_format == (uint)DataFormat::UInt32) |
-                                                    (pack_src_format == (uint)DataFormat::Float32) | (is_fp32_dest_acc_en ? 1 : 0);
-    dest_rd_ctrl.f.PCK_DEST_RD_CTRL_Read_int8 = !is_fp32_dest_acc_en && ((pack_src_format & 0xF) == (uint)DataFormat::Int8);
-    if (pack_dst_format == (uint)DataFormat::UInt8)
+    dest_rd_ctrl.val = 0;
+
+    bool is_32b_format = pack_src_format == static_cast<DataFormatType>(DataFormat::Int32) ||
+                         pack_src_format == static_cast<DataFormatType>(DataFormat::UInt32) ||
+                         pack_src_format == static_cast<DataFormatType>(DataFormat::Float32);
+    bool is_int8_format = pack_src_format == static_cast<DataFormatType>(DataFormat::Int8) || pack_src_format == static_cast<DataFormatType>(DataFormat::UInt8);
+
+    dest_rd_ctrl.f.PCK_DEST_RD_CTRL_Read_32b_data = is_32b_format || is_fp32_dest_acc_en;
+    dest_rd_ctrl.f.PCK_DEST_RD_CTRL_Read_int8     = !(is_fp32_dest_acc_en || is_32b_format) && is_int8_format;
+
+    if (pack_dst_format == static_cast<DataFormatType>(DataFormat::UInt8))
     {
         dest_rd_ctrl.f.PCK_DEST_RD_CTRL_Read_unsigned = 1;
     }
     // Round to 10 bit mantissa from fp32 dest
-    if (is_fp32_dest_acc_en && (pack_src_format == (uint)DataFormat::Float16))
+    if (is_fp32_dest_acc_en && (pack_src_format == static_cast<DataFormatType>(DataFormat::Float16)))
     {
         dest_rd_ctrl.f.PCK_DEST_RD_CTRL_Round_10b_mant = 1;
     }
@@ -384,19 +407,24 @@ inline void reconfig_packer_data_format(const uint pack_src_format, const uint p
         // Override exp section size for packers 1,2,3
         // Tile header + exp size + datum size
         TTI_REG2FLOP(1, 0, 0, 0, THCON_SEC0_REG1_Row_start_section_size_ADDR32 + 0 - THCON_CFGREG_BASE_ADDR32, p_gpr_pack::EXP0_SEC_SIZE_BFP);
-        if ((pack_dst_format & 0x1F) == (uint)DataFormat::Bfp8 || (pack_dst_format & 0x1F) == (uint)DataFormat::Bfp8_b)
+        if ((pack_dst_format & 0x1F) == static_cast<DataFormatType>(DataFormat::Bfp8) ||
+            (pack_dst_format & 0x1F) == static_cast<DataFormatType>(DataFormat::Bfp8_b))
         {
             TTI_REG2FLOP(1, 0, 0, 0, THCON_SEC0_REG8_Row_start_section_size_ADDR32 + 0 - THCON_CFGREG_BASE_ADDR32, p_gpr_pack::EXP1_SEC_SIZE_BFP8);
             TTI_REG2FLOP(1, 0, 0, 0, THCON_SEC1_REG1_Row_start_section_size_ADDR32 + 0 - THCON_CFGREG_BASE_ADDR32, p_gpr_pack::EXP2_SEC_SIZE_BFP8);
             TTI_REG2FLOP(1, 0, 0, 0, THCON_SEC1_REG8_Row_start_section_size_ADDR32 + 0 - THCON_CFGREG_BASE_ADDR32, p_gpr_pack::EXP3_SEC_SIZE_BFP8);
         }
-        else if ((pack_dst_format & 0x1F) == (uint)DataFormat::Bfp4 || (pack_dst_format & 0x1F) == (uint)DataFormat::Bfp4_b)
+        else if (
+            (pack_dst_format & 0x1F) == static_cast<DataFormatType>(DataFormat::Bfp4) ||
+            (pack_dst_format & 0x1F) == static_cast<DataFormatType>(DataFormat::Bfp4_b))
         {
             TTI_REG2FLOP(1, 0, 0, 0, THCON_SEC0_REG8_Row_start_section_size_ADDR32 + 0 - THCON_CFGREG_BASE_ADDR32, p_gpr_pack::EXP1_SEC_SIZE_BFP4);
             TTI_REG2FLOP(1, 0, 0, 0, THCON_SEC1_REG1_Row_start_section_size_ADDR32 + 0 - THCON_CFGREG_BASE_ADDR32, p_gpr_pack::EXP2_SEC_SIZE_BFP4);
             TTI_REG2FLOP(1, 0, 0, 0, THCON_SEC1_REG8_Row_start_section_size_ADDR32 + 0 - THCON_CFGREG_BASE_ADDR32, p_gpr_pack::EXP3_SEC_SIZE_BFP4);
         }
-        else if ((pack_dst_format & 0x1F) == (uint)DataFormat::Bfp2 || (pack_dst_format & 0x1F) == (uint)DataFormat::Bfp2_b)
+        else if (
+            (pack_dst_format & 0x1F) == static_cast<DataFormatType>(DataFormat::Bfp2) ||
+            (pack_dst_format & 0x1F) == static_cast<DataFormatType>(DataFormat::Bfp2_b))
         {
             TTI_REG2FLOP(1, 0, 0, 0, THCON_SEC0_REG8_Row_start_section_size_ADDR32 + 0 - THCON_CFGREG_BASE_ADDR32, p_gpr_pack::EXP1_SEC_SIZE_BFP2);
             TTI_REG2FLOP(1, 0, 0, 0, THCON_SEC1_REG1_Row_start_section_size_ADDR32 + 0 - THCON_CFGREG_BASE_ADDR32, p_gpr_pack::EXP2_SEC_SIZE_BFP2);
@@ -407,7 +435,7 @@ inline void reconfig_packer_data_format(const uint pack_src_format, const uint p
             FWASSERT("Other data formats not supported", false);
         }
     }
-    else if ((pack_dst_format == (uint)DataFormat::Lf8) || ((pack_dst_format & 0xF) == (uint)DataFormat::Int8))
+    else if ((pack_dst_format == static_cast<DataFormatType>(DataFormat::Lf8)) || ((pack_dst_format & 0xF) == static_cast<DataFormatType>(DataFormat::Int8)))
     {
         TTI_REG2FLOP(1, 0, 0, 0, THCON_SEC0_REG1_Row_start_section_size_ADDR32 + 0 - THCON_CFGREG_BASE_ADDR32, p_gpr::ZERO);
         TTI_REG2FLOP(1, 0, 0, 0, THCON_SEC0_REG8_Row_start_section_size_ADDR32 + 0 - THCON_CFGREG_BASE_ADDR32, p_gpr::ZERO);

--- a/tt_llk_wormhole_b0/common/inc/cpack_common.h
+++ b/tt_llk_wormhole_b0/common/inc/cpack_common.h
@@ -248,9 +248,9 @@ inline void set_packer_config(const uint pack_src_format, const uint pack_dst_fo
 
     dest_rd_ctrl_u dest_rd_ctrl;
     dest_rd_ctrl.val                              = 0;
-    dest_rd_ctrl.f.PCK_DEST_RD_CTRL_Read_32b_data = ((pack_src_format & 0xF) == (uint)DataFormat::Int8) | (pack_src_format == (uint)DataFormat::Int32) |
-                                                    (pack_src_format == (uint)DataFormat::UInt32) | (pack_src_format == (uint)DataFormat::Float32) |
-                                                    (is_fp32_dest_acc_en ? 1 : 0);
+    dest_rd_ctrl.f.PCK_DEST_RD_CTRL_Read_32b_data = (pack_src_format == (uint)DataFormat::Int32) | (pack_src_format == (uint)DataFormat::UInt32) |
+                                                    (pack_src_format == (uint)DataFormat::Float32) | (is_fp32_dest_acc_en ? 1 : 0);
+    dest_rd_ctrl.f.PCK_DEST_RD_CTRL_Read_int8     = !is_fp32_dest_acc_en && ((pack_src_format & 0xF) == (uint)DataFormat::Int8);
     if (pack_dst_format == (uint)DataFormat::UInt8)
     {
         dest_rd_ctrl.f.PCK_DEST_RD_CTRL_Read_unsigned = 1;
@@ -362,9 +362,9 @@ inline void reconfig_packer_data_format(const uint pack_src_format, const uint p
 
     dest_rd_ctrl_u dest_rd_ctrl;
     dest_rd_ctrl.val                              = 0;
-    dest_rd_ctrl.f.PCK_DEST_RD_CTRL_Read_32b_data = ((pack_src_format & 0xF) == (uint)DataFormat::Int8) | (pack_src_format == (uint)DataFormat::Int32) |
-                                                    (pack_src_format == (uint)DataFormat::UInt32) | (pack_src_format == (uint)DataFormat::Float32) |
-                                                    (is_fp32_dest_acc_en ? 1 : 0);
+    dest_rd_ctrl.f.PCK_DEST_RD_CTRL_Read_32b_data = (pack_src_format == (uint)DataFormat::Int32) | (pack_src_format == (uint)DataFormat::UInt32) |
+                                                    (pack_src_format == (uint)DataFormat::Float32) | (is_fp32_dest_acc_en ? 1 : 0);
+    dest_rd_ctrl.f.PCK_DEST_RD_CTRL_Read_int8     = !is_fp32_dest_acc_en && ((pack_src_format & 0xF) == (uint)DataFormat::Int8);
     if (pack_dst_format == (uint)DataFormat::UInt8)
     {
         dest_rd_ctrl.f.PCK_DEST_RD_CTRL_Read_unsigned = 1;

--- a/tt_llk_wormhole_b0/common/inc/cpack_common.h
+++ b/tt_llk_wormhole_b0/common/inc/cpack_common.h
@@ -250,7 +250,7 @@ inline void set_packer_config(const uint pack_src_format, const uint pack_dst_fo
     dest_rd_ctrl.val                              = 0;
     dest_rd_ctrl.f.PCK_DEST_RD_CTRL_Read_32b_data = (pack_src_format == (uint)DataFormat::Int32) | (pack_src_format == (uint)DataFormat::UInt32) |
                                                     (pack_src_format == (uint)DataFormat::Float32) | (is_fp32_dest_acc_en ? 1 : 0);
-    dest_rd_ctrl.f.PCK_DEST_RD_CTRL_Read_int8     = !is_fp32_dest_acc_en && ((pack_src_format & 0xF) == (uint)DataFormat::Int8);
+    dest_rd_ctrl.f.PCK_DEST_RD_CTRL_Read_int8 = !is_fp32_dest_acc_en && ((pack_src_format & 0xF) == (uint)DataFormat::Int8);
     if (pack_dst_format == (uint)DataFormat::UInt8)
     {
         dest_rd_ctrl.f.PCK_DEST_RD_CTRL_Read_unsigned = 1;
@@ -364,7 +364,7 @@ inline void reconfig_packer_data_format(const uint pack_src_format, const uint p
     dest_rd_ctrl.val                              = 0;
     dest_rd_ctrl.f.PCK_DEST_RD_CTRL_Read_32b_data = (pack_src_format == (uint)DataFormat::Int32) | (pack_src_format == (uint)DataFormat::UInt32) |
                                                     (pack_src_format == (uint)DataFormat::Float32) | (is_fp32_dest_acc_en ? 1 : 0);
-    dest_rd_ctrl.f.PCK_DEST_RD_CTRL_Read_int8     = !is_fp32_dest_acc_en && ((pack_src_format & 0xF) == (uint)DataFormat::Int8);
+    dest_rd_ctrl.f.PCK_DEST_RD_CTRL_Read_int8 = !is_fp32_dest_acc_en && ((pack_src_format & 0xF) == (uint)DataFormat::Int8);
     if (pack_dst_format == (uint)DataFormat::UInt8)
     {
         dest_rd_ctrl.f.PCK_DEST_RD_CTRL_Read_unsigned = 1;


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/18914

### Problem description
UInt8 packing is not correctly supported when DEST reg is in 16 bit operating mode, only 32 bit mode. This is because in BBE there was an assumption to always have 32 bit mode enabled for int formats.

### What's changed
Change the programming of PCK_DEST_RD_CTRL config regs based on 32 vs 16 bit Dest for (u)int8.

### Type of change

- [x] New feature (non-breaking change which adds functionality)

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14521751279) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14521752601) CI passes (if applicable)