### PR TITLE
Copy 32-bit _llk_math_transpose_dest_ implementation to Blackhole.

### DIFF
--- a/tests/python_tests/helpers/unpack.py
+++ b/tests/python_tests/helpers/unpack.py
@@ -42,7 +42,7 @@ def unpack_fp32(packed_list):
 def unpack_int32(packed_list):
     def bytes_to_int32(byte_list):
         bytes_data = bytes(byte_list)
-        unpacked_value = struct.unpack(">I", bytes_data)[0]
+        unpacked_value = struct.unpack(">i", bytes_data)[0]
         return unpacked_value
 
     return [

--- a/tt_llk_blackhole/llk_lib/llk_math_transpose_dest.h
+++ b/tt_llk_blackhole/llk_lib/llk_math_transpose_dest.h
@@ -19,10 +19,19 @@ using namespace ckernel;
 // local function declarations
 template <bool is_32bit>
 inline void transpose_dest_configure_addrmod();
-template <bool is_32bit>
+template <bool transpose_of_faces, bool is_32bit>
 inline void transpose_dest_configure_mop();
 
-template <bool is_32bit = false>
+// Notes on these template parameters:
+// 1. <transpose_of_faces=false, is_32bit=false>: not supported.
+// 2. <transpose_of_faces=false, is_32bit=true>: 4x 16x16 face transpose; can be combined with _llk_unpack_A_ with transpose_of_faces=true.
+// 3. <transpose_of_faces=true, is_32bit=false>: the default case (full 32x32 tile transpose, non-32-bit).
+// 4. <transpose_of_faces=true, is_32bit=true>: full 32x32 tile transpose for 32-bit.
+//
+// We may want to revisit these template parameters, and perhaps the
+// transpose_dest API generally as it's not currently widely used:
+// https://github.com/tenstorrent/tt-llk/issues/290
+template <bool transpose_of_faces = true, bool is_32bit = false>
 inline void _llk_math_transpose_dest_(const std::uint32_t dst_index)
 {
     math::set_dst_write_addr<DstTileLayout::Default, DstTileShape::Tile32x32>(dst_index);
@@ -31,8 +40,16 @@ inline void _llk_math_transpose_dest_(const std::uint32_t dst_index)
 
     if constexpr (is_32bit)
     {
-        // 4x 32b face transpositions followed by 8x middle-face row swaps.
-        ckernel_unpack_template::run(instrn_buffer, 12, 0xff0);
+        if constexpr (transpose_of_faces)
+        {
+            // 4x 32b face transpositions followed by 8x middle-face row swaps.
+            ckernel_unpack_template::run(instrn_buffer, 12, 0xff0);
+        }
+        else
+        {
+            // 4x 32b face transpositions.
+            ckernel_unpack_template::run(instrn_buffer, 4, 0);
+        }
     }
     else
     {
@@ -41,6 +58,8 @@ inline void _llk_math_transpose_dest_(const std::uint32_t dst_index)
 
     // clear SrcA, SrcB valids; reset SrcA, SrcB, Dst counters to zero
     TTI_SETRWC(p_setrwc::CLR_AB, 0, 0, 0, 0, p_setrwc::SET_ABD);
+    // completely reset SrcA/SrcB sync mechanism: see https://github.com/tenstorrent/tt-metal/issues/22383
+    TTI_CLEARDVALID(0, 1);
 }
 
 template <bool is_32bit>
@@ -75,7 +94,7 @@ inline void transpose_dest_configure_addrmod()
         .set(ADDR_MOD_3);
 }
 
-template <bool is_32bit>
+template <bool transpose_of_faces, bool is_32bit>
 inline void transpose_dest_configure_mop()
 {
     if (is_32bit)
@@ -192,9 +211,12 @@ inline void transpose_dest_configure_mop()
     }
 }
 
-template <bool is_32bit = false>
+template <bool transpose_of_faces = true, bool is_32bit = false>
 inline void _llk_math_transpose_dest_init_()
 {
     transpose_dest_configure_addrmod<is_32bit>();
-    transpose_dest_configure_mop<is_32bit>();
+    transpose_dest_configure_mop<transpose_of_faces, is_32bit>();
+
+    TTI_SETC16(CLR_DVALID_SrcA_Disable_ADDR32, 0);
+    math::reset_counters(p_setrwc::SET_ABD_F);
 }

