### PR TITLE
Use MOVD2A+MOVA2D to save two instructions.

### DIFF
--- a/tt_llk_wormhole_b0/llk_lib/llk_math_transpose_dest.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_math_transpose_dest.h
@@ -26,9 +26,6 @@ inline void _llk_math_transpose_dest_(const std::uint32_t dst_index)
 
     ckernel_template::run(instrn_buffer);
 
-    TTI_REPLAY(20, 5, 0, 0);
-    TTI_REPLAY(26, 4, 0, 0);
-
     TTI_SETRWC(p_setrwc::CLR_AB, 0, 0, 0, 0, p_setrwc::SET_AB);
 
     math::clear_dst_reg_addr();
@@ -63,10 +60,10 @@ inline void transpose_dest_configure_mop()
     TTI_REPLAY(16, 16, 0, 1);
 
     // A
-    TTI_MOVD2B(0, p_movd2b::SRC_ZERO_OFFSET + 0, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 0 - 16);
-    TTI_MOVD2B(0, p_movd2b::SRC_ZERO_OFFSET + 4, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 4 - 16);
-    TTI_MOVD2B(0, p_movd2b::SRC_ZERO_OFFSET + 8, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 8 - 16);
-    TTI_MOVD2B(0, p_movd2b::SRC_ZERO_OFFSET + 12, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 12 - 16);
+    TTI_MOVD2A(0, 0, ADDR_MOD_1, p_movd2a::MOV_4_ROWS, 0x3ff & -16);
+    TTI_MOVD2A(0, 4, ADDR_MOD_1, p_movd2a::MOV_4_ROWS, 0x3ff & -12);
+    TTI_MOVD2A(0, 8, ADDR_MOD_1, p_movd2a::MOV_4_ROWS, 0x3ff & -8);
+    TTI_MOVD2A(0, 12, ADDR_MOD_1, p_movd2a::MOV_4_ROWS, 0x3ff & -4);
 
     // B
     TTI_MOVD2B(0, p_movd2b::SRC_ROW16_OFFSET + 0, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 0);
@@ -87,19 +84,17 @@ inline void transpose_dest_configure_mop()
     TTI_MOVB2D(0, p_movd2b::SRC_ROW16_OFFSET + 12, ADDR_MOD_0, p_movb2d::MOV_4_ROWS, 12);
 
     // F
-    TTI_MOVB2D(0, p_movd2b::SRC_ZERO_OFFSET + 0, ADDR_MOD_1, p_movb2d::MOV_4_ROWS, 0);
-    TTI_MOVB2D(0, p_movd2b::SRC_ZERO_OFFSET + 4, ADDR_MOD_1, p_movb2d::MOV_4_ROWS, 4);
+    TTI_MOVA2D(0, 0, ADDR_MOD_1, p_mova2d::MOV_8_ROWS, 0);
+    TTI_MOVA2D(0, 8, ADDR_MOD_1, p_mova2d::MOV_8_ROWS, 8);
 
     uint AF = TT_OP_REPLAY(16, 16, 0, 0);
     uint BC = TT_OP_REPLAY(20, 5, 0, 0);
     uint E  = TT_OP_REPLAY(26, 4, 0, 0);
-    uint X  = TT_OP_MOVB2D(0, p_movd2b::SRC_ZERO_OFFSET + 8, ADDR_MOD_1, p_movb2d::MOV_4_ROWS, 8);
-    uint Y  = TT_OP_MOVB2D(0, p_movd2b::SRC_ZERO_OFFSET + 12, ADDR_MOD_0, p_movb2d::MOV_4_ROWS, 12);
 
     ckernel_template tmp(1, 2, E, BC);
     tmp.set_start_op(BC);
     tmp.set_last_outer_loop_instr(AF);
-    tmp.set_end_ops(X, Y);
+    tmp.set_end_ops(BC, E);
     tmp.program(instrn_buffer);
 }
 


### PR DESCRIPTION
### Ticket

#175

### Problem description

SrcA supports 8-row movement in the A2D direction.  This simplifies the transpose_dest LLK slightly.

### What's changed

- 4x MOVB2D replaced with 2x MOVA2D
- 0x3ff mask added to negative destination offsets to avoid strange macro expansion effects when using negative numbers there
- Two replay calls (BC, E) moved into the MOP

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
