### PR TITLE
fix: remove pytest-randomly

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,6 +1,5 @@
 numpy==2.2.5
 pytest-cov==6.1.1
-pytest-randomly==3.16.0
 pytest-repeat==0.9.4
 pytest-split==0.10.0
 pytest-sugar==1.0.0


### PR DESCRIPTION
### Ticket
None

### Problem description
pytest-split and pytest-randomly seem to not work well together. If a group fails and gets rerun, randomly plugin will randomize tests again and skip running failing tests.

### What's changed
Removed pytest-randomly

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
