### PR TITLE
[Test Infrastructure] Data format Inference Model 

### DIFF
--- a/tests/helpers/include/data_format_inference.h
+++ b/tests/helpers/include/data_format_inference.h
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+#include "tensix_types.h"
+
+#ifdef ARCH_WORMHOLE
+const bool is_blackhole = false;
+const bool is_wormhole  = true;
+#endif
+
+#ifdef ARCH_BLACKHOLE
+const bool is_blackhole = true;
+const bool is_wormhole  = false;
+#endif
+
+struct FormatConfig
+{
+    const uint32_t unpack_src;
+    const uint32_t unpack_dst;
+    const uint32_t pack_src;
+    const uint32_t pack_dst;
+};
+
+constexpr bool is_exponentB(uint32_t format)
+{
+    return (
+        format == static_cast<uint32_t>(DataFormat::Float16_b) || format == static_cast<uint32_t>(DataFormat::Bfp8_b) ||
+        format == static_cast<uint32_t>(DataFormat::Tf32));
+}
+
+constexpr bool is_format_combination_outlier(uint32_t input, uint32_t output, bool is_fp32_dest_acc_en)
+{
+    return (is_exponentB(input) && output == (uint32_t)DataFormat::Float16 && !is_fp32_dest_acc_en);
+}
+
+constexpr FormatConfig get_data_formats(uint32_t input, uint32_t output, bool is_fp32_dest_acc_en)
+{
+    uint32_t unpack_in  = input;
+    uint32_t unpack_out = input;
+    uint32_t pack_out   = output;
+    uint32_t pack_in;
+
+    if (input == (uint32_t)DataFormat::Float16 && output == (uint32_t)DataFormat::Bfp8_b && !is_fp32_dest_acc_en)
+    {
+        pack_in = static_cast<uint32_t>(DataFormat::Bfp8);
+    }
+    else if (is_wormhole && is_fp32_dest_acc_en && output == (uint32_t)DataFormat::Float16)
+    {
+        pack_in = static_cast<uint32_t>(DataFormat::Float32); // Gasket in wormhole cannot convert fp32 to fp16, and since dest accumulation turns on for
+                                                              // outlier cases we have fp32 in dest, so gasket cannot conver it to fp16, packer must do that
+    }
+    else if (is_format_combination_outlier(input, output, is_fp32_dest_acc_en))
+    {
+        pack_in = (is_wormhole) ? (uint32_t)DataFormat::Float32 : output;
+    }
+    else
+    {
+        pack_in = is_fp32_dest_acc_en ? output : input;
+    }
+
+    return {unpack_in, unpack_out, pack_in, pack_out};
+}

--- a/tests/sources/eltwise_unary_datacopy_test.cpp
+++ b/tests/sources/eltwise_unary_datacopy_test.cpp
@@ -14,18 +14,6 @@
 uint32_t unp_cfg_context        = 0;
 uint32_t pack_sync_tile_dst_ptr = 0;
 
-#ifdef DEST_ACC
-const bool is_fp32_dest_acc_en = true;
-#else
-const bool is_fp32_dest_acc_en = false;
-#endif
-
-#if defined(UNPACK_A_SRC_INT32) || defined(UNPACK_A_SRC_FLOAT32)
-const bool unpack_to_dest = true;
-#else
-const bool unpack_to_dest = false;
-#endif
-
 #ifdef LLK_TRISC_UNPACK
 
 #include "llk_unpack_A.h"

--- a/tests/sources/eltwise_unary_sfpu_test.cpp
+++ b/tests/sources/eltwise_unary_sfpu_test.cpp
@@ -10,17 +10,9 @@
 #include "ckernel.h"
 #include "llk_defs.h"
 
-const bool unpack_to_dest = true;
-
 // Globals
 uint32_t unp_cfg_context        = 0;
 uint32_t pack_sync_tile_dst_ptr = 0;
-
-#ifdef DEST_ACC
-const bool is_fp32_dest_acc_en = true;
-#else
-const bool is_fp32_dest_acc_en = false;
-#endif
 
 #ifdef LLK_TRISC_UNPACK
 

--- a/tests/sources/fill_dest_test.cpp
+++ b/tests/sources/fill_dest_test.cpp
@@ -13,12 +13,6 @@
 uint32_t unp_cfg_context        = 0;
 uint32_t pack_sync_tile_dst_ptr = 0;
 
-#ifdef DEST_ACC
-const bool is_fp32_dest_acc_en = true;
-#else
-const bool is_fp32_dest_acc_en = false;
-#endif
-
 #ifdef LLK_TRISC_UNPACK
 
 #include "llk_unpack_AB.h"

--- a/tests/sources/matmul_test.cpp
+++ b/tests/sources/matmul_test.cpp
@@ -14,12 +14,6 @@ uint32_t unp_cfg_context          = 0;
 uint32_t pack_sync_tile_dst_ptr   = 0;
 uint32_t math_sync_tile_dst_index = 0;
 
-#ifdef DEST_ACC
-const bool is_fp32_dest_acc_en = true;
-#else
-const bool is_fp32_dest_acc_en = false;
-#endif
-
 #ifdef LLK_TRISC_UNPACK
 
 #include "llk_unpack_AB_matmul.h"

