### PR TITLE
ci: switch to blackhole runners from pool

### DIFF
--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -72,8 +72,8 @@ jobs:
             needs.detect-changes.outputs.github == 'true' }}
     with:
       docker_image: ${{ needs.build-images.outputs.docker-image }}
-      runs_on: p150
-      test_group: "[1]"
+      runs_on: tt-beta-ubuntu-2204-p150a-large-stable
+      test_group: "[1, 2, 3, 4, 5]"
 
   check-all-green:
     name: "✅ Check all green"


### PR DESCRIPTION
### Ticket
None

### Problem description
Until recently, we only had one available BH runner, which meant we had to execute all of our tests sequentially. In contrast, we had access to Wormhole runners and recently began running tests in parallel by splitting them into five groups, with each group executing on a separate runner.
As of a few days ago, Blackhole runners became available in the shared pool, so we can now leverage them as well.
Just for comparison, BH tests currently take around 30 minutes to finish, while WH take ~8min (5 groups taking around ~7-8 minutes each, running concurrently). This is a significant speedup.

### What's changed
This PR switches BH tests to run on the runners from the org pool. Instead of 1 group of tests, we now divide them into 5 groups to parallelize them.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
