### PR TITLE
ci: add pull request write permissions to workflows

### DIFF
--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -11,6 +11,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  packages: write
 
 concurrency:
   # Use github.run_id on main branch (or any protected branch)

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -8,6 +8,10 @@ on:
     branches: ["main"]
   merge_group:
 
+permissions:
+  pull-requests: write
+  contents: read
+
 concurrency:
   # Use github.run_id on main branch (or any protected branch)
   # This ensures that no runs get cancelled on main.

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -9,9 +9,7 @@ on:
   merge_group:
 
 permissions:
-  pull-requests: write
-  packages: write
-  contents: read
+  contents: write
 
 concurrency:
   # Use github.run_id on main branch (or any protected branch)

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   pull-requests: write
+  packages: write
   contents: read
 
 concurrency:

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 concurrency:
   # Use github.run_id on main branch (or any protected branch)

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -66,6 +66,7 @@ jobs:
                 "Thank you for your contribution! 🚀\n\n" +
                 "You can run tt-metal integration tests by adding the `blackhole-integration-tests` and/or " +
                 "`wormhole-integration-tests` labels to this pull request.\n\n" +
-                "📖 For more information, please refer to our [CONTRIBUTING.md](" +
-                "https://github.com/tenstorrent/tt-llk/blob/main/CONTRIBUTING.md)."
+                "📖 For detailed instructions on how to contribute to tt-llk, please refer to our
+                [CONTRIBUTING](" +
+                "https://github.com/tenstorrent/tt-llk/blob/main/CONTRIBUTING.md) guide."
             });

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -66,7 +66,6 @@ jobs:
                 "Thank you for your contribution! 🚀\n\n" +
                 "You can run tt-metal integration tests by adding the `blackhole-integration-tests` and/or " +
                 "`wormhole-integration-tests` labels to this pull request.\n\n" +
-                "📖 For detailed instructions on how to contribute to tt-llk, please refer to our
-                [CONTRIBUTING](" +
+                "📖 For more information, please refer to our [CONTRIBUTING](" +
                 "https://github.com/tenstorrent/tt-llk/blob/main/CONTRIBUTING.md) guide."
             });


### PR DESCRIPTION
### Ticket
None

### Problem description
After we moved to GH Enterprise, our comment posting job started failing in all pull requests.

### What's changed
This change elevates permissions of workflows running on PRs to write, so it should fix our problem with comment posting job. It should now be able to write comments on PRs.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update