### PR TITLE
fix: pass format to generate_stimuli in matmul tests

### DIFF
--- a/tests/python_tests/test_matmul.py
+++ b/tests/python_tests/test_matmul.py
@@ -86,7 +86,7 @@ param_ids = generate_param_ids(all_params)
 )
 def test_matmul(testname, formats, dest_acc, math_fidelity):
 
-    src_A, src_B = generate_stimuli()
+    src_A, src_B = generate_stimuli(formats.input_format, formats.input_format)
 
     golden_tensor = generate_golden(src_A, src_B, formats.output_format, math_fidelity)
     golden_tensor = tilize(golden_tensor, format_dict[formats.input_format])

--- a/tests/python_tests/test_matmul_pack_untilize.py
+++ b/tests/python_tests/test_matmul_pack_untilize.py
@@ -87,7 +87,7 @@ param_ids = generate_param_ids(all_params)
 )
 def test_matmul_pack_untilize(testname, formats, dest_acc, math_fidelity):
 
-    src_A, src_B = generate_stimuli()
+    src_A, src_B = generate_stimuli(formats.input_format, formats.input_format)
 
     golden_tensor = generate_golden(src_A, src_B, formats.output_format, math_fidelity)
     golden_tensor = golden_tensor.to(format_dict[formats.output_format])


### PR DESCRIPTION
### Ticket
None

### Problem description
It turns out we missed to pass formats to stimuli generator.

### What's changed
<!-- Describe the approach used to solve the problem.
Summarize the changes made and its impact. -->

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
