### PR TITLE
Add rounding ops to LLK

### DIFF
--- a/tt_llk_blackhole/common/inc/ckernel_sfpu.h
+++ b/tt_llk_blackhole/common/inc/ckernel_sfpu.h
@@ -32,6 +32,7 @@
 #include "sfpu/ckernel_sfpu_quant.h"
 #include "sfpu/ckernel_sfpu_recip.h"
 #include "sfpu/ckernel_sfpu_relu.h"
+#include "sfpu/ckernel_sfpu_rounding_ops.h"
 #include "sfpu/ckernel_sfpu_shift.h"
 #include "sfpu/ckernel_sfpu_sigmoid.h"
 #include "sfpu/ckernel_sfpu_sign.h"

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_rounding_ops.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_rounding_ops.h
@@ -1,0 +1,163 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "sfpi.h"
+#include "limits.h"
+
+namespace ckernel {
+namespace sfpu {
+
+inline sfpi::vInt float_to_int32(sfpi::vFloat in) {
+    sfpi::vInt result;
+    sfpi::vInt exp = exexp(in);  // extract exponent
+    v_if(exp < 0) { result = 0; }
+    v_elseif(exp > 30) {
+        // set to int32 max value in case of overflow
+        result = std::numeric_limits<int32_t>::max();
+        // check sign
+        v_if(in < 0) {
+            result = sfpi::reinterpret<sfpi::vInt>(sfpi::setsgn(sfpi::reinterpret<sfpi::vFloat>(result), 1));
+        }
+        v_endif
+    }
+    v_else {
+        // extract mantissa
+        sfpi::vInt man = exman8(in);
+        // shift the mantissa by (23-exponent) to the right
+        sfpi::vInt shift = exp - 23;
+        man = shft(sfpi::reinterpret<sfpi::vUInt>(man), shift);
+        // check sign
+        v_if(in < 0) { man = sfpi::reinterpret<sfpi::vInt>(sfpi::setsgn(sfpi::reinterpret<sfpi::vFloat>(man), 1)); }
+        v_endif result = man;
+    }
+    v_endif return result;
+}
+
+inline sfpi::vInt float_to_int31(sfpi::vFloat v) {
+    sfpi::vInt q = float_to_int16(v * 0x1p-15f, 0);
+    sfpi::vInt r = float_to_int16(v - int32_to_float(q, 0) * 0x1p15f, 0);
+    v_if(r < 0) {
+        r = sfpi::setsgn(r, 0);
+        q = (q << 15) - r;
+    }
+    v_else { q = (q << 15) + r; }
+    v_endif return q;
+}
+
+inline constexpr float TABLE[] = {
+    1e-45F, 1e-44F, 1e-43F, 1e-42F, 1e-41F, 1e-40F, 1e-39F, 1e-38F, 1e-37F, 1e-36F, 1e-35F, 1e-34F, 1e-33F, 1e-32F,
+    1e-31F, 1e-30F, 1e-29F, 1e-28F, 1e-27F, 1e-26F, 1e-25F, 1e-24F, 1e-23F, 1e-22F, 1e-21F, 1e-20F, 1e-19F, 1e-18F,
+    1e-17F, 1e-16F, 1e-15F, 1e-14F, 1e-13F, 1e-12F, 1e-11F, 1e-10F, 1e-9F,  1e-8F,  1e-7F,  1e-6F,  1e-5F,  1e-4F,
+    1e-3F,  1e-2F,  1e-1F,  1e0F,   1e1F,   1e2F,   1e3F,   1e4F,   1e5F,   1e6F,   1e7F,   1e8F,   1e9F,   1e10F,
+    1e11F,  1e12F,  1e13F,  1e14F,  1e15F,  1e16F,  1e17F,  1e18F,  1e19F,  1e20F,  1e21F,  1e22F,  1e23F,  1e24F,
+    1e25F,  1e26F,  1e27F,  1e28F,  1e29F,  1e30F,  1e31F,  1e32F,  1e33F,  1e34F,  1e35F,  1e36F,  1e37F,  1e38F,
+};
+
+template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
+inline void calculate_floor() {
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::vFloat result = sfpi::dst_reg[0];
+        sfpi::vFloat v = result;
+        sfpi::vInt tmp = float_to_int16(result, 0);
+        result = int32_to_float(tmp, 0);
+        v_if(result > v) { result = result - 1; }
+        v_endif;
+        v_if(v <= SHRT_MIN || v >= SHRT_MAX) { result = v; }
+        v_endif;
+        sfpi::dst_reg[0] = result;
+        sfpi::dst_reg++;
+    }
+}
+
+template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
+inline void calculate_floor_float32() {
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::vFloat result = sfpi::dst_reg[0];
+        sfpi::vFloat v = result;
+        sfpi::vInt tmp = float_to_int32(result);
+        result = int32_to_float(tmp, 0);
+        v_if(result > v) { result = result - 1; }
+        v_endif;
+        sfpi::dst_reg[0] = result;
+        sfpi::dst_reg++;
+    }
+}
+
+template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
+inline void calculate_ceil() {
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::vFloat result = sfpi::dst_reg[0];
+        sfpi::vFloat v = result;
+        sfpi::vInt tmp = float_to_int16(result, 0);
+        result = int32_to_float(tmp, 0);
+        v_if(result < v) { result = result + 1; }
+        v_endif;
+        v_if(v <= SHRT_MIN || v >= SHRT_MAX) { result = v; }
+        v_endif;
+        sfpi::dst_reg[0] = result;
+        sfpi::dst_reg++;
+    }
+}
+
+template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
+inline void calculate_ceil_float32() {
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::vFloat result = sfpi::dst_reg[0];
+        sfpi::vFloat v = result;
+        sfpi::vInt tmp = float_to_int32(result);
+        result = int32_to_float(tmp, 0);
+        v_if(result < v) { result = result + 1; }
+        v_endif;
+        sfpi::dst_reg[0] = result;
+        sfpi::dst_reg++;
+    }
+}
+
+inline sfpi::vFloat round_even(sfpi::vFloat v) {
+    sfpi::vFloat result;
+    v_if(sfpi::abs(v) < 0x1p30f) {
+        result = int32_to_float(float_to_int31(v), 0);
+        v_if(sfpi::abs(v - result) == 0.5F) {
+            sfpi::vInt res = float_to_int16(result, 0);
+            res = res & 0x7FFE;
+            result = sfpi::int32_to_float(res, 0);
+        }
+        v_endif;
+    }
+    v_endif;
+    return result;
+}
+
+template <bool APPROXIMATE, int ITERATIONS = 8>
+void calculate_round(const int decimals) {
+    const auto exp10i = [](int n) {
+        if (n > 38) {
+            return 1.0F / 0.0F;
+        }
+
+        if (n < -45) {
+            return 0.0F;
+        }
+
+        return TABLE[n + 45];
+    };
+
+    const sfpi::vFloat coeff = exp10i(decimals);
+    const sfpi::vFloat inverse = exp10i(-decimals);
+
+    for (int _ = 0; _ < ITERATIONS; ++_) {
+        sfpi::vFloat v = sfpi::dst_reg[0];
+        sfpi::vFloat result = inverse * round_even(sfpi::abs(v) * coeff);
+        result = sfpi::setsgn(result, v);
+        sfpi::dst_reg[0] = result;
+        sfpi::dst_reg++;
+    }
+}
+
+}  // namespace sfpu
+}  // namespace ckernel

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_rounding_ops.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_rounding_ops.h
@@ -6,68 +6,92 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
-#include "sfpi.h"
 #include "limits.h"
