### PR TITLE
build: use latest tt-metal ci image for running integration tests

### DIFF
--- a/.github/workflows/tt-metal-integration-tests.yml
+++ b/.github/workflows/tt-metal-integration-tests.yml
@@ -26,6 +26,8 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           path: tt-metal
           submodules: recursive
+          fetch-depth: 500 # Need enough history for `git describe`
+          fetch-tags: true # Need tags for `git describe`
 
       - name: Override LLK submodule branch
         run: |

--- a/.github/workflows/tt-metal-integration-tests.yml
+++ b/.github/workflows/tt-metal-integration-tests.yml
@@ -15,7 +15,7 @@ jobs:
     name: 🔧 LLK unit tests
     env:
       DOCKER_IMAGE: ghcr.io/tenstorrent/tt-metal/tt-metalium/ubuntu-22.04-ci-build-amd64
-      IMAGE_HASH: ec366e61ff1989d6650d8ee0fc636189b3c08c13
+      IMAGE_HASH: a2e6e2031c340fdbeea0fe88b36a54ddfbf75031
     runs-on: ${{ inputs.runs_on }}
     timeout-minutes: 40
     steps:


### PR DESCRIPTION
### Ticket
None

### Problem description
After some changes landed in tt-metal (https://github.com/tenstorrent/tt-metal/pull/21035), our tt-metal integration tests workflow got broken. This change should fix it.

### What's changed
A few days ago a change was introduced that requires fetching latest tags. Our pipeline wasn’t set up for that.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update