### PR TITLE
build: use latest metallium docker image as base for llk ird

### DIFF
--- a/.github/Dockerfile.ird
+++ b/.github/Dockerfile.ird
@@ -1,4 +1,4 @@
-FROM ghcr.io/tenstorrent/tt-metal/tt-metalium/ubuntu-22.04-dev-amd64:latest
+FROM ghcr.io/tenstorrent/tt-metal/tt-metalium-ubuntu-22.04-release-amd64:latest-rc
 SHELL ["/bin/bash", "-c"]
 
 # Set environment variables


### PR DESCRIPTION
### Ticket
None

### Problem description
Latest metallium image has been updated. Switching llk ird base to it.

### What's changed
The size of the latest Metallium image has been significantly reduced without affecting functionality (850 MB vs. ~10 GB previously). Starting a new session used to take a few minutes when launching a machine for the first time. The improvement should be noticeable to everyone.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
