### PR TITLE
Add support for 32-bit types to _llk_math_transpose_dest_.

### DIFF
--- a/tt_llk_wormhole_b0/llk_lib/llk_defs.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_defs.h
@@ -43,12 +43,6 @@ enum DataCopyType
     B2D,
 };
 
-enum Dest32bLo
-{
-   Off = 0,
-   On = 1,
-};
-
 enum EltwiseBinaryType
 {
     ELWMUL,

--- a/tt_llk_wormhole_b0/llk_lib/llk_defs.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_defs.h
@@ -43,6 +43,12 @@ enum DataCopyType
     B2D,
 };
 
+enum Dest32bLo
+{
+   Off = 0,
+   On = 1,
+};
+
 enum EltwiseBinaryType
 {
     ELWMUL,

--- a/tt_llk_wormhole_b0/llk_lib/llk_math_transpose_dest.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_math_transpose_dest.h
@@ -118,8 +118,8 @@ inline void transpose_dest_configure_mop()
         // Set Sequence[1].
         TTI_SFPCONFIG(0, 5, 0);
 
-        // Reset "misc" macro config with UsesLoadMod0ForStore=1 for all macros.
-        TTI_SFPCONFIG(0x0f0, 8, 1);
+        // Misc: {UsesLoadMod0ForStore=1, WaitForElapsedInstructions=1} for macros 0 and 1.
+        TTI_SFPCONFIG(0x330, 8, 1);
 
         // A 32b face transpose consists of: (movd2b_hi, transpose, movb2d_hi_d2b_lo, transpose, movb2d_lo).
         uint movd2b_hi        = TT_OP_REPLAY(16, 4, 0, 0);

--- a/tt_llk_wormhole_b0/llk_lib/llk_math_transpose_dest.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_math_transpose_dest.h
@@ -16,8 +16,9 @@
 using namespace ckernel;
 
 // local function declarations
+template <bool is_32bit>
 inline void transpose_dest_configure_addrmod();
-template <int dest_32b_lo>
+template <bool is_32bit>
 inline void transpose_dest_configure_mop();
 
 template <bool is_32bit = false>
@@ -27,28 +28,38 @@ inline void _llk_math_transpose_dest_(const std::uint32_t dst_index)
 
     TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::WAIT_SFPU);
 
-    ckernel_template::run(instrn_buffer);
-
-    TTI_REPLAY(20, 5, 0, 0);
-    TTI_REPLAY(26, 4, 0, 0);
-
-    math::clear_dst_reg_addr();
-
     if constexpr (is_32bit)
     {
-        transpose_dest_configure_mop<Dest32bLo::On>();
-        ckernel_template::run(instrn_buffer);
-
-        TTI_REPLAY(20, 5, 0, 0);
-        TTI_REPLAY(26, 4, 0, 0);
+#pragma GCC unroll 4
+        for (int i = 0; i < 4; ++i)
+        {
+            TTI_REPLAY(16, 4, 0, 0);
+            TTI_TRNSPSRCB;
+            TTI_REPLAY(20, 4, 0, 0);
+        }
 
         math::clear_dst_reg_addr();
-        transpose_dest_configure_mop<Dest32bLo::Off>();
+
+#pragma GCC unroll 4
+        for (int i = 0; i < 4; ++i)
+        {
+            TTI_REPLAY(24, 4, 0, 0);
+            TTI_TRNSPSRCB;
+            TTI_REPLAY(28, 4, 0, 0);
+        }
+
+        math::clear_dst_reg_addr();
+        ckernel_template::run(instrn_buffer);
+    }
+    else
+    {
+        ckernel_template::run(instrn_buffer);
     }
 
-    TTI_SETRWC(p_setrwc::CLR_AB, 0, 0, 0, 0, p_setrwc::SET_AB);
+    TTI_SETRWC(p_setrwc::CLR_AB, 0, 0, 0, 0, p_setrwc::SET_ABD);
 }
 
