### PR TITLE
Add DataType instruction modifier template for bitwise ops

### DIFF
--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_binary_bitwise.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_binary_bitwise.h
@@ -20,16 +20,33 @@ enum class BinaryBitwiseOp : uint8_t
     XOR = 2,
 };
 
-template <bool APPROXIMATION_MODE, BinaryBitwiseOp BITWISE_OP, uint DTYPE = 12 int ITERATIONS = 8>
+enum class DataType : uint8_t
+{
+    DEFAULT    = 0,
+    FP16A      = 1,
+    FP16B      = 2,
+    FP32       = 3,
+    INT32      = 4,
+    INT32_COMP = 5,
+    INT8       = 6,
+    INT8_COMP  = 7,
+    LO16       = 8,
+    LO16_ONLY  = 9,
+    HI16       = 10,
+    HI16_ONLY  = 11,
+};
+
+template <bool APPROXIMATION_MODE, BinaryBitwiseOp BITWISE_OP, DataType DTYPE = INT32, int ITERATIONS = 8>
 inline void _calculate_sfpu_binary_bitwise_(const uint dst_offset)
 {
+    constexpr uint8_t dtype = static_cast<uint8_t>(DTYPE);
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++)
     {
         constexpr uint dst_tile_size = 64;
 
-        TTI_SFPLOAD(0, DTYPE, ADDR_MOD_7, 0);
-        TT_SFPLOAD(1, DTYPE, ADDR_MOD_7, dst_offset * dst_tile_size);
+        TTI_SFPLOAD(0, dtype, ADDR_MOD_7, 0);
+        TT_SFPLOAD(1, dtype, ADDR_MOD_7, dst_offset * dst_tile_size);
 
         if constexpr (BITWISE_OP == BinaryBitwiseOp::AND)
         {
@@ -44,7 +61,7 @@ inline void _calculate_sfpu_binary_bitwise_(const uint dst_offset)
             TTI_SFPXOR(0, 1, 0, 0);
         }
 
-        TTI_SFPSTORE(0, DTYPE, ADDR_MOD_7, 0);
+        TTI_SFPSTORE(0, dtype, ADDR_MOD_7, 0);
         sfpi::dst_reg++;
     }
 }

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_binary_bitwise.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_binary_bitwise.h
@@ -20,7 +20,7 @@ enum class BinaryBitwiseOp : uint8_t
     XOR = 2,
 };
 
-template <bool APPROXIMATION_MODE, BinaryBitwiseOp BITWISE_OP, uint DTYPE = INT32 int ITERATIONS = 8>
+template <bool APPROXIMATION_MODE, BinaryBitwiseOp BITWISE_OP, uint DTYPE = 12 int ITERATIONS = 8>
 inline void _calculate_sfpu_binary_bitwise_(const uint dst_offset)
 {
     // SFPU microcode

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_binary_bitwise.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_binary_bitwise.h
@@ -20,7 +20,7 @@ enum class BinaryBitwiseOp : uint8_t
     XOR = 2,
 };
 
-template <bool APPROXIMATION_MODE, BinaryBitwiseOp BITWISE_OP, int ITERATIONS = 8>
+template <bool APPROXIMATION_MODE, BinaryBitwiseOp BITWISE_OP, uint DTYPE = INT32 int ITERATIONS = 8>
 inline void _calculate_sfpu_binary_bitwise_(const uint dst_offset)
 {
     // SFPU microcode
@@ -28,8 +28,8 @@ inline void _calculate_sfpu_binary_bitwise_(const uint dst_offset)
     {
         constexpr uint dst_tile_size = 64;
 
-        TTI_SFPLOAD(0, 12, ADDR_MOD_7, 0);
-        TT_SFPLOAD(1, 12, ADDR_MOD_7, dst_offset * dst_tile_size);
+        TTI_SFPLOAD(0, DTYPE, ADDR_MOD_7, 0);
+        TT_SFPLOAD(1, DTYPE, ADDR_MOD_7, dst_offset * dst_tile_size);
 
         if constexpr (BITWISE_OP == BinaryBitwiseOp::AND)
         {
@@ -44,7 +44,7 @@ inline void _calculate_sfpu_binary_bitwise_(const uint dst_offset)
             TTI_SFPXOR(0, 1, 0, 0);
         }
 
-        TTI_SFPSTORE(0, 12, ADDR_MOD_7, 0);
+        TTI_SFPSTORE(0, DTYPE, ADDR_MOD_7, 0);
         sfpi::dst_reg++;
     }
 }

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_binary_bitwise.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_binary_bitwise.h
@@ -4,8 +4,11 @@
 
 #pragma once
 
