### PR TITLE
Add 32-bit support for transpose_of_faces to A2D datacopy.

### DIFF
--- a/tt_llk_wormhole_b0/common/inc/cunpack_common.h
+++ b/tt_llk_wormhole_b0/common/inc/cunpack_common.h
@@ -286,7 +286,8 @@ inline void configure_unpack_AB(
 
     cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG0_SrcA_ADDR32, 0, alu_mask>(alu_payload.val);
 
-    uint32_t src_zeroflags_disable = ((uint)unpA_dst_format == (uint)DataFormat::UInt16) || ((uint)unpB_dst_format == (uint)DataFormat::UInt16);
+    uint32_t src_zeroflags_disable = ((uint)unpA_dst_format == (uint)DataFormat::UInt16) || ((uint)unpB_dst_format == (uint)DataFormat::UInt16)
+      || ((uint)unpA_dst_format == (uint)DataFormat::Int32) || ((uint)unpB_dst_format == (uint)DataFormat::Int32);
     if constexpr (disable_src_zero_flag)
     {
         src_zeroflags_disable = true;

--- a/tt_llk_wormhole_b0/llk_lib/llk_math_transpose_dest.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_math_transpose_dest.h
@@ -25,9 +25,7 @@ inline void transpose_dest_configure_mop();
 template <bool transpose_of_faces = true, bool is_32bit = false>
 inline void _llk_math_transpose_dest_(const std::uint32_t dst_index)
 {
-    math_unpack_to_dest_math_ready();
-    math::set_dst_write_addr<DstTileLayout::Default, DstTileShape::Tile32x32, UnpackToDestEn>(dst_index);
-    math::math_unpack_to_dest_tile_ready();
+    math::set_dst_write_addr<DstTileLayout::Default, DstTileShape::Tile32x32>(dst_index);
 
     TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::WAIT_SFPU);
 
@@ -51,7 +49,8 @@ inline void _llk_math_transpose_dest_(const std::uint32_t dst_index)
 
     // clear SrcA, SrcB valids; reset SrcA, SrcB, Dst counters to zero
     TTI_SETRWC(p_setrwc::CLR_AB, 0, 0, 0, 0, p_setrwc::SET_ABD);
-    //TTI_CLEARDVALID(0, 1);
+    // completely reset SrcA/SrcB sync mechanism: see https://github.com/tenstorrent/tt-metal/issues/22383
+    TTI_CLEARDVALID(0, 1);
 }
 
 template <bool is_32bit>

--- a/tt_llk_wormhole_b0/llk_lib/llk_math_transpose_dest.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_math_transpose_dest.h
@@ -36,32 +36,17 @@ inline void _llk_math_transpose_dest_(const std::uint32_t dst_index)
         if constexpr (transpose_of_faces)
         {
             // 4x 32b face transpositions followed by 8x middle-face row swaps.
-            //ckernel_unpack_template::run(instrn_buffer, 12, 0xff0);
+            ckernel_unpack_template::run(instrn_buffer, 12, 0xff0);
         }
         else
         {
             // 4x 32b face transpositions.
-            //ckernel_unpack_template::run(instrn_buffer, 4, 0);
-          for (int i = 0; i < 4; ++i)
-          {
-              for (int dest_32b_lo = 0; dest_32b_lo < 2; ++dest_32b_lo)
-              {
-                  TTI_MOVD2B(dest_32b_lo, 16, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 0);
-                  TTI_MOVD2B(dest_32b_lo, 20, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 4);
-                  TTI_MOVD2B(dest_32b_lo, 24, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 8);
-                  TTI_MOVD2B(dest_32b_lo, 28, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 12);
-                  TTI_TRNSPSRCB;
-                  TTI_MOVB2D(dest_32b_lo, 16, ADDR_MOD_1, p_movb2d::MOV_4_ROWS, 0);
-                  TTI_MOVB2D(dest_32b_lo, 20, ADDR_MOD_1, p_movb2d::MOV_4_ROWS, 4);
-                  TTI_MOVB2D(dest_32b_lo, 24, ADDR_MOD_1, p_movb2d::MOV_4_ROWS, 8);
-                  TTI_MOVB2D(dest_32b_lo, 28, dest_32b_lo == 1 ? ADDR_MOD_0 : ADDR_MOD_1, p_movb2d::MOV_4_ROWS, 12);
-              }
-          }
+            ckernel_unpack_template::run(instrn_buffer, 4, 0);
         }
     }
     else
     {
-        //ckernel_unpack_template::run(instrn_buffer, 2, 2);
+        ckernel_unpack_template::run(instrn_buffer, 2, 2);
     }
 
     // clear SrcA, SrcB valids; reset SrcA, SrcB, Dst counters to zero

--- a/tt_llk_wormhole_b0/llk_lib/llk_math_transpose_dest.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_math_transpose_dest.h
@@ -22,6 +22,15 @@ inline void transpose_dest_configure_addrmod();
 template <bool transpose_of_faces, bool is_32bit>
 inline void transpose_dest_configure_mop();
 
