### PR TITLE
Comment out calls to disable_gathering

### DIFF
--- a/tt_llk_blackhole/common/inc/ckernel.h
+++ b/tt_llk_blackhole/common/inc/ckernel.h
@@ -690,7 +690,7 @@ inline void enable_gathering()
 template <uint start, uint len, bool exec_while_loading = false, typename F>
 inline void load_replay_buf(F fn)
 {
-    disable_gathering();
+    // disable_gathering();
 
     // Issue instruction to load replay buffer
     TTI_REPLAY(start, len, exec_while_loading, 1);
@@ -708,7 +708,7 @@ inline void load_replay_buf(F fn)
 template <typename F>
 inline void load_replay_buf(uint start, uint len, bool exec_while_loading, F fn)
 {
-    disable_gathering();
+    // disable_gathering();
 
     // Issue instruction to load replay buffer
     TT_REPLAY(start, len, exec_while_loading, 1);


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/19201

### Problem description
Although harmless to our knowledge, for easier debugging we want to comment out the redundant calls to disable_gathering as they are disabled at start. 

### What's changed
Commented out calls to disable_gathering

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
