### PR TITLE
[Test Infra] Added test to fuse matmul with unpack tilize

### DIFF
--- a/tests/python_tests/test_matmul_unpack_tilize.py
+++ b/tests/python_tests/test_matmul_unpack_tilize.py
@@ -4,24 +4,24 @@
 import pytest
 import torch
 
-from helpers.format_config import DataFormat
-from helpers.format_arg_mapping import format_dict, MathFidelity, DestAccumulation
-from helpers.param_config import (
-    clean_params,
-    generate_param_ids,
-    generate_params,
-    input_output_formats,
-)
 from helpers.device import (
     collect_results,
     run_elf_files,
     wait_for_tensix_operations_finished,
     write_stimuli_to_l1,
 )
+from helpers.format_arg_mapping import DestAccumulation, MathFidelity, format_dict
+from helpers.format_config import DataFormat
+from helpers.param_config import (
+    clean_params,
+    generate_param_ids,
+    generate_params,
+    input_output_formats,
+)
 from helpers.stimuli_generator import generate_stimuli
 from helpers.test_config import generate_make_command
-from helpers.utils import compare_pcc, run_shell_command
 from helpers.tilize_untilize import tilize
+from helpers.utils import compare_pcc, run_shell_command
 
 
 def generate_golden(operand1, operand2, data_format, math_fidelity):

--- a/tests/python_tests/test_matmul_unpack_tilize.py
+++ b/tests/python_tests/test_matmul_unpack_tilize.py
@@ -1,0 +1,133 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+
+from helpers.format_config import DataFormat
+from helpers.format_arg_mapping import format_dict, MathFidelity, DestAccumulation
+from helpers.param_config import clean_params, format_combination_sweep, generate_combination, generate_param_ids, generate_params, input_output_formats
+from helpers.device import collect_results, run_elf_files, wait_for_tensix_operations_finished, write_stimuli_to_l1
+from helpers.stimuli_generator import generate_stimuli
+from helpers.test_config import generate_make_command
+from helpers.utils import compare_pcc, run_shell_command
+from helpers.tilize_untilize import tilize
+
+
+def generate_golden(operand1, operand2, data_format, math_fidelity):
+
+    if data_format == DataFormat.Float16_b:
+        if math_fidelity in [MathFidelity.LoFi, MathFidelity.HiFi2]:  # LoFi or HiFi2
+            for element in operand2:
+                element = element.to(torch.int32)
+                element &= 0xFFFE
+        if math_fidelity == MathFidelity.LoFi:  # LoFi
+            for element in operand1:
+                element = element.to(torch.int32)
+                element &= 0xFFF8
+
+    operand1_matrix = operand1.view(32, 32).to(format_dict[data_format])
+    operand2_matrix = operand2.view(32, 32).to(format_dict[data_format])
+
+    result_matrix = torch.matmul(operand1_matrix, operand2_matrix)
+
+    return result_matrix.flatten()
+
+
+# SUPPORTED FORMATS FOR TEST
+supported_formats = [DataFormat.Float16, DataFormat.Float16_b]
+
+#   INPUT-OUTPUT FORMAT SWEEP
+#   input_output_formats(supported_formats)
+
+#   FULL FORMAT SWEEP
+#   format_combination_sweep(formats=supported_formats, all_same=False, same_src_reg_format=True)
+
+#   SPECIFIC FORMAT COMBINATION
+#   generate_combination(
+#       [(DataFormat.Float16_b,  # index 0 is for unpack_A_src
+#         DataFormat.Float16_b,  # index 1 is for unpack_A_dst
+#         DataFormat.Float16_b,  # index 2 is for pack_src (if src registers have same formats)
+#         DataFormat.Float16_b,  # index 3 is for pack_dst
+#         DataFormat.Float16_b,  # index 4 is for math format)])
+
+#   SPECIFIC INPUT-OUTPUT COMBINATION
+#   [InputOutputFormat(DataFormat.Float16, DataFormat.Float32)]
+
+test_formats = format_combination_sweep(formats=supported_formats, all_same=True, same_src_reg_format=True)
+all_params = generate_params(
+    ["matmul_unpack_tilize_test"],
+    test_formats,
+    dest_acc=[DestAccumulation.No, DestAccumulation.Yes],
+    math_fidelity=[
+        MathFidelity.LoFi,
+        MathFidelity.HiFi2,
+        MathFidelity.HiFi3,
+        MathFidelity.HiFi4,
+    ],
+)
+param_ids = generate_param_ids(all_params)
+
+
+@pytest.mark.parametrize(
+    "testname, formats, dest_acc, math_fidelity",
+    clean_params(all_params),
+    ids=param_ids,
+)
+def test_matmul_pack_untilize(testname, formats, dest_acc, math_fidelity):
+
+    src_A, src_B = generate_stimuli(formats.input_format, formats.input_format)
+
+    golden_tensor = tilize(generate_golden(src_A, src_B, formats.output_format, math_fidelity))
+    golden_tensor = golden_tensor.to(format_dict[formats.output_format])
+
+    write_stimuli_to_l1(
+        src_A,
+        src_B,
+        formats.input_format,
+        formats.input_format,
+    )
+    buffer_dest_address = 0x1E000
+    test_config = {
+        "formats": formats,
+        "testname": testname,
+        "dest_acc": dest_acc,
+        "math_fidelity": math_fidelity,
+    }
+
+    make_cmd = generate_make_command(test_config)
+    run_shell_command(f"cd .. && {make_cmd}")
+
+    run_elf_files(testname)
+
+    wait_for_tensix_operations_finished()
+    res_from_L1 = collect_results(formats, tensor_size=len(src_A), address=buffer_dest_address)
+    assert len(res_from_L1) == len(golden_tensor)
+
+    res_tensor = torch.tensor(
+        res_from_L1,
+        dtype=(
+            format_dict[formats.output_format]
+            if formats.output_format in [DataFormat.Float16, DataFormat.Float16_b]
+            else torch.bfloat16
+        ),
+    )
+
+    if formats.output_format in [DataFormat.Float16_b, DataFormat.Float16]:
+        atol = 0.1
+        rtol = 0.05
+    elif formats.output_format == DataFormat.Bfp8_b:
+        atol = 0.1
+        rtol = 0.2
+
+    print("\nGolden Tensor:\n", golden_tensor.view(64,16))
+    print("\nResult Tensor:\n", res_tensor.view(64,16))
+
+
+    for i in range(len(golden_tensor)):
+        assert torch.isclose(
+            golden_tensor[i], res_tensor[i], rtol=rtol, atol=atol
+        ), f"Failed at index {i} with values {golden_tensor[i]} and {res_from_L1[i]}"
+
+    _, pcc = compare_pcc(golden_tensor, res_tensor, pcc=0.99)
+    assert pcc > 0.98

