### PR TITLE
Conditionally call disable/enable_gathering based on compile option.

### DIFF
--- a/tt_llk_blackhole/common/inc/ckernel.h
+++ b/tt_llk_blackhole/common/inc/ckernel.h
@@ -690,7 +690,11 @@ inline void enable_gathering()
 template <uint start, uint len, bool exec_while_loading = false, typename F>
 inline void load_replay_buf(F fn)
 {
-    // disable_gathering();
+    // ENABLE_GATHERING is controlled by JIT build.
+    // Not enabled by default due to tt-metal#16439.
+#if defined(ENABLE_GATHERING)
+    disable_gathering();
+#endif
 
     // Issue instruction to load replay buffer
     TTI_REPLAY(start, len, exec_while_loading, 1);
@@ -698,9 +702,9 @@ inline void load_replay_buf(F fn)
     // Send in the user's desired instructions
     fn();
 
-    // Workaround for tt-metal#16439, making sure gathering is disabled
-    // WE DON'T UNDERSTAND WHY ENABLING GATHERING DOESN'T WORK
-    // enable_gathering();
+#if defined(ENABLE_GATHERING)
+    enable_gathering();
+#endif
 }
 
 // Same as above, but used if start/len/exec_while_loading are not known
@@ -708,7 +712,11 @@ inline void load_replay_buf(F fn)
 template <typename F>
 inline void load_replay_buf(uint start, uint len, bool exec_while_loading, F fn)
 {
-    // disable_gathering();
+    // ENABLE_GATHERING is controlled by JIT build.
+    // Not enabled by default due to tt-metal#16439.
+#if defined(ENABLE_GATHERING)
+    disable_gathering();
+#endif
 
     // Issue instruction to load replay buffer
     TT_REPLAY(start, len, exec_while_loading, 1);
@@ -716,9 +724,9 @@ inline void load_replay_buf(uint start, uint len, bool exec_while_loading, F fn)
     // Send in the user's desired instructions
     fn();
 
-    // Workaround for tt-metal#16439, making sure gathering is disabled
-    // WE DON'T UNDERSTAND WHY ENABLING GATHERING DOESN'T WORK
-    // enable_gathering();
+#if defined(ENABLE_GATHERING)
+    enable_gathering();
+#endif
 }
 
 enum class CSR : uint16_t


### PR DESCRIPTION
tt_metal will introduce a runtime option to enable gathering.  Whether these functions are called will be controlled on compile option in jit build.

### Ticket
https://github.com/tenstorrent/tt-metal/issues/22240

### Problem description
Gathering is now globally disabled, and load_replay_buf no longer toggles gathering when executing TTI_REPLAY load command.

### What's changed
Have the behavior controlled under the compile option `ENABLE_GATHERING` which will be provided by jit build.

https://github.com/tenstorrent/tt-metal/pull/22424 tracks the tt_metal change for this compile option.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
