### PR TITLE
Rewrite {recip,rsqrt,sqrt} LLKs.

### DIFF
--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_binary.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_binary.h
@@ -144,7 +144,7 @@ inline void _calculate_sfpu_binary_(const uint dst_offset)
             }
             v_else
             {
-                result = in0 * sfpi::setsgn(_sfpu_reciprocal_<4>(in1), in1);
+                result = in0 * sfpi::setsgn(_sfpu_reciprocal_(in1), in1);
             }
             v_endif;
         }
@@ -165,9 +165,14 @@ inline void _calculate_sfpu_binary_(const uint dst_offset)
 template <bool APPROXIMATION_MODE /*unused*/, BinaryOp BINOP>
 inline void _sfpu_binary_init_()
 {
-    if constexpr (BINOP == BinaryOp::DIV || BINOP == BinaryOp::POW)
+    if constexpr (BINOP == BinaryOp::DIV)
     {
-        _init_reciprocal_<APPROXIMATION_MODE>();
+        _init_reciprocal_<false>();
+    }
+    if constexpr (BINOP == BinaryOp::POW)
+    {
+        // note: calls _init_reciprocal_
+        _init_exponential_<false>();
     }
 }
 

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_exp.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_exp.h
@@ -25,7 +25,7 @@ sfpi_inline sfpi::vFloat _sfpu_exp_(sfpi::vFloat val)
     v_endif;
 
     // Run series in Horner form
-    sfpi::vFloat tmp = val * sfpi::vConst0p8373 + sfpi::s2vFloat16b(0.863281);
+    sfpi::vFloat tmp = val * sfpi::vConst0p8373 + sfpi::vConstFloatPrgm2;
     val              = val * tmp + sfpi::vConst1;
 
     v_if (exp >= 0)
