### PR TITLE
Be agnostic about target triple's manufacturer

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -7,9 +7,9 @@ BUILD_DIR ?=build
 
 RMDIR := rm -rf
 
-# Tool paths
-GXX=$(TOOL_PATH)/riscv32-unknown-elf-g++
-OBJDUMP=$(TOOL_PATH)/riscv32-unknown-elf-objdump
+# Tool paths, mfc changing from 'unknown' to 'tt'
+GXX:=$(wildcard $(TOOL_PATH)/riscv32-*-elf-g++)
+OBJDUMP:=$(wildcard $(TOOL_PATH)/riscv32-*-elf-objdump)
 
 # GCC options
 OPTIONS_ALL=-O3 -mabi=ilp32 -std=c++20 -ffast-math -ftest-coverage

--- a/tests/helpers/ld/sections.ld
+++ b/tests/helpers/ld/sections.ld
@@ -12,7 +12,6 @@ OUTPUT_FORMAT("elf32-littleriscv", "elf32-littleriscv",
        "elf32-littleriscv")
 OUTPUT_ARCH(riscv)
 ENTRY(_start)
-SEARCH_DIR("/opt/riscv32i/riscv32-unknown-elf/lib");
 SECTIONS
 {
   /*


### PR DESCRIPTION
We plan to change the target triple from `riscv32-unknown-elf` to `riscv32-tt-elf`, to reduce the possibility of confusion between riscv toolchains. This changes the Makefile so that it doesn't care what the manufacturer component is.

I notice that a linker script was incorrectly adding `/opt/riscv32i/riscv32-unknown-elf/lib` as a library search path. It should not be looking there.