### PR TITLE
[test Infra] Adding Bfp8_b to matmul tests

### DIFF
--- a/tests/python_tests/test_matmul.py
+++ b/tests/python_tests/test_matmul.py
@@ -26,28 +26,31 @@ from helpers.utils import compare_pcc, run_shell_command
 
 def generate_golden(operand1, operand2, data_format, math_fidelity):
 
-    if data_format == DataFormat.Float16_b:
-        if math_fidelity in [MathFidelity.LoFi, MathFidelity.HiFi2]:  # LoFi or HiFi2
-            for element in operand2:
-                element = element.to(torch.int32)
-                element &= 0xFFFE
-        if math_fidelity == MathFidelity.LoFi:  # LoFi
-            for element in operand1:
-                element = element.to(torch.int32)
-                element &= 0xFFF8
+    if math_fidelity in [MathFidelity.LoFi, MathFidelity.HiFi2]:  # LoFi or HiFi2
+        for element in operand2:
+            element = element.to(torch.int32)
+            element &= 0xFFFE
+    if math_fidelity == MathFidelity.LoFi:  # LoFi
+        for element in operand1:
+            element = element.to(torch.int32)
+            element &= 0xFFF8
 
-    operand1_matrix = operand1.view(32, 32).to(format_dict[data_format])
-    operand2_matrix = operand2.view(32, 32).to(format_dict[data_format])
+    operand1_matrix = operand1.view(32, 32).to(
+        format_dict.get(data_format, format_dict[DataFormat.Float16_b])
+    )
+    operand2_matrix = operand2.view(32, 32).to(
+        format_dict.get(data_format, format_dict[DataFormat.Float16_b])
+    )
 
-    result_matrix = torch.zeros(32, 32, dtype=operand1_matrix.dtype)
     result_matrix = torch.matmul(operand1_matrix, operand2_matrix)
 
-    return result_matrix.view(1024).to(format_dict[data_format])
+    return result_matrix.view(1024).to(
+        format_dict.get(data_format, format_dict[DataFormat.Float16_b])
+    )
 
 
 # SUPPORTED FORMATS FOR TEST
-supported_formats = [DataFormat.Float16, DataFormat.Float16_b]
-
+supported_formats = [DataFormat.Float16, DataFormat.Float16_b, DataFormat.Bfp8_b]
 #   INPUT-OUTPUT FORMAT SWEEP
 #   input_output_formats(supported_formats)
 
@@ -64,6 +67,7 @@ supported_formats = [DataFormat.Float16, DataFormat.Float16_b]
 
 #   SPECIFIC INPUT-OUTPUT COMBINATION
 #   [InputOutputFormat(DataFormat.Float16, DataFormat.Float32)]