--- a/tt_llk_blackhole/llk_lib/llk_math_transpose_dest.h
+++ b/tt_llk_blackhole/llk_lib/llk_math_transpose_dest.h
@@ -17,20 +17,33 @@
 using namespace ckernel;
 
 // local function declarations
+template <bool is_32bit>
 inline void transpose_dest_configure_addrmod();
+template <bool is_32bit>
+inline void transpose_dest_configure_mop();
 
+template <bool is_32bit = false>
 inline void _llk_math_transpose_dest_(const std::uint32_t dst_index)
 {
     math::set_dst_write_addr<DstTileLayout::Default, DstTileShape::Tile32x32>(dst_index);
 
     TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::WAIT_SFPU);
 
-    ckernel_unpack_template::run(instrn_buffer, 2, 2);
+    if constexpr (is_32bit)
+    {
+        // 4x 32b face transpositions followed by 8x middle-face row swaps.
+        ckernel_unpack_template::run(instrn_buffer, 12, 0xff0);
+    }
+    else
+    {
+        ckernel_unpack_template::run(instrn_buffer, 2, 2);
+    }
 
     // clear SrcA, SrcB valids; reset SrcA, SrcB, Dst counters to zero
     TTI_SETRWC(p_setrwc::CLR_AB, 0, 0, 0, 0, p_setrwc::SET_ABD);
 }
 