+#include <type_traits>
+
 #include "ckernel_addrmod.h"
 #include "ckernel_ops.h"
+#include "llk_defs.h"
 #include "sfpi.h"
 
 namespace ckernel
@@ -20,33 +23,17 @@ enum class BinaryBitwiseOp : uint8_t
     XOR = 2,
 };
 
-enum class DataType : uint8_t
-{
-    DEFAULT    = 0,
-    FP16A      = 1,
-    FP16B      = 2,
-    FP32       = 3,
-    INT32      = 4,
-    INT32_COMP = 5,
-    INT8       = 6,
-    INT8_COMP  = 7,
-    LO16       = 8,
-    LO16_ONLY  = 9,
-    HI16       = 10,
-    HI16_ONLY  = 11,
-};
-
-template <bool APPROXIMATION_MODE, BinaryBitwiseOp BITWISE_OP, DataType DTYPE = INT32, int ITERATIONS = 8>
+template <bool APPROXIMATION_MODE, BinaryBitwiseOp BITWISE_OP, InstrModLoadStore INSTRUCTION_MODE = INT32, int ITERATIONS = 8>
 inline void _calculate_sfpu_binary_bitwise_(const uint dst_offset)
 {
-    constexpr uint8_t dtype = static_cast<uint8_t>(DTYPE);
+    constexpr auto instruction_mode = static_cast<std::underlying_type_t<InstrModLoadStore>>(INSTRUCTION_MODE);
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++)
     {
         constexpr uint dst_tile_size = 64;
 
-        TTI_SFPLOAD(0, dtype, ADDR_MOD_7, 0);
-        TT_SFPLOAD(1, dtype, ADDR_MOD_7, dst_offset * dst_tile_size);
+        TTI_SFPLOAD(0, instruction_mode, ADDR_MOD_7, 0);
+        TT_SFPLOAD(1, instruction_mode, ADDR_MOD_7, dst_offset * dst_tile_size);
 
         if constexpr (BITWISE_OP == BinaryBitwiseOp::AND)
         {
@@ -61,7 +48,7 @@ inline void _calculate_sfpu_binary_bitwise_(const uint dst_offset)
             TTI_SFPXOR(0, 1, 0, 0);
         }
 
-        TTI_SFPSTORE(0, dtype, ADDR_MOD_7, 0);
+        TTI_SFPSTORE(0, instruction_mode, ADDR_MOD_7, 0);
         sfpi::dst_reg++;
     }
 }

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_binary_bitwise.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_binary_bitwise.h
@@ -19,7 +19,7 @@ enum class BinaryBitwiseOp : uint8_t
     XOR = 2,
 };
 
-template <bool APPROXIMATION_MODE, BinaryBitwiseOp BITWISE_OP, int ITERATIONS = 8>
+template <bool APPROXIMATION_MODE, BinaryBitwiseOp BITWISE_OP, uint DTYPE = INT32, int ITERATIONS = 8>
 inline void _calculate_sfpu_binary_bitwise_(const uint dst_offset)
 {
     // SFPU microcode
@@ -27,8 +27,8 @@ inline void _calculate_sfpu_binary_bitwise_(const uint dst_offset)
     {
         constexpr uint dst_tile_size = 64;
 
-        TTI_SFPLOAD(0, 4, 3, 0);
-        TT_SFPLOAD(1, 4, 3, dst_offset * dst_tile_size);
+        TTI_SFPLOAD(0, DTYPE, 3, 0);
+        TT_SFPLOAD(1, DTYPE, 3, dst_offset * dst_tile_size);
 
         if constexpr (BITWISE_OP == BinaryBitwiseOp::AND)
         {
@@ -43,7 +43,7 @@ inline void _calculate_sfpu_binary_bitwise_(const uint dst_offset)
             TTI_SFPXOR(0, 1, 0, 0);
         }
 
-        TTI_SFPSTORE(0, 4, 3, 0);
+        TTI_SFPSTORE(0, DTYPE, 3, 0);
         sfpi::dst_reg++;
     }
 }

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_binary_bitwise.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_binary_bitwise.h
@@ -19,7 +19,7 @@ enum class BinaryBitwiseOp : uint8_t
     XOR = 2,
 };
 
-template <bool APPROXIMATION_MODE, BinaryBitwiseOp BITWISE_OP, uint DTYPE = INT32, int ITERATIONS = 8>
+template <bool APPROXIMATION_MODE, BinaryBitwiseOp BITWISE_OP, uint DTYPE = 4, int ITERATIONS = 8>
 inline void _calculate_sfpu_binary_bitwise_(const uint dst_offset)
 {
     // SFPU microcode

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_binary_bitwise.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_binary_bitwise.h
@@ -19,16 +19,33 @@ enum class BinaryBitwiseOp : uint8_t
     XOR = 2,
 };
 