+template <bool is_32bit>
 inline void transpose_dest_configure_addrmod()
 {
     addr_mod_t {
@@ -68,60 +79,89 @@ inline void transpose_dest_configure_addrmod()
     addr_mod_t {
         .srca = {.incr = 0},
         .srcb = {.incr = 0},
-        .dest = {.incr = -16},
+        .dest = {.incr = is_32bit ? 2 : 0x3ff & -16},
     }
         .set(ADDR_MOD_2);
 }
 
-template <int dest_32b_lo>
+template <bool is_32bit>
 inline void transpose_dest_configure_mop()
 {
     TTI_REPLAY(16, 16, 0, 1);
 
-    // A
-    TTI_MOVD2B(dest_32b_lo, p_movd2b::SRC_ZERO_OFFSET + 0, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 0 - 16);
-    TTI_MOVD2B(dest_32b_lo, p_movd2b::SRC_ZERO_OFFSET + 4, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 4 - 16);
-    TTI_MOVD2B(dest_32b_lo, p_movd2b::SRC_ZERO_OFFSET + 8, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 8 - 16);
-    TTI_MOVD2B(dest_32b_lo, p_movd2b::SRC_ZERO_OFFSET + 12, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 12 - 16);
+    if (is_32bit)
+    {
 
-    // B
-    TTI_MOVD2B(dest_32b_lo, p_movd2b::SRC_ROW16_OFFSET + 0, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 0);
-    TTI_MOVD2B(dest_32b_lo, p_movd2b::SRC_ROW16_OFFSET + 4, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 4);
-    TTI_MOVD2B(dest_32b_lo, p_movd2b::SRC_ROW16_OFFSET + 8, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 8);
-    TTI_MOVD2B(dest_32b_lo, p_movd2b::SRC_ROW16_OFFSET + 12, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 12);
+#pragma GCC unroll 2
+        for (int dest_32b_lo = 0; dest_32b_lo < 2; ++dest_32b_lo)
+        {
+            TTI_MOVD2B(dest_32b_lo, 16, ADDR_MOD_1, p_movd2b::MOV_4_ROWS,  0);
+            TTI_MOVD2B(dest_32b_lo, 20, ADDR_MOD_1, p_movd2b::MOV_4_ROWS,  4);
+            TTI_MOVD2B(dest_32b_lo, 24, ADDR_MOD_1, p_movd2b::MOV_4_ROWS,  8);
+            TTI_MOVD2B(dest_32b_lo, 28, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 12);
+            TTI_MOVB2D(dest_32b_lo, 16, ADDR_MOD_1, p_movb2d::MOV_4_ROWS,  0);
+            TTI_MOVB2D(dest_32b_lo, 20, ADDR_MOD_1, p_movb2d::MOV_4_ROWS,  4);
+            TTI_MOVB2D(dest_32b_lo, 24, ADDR_MOD_1, p_movb2d::MOV_4_ROWS,  8);
+            TTI_MOVB2D(dest_32b_lo, 28, ADDR_MOD_0, p_movb2d::MOV_4_ROWS, 12);
+        }
 
-    // C
-    TTI_TRNSPSRCB;
+        uint A = TT_OP_SFPLOAD(p_sfpu::LREG0,  InstrModLoadStore::INT32, ADDR_MOD_1, 16);
+        uint B = TT_OP_SFPLOAD(p_sfpu::LREG1,  InstrModLoadStore::INT32, ADDR_MOD_1, 32);
+        uint C = TT_OP_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::INT32, ADDR_MOD_1, 16);
+        uint D = TT_OP_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_2, 32);
 
-    // D
-    TTI_MOVD2B(dest_32b_lo, p_movd2b::SRC_ZERO_OFFSET + 32, ADDR_MOD_2, p_movd2b::MOV_1_ROW, 0); // throwaway to decrement dst
+        ckernel_template tmp(8, 1, B, C);
+        tmp.set_start_op(A);
+        tmp.set_end_op(D);
+        tmp.program(instrn_buffer);
+    }
+    else
+    {
+        // A
+        TTI_MOVD2B(0,  0, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 0x3ff & -16);
+        TTI_MOVD2B(0,  4, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 0x3ff & -12);
+        TTI_MOVD2B(0,  8, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 0x3ff &  -8);
+        TTI_MOVD2B(0, 12, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 0x3ff &  -4);
 
-    // E
-    TTI_MOVB2D(dest_32b_lo, p_movd2b::SRC_ROW16_OFFSET + 0, ADDR_MOD_1, p_movb2d::MOV_4_ROWS, 0);
-    TTI_MOVB2D(dest_32b_lo, p_movd2b::SRC_ROW16_OFFSET + 4, ADDR_MOD_1, p_movb2d::MOV_4_ROWS, 4);
-    TTI_MOVB2D(dest_32b_lo, p_movd2b::SRC_ROW16_OFFSET + 8, ADDR_MOD_1, p_movb2d::MOV_4_ROWS, 8);
-    TTI_MOVB2D(dest_32b_lo, p_movd2b::SRC_ROW16_OFFSET + 12, ADDR_MOD_0, p_movb2d::MOV_4_ROWS, 12);
+        // B
+        TTI_MOVD2B(0, 16, ADDR_MOD_3, p_movd2b::MOV_4_ROWS, 0);
+        TTI_MOVD2B(0, 20, ADDR_MOD_3, p_movd2b::MOV_4_ROWS, 0);
+        TTI_MOVD2B(0, 24, ADDR_MOD_3, p_movd2b::MOV_4_ROWS, 0);
+        TTI_MOVD2B(0, 28, ADDR_MOD_4, p_movd2b::MOV_4_ROWS, 0);
 
-    // F
-    TTI_MOVB2D(dest_32b_lo, p_movd2b::SRC_ZERO_OFFSET + 0, ADDR_MOD_1, p_movb2d::MOV_4_ROWS, 0);
-    TTI_MOVB2D(dest_32b_lo, p_movd2b::SRC_ZERO_OFFSET + 4, ADDR_MOD_1, p_movb2d::MOV_4_ROWS, 4);
+        // C
+        TTI_TRNSPSRCB;
 
-    uint AF = TT_OP_REPLAY(16, 16, 0, 0);
-    uint BC = TT_OP_REPLAY(20, 5, 0, 0);
-    uint E  = TT_OP_REPLAY(26, 4, 0, 0);
-    uint X  = TT_OP_MOVB2D(dest_32b_lo, p_movd2b::SRC_ZERO_OFFSET + 8, ADDR_MOD_1, p_movb2d::MOV_4_ROWS, 8);
-    uint Y  = TT_OP_MOVB2D(dest_32b_lo, p_movd2b::SRC_ZERO_OFFSET + 12, ADDR_MOD_0, p_movb2d::MOV_4_ROWS, 12);
+        // D
+        TTI_MOVD2B(0, 32, ADDR_MOD_2, p_movd2b::MOV_1_ROW, 0); // throwaway to decrement dst
 
-    ckernel_template tmp(1, 2, E, BC);
-    tmp.set_start_op(BC);
-    tmp.set_last_outer_loop_instr(AF);
-    tmp.set_end_ops(X, Y);
-    tmp.program(instrn_buffer);
+        // E
+        TTI_MOVB2D(0, 16, ADDR_MOD_3, p_movb2d::MOV_4_ROWS, 0);
+        TTI_MOVB2D(0, 20, ADDR_MOD_3, p_movb2d::MOV_4_ROWS, 0);
+        TTI_MOVB2D(0, 24, ADDR_MOD_3, p_movb2d::MOV_4_ROWS, 0);
+        TTI_MOVB2D(0, 28, ADDR_MOD_3, p_movb2d::MOV_4_ROWS, 0);
+
+        // F
+        TTI_MOVB2D(0, 0, ADDR_MOD_1, p_movb2d::MOV_4_ROWS, 0);
+        TTI_MOVB2D(0, 4, ADDR_MOD_1, p_movb2d::MOV_4_ROWS, 4);
+
+        uint AF = TT_OP_REPLAY(16, 16, 0, 0);
+        uint BC = TT_OP_REPLAY(20, 5, 0, 0);
+        uint E  = TT_OP_REPLAY(26, 4, 0, 0);
+        uint X  = TT_OP_MOVB2D(0,  8, ADDR_MOD_1, p_movb2d::MOV_4_ROWS,  8);
+        uint Y  = TT_OP_MOVB2D(0, 12, ADDR_MOD_0, p_movb2d::MOV_4_ROWS, 12);
+
+        ckernel_template tmp(1, 2, E, BC);
+        tmp.set_start_op(BC);
+        tmp.set_last_outer_loop_instr(AF);
+        tmp.set_end_ops(X, Y);
+        tmp.program(instrn_buffer);
+    }
 }
 
