### PR TITLE
ci: reduce verbosity of pytests

### DIFF
--- a/.github/workflows/setup-and-test.yml
+++ b/.github/workflows/setup-and-test.yml
@@ -39,7 +39,7 @@ jobs:
         shell: bash
         run: |
           cd tests/python_tests/
-          pytest --timeout=60 --color=yes --force-sugar .
+          pytest --override-ini="addopts=--quiet" --timeout=60 --color=yes --force-sugar .
 
       # Step 4: Upload test log as an artifact
       - name: Upload logs if tests fail

--- a/.github/workflows/setup-and-test.yml
+++ b/.github/workflows/setup-and-test.yml
@@ -39,7 +39,7 @@ jobs:
         shell: bash
         run: |
           cd tests/python_tests/
-          pytest --override-ini="addopts=--quiet" --timeout=60 .
+          pytest --override-ini="addopts=-v" --timeout=60 .
 
       # Step 4: Upload test log as an artifact
       - name: Upload logs if tests fail

--- a/.github/workflows/setup-and-test.yml
+++ b/.github/workflows/setup-and-test.yml
@@ -39,7 +39,7 @@ jobs:
         shell: bash
         run: |
           cd tests/python_tests/
-          pytest --override-ini="addopts=--quiet" --timeout=60 --color=yes --force-sugar .
+          pytest --override-ini="addopts=--quiet" --timeout=60 .
 
       # Step 4: Upload test log as an artifact
       - name: Upload logs if tests fail


### PR DESCRIPTION
### Ticket
None

### Problem description
Tests take over 20 minutes to finish. This could, in part, be due to very verbose prints of pytests.

### What's changed
This change should reduce verbosity level of tests in the pipeline runs.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
