### PR TITLE
chore: update setup_testing_env.sh to display info in case of error

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
     - id: check-copyright
       args: ['--config', 'infra/check_copyright_config.yaml', "--replace"]
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v3.4.0
+  rev: v5.0.0
   hooks:
     - id: trailing-whitespace
     - id: end-of-file-fixer

--- a/tests/setup_testing_env.sh
+++ b/tests/setup_testing_env.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
-# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: (c) 2025 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0
+
+set -e  # Exit immediately if a command exits with a non-zero status
+set -o pipefail  # Fail if any command in a pipeline fails
 
 SFPI_VERSION=$(cat sfpi_version.txt)
 
@@ -9,8 +12,16 @@ SFPI_RELEASE_URL="https://github.com/tenstorrent/sfpi/releases/download/${SFPI_V
 
 if [ ! -d "sfpi" ]; then
     echo "sfpi directory not found. Downloading and extracting SFPI ${SFPI_VERSION} release..."
-    wget "$SFPI_RELEASE_URL" -O sfpi-release.tgz
-    tar -xzf sfpi-release.tgz
+    if ! wget "$SFPI_RELEASE_URL" -O sfpi-release.tgz; then
+        echo "Error: Failed to download SFPI release from $SFPI_RELEASE_URL" >&2
+        exit 1
+    fi
+
+    if ! tar -xzf sfpi-release.tgz; then
+        echo "Error: Failed to extract SFPI release" >&2
+        exit 1
+    fi
+
     rm sfpi-release.tgz
 else
     echo "sfpi directory already exists. Skipping download and extraction."

--- a/tests/setup_testing_env.sh
+++ b/tests/setup_testing_env.sh
@@ -12,7 +12,7 @@ SFPI_RELEASE_URL="https://github.com/tenstorrent/sfpi/releases/download/${SFPI_V
 
 if [ ! -d "sfpi" ]; then
     echo "sfpi directory not found. Downloading and extracting SFPI ${SFPI_VERSION} release..."
-    if ! wget "$SFPI_RELEASE_URL" -O sfpi-release.tgz; then
+    if ! wget --waitretry=5 --retry-connrefused "$SFPI_RELEASE_URL" -O sfpi-release.tgz; then
         echo "Error: Failed to download SFPI release from $SFPI_RELEASE_URL" >&2
         exit 1
     fi

--- a/tests/setup_testing_env.sh
+++ b/tests/setup_testing_env.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# SPDX-License-Identifier: (c) 2025 Tenstorrent AI ULC
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0
 


### PR DESCRIPTION
### Ticket
None

### Problem description
Currently, we are experiencing [random failures](https://github.com/tenstorrent/tt-llk/actions/runs/14880439156/job/41787137193?pr=169) caused by network issues when downloading the SFPI compiler. However, the error is misleading as it only appears during the pytest execution step. Instead, the failure should occur earlier, during the step where the SFPI compiler is being downloaded.

### What's changed
With this change, GH pipeline should stop if it fails to fetch the compiler or to unpack it. Pytests shouldn't even run.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