+template <bool is_32bit>
 inline void transpose_dest_configure_addrmod()
 {
     addr_mod_t {
@@ -50,7 +63,7 @@ inline void transpose_dest_configure_addrmod()
     addr_mod_t {
         .srca = {.incr = 0},
         .srcb = {.incr = 0},
-        .dest = {.incr = -16},
+        .dest = {.incr = is_32bit ? 2 : 0x3ff & -16},
     }
         .set(ADDR_MOD_2);
 
@@ -62,57 +75,126 @@ inline void transpose_dest_configure_addrmod()
         .set(ADDR_MOD_3);
 }
 
+template <bool is_32bit>
 inline void transpose_dest_configure_mop()
 {
-    load_replay_buf<16, 15, false>(
-        []
-        {
-            // ABCD
-            TTI_MOVB2A(0, ADDR_MOD_1, p_movb2a::MOV_4_ROWS, 16);
-            TTI_MOVB2A(4, ADDR_MOD_1, p_movb2a::MOV_4_ROWS, 20);
-            TTI_MOVB2A(8, ADDR_MOD_1, p_movb2a::MOV_4_ROWS, 24);
-            TTI_MOVB2A(12, ADDR_MOD_0, p_movb2a::MOV_4_ROWS, 28); // dst += 16
+    if (is_32bit)
+    {
+        load_replay_buf<16, 16, false>(
+            []
+            {
+#pragma GCC unroll 2
+                for (int dest_32b_lo = 0; dest_32b_lo < 2; ++dest_32b_lo)
+                {
+                    TTI_MOVD2B(dest_32b_lo, 16, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 0);
+                    TTI_MOVD2B(dest_32b_lo, 20, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 4);
+                    TTI_MOVD2B(dest_32b_lo, 24, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 8);
+                    TTI_MOVD2B(dest_32b_lo, 28, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 12);
+                    TTI_MOVB2D(dest_32b_lo, 16, ADDR_MOD_1, p_movb2d::MOV_4_ROWS, 0);
+                    TTI_MOVB2D(dest_32b_lo, 20, ADDR_MOD_1, p_movb2d::MOV_4_ROWS, 4);
+                    TTI_MOVB2D(dest_32b_lo, 24, ADDR_MOD_1, p_movb2d::MOV_4_ROWS, 8);
+                    TTI_MOVB2D(dest_32b_lo, 28, dest_32b_lo == 1 ? ADDR_MOD_0 : ADDR_MOD_1, p_movb2d::MOV_4_ROWS, 12);
+                }
+            });
 
-            // EFGHIJKLM
-            TTI_MOVD2B(0, 16, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 0);
-            TTI_MOVD2B(0, 20, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 4);
-            TTI_MOVD2B(0, 24, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 8);
-            TTI_MOVD2B(0, 28, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 12);
-            TTI_TRNSPSRCB;
-            TTI_MOVB2D(0, 16, ADDR_MOD_1, p_movb2d::MOV_4_ROWS, 0);
-            TTI_MOVB2D(0, 20, ADDR_MOD_1, p_movb2d::MOV_4_ROWS, 4);
-            TTI_MOVB2D(0, 24, ADDR_MOD_1, p_movb2d::MOV_4_ROWS, 8);
-            TTI_MOVB2D(0, 28, ADDR_MOD_0, p_movb2d::MOV_4_ROWS, 12); // dst += 16
+        // Macro 0: SFPLOAD VD; SFPMOV LReg[16],VD; SFPSTORE LReg[0].
+        // Intended for use with VD=LReg[1].
 
-            // NO
-            // Note: the 0x3ff mask ensures the negative offsets are 10 bits.
-            TTI_MOVA2D(0, 0, ADDR_MOD_2, p_mova2d::MOV_8_ROWS, 0x3ff & (0 - 32)); // dst -= 16
-            TTI_MOVA2D(0, 8, ADDR_MOD_2, p_mova2d::MOV_8_ROWS, 0x3ff & (8 - 16)); // dst -= 16
-        });
+        // Set InstructionTemplate[0] to SFPMOV.
+        TTI_SFPMOV(0, 0, 12, 0);
 
-    // The next 7 instructions expand as follows:
-    // Face 0: 4x MOVD2B, TRNSPSRCB, 4x MOVB2D, dst += 16 (EFGHIJKLM)
-    // Face 1: 4x MOVD2B, TRNSPSRCB, 4x MOVB2A, dst += 16 (EFGHI, ABCD..)
-    // Face 2: 4x MOVD2B (dst -= 16), TRNSPSRCB, 4x MOVB2D, dst += 32 (..EFG, P, IJKL, Q)
-    // Face 3: 4x MOVD2B, TRNSPSRCB, 4x MOVB2D, dst += 16 (EFGHIJKLM..)
-    // Face 1: 2x MOVA2D (2x dst -= 16) (..NO)
+        // StoreSubUnit: schedule SFPSTORE with VD=0 after 1 cycle.
+        TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_UPPER, (0x80 | (1 << 3) | 3) << 8);
+        // SimpleSubUnit: schedule SFPMOV LReg[16],VD after 0 cycles.
+        TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_LOWER, (0x40 | 4) << 0);
+        // Set Sequence[0].
+        TTI_SFPCONFIG(0, 4, 0);
 
-    uint EFGHIJKLM   = TT_OP_REPLAY(20, 9, 0, 0);
-    uint EFGHI       = TT_OP_REPLAY(20, 5, 0, 0);
-    uint ABCDEFG     = TT_OP_REPLAY(16, 7, 0, 0);
-    uint P           = TT_OP_MOVD2B(0, 28, ADDR_MOD_2, p_movd2b::MOV_4_ROWS, 12); // dst -= 16
-    uint IJKL        = TT_OP_REPLAY(24, 4, 0, 0);
-    uint Q           = TT_OP_MOVB2D(0, 28, ADDR_MOD_3, p_movb2d::MOV_4_ROWS, 12); // dst += 32
-    uint EFGHIJKLMNO = TT_OP_REPLAY(20, 11, 0, 0);
+        // Macro 1: SFPLOAD VD; delay; SFPSTORE LReg[16].
+        // Intended for use with VD=LReg[0].
 
-    // The following MOP config simply runs the above 7 instructions in order (when executed with zmask 0b10):
-    ckernel_unpack_template tmp(true, true, EFGHIJKLM, EFGHI, ABCDEFG, P, /* skip A */ Q, /* B */ IJKL, /* skip B */ EFGHIJKLMNO);
-    tmp.program(instrn_buffer);
+        // StoreSubUnit: schedule SFPSTORE with VD=LReg[16] after 1 cycle.
+        TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_UPPER, (0x40 | (1 << 3) | 3) << 8);
+        // Other sub-units: nothing scheduled.
+        TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_LOWER, 0);
+        // Set Sequence[1].
+        TTI_SFPCONFIG(0, 5, 0);
+
+        // Misc: {UsesLoadMod0ForStore=1, WaitForElapsedInstructions=1} for macros 0 and 1.
+        TTI_SFPCONFIG(0x330, 8, 1);
+
+        // A 32b face transpose consists of: (movd2b_hi, transpose, movb2d_hi_d2b_lo, transpose, movb2d_lo).
+        uint movd2b_hi        = TT_OP_REPLAY(16, 4, 0, 0);
+        uint movb2d_hi_d2b_lo = TT_OP_REPLAY(20, 8, 0, 0);
+        uint movb2d_lo        = TT_OP_REPLAY(28, 4, 0, 0);
+        uint transpose        = TT_OP_TRNSPSRCB;
+
+        // Macro 0: SFPLOAD LReg[1], 16 (addr_mod_1); SFPMOV LReg[16],LReg[1]; SFPSTORE LReg[0].
+        // Note: 0x3ff mask is used to ensure negative offset value is 10 bits.
+        uint macro0 = TT_OP_SFPLOADMACRO((0 << 2) | 1, 4, ADDR_MOD_1, 0x3ff & -48);
+
+        // Macro 1: SFPLOAD LReg[0], 32 (addr_mod_2); delay; SFPSTORE LReg[16].
+        // Note: 0x3ff mask is used to ensure negative offset value is 10 bits.
+        uint macro1 = TT_OP_SFPLOADMACRO((1 << 2) | 0, 4, ADDR_MOD_2, 0x3ff & -32);
+
+        // MOP config:
+        // - zmask 0-bits: 32b 16x16 face transpose.
+        // - zmask 1-bits: 32b 32x1 middle face row swap via SFPU.
+        ckernel_unpack_template tmp(true, true, movd2b_hi, transpose, movb2d_hi_d2b_lo, transpose, /* skip A */ macro0, /* B */ movb2d_lo, /* skip B */ macro1);
+        tmp.program(instrn_buffer);
+    }
+    else
+    {
+        load_replay_buf<16, 15, false>(
+            []
+            {
+                // ABCD
+                TTI_MOVB2A(0, ADDR_MOD_1, p_movb2a::MOV_4_ROWS, 16);
+                TTI_MOVB2A(4, ADDR_MOD_1, p_movb2a::MOV_4_ROWS, 20);
+                TTI_MOVB2A(8, ADDR_MOD_1, p_movb2a::MOV_4_ROWS, 24);
+                TTI_MOVB2A(12, ADDR_MOD_0, p_movb2a::MOV_4_ROWS, 28); // dst += 16
+
+                // EFGHIJKLM
+                TTI_MOVD2B(0, 16, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 0);
+                TTI_MOVD2B(0, 20, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 4);
+                TTI_MOVD2B(0, 24, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 8);
+                TTI_MOVD2B(0, 28, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 12);
+                TTI_TRNSPSRCB;
+                TTI_MOVB2D(0, 16, ADDR_MOD_1, p_movb2d::MOV_4_ROWS, 0);
+                TTI_MOVB2D(0, 20, ADDR_MOD_1, p_movb2d::MOV_4_ROWS, 4);
+                TTI_MOVB2D(0, 24, ADDR_MOD_1, p_movb2d::MOV_4_ROWS, 8);
+                TTI_MOVB2D(0, 28, ADDR_MOD_0, p_movb2d::MOV_4_ROWS, 12); // dst += 16
+
+                // NO
+                // Note: the 0x3ff mask ensures the negative offsets are 10 bits.
+                TTI_MOVA2D(0, 0, ADDR_MOD_2, p_mova2d::MOV_8_ROWS, 0x3ff & (0 - 32)); // dst -= 16
+                TTI_MOVA2D(0, 8, ADDR_MOD_2, p_mova2d::MOV_8_ROWS, 0x3ff & (8 - 16)); // dst -= 16
+            });
+
+        // The next 7 instructions expand as follows:
+        // Face 0: 4x MOVD2B, TRNSPSRCB, 4x MOVB2D, dst += 16 (EFGHIJKLM)
+        // Face 1: 4x MOVD2B, TRNSPSRCB, 4x MOVB2A, dst += 16 (EFGHI, ABCD..)
+        // Face 2: 4x MOVD2B (dst -= 16), TRNSPSRCB, 4x MOVB2D, dst += 32 (..EFG, P, IJKL, Q)
+        // Face 3: 4x MOVD2B, TRNSPSRCB, 4x MOVB2D, dst += 16 (EFGHIJKLM..)
+        // Face 1: 2x MOVA2D (2x dst -= 16) (..NO)
+
+        uint EFGHIJKLM   = TT_OP_REPLAY(20, 9, 0, 0);
+        uint EFGHI       = TT_OP_REPLAY(20, 5, 0, 0);
+        uint ABCDEFG     = TT_OP_REPLAY(16, 7, 0, 0);
+        uint P           = TT_OP_MOVD2B(0, 28, ADDR_MOD_2, p_movd2b::MOV_4_ROWS, 12); // dst -= 16
+        uint IJKL        = TT_OP_REPLAY(24, 4, 0, 0);
+        uint Q           = TT_OP_MOVB2D(0, 28, ADDR_MOD_3, p_movb2d::MOV_4_ROWS, 12); // dst += 32
+        uint EFGHIJKLMNO = TT_OP_REPLAY(20, 11, 0, 0);
+
+        // The following MOP config simply runs the above 7 instructions in order (when executed with zmask 0b10):
+        ckernel_unpack_template tmp(true, true, EFGHIJKLM, EFGHI, ABCDEFG, P, /* skip A */ Q, /* B */ IJKL, /* skip B */ EFGHIJKLMNO);
+        tmp.program(instrn_buffer);
+    }
 }
 