+// Notes on these template parameters:
+// 1. <transpose_of_faces=false, is_32bit=false>: not supported.
+// 2. <transpose_of_faces=false, is_32bit=true>: 4x 16x16 face transpose; can be combined with _llk_unpack_A_ with transpose_of_faces=true.
+// 3. <transpose_of_faces=true, is_32bit=false>: the default case (full 32x32 tile transpose, non-32-bit).
+// 4. <transpose_of_faces=true, is_32bit=true>: full 32x32 tile transpose for 32-bit.
+//
+// We may want to revisit these template parameters, and perhaps the
+// transpose_dest API generally as it's not currently widely used:
+// https://github.com/tenstorrent/tt-llk/issues/290
 template <bool transpose_of_faces = true, bool is_32bit = false>
 inline void _llk_math_transpose_dest_(const std::uint32_t dst_index)
 {

--- a/tt_llk_wormhole_b0/llk_lib/llk_unpack_A.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_unpack_A.h
@@ -53,6 +53,8 @@ inline void _llk_unpack_A_mop_config_(
         TT_OP_UNPACR(SrcA, 0b1 /*Z inc*/, 0, 0, 0, 1 /* Set OvrdThreadId*/, 1 /*Set Dvalid*/, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
     static constexpr uint unpack_srca_to_dest =
         TT_OP_UNPACR(SrcA, 0b00010001 /*Z inc*/, 0, 0, 0, 1 /* Set OvrdThreadId*/, 0 /*Set Dvalid*/, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1); // ch0/ch1 z_inc
+    static constexpr uint unpack_srca_to_dest_transpose_of_faces =
+        TT_OP_UNPACR(SrcA, 0b00010010, 0, 0, 0, 1, 0, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1); // inc srcA ch1_z+=1, ch0_z+=2
     static constexpr uint unpack_srca_zerosrc    = TT_OP_UNPACR_NOP(SrcA, p_unpacr_nop::UNP_ZEROSRC);
     static constexpr uint unpack_srca_set_dvalid = TT_OP_UNPACR_NOP(SrcA, p_unpacr_nop::UNP_SET_DVALID);
     static constexpr uint unpack_srcb =
@@ -75,10 +77,24 @@ inline void _llk_unpack_A_mop_config_(
 
     if (unpack_to_dest && is_32bit_input(unpack_src_format, unpack_dst_format))
     {
-        const uint32_t outerloop     = num_faces;
-        constexpr uint32_t innerloop = 1;
-        ckernel_template tmp(outerloop, innerloop, unpack_srca_to_dest);
-        tmp.program(instrn_buffer);
+        if (transpose_of_faces)
+        {
+            const uint32_t outerloop = num_faces < 4 ? 1 : 2;
+            const uint32_t innerloop = num_faces < 2 ? 1 : 2;
+            ckernel_template tmp(outerloop, innerloop, num_faces > 2 ? unpack_srca_to_dest_transpose_of_faces : unpack_srca_to_dest);
+            if (num_faces > 2)
+            {
+                tmp.set_end_op(TT_OP_SETADCZW(p_setadc::UNP_A, 0, 2, 0, 1, 0b0101));
+            }
+            tmp.program(instrn_buffer);
+        }
+        else
+        {
+            const uint32_t outerloop     = num_faces;
+            constexpr uint32_t innerloop = 1;
+            ckernel_template tmp(outerloop, innerloop, unpack_srca_to_dest);
+            tmp.program(instrn_buffer);
+        }
     }
     else if constexpr (BType == BroadcastType::COL)
     {

--- a/tt_llk_wormhole_b0/llk_lib/llk_unpack_A.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_unpack_A.h
@@ -77,9 +77,9 @@ inline void _llk_unpack_A_mop_config_(
 
     if (unpack_to_dest && is_32bit_input(unpack_src_format, unpack_dst_format))
     {
-        if (transpose_of_faces && num_faces > 2)
+        if (transpose_of_faces && num_faces == 4)
         {
-            const uint32_t outerloop = num_faces < 4 ? 1 : 2;
+            const uint32_t outerloop = 2;
             const uint32_t innerloop = 2;
             ckernel_template tmp(outerloop, innerloop, unpack_srca_to_dest_transpose_of_faces);
             tmp.set_end_op(TT_OP_SETADCZW(p_setadc::UNP_A, 0, 2, 0, 1, 0b0101));

--- a/tt_llk_wormhole_b0/llk_lib/llk_unpack_A.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_unpack_A.h
@@ -77,15 +77,12 @@ inline void _llk_unpack_A_mop_config_(
 
     if (unpack_to_dest && is_32bit_input(unpack_src_format, unpack_dst_format))
     {
-        if (transpose_of_faces)
+        if (transpose_of_faces && num_faces > 2)
         {
             const uint32_t outerloop = num_faces < 4 ? 1 : 2;
-            const uint32_t innerloop = num_faces < 2 ? 1 : 2;
-            ckernel_template tmp(outerloop, innerloop, num_faces > 2 ? unpack_srca_to_dest_transpose_of_faces : unpack_srca_to_dest);
-            if (num_faces > 2)
-            {
-                tmp.set_end_op(TT_OP_SETADCZW(p_setadc::UNP_A, 0, 2, 0, 1, 0b0101));
-            }
+            const uint32_t innerloop = 2;
+            ckernel_template tmp(outerloop, innerloop, unpack_srca_to_dest_transpose_of_faces);
+            tmp.set_end_op(TT_OP_SETADCZW(p_setadc::UNP_A, 0, 2, 0, 1, 0b0101));
             tmp.program(instrn_buffer);
         }
         else


### PR DESCRIPTION
### Ticket

tenstorrent/tt-metal#21270

### Problem description

This is a slightly more efficient way to do transpose_wh_tile, by doing the middle face swap via unpack_A, which leaves only the within_face_transpose parts remaining.

### What's changed

- Add support for transpose_of_faces for 32-bit inputs to unpack_A (previously this was ignored).
- Add new transpose_of_faces template parameter to transpose_dest LLK API.  Important: this is currently ignored for non-32-bit data.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
