### PR TITLE
build: use `latest` tag for metal CI docker image

### DIFF
--- a/.github/workflows/tt-metal-integration-tests.yml
+++ b/.github/workflows/tt-metal-integration-tests.yml
@@ -15,7 +15,7 @@ jobs:
     name: 🔧 LLK unit tests
     env:
       DOCKER_IMAGE: ghcr.io/tenstorrent/tt-metal/tt-metalium/ubuntu-22.04-ci-build-amd64
-      IMAGE_HASH: a2e6e2031c340fdbeea0fe88b36a54ddfbf75031
+      IMAGE_HASH: latest
     runs-on: ${{ inputs.runs_on }}
     timeout-minutes: 40
     steps:


### PR DESCRIPTION
### Ticket
None

### Problem description
Using `latest` tag should make our pipeline keep track of the changes in tt-metal docker setup. It could prove to be counterproductive if we start observing failures due to changes that aren’t under our control, but let’s give it a shot.

### What's changed
Image hash of the metal CI docker image is now set to use `latest` tag.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