--- a/tests/sources/multiple_tiles_eltwise_test.cpp
+++ b/tests/sources/multiple_tiles_eltwise_test.cpp
@@ -13,12 +13,6 @@
 uint32_t unp_cfg_context        = 0;
 uint32_t pack_sync_tile_dst_ptr = 0;
 
-#ifdef DEST_ACC
-const bool is_fp32_dest_acc_en = true;
-#else
-const bool is_fp32_dest_acc_en = false;
-#endif
-
 #ifdef LLK_TRISC_UNPACK
 
 #include "llk_unpack_AB.h"

--- a/tests/sources/pack_untilize_test.cpp
+++ b/tests/sources/pack_untilize_test.cpp
@@ -13,12 +13,6 @@
 uint32_t unp_cfg_context        = 0;
 uint32_t pack_sync_tile_dst_ptr = 0;
 
-#ifdef DEST_ACC
-const bool is_fp32_dest_acc_en = true;
-#else
-const bool is_fp32_dest_acc_en = false;
-#endif
-
 #ifdef LLK_TRISC_UNPACK
 
 #include "llk_unpack_A.h"

--- a/tests/sources/reduce_test.cpp
+++ b/tests/sources/reduce_test.cpp
@@ -14,12 +14,6 @@ uint32_t unp_cfg_context          = 0;
 uint32_t pack_sync_tile_dst_ptr   = 0;
 uint32_t math_sync_tile_dst_index = 0;
 
-#ifdef DEST_ACC
-const bool is_fp32_dest_acc_en = true;
-#else
-const bool is_fp32_dest_acc_en = false;
-#endif
-
 #ifdef REDUCE_ROW_OPERATION
 const std::uint32_t within_face_16x16_transpose = 1;
 #else

--- a/tests/sources/sfpu_binary_test.cpp
+++ b/tests/sources/sfpu_binary_test.cpp
@@ -14,12 +14,6 @@ const bool unpack_to_dest = true;
 uint32_t unp_cfg_context        = 0;
 uint32_t pack_sync_tile_dst_ptr = 0;
 
-#ifdef DEST_ACC
-const bool is_fp32_dest_acc_en = true;
-#else
-const bool is_fp32_dest_acc_en = false;
-#endif
-
 #ifdef LLK_TRISC_UNPACK
 
 #include "llk_unpack_A.h"

--- a/tests/sources/tilize_calculate_untilize_L1.cpp
+++ b/tests/sources/tilize_calculate_untilize_L1.cpp
@@ -14,12 +14,6 @@ uint32_t unp_cfg_context          = 0;
 uint32_t pack_sync_tile_dst_ptr   = 0;
 uint32_t math_sync_tile_dst_index = 0;
 
-#ifdef DEST_ACC
-const bool is_fp32_dest_acc_en = true;
-#else
-const bool is_fp32_dest_acc_en = false;
-#endif
-
 volatile uint32_t* const buffer_A = reinterpret_cast<volatile uint32_t*>(0x1a000);
 volatile uint32_t* const buffer_B = reinterpret_cast<volatile uint32_t*>(0x1b000);
 

--- a/tests/sources/unpack_tilize_test.cpp
+++ b/tests/sources/unpack_tilize_test.cpp
@@ -12,11 +12,6 @@
 // Globals
 uint32_t unp_cfg_context        = 0;
 uint32_t pack_sync_tile_dst_ptr = 0;
-#ifdef DEST_ACC
-const bool is_fp32_dest_acc_en = true;
-#else
-const bool is_fp32_dest_acc_en = false;
-#endif
 
 #ifdef LLK_TRISC_UNPACK
 

--- a/tests/sources/unpack_untilize_test.cpp
+++ b/tests/sources/unpack_untilize_test.cpp
@@ -13,12 +13,6 @@
 uint32_t unp_cfg_context        = 0;
 uint32_t pack_sync_tile_dst_ptr = 0;
 
-#ifdef DEST_ACC
-const bool is_fp32_dest_acc_en = true;
-#else
-const bool is_fp32_dest_acc_en = false;
-#endif
-
 #ifdef LLK_TRISC_UNPACK
 
 #include "llk_unpack_A.h"


### PR DESCRIPTION
### Ticket
<!-- Link to Github Issue -->
https://github.com/tenstorrent/tt-llk/issues/80
### Problem description
Tests support Input and Output format parametrization meaning that the user can define the format they what their input tensor in L1 to be and the format of their output in L1. However for the LLK pipeline to run we need to define the intermediary formats including unpacker formats, fpu formats and packer formats. This the user does not define and is left up to us to define according to the best combination which was developed during the format sweep effort. 

### What's changed
<!-- Describe the approach used to solve the problem.
Summarize the changes made and its impact. -->
The inference model looks at the input and output format defined by client, and dest accumulation, if it is on or off and sets the unpacker and packer src and dest formats accordingly. When dest accumulation is off the packer accepts the format seen in the dst register and then convert to the output formats wanted. However when dest accumulation is on then `Float32` is in dst register and packer gasket can covert to the output format before the data goes into packer for reformatting; thus the packer accepts the source format to be the wanted output format and does no conversion.
- Note that when our wanted output if `Float16_a` and dest accumulation is turned on we cannot have packer_src and packer_dst formats be the same because the packer gasket cannot perform conversion from `Float32` to `Float16_a`, so the packer_src format is `Float32` and packer_dst format is `Float16_a`. In wormhole architecture, the packer formats are decided specifically according to dest accumulation.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
