### PR TITLE
Added unpack_tilize_uninit to llk lib

### DIFF
--- a/tt_llk_blackhole/llk_lib/llk_unpack_tilize.h
+++ b/tt_llk_blackhole/llk_lib/llk_unpack_tilize.h
@@ -184,3 +184,27 @@ inline void _llk_unpack_tilize_(
     first_unpack_recorded = true;
 #endif
 }
+
+inline void _llk_unpack_tilize_uninit(const std::uint32_t num_faces, const std::uint32_t face_r_dim = FACE_R_DIM, const std::uint32_t unpack_dst_format = 0)
+{
+    // Revert X dim value to default.
+    TT_SETADCXX(p_setadc::UNP_A, face_r_dim * FACE_C_DIM - 1, 0x0);
+    TT_SETADCXX(p_setadc::UNP_B, face_r_dim * FACE_C_DIM - 1, 0x0);
+
+    // Revert Z dim value back to default.
+    const uint Tile_z_dim = num_faces;
+    cfg_reg_rmw_tensix<THCON_SEC0_REG0_TileDescriptor_ADDR32 + 1, 16, 0xffff0000>(Tile_z_dim);
+
+    unpack_config_u config = {0};
+
+    config.f.out_data_format = unpack_dst_format;
+    config.f.throttle_mode   = 2;
+    TT_SETDMAREG(0, LOWER_HALFWORD(config.val[0]), 0, LO_16(p_gpr_unpack::TMP0));
+    TT_SETDMAREG(0, UPPER_HALFWORD(config.val[0]), 0, HI_16(p_gpr_unpack::TMP0));
+    TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::THCON);
+    // Load unpack config[0]
+    TTI_WRCFG(p_gpr_unpack::TMP0, 0, THCON_SEC0_REG2_Out_data_format_ADDR32);
+    // GPR preloaded with  16 | (16 << 16)}
+    TTI_WRCFG(p_gpr_unpack::FACE_DIM_16x16, 0, THCON_SEC0_REG5_Tile_x_dim_cntx0_ADDR32);
+    TTI_NOP;
+}

--- a/tt_llk_blackhole/llk_lib/llk_unpack_tilize.h
+++ b/tt_llk_blackhole/llk_lib/llk_unpack_tilize.h
@@ -185,7 +185,7 @@ inline void _llk_unpack_tilize_(
 #endif
 }
 
-inline void _llk_unpack_tilize_uninit(const std::uint32_t num_faces, const std::uint32_t face_r_dim = FACE_R_DIM, const std::uint32_t unpack_dst_format = 0)
+inline void _llk_unpack_tilize_uninit_(const std::uint32_t num_faces, const std::uint32_t face_r_dim = FACE_R_DIM, const std::uint32_t unpack_dst_format = 0)
 {
     // Revert X dim value to default.
     TT_SETADCXX(p_setadc::UNP_A, face_r_dim * FACE_C_DIM - 1, 0x0);

--- a/tt_llk_wormhole_b0/llk_lib/llk_unpack_tilize.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_unpack_tilize.h
@@ -437,3 +437,24 @@ inline void _llk_unpack_tilizeA_B_(
         switch_config_context(unp_cfg_context);
     }
 }
+
+inline void _llk_unpack_tilize_uninit(const std::uint32_t unpack_dst_format, const std::uint32_t face_r_dim = FACE_R_DIM)
+{
+    TT_SETADCXX(p_setadc::UNP_A, face_r_dim * FACE_C_DIM - 1, 0x0);
+    TT_SETADCXX(p_setadc::UNP_B, face_r_dim * FACE_C_DIM - 1, 0x0);
+    unpack_config_u config = {0};
+
+    config.f.out_data_format = unpack_dst_format;
+    config.f.throttle_mode   = 2;
+    TT_SETDMAREG(0, LOWER_HALFWORD(config.val[0]), 0, LO_16(p_gpr_unpack::TMP0));
+    TT_SETDMAREG(0, UPPER_HALFWORD(config.val[0]), 0, HI_16(p_gpr_unpack::TMP0));
+    TTI_REG2FLOP(1, 0, 0, 0, THCON_SEC0_REG2_Out_data_format_ADDR32 + 0 - THCON_CFGREG_BASE_ADDR32,
+                 p_gpr_unpack::TMP0); // Load unpack config[0]
+    TTI_REG2FLOP(
+        1,
+        0,
+        0,
+        0,
+        THCON_SEC0_REG5_Tile_x_dim_cntx0_ADDR32 - THCON_CFGREG_BASE_ADDR32,
+        p_gpr_unpack::FACE_DIM_16x16); // GPR preloaded with  16 | (16 << 16)}
+}

--- a/tt_llk_wormhole_b0/llk_lib/llk_unpack_tilize.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_unpack_tilize.h
@@ -438,7 +438,7 @@ inline void _llk_unpack_tilizeA_B_(
     }
 }
 
-inline void _llk_unpack_tilize_uninit(const std::uint32_t unpack_dst_format, const std::uint32_t face_r_dim = FACE_R_DIM)
+inline void _llk_unpack_tilize_uninit_(const std::uint32_t unpack_dst_format, const std::uint32_t face_r_dim = FACE_R_DIM)
 {
     TT_SETADCXX(p_setadc::UNP_A, face_r_dim * FACE_C_DIM - 1, 0x0);
     TT_SETADCXX(p_setadc::UNP_B, face_r_dim * FACE_C_DIM - 1, 0x0);


### PR DESCRIPTION
### Ticket
<!-- Link to Github Issue -->
https://github.com/orgs/tenstorrent/projects/123/views/1?pane=issue&itemId=111603646&issue=tenstorrent%7Ctt-llk%7C220
### Problem description
<!-- Provide context for the problem. -->
When writing tests that incorporate unpack_tilize with other unpacker kernels, we need to uninit the unpack_tilize_init otherwise we cannot properly initialize a different unpack kernel and the tests fail. This uninit function is defined and called in metal, but we need one for llk.
### What's changed
<!-- Describe the approach used to solve the problem.
Summarize the changes made and its impact. -->

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update