+template <bool is_32bit = false>
 inline void _llk_math_transpose_dest_init_()
 {
-    transpose_dest_configure_addrmod();
-
-    transpose_dest_configure_mop<Dest32bLo::Off>();
+    transpose_dest_configure_addrmod<is_32bit>();
+    transpose_dest_configure_mop<is_32bit>();
 }

--- a/tt_llk_wormhole_b0/llk_lib/llk_math_transpose_dest.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_math_transpose_dest.h
@@ -15,9 +15,6 @@
 
 using namespace ckernel;
 
-constexpr int DEST_32B_LO_OFF = 0;
-constexpr int DEST_32B_LO_ON  = 1;
-
 // local function declarations
 inline void transpose_dest_configure_addrmod();
 template <int dest_32b_lo>
@@ -39,14 +36,14 @@ inline void _llk_math_transpose_dest_(const std::uint32_t dst_index)
 
     if constexpr (is_32bit)
     {
-        transpose_dest_configure_mop<DEST_32B_LO_ON>();
+        transpose_dest_configure_mop<Dest32bLo::On>();
         ckernel_template::run(instrn_buffer);
 
         TTI_REPLAY(20, 5, 0, 0);
         TTI_REPLAY(26, 4, 0, 0);
 
         math::clear_dst_reg_addr();
-        transpose_dest_configure_mop<DEST_32B_LO_OFF>();
+        transpose_dest_configure_mop<Dest32bLo::Off>();
     }
 
     TTI_SETRWC(p_setrwc::CLR_AB, 0, 0, 0, 0, p_setrwc::SET_AB);
