### PR TITLE
fix: speed up test build times

### DIFF
--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -84,8 +84,8 @@ jobs:
             needs.detect-changes.outputs.github == 'true' }}
     with:
       docker_image: ${{ needs.build-images.outputs.docker-image }}
-      runs_on: tt-beta-ubuntu-2204-p150a-large-stable
-      test_group: "[1, 2]"
+      runs_on: p150
+      test_group: "[1]"
 
   check-all-green:
     name: "✅ Check all green"

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -73,7 +73,7 @@ jobs:
     with:
       docker_image: ${{ needs.build-images.outputs.docker-image }}
       runs_on: tt-beta-ubuntu-2204-n150-large-stable
-      test_group: "[1, 2, 3, 4, 5]"
+      test_group: "[1, 2]"
 
   setup-and-test-blackhole:
     name: "🕳️ Perform checks (Blackhole)"
@@ -85,7 +85,7 @@ jobs:
     with:
       docker_image: ${{ needs.build-images.outputs.docker-image }}
       runs_on: tt-beta-ubuntu-2204-p150a-large-stable
-      test_group: "[1, 2, 3, 4, 5]"
+      test_group: "[1, 2]"
 
   check-all-green:
     name: "✅ Check all green"

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -73,7 +73,7 @@ jobs:
     with:
       docker_image: ${{ needs.build-images.outputs.docker-image }}
       runs_on: tt-beta-ubuntu-2204-n150-large-stable
-      test_group: "[1, 2]"
+      test_group: "[1, 2, 3]"
 
   setup-and-test-blackhole:
     name: "🕳️ Perform checks (Blackhole)"

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -12,7 +12,7 @@ GXX:=$(wildcard $(TOOL_PATH)/riscv32-*-elf-g++)
 OBJDUMP:=$(wildcard $(TOOL_PATH)/riscv32-*-elf-objdump)
 
 # GCC options
-OPTIONS_ALL=-O3 -mabi=ilp32 -std=c++20 -ffast-math -ftest-coverage
+OPTIONS_ALL=-O3 -mabi=ilp32 -std=c++17 -ffast-math
 OPTIONS_COMPILE=-fno-use-cxa-atexit -Wall -fpermissive -fno-exceptions -fno-rtti -Werror -Wno-unknown-pragmas -Wno-error=multistatement-macros -Wno-error=parentheses -Wno-error=unused-but-set-variable -Wno-unused-variable -DTENSIX_FIRMWARE #-DDEBUG_PRINT_ENABLED
 
 # Default values

--- a/tests/helpers/include/data_format_inference.h
+++ b/tests/helpers/include/data_format_inference.h
@@ -40,7 +40,7 @@ constexpr FormatConfig get_data_formats(uint32_t input, uint32_t output, bool is
     uint32_t unpack_in  = input;
     uint32_t unpack_out = input;
     uint32_t pack_out   = output;
-    uint32_t pack_in;
+    uint32_t pack_in    = 0;
 
     if (input == (uint32_t)DataFormat::Float16 && output == (uint32_t)DataFormat::Bfp8_b && !is_fp32_dest_acc_en)
     {

--- a/tests/python_tests/helpers/test_config.py
+++ b/tests/python_tests/helpers/test_config.py
@@ -20,7 +20,7 @@ from .format_config import InputOutputFormat
 
 
 def generate_make_command(test_config):
-    make_cmd = f"make --silent --always-make "
+    make_cmd = f"make -j 6 --silent --always-make "
     formats = test_config.get("formats")
     testname = test_config.get("testname")
     dest_acc = test_config.get(


### PR DESCRIPTION
### Ticket
None

### Problem description
A large portion of the test execution time was actually spent on build time. We were building ELF files inefficiently, and there was room for improvement by parallelizing the make process. This should have significant impact on the amount of time we spend on running the tests.

### What's changed
We now run make in parallel using 6 cores instead of building sequentially on a single core. I chose this number after testing locally to measure the improvement. The tests were performed on a machine with 12 cores, but using all available cores actually resulted in slower builds compared to using half of them. After several tests with different core counts, I found that 6 cores consistently gave the best results, achieving around a 3x speed improvement.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
