### PR TITLE
Make topk_replay_init internal to LLK.

### DIFF
--- a/tt_llk_blackhole/common/inc/ckernel_globals.h
+++ b/tt_llk_blackhole/common/inc/ckernel_globals.h
@@ -20,5 +20,3 @@ extern uint32_t math_sync_tile_dst_index;
 extern uint32_t __local_mem_rodata_start_addr[];
 extern uint32_t __local_mem_rodata_end_addr[];
 extern uint32_t __firmware_start[];
-
-extern int32_t topk_replay_init;

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_topk.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_topk.h
@@ -16,6 +16,8 @@ namespace ckernel
 namespace sfpu
 {
 
+static int32_t topk_replay_init = 0;
+
 inline void set_dst_write_addr(uint32_t addr)
 {
     uint dst_index = addr + get_dest_buffer_base();
@@ -699,6 +701,7 @@ inline void _bitonic_topk_rebuild(const bool idir, const int m_iter, const int k
 
 inline void _init_topk()
 {
+    topk_replay_init = 0;
     _sfpu_load_config32_(0xF, 0x0, 0x4); // Set bit [2] of the SFPU_CONTROL_REG to enable index tracking mode
 }
 

--- a/tt_llk_wormhole_b0/common/inc/ckernel_globals.h
+++ b/tt_llk_wormhole_b0/common/inc/ckernel_globals.h
@@ -20,5 +20,3 @@ extern uint32_t math_sync_tile_dst_index;
 extern uint32_t __local_mem_rodata_start_addr[];
 extern uint32_t __local_mem_rodata_end_addr[];
 extern uint32_t __firmware_start[];
-
-extern int32_t topk_replay_init;

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_topk.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_topk.h
@@ -16,6 +16,8 @@ namespace ckernel
 namespace sfpu
 {
 
+static int32_t topk_replay_init = 0;
+
 inline void set_dst_write_addr(uint32_t addr)
 {
     uint dst_index = addr + get_dest_buffer_base();
@@ -691,6 +693,7 @@ inline void _bitonic_topk_rebuild(const bool idir, const int m_iter, const int k
 
 inline void _init_topk()
 {
+    topk_replay_init = 0;
     _sfpu_load_config32_(0xF, 0x0, 0x4); // Set bit [2] of the SFPU_CONTROL_REG to enable index tracking mode
 }
 


### PR DESCRIPTION

### Ticket

tenstorrent/tt-metal#21301

### Problem description

`topk_replay_init` shouldn't be exposed to LLK users.  This change makes it internal to the LLK.

### What's changed

For both Wormhole and Blackhole:

- Removed `topk_replay_init` `extern` declaration.
- Added `static int32_t topk_replay_init = 0;`
- Added `topk_replay_init = 0` to `_init_topk`.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