@@ -126,5 +123,5 @@ inline void _llk_math_transpose_dest_init_()
 {
     transpose_dest_configure_addrmod();
 
-    transpose_dest_configure_mop<DEST_32B_LO_OFF>();
+    transpose_dest_configure_mop<Dest32bLo::Off>();
 }

--- a/tt_llk_wormhole_b0/llk_lib/llk_math_transpose_dest.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_math_transpose_dest.h
@@ -111,10 +111,10 @@ inline void transpose_dest_configure_mop()
     else
     {
         // A
-        TTI_MOVD2B(0,  0, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 0x3ff & -16);
-        TTI_MOVD2B(0,  4, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 0x3ff & -12);
-        TTI_MOVD2B(0,  8, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 0x3ff &  -8);
-        TTI_MOVD2B(0, 12, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 0x3ff &  -4);
+        TTI_MOVD2A(0,  0, ADDR_MOD_1, p_movd2a::MOV_4_ROWS, 0x3ff & -16);
+        TTI_MOVD2A(0,  4, ADDR_MOD_1, p_movd2a::MOV_4_ROWS, 0x3ff & -12);
+        TTI_MOVD2A(0,  8, ADDR_MOD_1, p_movd2a::MOV_4_ROWS, 0x3ff &  -8);
+        TTI_MOVD2A(0, 12, ADDR_MOD_1, p_movd2a::MOV_4_ROWS, 0x3ff &  -4);
 
         // B
         TTI_MOVD2B(0, 16, ADDR_MOD_3, p_movd2b::MOV_4_ROWS, 0);
@@ -135,19 +135,17 @@ inline void transpose_dest_configure_mop()
         TTI_MOVB2D(0, 28, ADDR_MOD_3, p_movb2d::MOV_4_ROWS, 0);
 
         // F
-        TTI_MOVB2D(0, 0, ADDR_MOD_1, p_movb2d::MOV_4_ROWS, 0);
-        TTI_MOVB2D(0, 4, ADDR_MOD_1, p_movb2d::MOV_4_ROWS, 4);
+        TTI_MOVA2B(0, 0, ADDR_MOD_1, p_mova2d::MOV_8_ROWS, 0);
+        TTI_MOVA2B(0, 8, ADDR_MOD_1, p_mova2d::MOV_8_ROWS, 8);
 
         uint AF = TT_OP_REPLAY(16, 16, 0, 0);
         uint BC = TT_OP_REPLAY(20, 5, 0, 0);
         uint E  = TT_OP_REPLAY(26, 4, 0, 0);
-        uint X  = TT_OP_MOVB2D(0,  8, ADDR_MOD_1, p_movb2d::MOV_4_ROWS,  8);
-        uint Y  = TT_OP_MOVB2D(0, 12, ADDR_MOD_0, p_movb2d::MOV_4_ROWS, 12);
 
         ckernel_template tmp(1, 2, E, BC);
         tmp.set_start_op(BC);
         tmp.set_last_outer_loop_instr(AF);
-        tmp.set_end_ops(X, Y);
+        tmp.set_end_ops(BC, E);
         tmp.program(instrn_buffer);
     }
 }

--- a/tt_llk_wormhole_b0/llk_lib/llk_math_transpose_dest.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_math_transpose_dest.h
@@ -15,6 +15,9 @@
 
 using namespace ckernel;
 
+constexpr int DEST_32B_LO_OFF = 0;
+constexpr int DEST_32B_LO_ON  = 1;
+
 // local function declarations
 inline void transpose_dest_configure_addrmod();
 template <int dest_32b_lo>
@@ -36,14 +39,14 @@ inline void _llk_math_transpose_dest_(const std::uint32_t dst_index)
 
     if constexpr (is_32bit)
     {
-        transpose_dest_configure_mop<1>();
+        transpose_dest_configure_mop<DEST_32B_LO_ON>();
         ckernel_template::run(instrn_buffer);
 
         TTI_REPLAY(20, 5, 0, 0);
         TTI_REPLAY(26, 4, 0, 0);
 
         math::clear_dst_reg_addr();
-        transpose_dest_configure_mop<0>(); // TODO use length 32 replay buffer
+        transpose_dest_configure_mop<DEST_32B_LO_OFF>();
     }
 
     TTI_SETRWC(p_setrwc::CLR_AB, 0, 0, 0, 0, p_setrwc::SET_AB);
@@ -73,7 +76,7 @@ inline void transpose_dest_configure_addrmod()
         .set(ADDR_MOD_2);
 }
 
