### PR TITLE
Fix ordering of mailbox_write and semaphore_post in unpack_get_tile

### DIFF
--- a/tt_llk_blackhole/llk_lib/llk_unpack_common.h
+++ b/tt_llk_blackhole/llk_lib/llk_unpack_common.h
@@ -40,14 +40,14 @@ inline void _llk_unpack_get_tile_(std::uint32_t address, std::uint32_t *p_tile)
 
     if constexpr (mail2math)
     {
-        mailbox_write(ThreadId::MathThreadId, byte_address);
         semaphore_post(semaphore::UNPACK_OPERAND_SYNC);
+        mailbox_write(ThreadId::MathThreadId, byte_address);
     }
 
     if constexpr (mail2pack)
     {
-        mailbox_write(ThreadId::PackThreadId, byte_address);
         semaphore_post(semaphore::UNPACK_OPERAND_SYNC);
+        mailbox_write(ThreadId::PackThreadId, byte_address);
     }
 
     *p_tile = byte_address;

--- a/tt_llk_wormhole_b0/llk_lib/llk_unpack_common.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_unpack_common.h
@@ -41,14 +41,14 @@ inline void _llk_unpack_get_tile_(std::uint32_t address, std::uint32_t *p_tile)
 
     if constexpr (mail2math)
     {
-        mailbox_write(ThreadId::MathThreadId, byte_address);
         semaphore_post(semaphore::UNPACK_OPERAND_SYNC);
+        mailbox_write(ThreadId::MathThreadId, byte_address);
     }
 
     if constexpr (mail2pack)
     {
-        mailbox_write(ThreadId::PackThreadId, byte_address);
         semaphore_post(semaphore::UNPACK_OPERAND_SYNC);
+        mailbox_write(ThreadId::PackThreadId, byte_address);
     }
 
     *p_tile = byte_address;


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/19201

### Problem description
The unpacker in _llk_unpack_get_tile function used to do mailbox_writes and then post (increment) a semaphore. It is possible for math and pack thread to read the mailboxes and try to get (decrement) a semaphore which is already zero, thus dropping the decrements. Then later on in _llk_unpack_release_tile the unpacker would wait for the semaphore to be zero, but since the decrements were dropped it would get stuck.

### What's changed
The order of doing the mailbox write and semaphore post has been changed, so the packer and math thread would only try to decrement the semaphore after the sempahore post since that happens before the mailbox write now which will happen before packer and math thread can decrement since their execution is depedent on the mailbox read.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