-template <bool APPROXIMATION_MODE, BinaryBitwiseOp BITWISE_OP, uint DTYPE = 4, int ITERATIONS = 8>
+enum class DataType : uint8_t
+{
+    DEFAULT    = 0,
+    FP16A      = 1,
+    FP16B      = 2,
+    FP32       = 3,
+    INT32      = 4,
+    INT32_COMP = 5,
+    INT8       = 6,
+    INT8_COMP  = 7,
+    LO16       = 8,
+    LO16_ONLY  = 9,
+    HI16       = 10,
+    HI16_ONLY  = 11,
+};
+
+template <bool APPROXIMATION_MODE, BinaryBitwiseOp BITWISE_OP, DataType DTYPE = INT32, int ITERATIONS = 8>
 inline void _calculate_sfpu_binary_bitwise_(const uint dst_offset)
 {
+    constexpr uint8_t dtype = static_cast<uint8_t>(DTYPE);
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++)
     {
         constexpr uint dst_tile_size = 64;
 
-        TTI_SFPLOAD(0, DTYPE, 3, 0);
-        TT_SFPLOAD(1, DTYPE, 3, dst_offset * dst_tile_size);
+        TTI_SFPLOAD(0, dtype, 3, 0);
+        TT_SFPLOAD(1, dtype, 3, dst_offset * dst_tile_size);
 
         if constexpr (BITWISE_OP == BinaryBitwiseOp::AND)
         {
@@ -43,7 +60,7 @@ inline void _calculate_sfpu_binary_bitwise_(const uint dst_offset)
             TTI_SFPXOR(0, 1, 0, 0);
         }
 
-        TTI_SFPSTORE(0, DTYPE, 3, 0);
+        TTI_SFPSTORE(0, dtype, 3, 0);
         sfpi::dst_reg++;
     }
 }

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_binary_bitwise.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_binary_bitwise.h
@@ -4,7 +4,11 @@
 
 #pragma once
 
+#include <type_traits>
+
+#include "ckernel_addrmod.h"
 #include "ckernel_ops.h"
+#include "llk_defs.h"
 #include "sfpi.h"
 
 namespace ckernel
@@ -19,33 +23,17 @@ enum class BinaryBitwiseOp : uint8_t
     XOR = 2,
 };
 
-enum class DataType : uint8_t
-{
-    DEFAULT    = 0,
-    FP16A      = 1,
-    FP16B      = 2,
-    FP32       = 3,
-    INT32      = 4,
-    INT32_COMP = 5,
-    INT8       = 6,
-    INT8_COMP  = 7,
-    LO16       = 8,
-    LO16_ONLY  = 9,
-    HI16       = 10,
-    HI16_ONLY  = 11,
-};
-
-template <bool APPROXIMATION_MODE, BinaryBitwiseOp BITWISE_OP, DataType DTYPE = INT32, int ITERATIONS = 8>
+template <bool APPROXIMATION_MODE, BinaryBitwiseOp BITWISE_OP, InstrModLoadStore INSTRUCTION_MODE = INT32, int ITERATIONS = 8>
 inline void _calculate_sfpu_binary_bitwise_(const uint dst_offset)
 {
-    constexpr uint8_t dtype = static_cast<uint8_t>(DTYPE);
+    constexpr auto instruction_mode = static_cast<std::underlying_type_t<InstrModLoadStore>>(INSTRUCTION_MODE);
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++)
     {
         constexpr uint dst_tile_size = 64;
 
-        TTI_SFPLOAD(0, dtype, 3, 0);
-        TT_SFPLOAD(1, dtype, 3, dst_offset * dst_tile_size);
+        TTI_SFPLOAD(0, instruction_mode, 3, 0);
+        TT_SFPLOAD(1, instruction_mode, 3, dst_offset * dst_tile_size);
 
         if constexpr (BITWISE_OP == BinaryBitwiseOp::AND)
         {
@@ -60,7 +48,7 @@ inline void _calculate_sfpu_binary_bitwise_(const uint dst_offset)
             TTI_SFPXOR(0, 1, 0, 0);
         }
 
-        TTI_SFPSTORE(0, dtype, 3, 0);
+        TTI_SFPSTORE(0, instruction_mode, 3, 0);
         sfpi::dst_reg++;
     }
 }


### PR DESCRIPTION
### Ticket
NA

### Problem description
Only int32 dtype supported

### What's changed
Expose the dtype param as a template parameter

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
