### PR TITLE
ci: run LLK test infra conditionally, depending on the changed files

### DIFF
--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -21,6 +21,30 @@ jobs:
     name: "🔍 Static checks"
     uses: ./.github/workflows/pre-commit.yml
 
+  detect-changes:
+    name: "🔍 Detect changes"
+    runs-on: ubuntu-latest
+    needs: pre-commit
+    outputs:
+      wormhole: ${{ steps.filter.outputs.wormhole }}
+      blackhole: ${{ steps.filter.outputs.blackhole }}
+      tests: ${{ steps.filter.outputs.tests }}
+      github: ${{ steps.filter.outputs.github }}
+    steps:
+      - name: Detect which directories changed
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+              wormhole:
+                - 'tt_llk_wormhole_b0/**'
+              blackhole:
+                - 'tt_llk_blackhole/**'
+              tests:
+                - 'tests/**'
+              github:
+                - '.github/**'
+
   build-images:
     name: "🐳️ Docker setup"
     uses: ./.github/workflows/build-images.yml
@@ -30,7 +54,10 @@ jobs:
   setup-and-test-wormhole:
     name: "🌀 Perform checks (Wormhole)"
     uses: ./.github/workflows/setup-and-test.yml
-    needs: build-images
+    needs: [build-images, detect-changes]
+    if: ${{ needs.detect-changes.outputs.wormhole == 'true' ||
+            needs.detect-changes.outputs.tests == 'true' ||
+            needs.detect-changes.outputs.github == 'true' }}
     with:
       docker_image: ${{ needs.build-images.outputs.docker-image }}
       runs_on: tt-beta-ubuntu-2204-n150-large-stable
@@ -38,7 +65,10 @@ jobs:
   setup-and-test-blackhole:
     name: "🕳️ Perform checks (Blackhole)"
     uses: ./.github/workflows/setup-and-test.yml
-    needs: build-images
+    needs: [build-images, detect-changes]
+    if: ${{ needs.detect-changes.outputs.blackhole == 'true' ||
+            needs.detect-changes.outputs.tests == 'true' ||
+            needs.detect-changes.outputs.github == 'true' }}
     with:
       docker_image: ${{ needs.build-images.outputs.docker-image }}
       runs_on: p150
@@ -57,3 +87,4 @@ jobs:
         uses: re-actors/alls-green@release/v1
         with:
           jobs: ${{ toJSON(needs) }}
+          allowed-skips: setup-and-test-wormhole, setup-and-test-blackhole

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -64,7 +64,7 @@ jobs:
               issue_number: context.payload.pull_request.number,
               body:
                 "Thank you for your contribution! 🚀\n\n" +
-                "You can run tt-metal integration tests by adding the `blackole-integration-tests` and/or " +
+                "You can run tt-metal integration tests by adding the `blackhole-integration-tests` and/or " +
                 "`wormhole-integration-tests` labels to this pull request.\n\n" +
                 "📖 For more information, please refer to our [CONTRIBUTING.md](" +
                 "https://github.com/tenstorrent/tt-llk/blob/main/CONTRIBUTING.md)."

--- a/.github/workflows/setup-and-test.yml
+++ b/.github/workflows/setup-and-test.yml
@@ -16,7 +16,7 @@ jobs:
   setup-and-test:
     name: "🦄 Run tests"
     runs-on: ${{ inputs.runs_on }}
-    timeout-minutes: 40
+    timeout-minutes: 80
     container:
       image: ${{ inputs.docker_image }}
       options: "--rm --device /dev/tenstorrent"


### PR DESCRIPTION
### Ticket
None

### Problem description
Currently, both Blackhole and Wormhole tests are being run regardless of the changes introduced in the PR. Since we only have a limited number of WH runners and just one BH runner available, optimizing resource usage is crucial.

### What's changed
With this change, the CI pipeline will only run the appropriate tests. For example:
- If Wormhole-specific code is changed, tests will only run on the Wormhole runner.
- If Blackhole-specific code is changed, tests will only run on the Blackhole runner.
- If unrelated files (e.g., README) are changed, unit tests will not run, as they are not expected to fail.

This ensures efficient use of resources.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
