### PR TITLE
ci: remove docker container after each run

### DIFF
--- a/.github/workflows/setup-and-test.yml
+++ b/.github/workflows/setup-and-test.yml
@@ -19,7 +19,7 @@ jobs:
     timeout-minutes: 40
     container:
       image: ${{ inputs.docker_image }}
-      options: "--device /dev/tenstorrent"
+      options: "--rm --device /dev/tenstorrent"
 
     steps:
       # Step 1: Checkout the repository

--- a/.github/workflows/tt-metal-integration-tests.yml
+++ b/.github/workflows/tt-metal-integration-tests.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 40
     container:
       image: ghcr.io/tenstorrent/tt-metal/tt-metalium/ubuntu-22.04-ci-build-amd64:latest
-      options: --user root --device /dev/tenstorrent
+      options: --user root --device /dev/tenstorrent --rm
       volumes:
         - /dev/hugepages:/dev/hugepages
         - /dev/hugepages-1G:/dev/hugepages-1G


### PR DESCRIPTION
### Ticket
None

### Problem description
This change removes docker container after running.

### What's changed
We used to have this setting in the previous version of metal integration tests workflow, but I mistakenly dropped after the last change. This is now causing issues with PRs coming from forks.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update