@@ -360,8 +360,7 @@ inline void _init_exponential_()
     }
     else
     {
-        sfpi::vConstFloatPrgm0 = 1.442695f; // ln2_recip
-        sfpi::vConstFloatPrgm1 = 2.0f;
+        _init_reciprocal_<APPROXIMATION_MODE>();
         sfpi::vConstFloatPrgm2 = 0.863281f;
     }
 }

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_gelu.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_gelu.h
@@ -189,10 +189,6 @@ inline void _init_gelu_()
 template <bool APPROXIMATION_MODE>
 inline void _init_gelu_derivative_()
 {
-    sfpi::vConstFloatPrgm0 = 1.442695f; // ln2_recip
-    sfpi::vConstFloatPrgm1 = 2.0f;
-    sfpi::vConstFloatPrgm2 = 0.863281f;
-
     uint imm0;
     uint imm1;
     uint imm2;
@@ -230,6 +226,8 @@ inline void _init_gelu_derivative_()
     }
     else
     {
+        _init_exponential_<false>();
+
         imm0 = 0x28FF;
         imm1 = 0x3020;
         _sfpu_load_imm16_(0, imm0);

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_recip.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_recip.h
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2025 Jason Davies <jason@jasondavies.com>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -11,61 +12,37 @@ namespace ckernel
 namespace sfpu
 {
 
-template <int max_iter = 3>
+// See: Cezary J. Walczyk, Leonid V. Moroz, Volodymyr Samotyy, and Jan L. Cieśliński.
+// Optimal Approximation of the 1/x Function using Chebyshev Polynomials and Magic Constants.
+// https://doi.org/10.1145/3708472
+
+template <bool APPROXIMATE = false>
 sfpi_inline sfpi::vFloat _sfpu_reciprocal_(const sfpi::vFloat in)
 {
-    // Force sign to 1 (make number negative)
-    sfpi::vFloat val = sfpi::setsgn(in, 1);
+    sfpi::vFloat negative_x = -in;
+    sfpi::vFloat y = sfpi::reinterpret<sfpi::vFloat>(sfpi::vConstIntPrgm0 - sfpi::reinterpret<sfpi::vInt>(in));
+    sfpi::vFloat t = sfpi::vConstFloatPrgm2 + negative_x * y;
+    y = y * sfpi::vConstFloatPrgm1;
+    y = y * t;
 
-    val = setexp(val, 126); // Set exponent to 126 to make the number in 0.5-1
-    // Use 1.44 as first guess at x, ideal value would be 1.33.
-    // Grayskull has hardwired 1.44 and uses it to avoid a load.
-    // We use it here for consistency.
-    sfpi::vFloat vConstLn2Recip = sfpi::vConstFloatPrgm0;
-    sfpi::vFloat two            = sfpi::vConstFloatPrgm1;
-    sfpi::vFloat result         = vConstLn2Recip * (val * vConstLn2Recip + two);
-
-    for (int s_iter = 0; s_iter < (max_iter - 1); s_iter++)
+    if constexpr (!APPROXIMATE)
     {
-        result = result * (val * result + two);
+        // 2nd iteration of Newton-Raphson
+        t = y * negative_x + sfpi::vConst1;
+        y = y * t + y;
     }
 
-    sfpi::vInt orig_exp = exexp(in);
-    sfpi::vInt new_exp  = exexp(result);
-
-    // "Subtract" exponents, and re-bias.
-    // Execute: -1 - exp, then exp += 127
-    new_exp -= orig_exp;
-    new_exp += 126;
-
-    v_if (new_exp < 0)
-    {
-        // If rebiased exponent is negative, we need to saturate at 0.
-        // This means the initial number was too big so reciprocal result should be 0
-        result  = 0.0F;
-        new_exp = 0;
-    }
-    v_endif;
-
-    // Set newly denormalized exponent to result exponent field
-    return setexp(result, new_exp);
+    return y;
 }
 
-template <bool APPROXIMATION_MODE, int ITERATIONS, bool is_fp32_dest_acc_en = true>
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en = true>
 inline void _calculate_reciprocal_(const int iterations)
 {
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
     {
         sfpi::vFloat in  = sfpi::dst_reg[0];
-        sfpi::vFloat out = _sfpu_reciprocal_<APPROXIMATION_MODE ? 2 : 3>(in);
-
-        v_if (in < 0.0F)
-        {
-            // Invert sign on calculated value if CC=1 (number is negative)
-            out = -out;
-        }
-        v_endif;
+        sfpi::vFloat out = _sfpu_reciprocal_<APPROXIMATION_MODE>(in);
 
         if constexpr (is_fp32_dest_acc_en || APPROXIMATION_MODE)
         {
@@ -83,8 +60,9 @@ inline void _calculate_reciprocal_(const int iterations)
 template <bool APPROXIMATION_MODE>
 inline void _init_reciprocal_()
 {
-    sfpi::vConstFloatPrgm0 = 1.442695f; // ln2_recip
-    sfpi::vConstFloatPrgm1 = 2.0f;
+    sfpi::vConstIntPrgm0 = 0x7eb504f3;
+    sfpi::vConstFloatPrgm1 = 1.94090888923f;
+    sfpi::vConstFloatPrgm2 = 1.43566017178f;
 }
 
 } // namespace sfpu

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_sqrt.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_sqrt.h
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2025 Jason Davies <jason@jasondavies.com>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -12,48 +13,58 @@ namespace ckernel
 namespace sfpu
 {
 
-template <bool APPROXIMATION_MODE, int ITERATIONS, int RECIPROCAL_ITERATIONS>
-inline void _calculate_sqrt_(const int iterations)
+// See: Kokosiński, Z., Gepner, P., Moroz, L. et al.
+// Fast and accurate approximation algorithms for computing floating point square root. Numer Algor (2024).
+// https://doi.org/10.1007/s11075-024-01932-7
+
+template <bool APPROXIMATE = false, bool RECIPROCAL = false>
+sfpi_inline sfpi::vFloat _sfpu_sqrt_(const sfpi::vFloat x)
 {
-#pragma GCC unroll 8
-    for (int d = 0; d < iterations; d++)
+    sfpi::vInt i = sfpi::reinterpret<sfpi::vInt>(sfpi::reinterpret<sfpi::vUInt>(x) >> 1);
+    sfpi::vFloat y = sfpi::reinterpret<sfpi::vFloat>(sfpi::vConstIntPrgm0 - i);
+
+    if constexpr (APPROXIMATE)
     {
-        sfpi::vFloat val = sfpi::dst_reg[0];
-
-        if constexpr (APPROXIMATION_MODE)
-        {
-            sfpi::vUInt magic = sfpi::vConstIntPrgm0;
-
-            // sqrt initial approximation
-            //  adjust bias
-            sfpi::vUInt val_s = magic + sfpi::reinterpret<sfpi::vUInt>(val);
-
-            // approximation of square root
-            val_s >>= 1;
-            sfpi::dst_reg[0] = sfpi::reinterpret<sfpi::vFloat>(val_s);
+        // Algorithm SQRT_10-bits, with modifications for reciprocal.
+        sfpi::vFloat c = x * y;
+        sfpi::vFloat negative_y = -y;
+        if constexpr (RECIPROCAL) {
+            y = y * (sfpi::vConstFloatPrgm1 + negative_y * c);
         }
         else
         {
-            // Recip root method
-            //// Init approx
-            // u.i = SQRT_MAGIC_F - (u.i >> 1);
-            v_if (val != 0.0f)
-            {
-                sfpi::vUInt magic   = sfpi::vConstIntPrgm0;
-                sfpi::vFloat approx = sfpi::reinterpret<sfpi::vFloat>(magic - (sfpi::reinterpret<sfpi::vUInt>(val) >> 1));
-
-                // Reciproot iterations
-                for (int r = 0; r < RECIPROCAL_ITERATIONS; r++)
-                {
-                    // x*r*(1.5f - xhalf*r*r);
-                    approx = ((approx * approx) * (val * -0.5f) + 1.5f) * approx;
-                }
-
-                sfpi::dst_reg[0] = approx * val;
-            }
-            v_endif;
+            y = c * (sfpi::vConstFloatPrgm1 + negative_y * c);
         }
+    }
+    else
+    {
+        // Algorithm SQRT_23-bits, with modifications for reciprocal.
+        sfpi::vFloat negative_x = -x;
+        sfpi::vFloat c = negative_x * y * y;
+        y = y * (sfpi::vConstFloatPrgm1 + c * (sfpi::vConstFloatPrgm2 + c));
+        sfpi::vFloat half_y = sfpi::addexp(y, -1);
 
+        if constexpr (RECIPROCAL) {
+            y = y + (sfpi::vConst1 + negative_x * y * y) * half_y;
+        }
+        else
+        {
+            half_y = -half_y;
+            y = x * y;
+            y = y + (y * y + negative_x) * half_y;
+        }
+    }
+
+    return y;
+}
+
+template <bool APPROXIMATION_MODE, int ITERATIONS, bool RECIPROCAL>
+inline void _calculate_sqrt_()
+{
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++)
+    {
+        sfpi::dst_reg[0] = _sfpu_sqrt_<APPROXIMATION_MODE, RECIPROCAL>(sfpi::dst_reg[0]);
         sfpi::dst_reg++;
     }
 }
@@ -63,11 +74,14 @@ inline void _init_sqrt_()
 {
     if (APPROXIMATION_MODE)
     {
-        sfpi::vConstFloatPrgm0 = sfpi::s2vFloat16b(127 << 7);
+        sfpi::vConstIntPrgm0 = 0x5f0b3892;
+        sfpi::vConstFloatPrgm1 = 1.89099014875f;
     }
     else
     {
-        sfpi::vConstFloatPrgm0 = sfpi::s2vFloat16b(0x5f37);
+        sfpi::vConstIntPrgm0 = 0x5f1110a0;
+        sfpi::vConstFloatPrgm1 = 2.2825186f;
+        sfpi::vConstFloatPrgm2 = 2.2533049f;
     }
 }
 


### PR DESCRIPTION
See:

- tenstorrent/tt-metal#21622

The original implementations used poor initial guesses for Newton-Raphson, resulting in poor results even when using 3 iterations.

These new implementations use state-of-the-art constants for the initial guesses, along with algorithmic improvements.

The new implementations have ~1 ulps error for either approximate mode (10 bits) or non-approximate mode (~23 bits).

The sqrt LLK now also has support for optional rsqrt (reciprocal sqrt), which uses the same number of multiplies as sqrt.

### Ticket
<!-- Link to Github Issue -->

### Problem description
<!-- Provide context for the problem. -->

### What's changed
<!-- Describe the approach used to solve the problem.
Summarize the changes made and its impact. -->

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