-template <int dest_32b_lo = 0>
+template <int dest_32b_lo>
 inline void transpose_dest_configure_mop()
 {
     TTI_REPLAY(16, 16, 0, 1);
@@ -123,5 +126,5 @@ inline void _llk_math_transpose_dest_init_()
 {
     transpose_dest_configure_addrmod();
 
-    transpose_dest_configure_mop<0>();
+    transpose_dest_configure_mop<DEST_32B_LO_OFF>();
 }

--- a/tt_llk_wormhole_b0/llk_lib/llk_math_transpose_dest.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_math_transpose_dest.h
@@ -17,10 +17,10 @@ using namespace ckernel;
 
 // local function declarations
 inline void transpose_dest_configure_addrmod();
-inline void transpose_dest_configure_mop_hi();
+template <int dest_32b_lo>
 inline void transpose_dest_configure_mop();
 
-template<bool is_32bit = false>
+template <bool is_32bit = false>
 inline void _llk_math_transpose_dest_(const std::uint32_t dst_index)
 {
     math::set_dst_write_addr<DstTileLayout::Default, DstTileShape::Tile32x32>(dst_index);
@@ -36,14 +36,14 @@ inline void _llk_math_transpose_dest_(const std::uint32_t dst_index)
 
     if constexpr (is_32bit)
     {
-        transpose_dest_configure_mop_hi();
+        transpose_dest_configure_mop<1>();
         ckernel_template::run(instrn_buffer);
 
         TTI_REPLAY(20, 5, 0, 0);
         TTI_REPLAY(26, 4, 0, 0);
 
         math::clear_dst_reg_addr();
-        transpose_dest_configure_mop(); // TODO use length 32 replay buffer
+        transpose_dest_configure_mop<0>(); // TODO use length 32 replay buffer
     }
 
     TTI_SETRWC(p_setrwc::CLR_AB, 0, 0, 0, 0, p_setrwc::SET_AB);
@@ -73,88 +73,44 @@ inline void transpose_dest_configure_addrmod()
         .set(ADDR_MOD_2);
 }
 
-inline void transpose_dest_configure_mop_hi()
-{
-    TTI_REPLAY(16, 16, 0, 1);
-
-    // A
-    TTI_MOVD2B(1, p_movd2b::SRC_ZERO_OFFSET + 0, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 0 - 16);
-    TTI_MOVD2B(1, p_movd2b::SRC_ZERO_OFFSET + 4, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 4 - 16);
-    TTI_MOVD2B(1, p_movd2b::SRC_ZERO_OFFSET + 8, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 8 - 16);
-    TTI_MOVD2B(1, p_movd2b::SRC_ZERO_OFFSET + 12, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 12 - 16);
-
-    // B
-    TTI_MOVD2B(1, p_movd2b::SRC_ROW16_OFFSET + 0, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 0);
-    TTI_MOVD2B(1, p_movd2b::SRC_ROW16_OFFSET + 4, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 4);
-    TTI_MOVD2B(1, p_movd2b::SRC_ROW16_OFFSET + 8, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 8);
-    TTI_MOVD2B(1, p_movd2b::SRC_ROW16_OFFSET + 12, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 12);
-
-    // C
-    TTI_TRNSPSRCB;
-
-    // D
-    TTI_MOVD2B(1, p_movd2b::SRC_ZERO_OFFSET + 32, ADDR_MOD_2, p_movd2b::MOV_1_ROW, 0); // throwaway to decrement dst
-
-    // E
-    TTI_MOVB2D(1, p_movd2b::SRC_ROW16_OFFSET + 0, ADDR_MOD_1, p_movb2d::MOV_4_ROWS, 0);
-    TTI_MOVB2D(1, p_movd2b::SRC_ROW16_OFFSET + 4, ADDR_MOD_1, p_movb2d::MOV_4_ROWS, 4);
-    TTI_MOVB2D(1, p_movd2b::SRC_ROW16_OFFSET + 8, ADDR_MOD_1, p_movb2d::MOV_4_ROWS, 8);
-    TTI_MOVB2D(1, p_movd2b::SRC_ROW16_OFFSET + 12, ADDR_MOD_0, p_movb2d::MOV_4_ROWS, 12);
-
-    // F
-    TTI_MOVB2D(1, p_movd2b::SRC_ZERO_OFFSET + 0, ADDR_MOD_1, p_movb2d::MOV_4_ROWS, 0);
-    TTI_MOVB2D(1, p_movd2b::SRC_ZERO_OFFSET + 4, ADDR_MOD_1, p_movb2d::MOV_4_ROWS, 4);
-
-    uint AF = TT_OP_REPLAY(16, 16, 0, 0);
-    uint BC = TT_OP_REPLAY(20, 5, 0, 0);
-    uint E  = TT_OP_REPLAY(26, 4, 0, 0);
-    uint X  = TT_OP_MOVB2D(1, p_movd2b::SRC_ZERO_OFFSET + 8, ADDR_MOD_1, p_movb2d::MOV_4_ROWS, 8);
-    uint Y  = TT_OP_MOVB2D(1, p_movd2b::SRC_ZERO_OFFSET + 12, ADDR_MOD_0, p_movb2d::MOV_4_ROWS, 12);
-
-    ckernel_template tmp(1, 2, E, BC);
-    tmp.set_start_op(BC);
-    tmp.set_last_outer_loop_instr(AF);
-    tmp.set_end_ops(X, Y);
-    tmp.program(instrn_buffer);
-}
-
+template <int dest_32b_lo = 0>
 inline void transpose_dest_configure_mop()
 {
     TTI_REPLAY(16, 16, 0, 1);
 
     // A
-    TTI_MOVD2B(0, p_movd2b::SRC_ZERO_OFFSET + 0, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 0 - 16);
-    TTI_MOVD2B(0, p_movd2b::SRC_ZERO_OFFSET + 4, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 4 - 16);
-    TTI_MOVD2B(0, p_movd2b::SRC_ZERO_OFFSET + 8, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 8 - 16);
-    TTI_MOVD2B(0, p_movd2b::SRC_ZERO_OFFSET + 12, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 12 - 16);
+    TTI_MOVD2B(dest_32b_lo, p_movd2b::SRC_ZERO_OFFSET + 0, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 0 - 16);
+    TTI_MOVD2B(dest_32b_lo, p_movd2b::SRC_ZERO_OFFSET + 4, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 4 - 16);
+    TTI_MOVD2B(dest_32b_lo, p_movd2b::SRC_ZERO_OFFSET + 8, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 8 - 16);
+    TTI_MOVD2B(dest_32b_lo, p_movd2b::SRC_ZERO_OFFSET + 12, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 12 - 16);
 
     // B
-    TTI_MOVD2B(0, p_movd2b::SRC_ROW16_OFFSET + 0, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 0);
-    TTI_MOVD2B(0, p_movd2b::SRC_ROW16_OFFSET + 4, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 4);
-    TTI_MOVD2B(0, p_movd2b::SRC_ROW16_OFFSET + 8, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 8);
-    TTI_MOVD2B(0, p_movd2b::SRC_ROW16_OFFSET + 12, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 12);
+    TTI_MOVD2B(dest_32b_lo, p_movd2b::SRC_ROW16_OFFSET + 0, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 0);
+    TTI_MOVD2B(dest_32b_lo, p_movd2b::SRC_ROW16_OFFSET + 4, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 4);
+    TTI_MOVD2B(dest_32b_lo, p_movd2b::SRC_ROW16_OFFSET + 8, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 8);
+    TTI_MOVD2B(dest_32b_lo, p_movd2b::SRC_ROW16_OFFSET + 12, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 12);
 
     // C
     TTI_TRNSPSRCB;
 
     // D
-    TTI_MOVD2B(0, p_movd2b::SRC_ZERO_OFFSET + 32, ADDR_MOD_2, p_movd2b::MOV_1_ROW, 0); // throwaway to decrement dst
+    TTI_MOVD2B(dest_32b_lo, p_movd2b::SRC_ZERO_OFFSET + 32, ADDR_MOD_2, p_movd2b::MOV_1_ROW, 0); // throwaway to decrement dst
 
     // E
-    TTI_MOVB2D(0, p_movd2b::SRC_ROW16_OFFSET + 0, ADDR_MOD_1, p_movb2d::MOV_4_ROWS, 0);
-    TTI_MOVB2D(0, p_movd2b::SRC_ROW16_OFFSET + 4, ADDR_MOD_1, p_movb2d::MOV_4_ROWS, 4);
-    TTI_MOVB2D(0, p_movd2b::SRC_ROW16_OFFSET + 8, ADDR_MOD_1, p_movb2d::MOV_4_ROWS, 8);
-    TTI_MOVB2D(0, p_movd2b::SRC_ROW16_OFFSET + 12, ADDR_MOD_0, p_movb2d::MOV_4_ROWS, 12);
+    TTI_MOVB2D(dest_32b_lo, p_movd2b::SRC_ROW16_OFFSET + 0, ADDR_MOD_1, p_movb2d::MOV_4_ROWS, 0);
+    TTI_MOVB2D(dest_32b_lo, p_movd2b::SRC_ROW16_OFFSET + 4, ADDR_MOD_1, p_movb2d::MOV_4_ROWS, 4);
+    TTI_MOVB2D(dest_32b_lo, p_movd2b::SRC_ROW16_OFFSET + 8, ADDR_MOD_1, p_movb2d::MOV_4_ROWS, 8);
+    TTI_MOVB2D(dest_32b_lo, p_movd2b::SRC_ROW16_OFFSET + 12, ADDR_MOD_0, p_movb2d::MOV_4_ROWS, 12);
 
     // F
-    TTI_MOVB2D(0, p_movd2b::SRC_ZERO_OFFSET + 0, ADDR_MOD_1, p_movb2d::MOV_4_ROWS, 0);
-    TTI_MOVB2D(0, p_movd2b::SRC_ZERO_OFFSET + 4, ADDR_MOD_1, p_movb2d::MOV_4_ROWS, 4);
+    TTI_MOVB2D(dest_32b_lo, p_movd2b::SRC_ZERO_OFFSET + 0, ADDR_MOD_1, p_movb2d::MOV_4_ROWS, 0);
+    TTI_MOVB2D(dest_32b_lo, p_movd2b::SRC_ZERO_OFFSET + 4, ADDR_MOD_1, p_movb2d::MOV_4_ROWS, 4);
 
     uint AF = TT_OP_REPLAY(16, 16, 0, 0);
     uint BC = TT_OP_REPLAY(20, 5, 0, 0);
     uint E  = TT_OP_REPLAY(26, 4, 0, 0);
-    uint X  = TT_OP_MOVB2D(0, p_movd2b::SRC_ZERO_OFFSET + 8, ADDR_MOD_1, p_movb2d::MOV_4_ROWS, 8);
-    uint Y  = TT_OP_MOVB2D(0, p_movd2b::SRC_ZERO_OFFSET + 12, ADDR_MOD_0, p_movb2d::MOV_4_ROWS, 12);
+    uint X  = TT_OP_MOVB2D(dest_32b_lo, p_movd2b::SRC_ZERO_OFFSET + 8, ADDR_MOD_1, p_movb2d::MOV_4_ROWS, 8);
+    uint Y  = TT_OP_MOVB2D(dest_32b_lo, p_movd2b::SRC_ZERO_OFFSET + 12, ADDR_MOD_0, p_movb2d::MOV_4_ROWS, 12);
 
     ckernel_template tmp(1, 2, E, BC);
     tmp.set_start_op(BC);
@@ -167,5 +123,5 @@ inline void _llk_math_transpose_dest_init_()
 {
     transpose_dest_configure_addrmod();
 
-    transpose_dest_configure_mop();
+    transpose_dest_configure_mop<0>();
 }

--- a/tt_llk_wormhole_b0/llk_lib/llk_math_transpose_dest.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_math_transpose_dest.h
@@ -98,12 +98,8 @@ inline void transpose_dest_configure_mop()
         // Macro 0: SFPLOAD VD; SFPMOV LReg[16],VD; SFPSTORE LReg[0].
         // Intended for use with VD=LReg[1].
 
-        // SFPMOV template: the macro will overwrite VC and VD anyway so we leave them set to zero.
-        uint mov = TT_OP_SFPMOV(0, 0, 0, 0);
-        TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_UPPER, mov >> 16);
-        TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_LOWER, mov & 0xffff);
-        // Set InstructionTemplate[0].
-        TTI_SFPCONFIG(0, 0, 0);
+        // Set InstructionTemplate[0] to SFPMOV.
+        TTI_SFPMOV(0, 0, 12, 0);
 
         // StoreSubUnit: schedule SFPSTORE with VD=0 after 1 cycle.
         TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_UPPER, (0x80 | (1 << 3) | 3) << 8);

