### PR TITLE
fix: revert "Improve reciprocal precision. (#155)"

### DIFF
--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_binary.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_binary.h
@@ -144,7 +144,7 @@ inline void _calculate_sfpu_binary_(const uint dst_offset)
             }
             v_else
             {
-                result = in0 * sfpi::setsgn(_sfpu_reciprocal_<3>(in1), in1);
+                result = in0 * sfpi::setsgn(_sfpu_reciprocal_<4>(in1), in1);
             }
             v_endif;
         }
@@ -165,14 +165,9 @@ inline void _calculate_sfpu_binary_(const uint dst_offset)
 template <bool APPROXIMATION_MODE /*unused*/, BinaryOp BINOP>
 inline void _sfpu_binary_init_()
 {
-    if constexpr (BINOP == BinaryOp::DIV)
+    if constexpr (BINOP == BinaryOp::DIV || BINOP == BinaryOp::POW)
     {
         _init_reciprocal_<APPROXIMATION_MODE>();
-    }
-    if constexpr (BINOP == BinaryOp::POW)
-    {
-        // note: calls _init_reciprocal_
-        _init_exponential_<APPROXIMATION_MODE>();
     }
 }
 

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_exp.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_exp.h
@@ -25,7 +25,7 @@ sfpi_inline sfpi::vFloat _sfpu_exp_(sfpi::vFloat val)
     v_endif;
 
     // Run series in Horner form
-    sfpi::vFloat tmp = val * sfpi::vConst0p8373 + sfpi::vConstFloatPrgm2;
+    sfpi::vFloat tmp = val * sfpi::vConst0p8373 + sfpi::s2vFloat16b(0.863281);
     val              = val * tmp + sfpi::vConst1;
 
     v_if (exp >= 0)
@@ -360,7 +360,8 @@ inline void _init_exponential_()
     }
     else
     {
-        _init_reciprocal_<APPROXIMATION_MODE>();
+        sfpi::vConstFloatPrgm0 = 1.442695f; // ln2_recip
+        sfpi::vConstFloatPrgm1 = 2.0f;
         sfpi::vConstFloatPrgm2 = 0.863281f;
     }
 }

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_gelu.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_gelu.h
@@ -189,6 +189,10 @@ inline void _init_gelu_()
 template <bool APPROXIMATION_MODE>
 inline void _init_gelu_derivative_()
 {
+    sfpi::vConstFloatPrgm0 = 1.442695f; // ln2_recip
+    sfpi::vConstFloatPrgm1 = 2.0f;
+    sfpi::vConstFloatPrgm2 = 0.863281f;
+
     uint imm0;
     uint imm1;
     uint imm2;
@@ -226,8 +230,6 @@ inline void _init_gelu_derivative_()
     }
     else
     {
-        _init_exponential_<false>();
-
         imm0 = 0x28FF;
         imm1 = 0x3020;
         _sfpu_load_imm16_(0, imm0);


### PR DESCRIPTION
### Ticket
None

### Problem description
We have to revert #155, because it's causing issues in tt-metal's ttnn tests. The tests seem off, but this needs to be investigated further, and we're blocked by this commit. So, we will revisit this change after some high priority changes land into metal.

### What's changed
This reverts commit 0c54f3b13e4533bb6a666dba748e698404ab52e7.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update