+#include "sfpi.h"
 
-namespace ckernel {
-namespace sfpu {
+namespace ckernel
+{
+namespace sfpu
+{
 
-inline sfpi::vInt float_to_int32(sfpi::vFloat in) {
+inline sfpi::vInt float_to_int32(sfpi::vFloat in)
+{
     sfpi::vInt result;
-    sfpi::vInt exp = exexp(in);  // extract exponent
-    v_if(exp < 0) { result = 0; }
-    v_elseif(exp > 30) {
+    sfpi::vInt exp = exexp(in); // extract exponent
+    v_if (exp < 0)
+    {
+        result = 0;
+    }
+    v_elseif (exp > 30)
+    {
         // set to int32 max value in case of overflow
         result = std::numeric_limits<int32_t>::max();
         // check sign
-        v_if(in < 0) {
+        v_if (in < 0)
+        {
             result = sfpi::reinterpret<sfpi::vInt>(sfpi::setsgn(sfpi::reinterpret<sfpi::vFloat>(result), 1));
         }
         v_endif
     }
-    v_else {
+    v_else
+    {
         // extract mantissa
         sfpi::vInt man = exman8(in);
         // shift the mantissa by (23-exponent) to the right
         sfpi::vInt shift = exp - 23;
-        man = shft(sfpi::reinterpret<sfpi::vUInt>(man), shift);
+        man              = shft(sfpi::reinterpret<sfpi::vUInt>(man), shift);
         // check sign
-        v_if(in < 0) { man = sfpi::reinterpret<sfpi::vInt>(sfpi::setsgn(sfpi::reinterpret<sfpi::vFloat>(man), 1)); }
+        v_if (in < 0)
+        {
+            man = sfpi::reinterpret<sfpi::vInt>(sfpi::setsgn(sfpi::reinterpret<sfpi::vFloat>(man), 1));
+        }
         v_endif result = man;
     }
     v_endif return result;
 }
 
-inline sfpi::vInt float_to_int31(sfpi::vFloat v) {
+inline sfpi::vInt float_to_int31(sfpi::vFloat v)
+{
     sfpi::vInt q = float_to_int16(v * 0x1p-15f, 0);
     sfpi::vInt r = float_to_int16(v - int32_to_float(q, 0) * 0x1p15f, 0);
-    v_if(r < 0) {
+    v_if (r < 0)
+    {
         r = sfpi::setsgn(r, 0);
         q = (q << 15) - r;
     }
-    v_else { q = (q << 15) + r; }
+    v_else
+    {
+        q = (q << 15) + r;
+    }
     v_endif return q;
 }
 
 inline constexpr float TABLE[] = {
-    1e-45F, 1e-44F, 1e-43F, 1e-42F, 1e-41F, 1e-40F, 1e-39F, 1e-38F, 1e-37F, 1e-36F, 1e-35F, 1e-34F, 1e-33F, 1e-32F,
-    1e-31F, 1e-30F, 1e-29F, 1e-28F, 1e-27F, 1e-26F, 1e-25F, 1e-24F, 1e-23F, 1e-22F, 1e-21F, 1e-20F, 1e-19F, 1e-18F,
-    1e-17F, 1e-16F, 1e-15F, 1e-14F, 1e-13F, 1e-12F, 1e-11F, 1e-10F, 1e-9F,  1e-8F,  1e-7F,  1e-6F,  1e-5F,  1e-4F,
-    1e-3F,  1e-2F,  1e-1F,  1e0F,   1e1F,   1e2F,   1e3F,   1e4F,   1e5F,   1e6F,   1e7F,   1e8F,   1e9F,   1e10F,
-    1e11F,  1e12F,  1e13F,  1e14F,  1e15F,  1e16F,  1e17F,  1e18F,  1e19F,  1e20F,  1e21F,  1e22F,  1e23F,  1e24F,
-    1e25F,  1e26F,  1e27F,  1e28F,  1e29F,  1e30F,  1e31F,  1e32F,  1e33F,  1e34F,  1e35F,  1e36F,  1e37F,  1e38F,
+    1e-45F, 1e-44F, 1e-43F, 1e-42F, 1e-41F, 1e-40F, 1e-39F, 1e-38F, 1e-37F, 1e-36F, 1e-35F, 1e-34F, 1e-33F, 1e-32F, 1e-31F, 1e-30F, 1e-29F,
+    1e-28F, 1e-27F, 1e-26F, 1e-25F, 1e-24F, 1e-23F, 1e-22F, 1e-21F, 1e-20F, 1e-19F, 1e-18F, 1e-17F, 1e-16F, 1e-15F, 1e-14F, 1e-13F, 1e-12F,
+    1e-11F, 1e-10F, 1e-9F,  1e-8F,  1e-7F,  1e-6F,  1e-5F,  1e-4F,  1e-3F,  1e-2F,  1e-1F,  1e0F,   1e1F,   1e2F,   1e3F,   1e4F,   1e5F,
+    1e6F,   1e7F,   1e8F,   1e9F,   1e10F,  1e11F,  1e12F,  1e13F,  1e14F,  1e15F,  1e16F,  1e17F,  1e18F,  1e19F,  1e20F,  1e21F,  1e22F,
+    1e23F,  1e24F,  1e25F,  1e26F,  1e27F,  1e28F,  1e29F,  1e30F,  1e31F,  1e32F,  1e33F,  1e34F,  1e35F,  1e36F,  1e37F,  1e38F,
 };
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_floor() {
-    for (int d = 0; d < ITERATIONS; d++) {
+inline void calculate_floor()
+{
+    for (int d = 0; d < ITERATIONS; d++)
+    {
         sfpi::vFloat result = sfpi::dst_reg[0];
-        sfpi::vFloat v = result;
-        sfpi::vInt tmp = float_to_int16(result, 0);
-        result = int32_to_float(tmp, 0);
-        v_if(result > v) { result = result - 1; }
+        sfpi::vFloat v      = result;
+        sfpi::vInt tmp      = float_to_int16(result, 0);
+        result              = int32_to_float(tmp, 0);
+        v_if (result > v)
+        {
+            result = result - 1;
+        }
         v_endif;
-        v_if(v <= SHRT_MIN || v >= SHRT_MAX) { result = v; }
+        v_if (v <= SHRT_MIN || v >= SHRT_MAX)
+        {
+            result = v;
+        }
         v_endif;
         sfpi::dst_reg[0] = result;
         sfpi::dst_reg++;
@@ -75,13 +99,18 @@ inline void calculate_floor() {
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_floor_float32() {
-    for (int d = 0; d < ITERATIONS; d++) {
+inline void calculate_floor_float32()
+{
+    for (int d = 0; d < ITERATIONS; d++)
+    {
         sfpi::vFloat result = sfpi::dst_reg[0];
-        sfpi::vFloat v = result;
-        sfpi::vInt tmp = float_to_int32(result);
-        result = int32_to_float(tmp, 0);
-        v_if(result > v) { result = result - 1; }
+        sfpi::vFloat v      = result;
+        sfpi::vInt tmp      = float_to_int32(result);
+        result              = int32_to_float(tmp, 0);
+        v_if (result > v)
+        {
+            result = result - 1;
+        }
         v_endif;
         sfpi::dst_reg[0] = result;
         sfpi::dst_reg++;
@@ -89,15 +118,23 @@ inline void calculate_floor_float32() {
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_ceil() {
-    for (int d = 0; d < ITERATIONS; d++) {
+inline void calculate_ceil()
+{
+    for (int d = 0; d < ITERATIONS; d++)
+    {
         sfpi::vFloat result = sfpi::dst_reg[0];
-        sfpi::vFloat v = result;
-        sfpi::vInt tmp = float_to_int16(result, 0);
-        result = int32_to_float(tmp, 0);
-        v_if(result < v) { result = result + 1; }
+        sfpi::vFloat v      = result;
+        sfpi::vInt tmp      = float_to_int16(result, 0);
+        result              = int32_to_float(tmp, 0);
+        v_if (result < v)
+        {
+            result = result + 1;
+        }
         v_endif;
-        v_if(v <= SHRT_MIN || v >= SHRT_MAX) { result = v; }
+        v_if (v <= SHRT_MIN || v >= SHRT_MAX)
+        {
+            result = v;
+        }
         v_endif;
         sfpi::dst_reg[0] = result;
         sfpi::dst_reg++;
@@ -105,27 +142,35 @@ inline void calculate_ceil() {
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_ceil_float32() {
-    for (int d = 0; d < ITERATIONS; d++) {
+inline void calculate_ceil_float32()
+{
+    for (int d = 0; d < ITERATIONS; d++)
+    {
         sfpi::vFloat result = sfpi::dst_reg[0];
-        sfpi::vFloat v = result;
-        sfpi::vInt tmp = float_to_int32(result);
-        result = int32_to_float(tmp, 0);
-        v_if(result < v) { result = result + 1; }
+        sfpi::vFloat v      = result;
+        sfpi::vInt tmp      = float_to_int32(result);
+        result              = int32_to_float(tmp, 0);
+        v_if (result < v)
+        {
+            result = result + 1;
+        }
         v_endif;
         sfpi::dst_reg[0] = result;
         sfpi::dst_reg++;
     }
 }
 
-inline sfpi::vFloat round_even(sfpi::vFloat v) {
+inline sfpi::vFloat round_even(sfpi::vFloat v)
+{
     sfpi::vFloat result;
-    v_if(sfpi::abs(v) < 0x1p30f) {
+    v_if (sfpi::abs(v) < 0x1p30f)
+    {
         result = int32_to_float(float_to_int31(v), 0);
-        v_if(sfpi::abs(v - result) == 0.5F) {
+        v_if (sfpi::abs(v - result) == 0.5F)
+        {
             sfpi::vInt res = float_to_int16(result, 0);
-            res = res & 0x7FFE;
-            result = sfpi::int32_to_float(res, 0);
+            res            = res & 0x7FFE;
+            result         = sfpi::int32_to_float(res, 0);
         }
         v_endif;
     }
@@ -134,30 +179,35 @@ inline sfpi::vFloat round_even(sfpi::vFloat v) {
 }
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
-void calculate_round(const int decimals) {
-    const auto exp10i = [](int n) {
-        if (n > 38) {
+void calculate_round(const int decimals)
+{
+    const auto exp10i = [](int n)
+    {
+        if (n > 38)
+        {
             return 1.0F / 0.0F;
         }
 
-        if (n < -45) {
+        if (n < -45)
+        {
             return 0.0F;
         }
 
         return TABLE[n + 45];
     };
 
-    const sfpi::vFloat coeff = exp10i(decimals);
+    const sfpi::vFloat coeff   = exp10i(decimals);
     const sfpi::vFloat inverse = exp10i(-decimals);
 
-    for (int _ = 0; _ < ITERATIONS; ++_) {
-        sfpi::vFloat v = sfpi::dst_reg[0];
+    for (int _ = 0; _ < ITERATIONS; ++_)
+    {
+        sfpi::vFloat v      = sfpi::dst_reg[0];
         sfpi::vFloat result = inverse * round_even(sfpi::abs(v) * coeff);
-        result = sfpi::setsgn(result, v);
-        sfpi::dst_reg[0] = result;
+        result              = sfpi::setsgn(result, v);
+        sfpi::dst_reg[0]    = result;
         sfpi::dst_reg++;
     }
 }
 
-}  // namespace sfpu
-}  // namespace ckernel
+} // namespace sfpu
+} // namespace ckernel

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_rounding_ops.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_rounding_ops.h
@@ -78,46 +78,43 @@ inline constexpr std::array<float, 84> PRECOMPUTED_POW10_TABLE = {
     1e23F,  1e24F,  1e25F,  1e26F,  1e27F,  1e28F,  1e29F,  1e30F,  1e31F,  1e32F,  1e33F,  1e34F,  1e35F,  1e36F,  1e37F,  1e38F,
 };
 
-template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void _calculate_floor_()
+template <bool APPROXIMATION_MODE, int ITERATIONS = 8, bool USE_FP32 = false>
+inline void calculate_floor()
 {
     for (int d = 0; d < ITERATIONS; d++)
     {
-        sfpi::vFloat result = sfpi::dst_reg[0];
-        sfpi::vFloat v      = result;
-        sfpi::vInt tmp      = float_to_int16(result, 0);
-        result              = int32_to_float(tmp, 0);
-        v_if (result > v)
-        {
-            result = result - 1;
-        }
-        v_endif;
-        v_if (v <= SHRT_MIN || v >= SHRT_MAX)
-        {
-            result = v;
-        }
-        v_endif;
-        sfpi::dst_reg[0] = result;
-        sfpi::dst_reg++;
-    }
-}
+        vFloat v      = dst_reg[0];
+        vFloat result = v;
+        vInt tmp;
 
-template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void _calculate_floor_float32_()
-{
-    for (int d = 0; d < ITERATIONS; d++)
-    {
-        sfpi::vFloat result = sfpi::dst_reg[0];
-        sfpi::vFloat v      = result;
-        sfpi::vInt tmp      = _float_to_int32_(result);
-        result              = int32_to_float(tmp, 0);
+        if constexpr (USE_FP32)
+        {
+            tmp = float_to_int32(result);
+        }
+        else
+        {
+            tmp = float_to_int16(result, 0);
+        }
+
+        result = int32_to_float(tmp, 0);
+
         v_if (result > v)
         {
             result = result - 1;
         }
         v_endif;
-        sfpi::dst_reg[0] = result;
-        sfpi::dst_reg++;
+
+        if constexpr (!USE_FP32)
+        {
+            v_if (v <= SHRT_MIN || v >= SHRT_MAX)
+            {
+                result = v;
+            }
+            v_endif;
+        }
+
+        dst_reg[0] = result;
+        dst_reg++;
     }
 }
 

--- a/tt_llk_wormhole_b0/common/inc/ckernel_sfpu.h
+++ b/tt_llk_wormhole_b0/common/inc/ckernel_sfpu.h
@@ -33,6 +33,7 @@
 #include "sfpu/ckernel_sfpu_recip.h"
 #include "sfpu/ckernel_sfpu_relu.h"
 #include "sfpu/ckernel_sfpu_reshuffle_rows.h"
+#include "sfpu/ckernel_sfpu_rounding_ops.h"
 #include "sfpu/ckernel_sfpu_shift.h"
 #include "sfpu/ckernel_sfpu_sigmoid.h"
 #include "sfpu/ckernel_sfpu_sign.h"

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_rounding_ops.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_rounding_ops.h
@@ -1,0 +1,163 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "sfpi.h"
+#include "limits.h"
+
+namespace ckernel {
+namespace sfpu {
+
+inline sfpi::vInt float_to_int32(sfpi::vFloat in) {
+    sfpi::vInt result;
+    sfpi::vInt exp = exexp(in);  // extract exponent
+    v_if(exp < 0) { result = 0; }
+    v_elseif(exp > 30) {
+        // set to int32 max value in case of overflow
+        result = std::numeric_limits<int32_t>::max();
+        // check sign
+        v_if(in < 0) {
+            result = sfpi::reinterpret<sfpi::vInt>(sfpi::setsgn(sfpi::reinterpret<sfpi::vFloat>(result), 1));
+        }
+        v_endif
+    }
+    v_else {
+        // extract mantissa
+        sfpi::vInt man = exman8(in);
+        // shift the mantissa by (23-exponent) to the right
+        sfpi::vInt shift = exp - 23;
+        man = shft(sfpi::reinterpret<sfpi::vUInt>(man), shift);
+        // check sign
+        v_if(in < 0) { man = sfpi::reinterpret<sfpi::vInt>(sfpi::setsgn(sfpi::reinterpret<sfpi::vFloat>(man), 1)); }
+        v_endif result = man;
+    }
+    v_endif return result;
+}
+
+inline sfpi::vInt float_to_int31(sfpi::vFloat v) {
+    sfpi::vInt q = float_to_int16(v * 0x1p-15f, 0);
+    sfpi::vInt r = float_to_int16(v - int32_to_float(q, 0) * 0x1p15f, 0);
+    v_if(r < 0) {
+        r = sfpi::setsgn(r, 0);
+        q = (q << 15) - r;
+    }
+    v_else { q = (q << 15) + r; }
+    v_endif return q;
+}
+
+inline constexpr float TABLE[] = {
+    1e-45F, 1e-44F, 1e-43F, 1e-42F, 1e-41F, 1e-40F, 1e-39F, 1e-38F, 1e-37F, 1e-36F, 1e-35F, 1e-34F, 1e-33F, 1e-32F,
+    1e-31F, 1e-30F, 1e-29F, 1e-28F, 1e-27F, 1e-26F, 1e-25F, 1e-24F, 1e-23F, 1e-22F, 1e-21F, 1e-20F, 1e-19F, 1e-18F,
+    1e-17F, 1e-16F, 1e-15F, 1e-14F, 1e-13F, 1e-12F, 1e-11F, 1e-10F, 1e-9F,  1e-8F,  1e-7F,  1e-6F,  1e-5F,  1e-4F,
+    1e-3F,  1e-2F,  1e-1F,  1e0F,   1e1F,   1e2F,   1e3F,   1e4F,   1e5F,   1e6F,   1e7F,   1e8F,   1e9F,   1e10F,
+    1e11F,  1e12F,  1e13F,  1e14F,  1e15F,  1e16F,  1e17F,  1e18F,  1e19F,  1e20F,  1e21F,  1e22F,  1e23F,  1e24F,
+    1e25F,  1e26F,  1e27F,  1e28F,  1e29F,  1e30F,  1e31F,  1e32F,  1e33F,  1e34F,  1e35F,  1e36F,  1e37F,  1e38F,
+};
+
+template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
+inline void calculate_floor() {
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::vFloat result = sfpi::dst_reg[0];
+        sfpi::vFloat v = result;
+        sfpi::vInt tmp = float_to_int16(result, 0);
+        result = int32_to_float(tmp, 0);
+        v_if(result > v) { result = result - 1; }
+        v_endif;
+        v_if(v <= SHRT_MIN || v >= SHRT_MAX) { result = v; }
+        v_endif;
+        sfpi::dst_reg[0] = result;
+        sfpi::dst_reg++;
+    }
+}
+
+template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
+inline void calculate_floor_float32() {
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::vFloat result = sfpi::dst_reg[0];
+        sfpi::vFloat v = result;
+        sfpi::vInt tmp = float_to_int32(result);
+        result = int32_to_float(tmp, 0);
+        v_if(result > v) { result = result - 1; }
+        v_endif;
+        sfpi::dst_reg[0] = result;
+        sfpi::dst_reg++;
+    }
+}
+
+template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
+inline void calculate_ceil() {
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::vFloat result = sfpi::dst_reg[0];
+        sfpi::vFloat v = result;
+        sfpi::vInt tmp = float_to_int16(result, 0);
+        result = int32_to_float(tmp, 0);
+        v_if(result < v) { result = result + 1; }
+        v_endif;
+        v_if(v <= SHRT_MIN || v >= SHRT_MAX) { result = v; }
+        v_endif;
+        sfpi::dst_reg[0] = result;
+        sfpi::dst_reg++;
+    }
+}
+
+template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
+inline void calculate_ceil_float32() {
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::vFloat result = sfpi::dst_reg[0];
+        sfpi::vFloat v = result;
+        sfpi::vInt tmp = float_to_int32(result);
+        result = int32_to_float(tmp, 0);
+        v_if(result < v) { result = result + 1; }
+        v_endif;
+        sfpi::dst_reg[0] = result;
+        sfpi::dst_reg++;
+    }
+}
+
+inline sfpi::vFloat round_even(sfpi::vFloat v) {
+    sfpi::vFloat result;
+    v_if(sfpi::abs(v) < 0x1p30f) {
+        result = int32_to_float(float_to_int31(v), 0);
+        v_if(sfpi::abs(v - result) == 0.5F) {
+            sfpi::vInt res = float_to_int16(result, 0);
+            res = res & 0x7FFE;
+            result = sfpi::int32_to_float(res, 0);
+        }
+        v_endif;
+    }
+    v_endif;
+    return result;
+}
+
+template <bool APPROXIMATE, int ITERATIONS = 8>
+void calculate_round(const int decimals) {
+    const auto exp10i = [](int n) {
+        if (n > 38) {
+            return 1.0F / 0.0F;
+        }
+
+        if (n < -45) {
+            return 0.0F;
+        }
+
+        return TABLE[n + 45];
+    };
+
+    const sfpi::vFloat coeff = exp10i(decimals);
+    const sfpi::vFloat inverse = exp10i(-decimals);
+
+    for (int _ = 0; _ < ITERATIONS; ++_) {
+        sfpi::vFloat v = sfpi::dst_reg[0];
+        sfpi::vFloat result = inverse * round_even(sfpi::abs(v) * coeff);
+        result = sfpi::setsgn(result, v);
+        sfpi::dst_reg[0] = result;
+        sfpi::dst_reg++;
+    }
+}
+
+}  // namespace sfpu
+}  // namespace ckernel

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_rounding_ops.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_rounding_ops.h
@@ -6,68 +6,92 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
-#include "sfpi.h"
 #include "limits.h"
+#include "sfpi.h"
 
-namespace ckernel {
-namespace sfpu {
+namespace ckernel
+{
+namespace sfpu
+{
 
-inline sfpi::vInt float_to_int32(sfpi::vFloat in) {
+inline sfpi::vInt float_to_int32(sfpi::vFloat in)
+{
     sfpi::vInt result;
-    sfpi::vInt exp = exexp(in);  // extract exponent
-    v_if(exp < 0) { result = 0; }
-    v_elseif(exp > 30) {
+    sfpi::vInt exp = exexp(in); // extract exponent
+    v_if (exp < 0)
+    {
+        result = 0;
+    }
+    v_elseif (exp > 30)
+    {
         // set to int32 max value in case of overflow
         result = std::numeric_limits<int32_t>::max();
         // check sign
-        v_if(in < 0) {
+        v_if (in < 0)
+        {
             result = sfpi::reinterpret<sfpi::vInt>(sfpi::setsgn(sfpi::reinterpret<sfpi::vFloat>(result), 1));
         }
         v_endif
     }
-    v_else {
+    v_else
+    {
         // extract mantissa
         sfpi::vInt man = exman8(in);
         // shift the mantissa by (23-exponent) to the right
         sfpi::vInt shift = exp - 23;
-        man = shft(sfpi::reinterpret<sfpi::vUInt>(man), shift);
+        man              = shft(sfpi::reinterpret<sfpi::vUInt>(man), shift);
         // check sign
-        v_if(in < 0) { man = sfpi::reinterpret<sfpi::vInt>(sfpi::setsgn(sfpi::reinterpret<sfpi::vFloat>(man), 1)); }
+        v_if (in < 0)
+        {
+            man = sfpi::reinterpret<sfpi::vInt>(sfpi::setsgn(sfpi::reinterpret<sfpi::vFloat>(man), 1));
+        }
         v_endif result = man;
     }
     v_endif return result;
 }
 
-inline sfpi::vInt float_to_int31(sfpi::vFloat v) {
+inline sfpi::vInt float_to_int31(sfpi::vFloat v)
+{
     sfpi::vInt q = float_to_int16(v * 0x1p-15f, 0);
     sfpi::vInt r = float_to_int16(v - int32_to_float(q, 0) * 0x1p15f, 0);
-    v_if(r < 0) {
+    v_if (r < 0)
+    {
         r = sfpi::setsgn(r, 0);
         q = (q << 15) - r;
     }
-    v_else { q = (q << 15) + r; }
+    v_else
+    {
+        q = (q << 15) + r;
+    }
     v_endif return q;
 }
 
 inline constexpr float TABLE[] = {
-    1e-45F, 1e-44F, 1e-43F, 1e-42F, 1e-41F, 1e-40F, 1e-39F, 1e-38F, 1e-37F, 1e-36F, 1e-35F, 1e-34F, 1e-33F, 1e-32F,
-    1e-31F, 1e-30F, 1e-29F, 1e-28F, 1e-27F, 1e-26F, 1e-25F, 1e-24F, 1e-23F, 1e-22F, 1e-21F, 1e-20F, 1e-19F, 1e-18F,
-    1e-17F, 1e-16F, 1e-15F, 1e-14F, 1e-13F, 1e-12F, 1e-11F, 1e-10F, 1e-9F,  1e-8F,  1e-7F,  1e-6F,  1e-5F,  1e-4F,
-    1e-3F,  1e-2F,  1e-1F,  1e0F,   1e1F,   1e2F,   1e3F,   1e4F,   1e5F,   1e6F,   1e7F,   1e8F,   1e9F,   1e10F,
-    1e11F,  1e12F,  1e13F,  1e14F,  1e15F,  1e16F,  1e17F,  1e18F,  1e19F,  1e20F,  1e21F,  1e22F,  1e23F,  1e24F,
-    1e25F,  1e26F,  1e27F,  1e28F,  1e29F,  1e30F,  1e31F,  1e32F,  1e33F,  1e34F,  1e35F,  1e36F,  1e37F,  1e38F,
+    1e-45F, 1e-44F, 1e-43F, 1e-42F, 1e-41F, 1e-40F, 1e-39F, 1e-38F, 1e-37F, 1e-36F, 1e-35F, 1e-34F, 1e-33F, 1e-32F, 1e-31F, 1e-30F, 1e-29F,
+    1e-28F, 1e-27F, 1e-26F, 1e-25F, 1e-24F, 1e-23F, 1e-22F, 1e-21F, 1e-20F, 1e-19F, 1e-18F, 1e-17F, 1e-16F, 1e-15F, 1e-14F, 1e-13F, 1e-12F,
+    1e-11F, 1e-10F, 1e-9F,  1e-8F,  1e-7F,  1e-6F,  1e-5F,  1e-4F,  1e-3F,  1e-2F,  1e-1F,  1e0F,   1e1F,   1e2F,   1e3F,   1e4F,   1e5F,
+    1e6F,   1e7F,   1e8F,   1e9F,   1e10F,  1e11F,  1e12F,  1e13F,  1e14F,  1e15F,  1e16F,  1e17F,  1e18F,  1e19F,  1e20F,  1e21F,  1e22F,
+    1e23F,  1e24F,  1e25F,  1e26F,  1e27F,  1e28F,  1e29F,  1e30F,  1e31F,  1e32F,  1e33F,  1e34F,  1e35F,  1e36F,  1e37F,  1e38F,
 };
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_floor() {
-    for (int d = 0; d < ITERATIONS; d++) {
+inline void calculate_floor()
+{
+    for (int d = 0; d < ITERATIONS; d++)
+    {
         sfpi::vFloat result = sfpi::dst_reg[0];
-        sfpi::vFloat v = result;
-        sfpi::vInt tmp = float_to_int16(result, 0);
-        result = int32_to_float(tmp, 0);
-        v_if(result > v) { result = result - 1; }
+        sfpi::vFloat v      = result;
+        sfpi::vInt tmp      = float_to_int16(result, 0);
+        result              = int32_to_float(tmp, 0);
+        v_if (result > v)
+        {
+            result = result - 1;
+        }
         v_endif;
-        v_if(v <= SHRT_MIN || v >= SHRT_MAX) { result = v; }
+        v_if (v <= SHRT_MIN || v >= SHRT_MAX)
+        {
+            result = v;
+        }
         v_endif;
         sfpi::dst_reg[0] = result;
         sfpi::dst_reg++;
@@ -75,13 +99,18 @@ inline void calculate_floor() {
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_floor_float32() {
-    for (int d = 0; d < ITERATIONS; d++) {
+inline void calculate_floor_float32()
+{
+    for (int d = 0; d < ITERATIONS; d++)
+    {
         sfpi::vFloat result = sfpi::dst_reg[0];
-        sfpi::vFloat v = result;
-        sfpi::vInt tmp = float_to_int32(result);
-        result = int32_to_float(tmp, 0);
-        v_if(result > v) { result = result - 1; }
+        sfpi::vFloat v      = result;
+        sfpi::vInt tmp      = float_to_int32(result);
+        result              = int32_to_float(tmp, 0);
+        v_if (result > v)
+        {
+            result = result - 1;
+        }
         v_endif;
         sfpi::dst_reg[0] = result;
         sfpi::dst_reg++;
@@ -89,15 +118,23 @@ inline void calculate_floor_float32() {
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_ceil() {
-    for (int d = 0; d < ITERATIONS; d++) {
+inline void calculate_ceil()
+{
+    for (int d = 0; d < ITERATIONS; d++)
+    {
         sfpi::vFloat result = sfpi::dst_reg[0];
-        sfpi::vFloat v = result;
-        sfpi::vInt tmp = float_to_int16(result, 0);
-        result = int32_to_float(tmp, 0);
-        v_if(result < v) { result = result + 1; }
+        sfpi::vFloat v      = result;
+        sfpi::vInt tmp      = float_to_int16(result, 0);
+        result              = int32_to_float(tmp, 0);
+        v_if (result < v)
+        {
+            result = result + 1;
+        }
         v_endif;
-        v_if(v <= SHRT_MIN || v >= SHRT_MAX) { result = v; }
+        v_if (v <= SHRT_MIN || v >= SHRT_MAX)
+        {
+            result = v;
+        }
         v_endif;
         sfpi::dst_reg[0] = result;
         sfpi::dst_reg++;
@@ -105,27 +142,35 @@ inline void calculate_ceil() {
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_ceil_float32() {
-    for (int d = 0; d < ITERATIONS; d++) {
+inline void calculate_ceil_float32()
+{
+    for (int d = 0; d < ITERATIONS; d++)
+    {
         sfpi::vFloat result = sfpi::dst_reg[0];
-        sfpi::vFloat v = result;
-        sfpi::vInt tmp = float_to_int32(result);
-        result = int32_to_float(tmp, 0);
-        v_if(result < v) { result = result + 1; }
+        sfpi::vFloat v      = result;
+        sfpi::vInt tmp      = float_to_int32(result);
+        result              = int32_to_float(tmp, 0);
+        v_if (result < v)
+        {
+            result = result + 1;
+        }
         v_endif;
         sfpi::dst_reg[0] = result;
         sfpi::dst_reg++;
     }
 }
 
-inline sfpi::vFloat round_even(sfpi::vFloat v) {
+inline sfpi::vFloat round_even(sfpi::vFloat v)
+{
     sfpi::vFloat result;
-    v_if(sfpi::abs(v) < 0x1p30f) {
+    v_if (sfpi::abs(v) < 0x1p30f)
+    {
         result = int32_to_float(float_to_int31(v), 0);
-        v_if(sfpi::abs(v - result) == 0.5F) {
+        v_if (sfpi::abs(v - result) == 0.5F)
+        {
             sfpi::vInt res = float_to_int16(result, 0);
-            res = res & 0x7FFE;
-            result = sfpi::int32_to_float(res, 0);
+            res            = res & 0x7FFE;
+            result         = sfpi::int32_to_float(res, 0);
         }
         v_endif;
     }
@@ -134,30 +179,35 @@ inline sfpi::vFloat round_even(sfpi::vFloat v) {
 }
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
-void calculate_round(const int decimals) {
-    const auto exp10i = [](int n) {
-        if (n > 38) {
+void calculate_round(const int decimals)
+{
+    const auto exp10i = [](int n)
+    {
+        if (n > 38)
+        {
             return 1.0F / 0.0F;
         }
 
-        if (n < -45) {
+        if (n < -45)
+        {
             return 0.0F;
         }
 
         return TABLE[n + 45];
     };
 
-    const sfpi::vFloat coeff = exp10i(decimals);
+    const sfpi::vFloat coeff   = exp10i(decimals);
     const sfpi::vFloat inverse = exp10i(-decimals);
 
-    for (int _ = 0; _ < ITERATIONS; ++_) {
-        sfpi::vFloat v = sfpi::dst_reg[0];
+    for (int _ = 0; _ < ITERATIONS; ++_)
+    {
+        sfpi::vFloat v      = sfpi::dst_reg[0];
         sfpi::vFloat result = inverse * round_even(sfpi::abs(v) * coeff);
-        result = sfpi::setsgn(result, v);
-        sfpi::dst_reg[0] = result;
+        result              = sfpi::setsgn(result, v);
+        sfpi::dst_reg[0]    = result;
         sfpi::dst_reg++;
     }
 }
 
-}  // namespace sfpu
-}  // namespace ckernel
+} // namespace sfpu
+} // namespace ckernel


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/22131

### Problem description
Rounding op LLKs are spilled across multiple headers, need to combine it into common header and port to LLK side

### What's changed
Move implementation to LLK repo

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