--- a/tt_llk_wormhole_b0/llk_lib/llk_math_transpose_dest.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_math_transpose_dest.h
@@ -49,12 +49,9 @@ inline void _llk_math_transpose_dest_(const std::uint32_t dst_index)
         }
 
         math::clear_dst_reg_addr();
-        ckernel_template::run(instrn_buffer);
     }
-    else
-    {
-        ckernel_template::run(instrn_buffer);
-    }
+
+    ckernel_template::run(instrn_buffer);
 
     TTI_SETRWC(p_setrwc::CLR_AB, 0, 0, 0, 0, p_setrwc::SET_ABD);
 }

--- a/tt_llk_wormhole_b0/llk_lib/llk_math_transpose_dest.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_math_transpose_dest.h
@@ -17,7 +17,10 @@ using namespace ckernel;
 
 // local function declarations
 inline void transpose_dest_configure_addrmod();
+inline void transpose_dest_configure_mop_hi();
+inline void transpose_dest_configure_mop();
 
+template<bool is_32bit = false>
 inline void _llk_math_transpose_dest_(const std::uint32_t dst_index)
 {
     math::set_dst_write_addr<DstTileLayout::Default, DstTileShape::Tile32x32>(dst_index);
@@ -29,9 +32,21 @@ inline void _llk_math_transpose_dest_(const std::uint32_t dst_index)
     TTI_REPLAY(20, 5, 0, 0);
     TTI_REPLAY(26, 4, 0, 0);
 
-    TTI_SETRWC(p_setrwc::CLR_AB, 0, 0, 0, 0, p_setrwc::SET_AB);
-
     math::clear_dst_reg_addr();
+
+    if constexpr (is_32bit)
+    {
+        transpose_dest_configure_mop_hi();
+        ckernel_template::run(instrn_buffer);
+
+        TTI_REPLAY(20, 5, 0, 0);
+        TTI_REPLAY(26, 4, 0, 0);
+
+        math::clear_dst_reg_addr();
+        transpose_dest_configure_mop(); // TODO use length 32 replay buffer
+    }
+
+    TTI_SETRWC(p_setrwc::CLR_AB, 0, 0, 0, 0, p_setrwc::SET_AB);
 }
 
 inline void transpose_dest_configure_addrmod()