+
 
 test_formats = input_output_formats(supported_formats)
 all_params = generate_params(
@@ -90,12 +94,23 @@ def test_matmul(testname, formats, dest_acc, math_fidelity):
     src_A, src_B = generate_stimuli(formats.input_format, formats.input_format)
 
     golden_tensor = generate_golden(src_A, src_B, formats.output_format, math_fidelity)
-    golden_tensor = tilize(golden_tensor, format_dict[formats.input_format])
-    golden_tensor = golden_tensor.to(format_dict[formats.output_format])
+    golden_tensor = tilize(
+        golden_tensor,
+        format_dict.get(formats.output_format, format_dict[DataFormat.Float16_b]),
+    )
+    golden_tensor = golden_tensor.to(
+        format_dict.get(formats.output_format, format_dict[DataFormat.Float16_b])
+    )
 
     write_stimuli_to_l1(
-        tilize(src_A, format_dict[formats.input_format]),
-        tilize(src_B, format_dict[formats.input_format]),
+        tilize(
+            src_A,
+            format_dict.get(formats.output_format, format_dict[DataFormat.Float16_b]),
+        ),
+        tilize(
+            src_B,
+            format_dict.get(formats.output_format, format_dict[DataFormat.Float16_b]),
+        ),
         formats.input_format,
         formats.input_format,
     )
@@ -113,24 +128,19 @@ def test_matmul(testname, formats, dest_acc, math_fidelity):
     run_elf_files(testname)
 
     wait_for_tensix_operations_finished()
-    res_from_L1 = collect_results(
-        formats, tensor_size=len(src_A)
-    )  # Bug patchup in (unpack.py): passing formats struct to check unpack_src with pack_dst and distinguish when input and output formats have different exponent widths then reading from L1 changes
+    res_from_L1 = collect_results(formats, tensor_size=len(src_A))
     assert len(res_from_L1) == len(golden_tensor)
 
     res_tensor = torch.tensor(
         res_from_L1,
         dtype=(
-            format_dict[formats.output_format]
-            if formats.output_format in [DataFormat.Float16, DataFormat.Float16_b]
-            else torch.bfloat16
+            format_dict.get(formats.output_format, format_dict[DataFormat.Float16_b])
         ),
     )
 
-    if formats.output_format in [DataFormat.Float16_b, DataFormat.Float16]:
-        atol = 0.1
-        rtol = 0.05
-    elif formats.output_format == DataFormat.Bfp8_b:
+    atol = 0.1
+    rtol = 0.05
+    if formats.output_format == DataFormat.Bfp8_b:
         atol = 0.1
         rtol = 0.2
 

--- a/tests/python_tests/test_matmul_pack_untilize.py
+++ b/tests/python_tests/test_matmul_pack_untilize.py
@@ -4,6 +4,7 @@
 import pytest
 import torch
 
+from helpers.chip_architecture import ChipArchitecture, get_chip_architecture
 from helpers.device import (
     collect_results,
     run_elf_files,
@@ -66,7 +67,7 @@ supported_formats = [DataFormat.Float16_b, DataFormat.Float16, DataFormat.Bfp8_b
 #   SPECIFIC INPUT-OUTPUT COMBINATION
 #   [InputOutputFormat(DataFormat.Float16, DataFormat.Float32)]
 
-test_formats = input_output_formats(supported_formats, same=True)
+test_formats = input_output_formats(supported_formats)
 all_params = generate_params(
     ["matmul_pack_untilize_test"],
     test_formats,
@@ -87,6 +88,10 @@ param_ids = generate_param_ids(all_params)
     ids=param_ids,
 )
 def test_matmul_pack_untilize(testname, formats, dest_acc, math_fidelity):
+    arch = get_chip_architecture()
+    if formats.output == DataFormat.Bfp8_b and arch == ChipArchitecture.WORMHOLE:
+        pytest.skip("Pack untilize does not support Bfp8_b")
+
     data_type = format_dict.get(
         formats.output_format, format_dict[DataFormat.Float16_b]
     )

--- a/tests/python_tests/test_matmul_pack_untilize.py
+++ b/tests/python_tests/test_matmul_pack_untilize.py
@@ -99,7 +99,6 @@ def test_matmul_pack_untilize(testname, formats, dest_acc, math_fidelity):
     src_A, src_B = generate_stimuli(formats.input_format, formats.input_format)
 
     golden_tensor = generate_golden(src_A, src_B, formats.output_format, math_fidelity)
-    golden_tensor = golden_tensor.to(data_type)
 
     write_stimuli_to_l1(
         tilize(src_A, data_type),

--- a/tests/python_tests/test_matmul_pack_untilize.py
+++ b/tests/python_tests/test_matmul_pack_untilize.py
@@ -28,18 +28,21 @@ torch.set_printoptions(linewidth=500, sci_mode=False, precision=2, threshold=100
 
 def generate_golden(operand1, operand2, data_format, math_fidelity):
 
-    if data_format == DataFormat.Float16_b:
-        if math_fidelity in [MathFidelity.LoFi, MathFidelity.HiFi2]:  # LoFi or HiFi2
-            for element in operand2:
-                element = element.to(torch.int32)
-                element &= 0xFFFE
-        if math_fidelity == MathFidelity.LoFi:  # LoFi
-            for element in operand1:
-                element = element.to(torch.int32)
-                element &= 0xFFF8
+    if math_fidelity in [MathFidelity.LoFi, MathFidelity.HiFi2]:  # LoFi or HiFi2
+        for element in operand2:
+            element = element.to(torch.int32)
+            element &= 0xFFFE
+    if math_fidelity == MathFidelity.LoFi:  # LoFi
+        for element in operand1:
+            element = element.to(torch.int32)
+            element &= 0xFFF8
 
-    operand1_matrix = operand1.view(32, 32).to(format_dict[data_format])
-    operand2_matrix = operand2.view(32, 32).to(format_dict[data_format])
+    operand1_matrix = operand1.view(32, 32).to(
+        format_dict.get(data_format, format_dict[DataFormat.Float16_b])
+    )
+    operand2_matrix = operand2.view(32, 32).to(
+        format_dict.get(data_format, format_dict[DataFormat.Float16_b])
+    )
 
     result_matrix = torch.matmul(operand1_matrix, operand2_matrix)
 
@@ -47,7 +50,7 @@ def generate_golden(operand1, operand2, data_format, math_fidelity):
 
 
 # SUPPORTED FORMATS FOR TEST
-supported_formats = [DataFormat.Float16, DataFormat.Float16_b]
+supported_formats = [DataFormat.Float16_b, DataFormat.Float16, DataFormat.Bfp8_b]
 
 #   INPUT-OUTPUT FORMAT SWEEP
 #   input_output_formats(supported_formats)
@@ -66,11 +69,11 @@ supported_formats = [DataFormat.Float16, DataFormat.Float16_b]
 #   SPECIFIC INPUT-OUTPUT COMBINATION
 #   [InputOutputFormat(DataFormat.Float16, DataFormat.Float32)]
 
-test_formats = input_output_formats(supported_formats)
+test_formats = input_output_formats(supported_formats, same=True)
 all_params = generate_params(
     ["matmul_pack_untilize_test"],
     test_formats,
-    dest_acc=[DestAccumulation.No, DestAccumulation.Yes],
+    dest_acc=[DestAccumulation.Yes, DestAccumulation.No],
     math_fidelity=[
         MathFidelity.LoFi,
         MathFidelity.HiFi2,
@@ -91,11 +94,19 @@ def test_matmul_pack_untilize(testname, formats, dest_acc, math_fidelity):
     src_A, src_B = generate_stimuli(formats.input_format, formats.input_format)
 
     golden_tensor = generate_golden(src_A, src_B, formats.output_format, math_fidelity)
-    golden_tensor = golden_tensor.to(format_dict[formats.output_format])
+    golden_tensor = golden_tensor.to(
+        format_dict.get(formats.output_format, format_dict[DataFormat.Float16_b])
+    )
 
     write_stimuli_to_l1(
-        tilize(src_A, format_dict[formats.input_format]),
-        tilize(src_B, format_dict[formats.input_format]),
+        tilize(
+            src_A,
+            format_dict.get(formats.output_format, format_dict[DataFormat.Float16_b]),
+        ),
+        tilize(
+            src_B,
+            format_dict.get(formats.output_format, format_dict[DataFormat.Float16_b]),
+        ),
         formats.input_format,
         formats.input_format,
     )
@@ -119,16 +130,13 @@ def test_matmul_pack_untilize(testname, formats, dest_acc, math_fidelity):
     res_tensor = torch.tensor(
         res_from_L1,
         dtype=(
-            format_dict[formats.output_format]
-            if formats.output_format in [DataFormat.Float16, DataFormat.Float16_b]
-            else torch.bfloat16
+            format_dict.get(formats.output_format, format_dict[DataFormat.Float16_b])
         ),
     )
 
-    if formats.output_format in [DataFormat.Float16_b, DataFormat.Float16]:
-        atol = 0.1
-        rtol = 0.05
-    elif formats.output_format == DataFormat.Bfp8_b:
+    atol = 0.1
+    rtol = 0.05
+    if formats.output_format == DataFormat.Bfp8_b:
         atol = 0.1
         rtol = 0.2
 

--- a/tests/python_tests/test_matmul_pack_untilize.py
+++ b/tests/python_tests/test_matmul_pack_untilize.py
@@ -28,7 +28,7 @@ torch.set_printoptions(linewidth=500, sci_mode=False, precision=2, threshold=100
 
 
 def generate_golden(operand1, operand2, data_format, math_fidelity):
-    data_type = format_dict.get(data_format, format_dict[DataFormat.Float16_b])
+    torch_format = format_dict.get(data_format, format_dict[DataFormat.Float16_b])
 
     if math_fidelity in [MathFidelity.LoFi, MathFidelity.HiFi2]:  # LoFi or HiFi2
         for element in operand2:
@@ -39,8 +39,8 @@ def generate_golden(operand1, operand2, data_format, math_fidelity):
             element = element.to(torch.int32)
             element &= 0xFFF8
 
-    operand1_matrix = operand1.view(32, 32).to(data_type)
-    operand2_matrix = operand2.view(32, 32).to(data_type)
+    operand1_matrix = operand1.view(32, 32).to(torch_format)
+    operand2_matrix = operand2.view(32, 32).to(torch_format)
 
     result_matrix = torch.matmul(operand1_matrix, operand2_matrix)
 
@@ -92,7 +92,7 @@ def test_matmul_pack_untilize(testname, formats, dest_acc, math_fidelity):
     if formats.output == DataFormat.Bfp8_b and arch == ChipArchitecture.WORMHOLE:
         pytest.skip("Pack untilize does not support Bfp8_b")
 
-    data_type = format_dict.get(
+    torch_format = format_dict.get(
         formats.output_format, format_dict[DataFormat.Float16_b]
     )
 
@@ -101,8 +101,8 @@ def test_matmul_pack_untilize(testname, formats, dest_acc, math_fidelity):
     golden_tensor = generate_golden(src_A, src_B, formats.output_format, math_fidelity)
 
     write_stimuli_to_l1(
-        tilize(src_A, data_type),
-        tilize(src_B, data_type),
+        tilize(src_A, torch_format),
+        tilize(src_B, torch_format),
         formats.input_format,
         formats.input_format,
     )
@@ -123,7 +123,7 @@ def test_matmul_pack_untilize(testname, formats, dest_acc, math_fidelity):
     res_from_L1 = collect_results(formats, tensor_size=len(src_A))
     assert len(res_from_L1) == len(golden_tensor)
 
-    res_tensor = torch.tensor(res_from_L1, dtype=(data_type))
+    res_tensor = torch.tensor(res_from_L1, dtype=(torch_format))
 
     atol = 0.1
     rtol = 0.05


### PR DESCRIPTION
### Ticket
<!-- Link to Github Issue -->
https://github.com/tenstorrent/tt-llk/issues/140
### Problem description
<!-- Provide context for the problem. -->
Enabled Matmul testing for format `Bfp8_b`, except for `test_matmul_unpack_tilize.py` since unpack_tilize doesn't work on block formats.

### What's changed
<!-- Describe the approach used to solve the problem.
Summarize the changes made and its impact. -->
Now all tests run with format combinations including Bfp8_b, where the data format inference model infers all formats for kernels. By calling tests with ```test_formats = input_output_formats(supported_formats)``` this triggers use of data format inference model to determine the rest of the formats needed to support input and output formats in L1. 
Needed to change python test files because they leverage torch to generate tensors and torch doesn't recognize Bfp8_b so this needs to be worked around -- this work around is done throughout the entire test infra. 

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Task on LLK Test Infra
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