+template <bool is_32bit = false>
 inline void _llk_math_transpose_dest_init_()
 {
-    transpose_dest_configure_addrmod();
-
-    transpose_dest_configure_mop();
+    transpose_dest_configure_addrmod<is_32bit>();
+    transpose_dest_configure_mop<is_32bit>();
 }

--- a/tt_llk_blackhole/llk_lib/llk_unpack_A.h
+++ b/tt_llk_blackhole/llk_lib/llk_unpack_A.h
@@ -52,6 +52,8 @@ inline void _llk_unpack_A_mop_config_(
         TT_OP_UNPACR(SrcA, 0b1 /*Z inc*/, 0, 0, 0, 1 /* Set OvrdThreadId*/, 1 /*Set Dvalid*/, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
     static constexpr uint unpack_srca_to_dest =
         TT_OP_UNPACR(SrcA, 0b00010001 /*Z inc*/, 0, 0, 0, 1 /* Set OvrdThreadId*/, 0 /*Set Dvalid*/, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1); // ch0/ch1 z_inc
+    static constexpr uint unpack_srca_to_dest_transpose_of_faces =
+        TT_OP_UNPACR(SrcA, 0b00010010, 0, 0, 0, 1, 0, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1); // inc srcA ch1_z+=1, ch0_z+=2
     static constexpr uint unpack_srca_set_dvalid = TT_OP_UNPACR_NOP(SrcA, 0, 0, p_unpacr_nop::SET_DVALID, 0, 0, 0, 0, p_unpacr_nop::UNP_ZEROSRC);
     static constexpr uint unpack_srcb =
         TT_OP_UNPACR(SrcB, 0b1 /*Z inc*/, 0, 0, 0, 1 /* Set OvrdThreadId*/, 1 /*Set Dvalid*/, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
@@ -65,10 +67,21 @@ inline void _llk_unpack_A_mop_config_(
 
     if (unpack_to_dest && is_32bit_input(unpack_src_format, unpack_dst_format))
     {
-        const uint32_t outerloop     = num_faces;
-        constexpr uint32_t innerloop = 1;
-        ckernel_template tmp(outerloop, innerloop, unpack_srca_to_dest);
-        tmp.program(instrn_buffer);
+        if (transpose_of_faces && num_faces == 4)
+        {
+            const uint32_t outerloop = 2;
+            const uint32_t innerloop = 2;
+            ckernel_template tmp(outerloop, innerloop, unpack_srca_to_dest_transpose_of_faces);
+            tmp.set_end_op(TT_OP_SETADCZW(p_setadc::UNP_A, 0, 2, 0, 1, 0b0101));
+            tmp.program(instrn_buffer);
+        }
+        else
+        {
+            const uint32_t outerloop     = num_faces;
+            constexpr uint32_t innerloop = 1;
+            ckernel_template tmp(outerloop, innerloop, unpack_srca_to_dest);
+            tmp.program(instrn_buffer);
+        }
     }
     else if constexpr (BType == BroadcastType::COL)
     {


### PR DESCRIPTION
### Ticket

#134

### Problem description

`_llk_math_transpose_dest_` doesn't work for 32-bit types, e.g. Int32. 

### What's changed

Copy the 32-bit support added for Wormhole to Blackhole, including the support for 32-bit `transpose_of_faces` for `unpack_A`.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