--- a/tests/python_tests/test_matmul_unpack_tilize.py
+++ b/tests/python_tests/test_matmul_unpack_tilize.py
@@ -45,7 +45,7 @@ def generate_golden(operand1, operand2, data_format, math_fidelity):
 
 
 # SUPPORTED FORMATS FOR TEST
-supported_formats = [DataFormat.Float16, DataFormat.Float16_b]
+supported_formats = [DataFormat.Float16]
 
 #   INPUT-OUTPUT FORMAT SWEEP
 #   input_output_formats(supported_formats)
@@ -70,7 +70,7 @@ test_formats = format_combination_sweep(
 all_params = generate_params(
     ["matmul_unpack_tilize_test"],
     test_formats,
-    dest_acc=[DestAccumulation.No, DestAccumulation.Yes],
+    dest_acc=[DestAccumulation.Yes],
     math_fidelity=[
         MathFidelity.LoFi,
         MathFidelity.HiFi2,
@@ -86,10 +86,24 @@ param_ids = generate_param_ids(all_params)
     clean_params(all_params),
     ids=param_ids,
 )
-def test_matmul_pack_untilize(testname, formats, dest_acc, math_fidelity):
+def test_matmul_unpack_tilize(testname, formats, dest_acc, math_fidelity):
 
     src_A, src_B = generate_stimuli(formats.input_format, formats.input_format)
-
+    src_A = []
+    for i in range(32):
+        num = 2
+        if i % 2 == 0:
+            num = 1
+        tens = [num]*16
+        src_A.extend(tens)
+    for i in range(32):
+        num = 4
+        if i % 2 == 0:
+            num = 3
+        tens = [num]*16
+        src_A.extend(tens)
+    src_B = torch.eye(32).flatten()
+    src_A = torch.tensor(src_A, dtype = format_dict[formats.input_format]).flatten()
     golden_tensor = tilize(
         generate_golden(src_A, src_B, formats.output_format, math_fidelity)
     )

--- a/tests/python_tests/test_matmul_unpack_tilize.py
+++ b/tests/python_tests/test_matmul_unpack_tilize.py
@@ -45,7 +45,7 @@ def generate_golden(operand1, operand2, data_format, math_fidelity):
 
 
 # SUPPORTED FORMATS FOR TEST
-supported_formats = [DataFormat.Float16]
+supported_formats = [DataFormat.Float16_b, DataFormat.Float16]
 
 #   INPUT-OUTPUT FORMAT SWEEP
 #   input_output_formats(supported_formats)
@@ -70,7 +70,7 @@ test_formats = format_combination_sweep(
 all_params = generate_params(
     ["matmul_unpack_tilize_test"],
     test_formats,
-    dest_acc=[DestAccumulation.Yes],
+    dest_acc=[DestAccumulation.Yes, DestAccumulation.No],
     math_fidelity=[
         MathFidelity.LoFi,
         MathFidelity.HiFi2,
@@ -94,16 +94,16 @@ def test_matmul_unpack_tilize(testname, formats, dest_acc, math_fidelity):
         num = 2
         if i % 2 == 0:
             num = 1
-        tens = [num]*16
+        tens = [num] * 16
         src_A.extend(tens)
     for i in range(32):
         num = 4
         if i % 2 == 0:
             num = 3
-        tens = [num]*16
+        tens = [num] * 16
         src_A.extend(tens)
     src_B = torch.eye(32).flatten()
-    src_A = torch.tensor(src_A, dtype = format_dict[formats.input_format]).flatten()
+    src_A = torch.tensor(src_A, dtype=format_dict[formats.input_format]).flatten()
     golden_tensor = tilize(
         generate_golden(src_A, src_B, formats.output_format, math_fidelity)
     )

--- a/tests/python_tests/test_matmul_unpack_tilize.py
+++ b/tests/python_tests/test_matmul_unpack_tilize.py
@@ -6,8 +6,18 @@ import torch
 
 from helpers.format_config import DataFormat
 from helpers.format_arg_mapping import format_dict, MathFidelity, DestAccumulation
-from helpers.param_config import clean_params, format_combination_sweep, generate_combination, generate_param_ids, generate_params, input_output_formats
-from helpers.device import collect_results, run_elf_files, wait_for_tensix_operations_finished, write_stimuli_to_l1
+from helpers.param_config import (
+    clean_params,
+    format_combination_sweep,
+    generate_param_ids,
+    generate_params,
+)
+from helpers.device import (
+    collect_results,
+    run_elf_files,
+    wait_for_tensix_operations_finished,
+    write_stimuli_to_l1,
+)
 from helpers.stimuli_generator import generate_stimuli
 from helpers.test_config import generate_make_command
 from helpers.utils import compare_pcc, run_shell_command
@@ -54,7 +64,9 @@ supported_formats = [DataFormat.Float16, DataFormat.Float16_b]
 #   SPECIFIC INPUT-OUTPUT COMBINATION
 #   [InputOutputFormat(DataFormat.Float16, DataFormat.Float32)]
 
-test_formats = format_combination_sweep(formats=supported_formats, all_same=True, same_src_reg_format=True)
+test_formats = format_combination_sweep(
+    formats=supported_formats, all_same=True, same_src_reg_format=True
+)
 all_params = generate_params(
     ["matmul_unpack_tilize_test"],
     test_formats,
@@ -78,7 +90,9 @@ def test_matmul_pack_untilize(testname, formats, dest_acc, math_fidelity):
 
     src_A, src_B = generate_stimuli(formats.input_format, formats.input_format)
 
-    golden_tensor = tilize(generate_golden(src_A, src_B, formats.output_format, math_fidelity))
+    golden_tensor = tilize(
+        generate_golden(src_A, src_B, formats.output_format, math_fidelity)
+    )
     golden_tensor = golden_tensor.to(format_dict[formats.output_format])
 
     write_stimuli_to_l1(
@@ -101,7 +115,9 @@ def test_matmul_pack_untilize(testname, formats, dest_acc, math_fidelity):
     run_elf_files(testname)
 
     wait_for_tensix_operations_finished()
-    res_from_L1 = collect_results(formats, tensor_size=len(src_A), address=buffer_dest_address)
+    res_from_L1 = collect_results(
+        formats, tensor_size=len(src_A), address=buffer_dest_address
+    )
     assert len(res_from_L1) == len(golden_tensor)
 
     res_tensor = torch.tensor(
@@ -120,9 +136,8 @@ def test_matmul_pack_untilize(testname, formats, dest_acc, math_fidelity):
         atol = 0.1
         rtol = 0.2
 
-    print("\nGolden Tensor:\n", golden_tensor.view(64,16))
-    print("\nResult Tensor:\n", res_tensor.view(64,16))
-
+    print("\nGolden Tensor:\n", golden_tensor.view(64, 16))
+    print("\nResult Tensor:\n", res_tensor.view(64, 16))
 
     for i in range(len(golden_tensor)):
         assert torch.isclose(

--- a/tests/python_tests/test_matmul_unpack_tilize.py
+++ b/tests/python_tests/test_matmul_unpack_tilize.py
@@ -134,9 +134,6 @@ def test_matmul_unpack_tilize(testname, formats, dest_acc, math_fidelity):
         atol = 0.1
         rtol = 0.2
 
-    print("\nGolden Tensor:\n", golden_tensor.view(64, 16))
-    print("\nResult Tensor:\n", res_tensor.view(64, 16))
-
     for i in range(len(golden_tensor)):
         assert torch.isclose(
             golden_tensor[i], res_tensor[i], rtol=rtol, atol=atol

--- a/tests/python_tests/test_matmul_unpack_tilize.py
+++ b/tests/python_tests/test_matmul_unpack_tilize.py
@@ -8,9 +8,9 @@ from helpers.format_config import DataFormat
 from helpers.format_arg_mapping import format_dict, MathFidelity, DestAccumulation
 from helpers.param_config import (
     clean_params,
-    format_combination_sweep,
     generate_param_ids,
     generate_params,
+    input_output_formats,
 )
 from helpers.device import (
     collect_results,
@@ -64,9 +64,7 @@ supported_formats = [DataFormat.Float16_b, DataFormat.Float16]
 #   SPECIFIC INPUT-OUTPUT COMBINATION
 #   [InputOutputFormat(DataFormat.Float16, DataFormat.Float32)]
 
-test_formats = format_combination_sweep(
-    formats=supported_formats, all_same=True, same_src_reg_format=True
-)
+test_formats = input_output_formats(supported_formats, same=True)
 all_params = generate_params(
     ["matmul_unpack_tilize_test"],
     test_formats,
@@ -89,21 +87,7 @@ param_ids = generate_param_ids(all_params)
 def test_matmul_unpack_tilize(testname, formats, dest_acc, math_fidelity):
 
     src_A, src_B = generate_stimuli(formats.input_format, formats.input_format)
-    src_A = []
-    for i in range(32):
-        num = 2
-        if i % 2 == 0:
-            num = 1
-        tens = [num] * 16
-        src_A.extend(tens)
-    for i in range(32):
-        num = 4
-        if i % 2 == 0:
-            num = 3
-        tens = [num] * 16
-        src_A.extend(tens)
-    src_B = torch.eye(32).flatten()
-    src_A = torch.tensor(src_A, dtype=format_dict[formats.input_format]).flatten()
+
     golden_tensor = tilize(
         generate_golden(src_A, src_B, formats.output_format, math_fidelity)
     )

--- a/tests/sources/matmul_unpack_tilize_test.cpp
+++ b/tests/sources/matmul_unpack_tilize_test.cpp
@@ -1,0 +1,152 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdio>
+
+#include "ckernel.h"
+#include "llk_defs.h"
+
+// Globals
+uint32_t unp_cfg_context          = 0;
+uint32_t pack_sync_tile_dst_ptr   = 0;
+uint32_t math_sync_tile_dst_index = 0;
+uint32_t tile_size                = 128;
+
+volatile uint32_t* const buffer_A = reinterpret_cast<volatile uint32_t*>(0x1a000);
+volatile uint32_t* const buffer_B = reinterpret_cast<volatile uint32_t*>(0x1b000);
+
+volatile uint32_t* const buffer_A_tilized = reinterpret_cast<volatile uint32_t*>(0x1c000);
+volatile uint32_t* const buffer_B_tilized = reinterpret_cast<volatile uint32_t*>(0x1d000);
+
+#ifdef LLK_TRISC_UNPACK
+
+#include "llk_unpack_AB_matmul.h"
+#include "llk_unpack_common.h"
+#include "llk_unpack_tilize.h"
+#include "params.h"
+
+void run_kernel()
+{
+    _llk_unpack_tilize_hw_configure_<is_fp32_dest_acc_en, StochRndType::None>(UNPACK_A_IN, UNPACK_A_OUT, FACE_R_DIM, 0, 4);
+
+    _llk_unpack_tilize_init_(UNPACK_A_IN, UNPACK_A_OUT, 1, FACE_R_DIM, false);
+    _llk_unpack_tilize_(L1_ADDRESS(buffer_A), 0, UNPACK_A_IN, 1, FACE_R_DIM, 4, false);
+
+    _llk_unpack_tilize_init_(UNPACK_B_IN, UNPACK_B_OUT, 1, FACE_R_DIM, false);
+    _llk_unpack_tilize_(L1_ADDRESS(buffer_B), 0, UNPACK_B_IN, 1, FACE_R_DIM, 4, false);
+
+
+    t6_semaphore_wait_on_zero<p_stall::STALL_SYNC>(
+        semaphore::PACK_DONE); // Unpacker waits on signal when packer will increment semaphore to 1 (waits while semaphore == 0), utilizing SEMWAIT.
+    t6_semaphore_get<>(semaphore::PACK_DONE); // It will acquire the semaphore t6_semaphore_get (decrementing the semaphore back to 0) signalling it has begun
+                                              // processing data from L1
+
+    _llk_unpack_AB_matmul_init_<>();
+    _llk_unpack_AB_matmul_<>(L1_ADDRESS(buffer_A_tilized), L1_ADDRESS(buffer_B_tilized), 0, 0, tile_size, tile_size);
+
+}
+
+#endif
+
+#ifdef LLK_TRISC_MATH
+
+#include "llk_math_common.h"
+#include "llk_math_matmul.h"
+#include "llk_math_eltwise_unary_datacopy.h"
+#include "params.h"
+
+using namespace ckernel;
+
+void run_kernel()
+{
+    // asm volatile ("ebreak");
+    const bool is_int_fpu_en                = false;
+    const std::uint32_t operand_A_dst_index = 1;
+    const std::uint32_t operand_B_dst_index = 2;
+    const std::uint32_t res_dst_index       = 0;
+    const bool TILIZE                       = true;
+
+// copy srca to dest
+#ifdef ARCH_BLACKHOLE
+    _llk_math_eltwise_unary_datacopy_init_<DataCopyType::A2D, BroadcastType::NONE, TILIZE, is_fp32_dest_acc_en, is_int_fpu_en>(0, 0, 4, MATH_FORMAT);
+#else
+    _llk_math_eltwise_unary_datacopy_init_<DataCopyType::A2D, BroadcastType::NONE, is_fp32_dest_acc_en, is_int_fpu_en>(0, 0, 4, MATH_FORMAT);
+#endif
+
+    _llk_math_pack_sync_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+    _llk_math_hw_configure_<false, false>(MATH_FORMAT, MATH_FORMAT);
+
+    // copy tilized inputs to dest indexes 0 and 1
+    _llk_math_wait_for_dest_available_<DstSync::SyncHalf>();
+    _llk_math_eltwise_unary_datacopy_<DataCopyType::A2D, DstSync::SyncHalf, BroadcastType::NONE, is_fp32_dest_acc_en, false>(
+        operand_A_dst_index, MATH_FORMAT, MATH_FORMAT);
+    _llk_math_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+
+    _llk_math_wait_for_dest_available_<DstSync::SyncHalf>();
+    _llk_math_eltwise_unary_datacopy_<DataCopyType::A2D, DstSync::SyncHalf, BroadcastType::NONE, is_fp32_dest_acc_en, false>(
+        operand_B_dst_index, MATH_FORMAT, MATH_FORMAT);
+    _llk_math_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+
+    _llk_math_matmul_init_<MATH_FIDELITY, DstTileFaceLayout::RowMajor>();
+    _llk_math_wait_for_dest_available_<DstSync::SyncHalf>();
+    _llk_math_matmul_<MATH_FIDELITY, DstTileFaceLayout::RowMajor>(0);
+    _llk_math_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+}
+
+#endif
+
+#ifdef LLK_TRISC_PACK
+
+#include "llk_pack.h"
+#include "llk_pack_common.h"
+#include "params.h"
+
+void run_kernel()
+{
+    // asm volatile ("ebreak");
+    volatile uint32_t* const buffer_Dest    = reinterpret_cast<volatile uint32_t*>(0x1e000);
+    const std::uint32_t ct_dim              = 1;
+    const std::uint32_t operand_A_dst_index = 1;
+    const std::uint32_t operand_B_dst_index = 2;
+    const std::uint32_t res_dst_index       = 0;
+    const bool UNTILIZE                     = false;
+    const bool TILIZE                       = true;
+
+    std::fill(buffer_Dest, buffer_Dest + 16 * 16 * 4, 0xdeadbeef);
+
+#ifdef ARCH_BLACKHOLE
+    _llk_pack_hw_configure_<UNTILIZE, is_fp32_dest_acc_en, TILIZE>(PACK_IN, PACK_OUT, 16 * 16 * 4);
+    _llk_pack_init_<UNTILIZE, false, DstTileFaceLayout::RowMajor, false, TILIZE>(PACK_OUT);
+    _llk_pack_dest_init_<DstSync::SyncHalf, DstTileFaceLayout::RowMajor, is_fp32_dest_acc_en>();
+#else
+    _llk_pack_hw_configure_<UNTILIZE, is_fp32_dest_acc_en>(PACK_IN, PACK_OUT, 16 * 16 * 4);
+    _llk_pack_init_<UNTILIZE, false, DstTileFaceLayout::RowMajor, false>(PACK_OUT);
+    _llk_pack_dest_init_<DstSync::SyncHalf, DstTileFaceLayout::RowMajor, UNTILIZE, is_fp32_dest_acc_en>();
+#endif
+
+    _llk_packer_wait_for_math_done_();
+    _llk_pack_<DstSync::SyncHalf, UNTILIZE, is_fp32_dest_acc_en>(operand_A_dst_index, L1_ADDRESS(buffer_A_tilized));
+    _llk_pack_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+
+    _llk_packer_wait_for_math_done_();
+    _llk_pack_<DstSync::SyncHalf, UNTILIZE, is_fp32_dest_acc_en>(operand_B_dst_index, L1_ADDRESS(buffer_B_tilized));
+    _llk_pack_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>(); // Packer will execute _llk_pack_dest_section_done_ function which ensures the write
+                                                                            // to L1 is fully is complete.
+    t6_semaphore_post<>(semaphore::PACK_DONE); // The packer signals to the unpacker that it has finished writing to L1 by posting (incrementing) the semaphore.
+                                               // Now unpacker's wait condition is satisfied, allowing it to begin processing data from L1.
+
+    _llk_pack_reconfig_data_format_<is_fp32_dest_acc_en>(PACK_IN,PACK_OUT,tile_size,FACE_R_DIM,TILE_C_DIM,4);  // need to reconfigure data formats for next pack, also calls set_packer_strides to readjust strides after pack tilizing
+
+#ifdef ARCH_BLACKHOLE
+    _llk_pack_init_<false, false, DstTileFaceLayout::RowMajor, false, false>(PACK_OUT);
+#endif
+
+    _llk_packer_wait_for_math_done_();
+    _llk_pack_<DstSync::SyncHalf, false, is_fp32_dest_acc_en>(res_dst_index, L1_ADDRESS(buffer_Dest));
+    _llk_pack_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+}
+
+#endif

--- a/tests/sources/matmul_unpack_tilize_test.cpp
+++ b/tests/sources/matmul_unpack_tilize_test.cpp
@@ -64,7 +64,6 @@ using namespace ckernel;
 
 void run_kernel()
 {
-    // asm volatile ("ebreak");
     const bool is_int_fpu_en                = false;
     const std::uint32_t operand_A_dst_index = 1;
     const std::uint32_t operand_B_dst_index = 2;

--- a/tests/sources/matmul_unpack_tilize_test.cpp
+++ b/tests/sources/matmul_unpack_tilize_test.cpp
@@ -44,7 +44,7 @@ void run_kernel()
 
     // processing data from L1
     _llk_unpack_reconfig_data_format_srca_impl_<false, is_fp32_dest_acc_en>(
-        UNPACK_A_IN, UNPACK_A_OUT, tile_size); // have to reconfigure unpacker for data formats if they change
+        UNPACK_A_IN, UNPACK_A_OUT, tile_size); // have to reconfigure unpack kernel data formats if they change in this run
     _llk_unpack_reconfig_data_format_srcb_impl_<false, is_fp32_dest_acc_en>(UNPACK_B_IN, UNPACK_B_OUT, tile_size);
     _llk_unpack_AB_matmul_init_<>();
     _llk_unpack_AB_matmul_<>(L1_ADDRESS(buffer_A_tilized), L1_ADDRESS(buffer_B_tilized), 0, 0, tile_size, tile_size);
@@ -91,7 +91,7 @@ void run_kernel()
         operand_B_dst_index, MATH_FORMAT, MATH_FORMAT);
     _llk_math_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
 
-    _llk_math_reconfig_data_format_srca_<false, is_fp32_dest_acc_en>(MATH_FORMAT); // have to reconfigure unpacker for data formats if they change
+    _llk_math_reconfig_data_format_srca_<false, is_fp32_dest_acc_en>(MATH_FORMAT); // have to reconfigure math kernel data formats if they change in this run
     _llk_math_reconfig_data_format_srcb_<false, is_fp32_dest_acc_en>(MATH_FORMAT);
     _llk_math_matmul_init_<MATH_FIDELITY, DstTileFaceLayout::RowMajor>();
     _llk_math_wait_for_dest_available_<DstSync::SyncHalf>();

--- a/tt_llk_blackhole/llk_lib/llk_unpack_tilize.h
+++ b/tt_llk_blackhole/llk_lib/llk_unpack_tilize.h
@@ -185,7 +185,7 @@ inline void _llk_unpack_tilize_(
 #endif
 }
 
-inline void _llk_unpack_tilize_uninit_(const std::uint32_t num_faces, const std::uint32_t face_r_dim = FACE_R_DIM, const std::uint32_t unpack_dst_format = 0)
+inline void _llk_unpack_tilize_uninit_(const std::uint32_t unpack_dst_format, const std::uint32_t num_faces = 4, const std::uint32_t face_r_dim = FACE_R_DIM)
 {
     // Revert X dim value to default.
     TT_SETADCXX(p_setadc::UNP_A, face_r_dim * FACE_C_DIM - 1, 0x0);


### PR DESCRIPTION
### Ticket
<!-- Link to Github Issue -->
https://github.com/orgs/tenstorrent/projects/123?pane=issue&itemId=109488923&issue=tenstorrent%7Ctt-llk%7C173
### Problem description
<!-- Provide context for the problem. -->
Adding Matmul test coverage by testing matmul with unpack_tilize. This test cannot fuse this in one llk pipeline. We must first unpack tilize the input tensors and then pack them into L1 and unpack them again to run a matmul on them. 
Needed to incorporate synchronization with `t6_semaphore`, as well as reconfiguring data formats for the next unpack, math and pack kernels in the case that we want to alter our formats when we execute the matmul in the second llk pipeline run. In packer code block, reconfiguring the data formats also sets packer strides.
- In this specific case in the first pipeline run we set the packer strides to pack in tilized format, but in the second run we don't pack in tilized format so this is set properly in the `set_packer_strides` call which is invoked in the `_llk_pack_reconfig_data_format_` function we call when we pack the second time.

I also plan to re-init for next unpack kernel but for that I need to bring in `llk_unpack_tilize_uninit` from metal into our llk library, this is in another PR; once it is merged I will add it in this test file. 
- For the time being the test runs and passes but this is a part of good calling conventions and llk programming model


### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