@@ -56,6 +71,51 @@ inline void transpose_dest_configure_addrmod()
         .dest = {.incr = -16},
     }
         .set(ADDR_MOD_2);
+}
+
+inline void transpose_dest_configure_mop_hi()
+{
+    TTI_REPLAY(16, 16, 0, 1);
+
+    // A
+    TTI_MOVD2B(1, p_movd2b::SRC_ZERO_OFFSET + 0, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 0 - 16);
+    TTI_MOVD2B(1, p_movd2b::SRC_ZERO_OFFSET + 4, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 4 - 16);
+    TTI_MOVD2B(1, p_movd2b::SRC_ZERO_OFFSET + 8, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 8 - 16);
+    TTI_MOVD2B(1, p_movd2b::SRC_ZERO_OFFSET + 12, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 12 - 16);
+
+    // B
+    TTI_MOVD2B(1, p_movd2b::SRC_ROW16_OFFSET + 0, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 0);
+    TTI_MOVD2B(1, p_movd2b::SRC_ROW16_OFFSET + 4, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 4);
+    TTI_MOVD2B(1, p_movd2b::SRC_ROW16_OFFSET + 8, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 8);
+    TTI_MOVD2B(1, p_movd2b::SRC_ROW16_OFFSET + 12, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 12);
+
+    // C
+    TTI_TRNSPSRCB;
+
+    // D
+    TTI_MOVD2B(1, p_movd2b::SRC_ZERO_OFFSET + 32, ADDR_MOD_2, p_movd2b::MOV_1_ROW, 0); // throwaway to decrement dst
+
+    // E
+    TTI_MOVB2D(1, p_movd2b::SRC_ROW16_OFFSET + 0, ADDR_MOD_1, p_movb2d::MOV_4_ROWS, 0);
+    TTI_MOVB2D(1, p_movd2b::SRC_ROW16_OFFSET + 4, ADDR_MOD_1, p_movb2d::MOV_4_ROWS, 4);
+    TTI_MOVB2D(1, p_movd2b::SRC_ROW16_OFFSET + 8, ADDR_MOD_1, p_movb2d::MOV_4_ROWS, 8);
+    TTI_MOVB2D(1, p_movd2b::SRC_ROW16_OFFSET + 12, ADDR_MOD_0, p_movb2d::MOV_4_ROWS, 12);
+
+    // F
+    TTI_MOVB2D(1, p_movd2b::SRC_ZERO_OFFSET + 0, ADDR_MOD_1, p_movb2d::MOV_4_ROWS, 0);
+    TTI_MOVB2D(1, p_movd2b::SRC_ZERO_OFFSET + 4, ADDR_MOD_1, p_movb2d::MOV_4_ROWS, 4);
+
+    uint AF = TT_OP_REPLAY(16, 16, 0, 0);
+    uint BC = TT_OP_REPLAY(20, 5, 0, 0);
+    uint E  = TT_OP_REPLAY(26, 4, 0, 0);
+    uint X  = TT_OP_MOVB2D(1, p_movd2b::SRC_ZERO_OFFSET + 8, ADDR_MOD_1, p_movb2d::MOV_4_ROWS, 8);
+    uint Y  = TT_OP_MOVB2D(1, p_movd2b::SRC_ZERO_OFFSET + 12, ADDR_MOD_0, p_movb2d::MOV_4_ROWS, 12);
+
+    ckernel_template tmp(1, 2, E, BC);
+    tmp.set_start_op(BC);
+    tmp.set_last_outer_loop_instr(AF);
+    tmp.set_end_ops(X, Y);
+    tmp.program(instrn_buffer);
 }
 
 inline void transpose_dest_configure_mop()


### PR DESCRIPTION
As suggested by @corsix, this performs a transpose on a 16x16 face of 32-bit values by splitting into two faces of 16-bit values (the low 16 bits and high 16 bits), transposing each face separately using `TRNSPSRCB`, and then recombining into 32-bit values.

A neat way to achieve this (also suggested by @corsix!) is to use the `dest_32b_lo` instruction mode flag on `MOVD2B`/`MOVB2D`.  This allows the low bits to be copied to SrcB, transposed, and copied back.  Followed by the same operation on the high bits.

Further optimisation would involve using the full 32 slots in the replay buffer, rather than overwriting slots 16 to 32 as I'm doing currently.

This was just the most straightforward way to get a working proof of concept.

### Ticket

#134

### Problem description

32-bit types aren't supported by transpose_dest.

### What's changed

See above.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
