### PR TITLE
ci: fix permission issues for community-issue-tagging [skip ci]

### DIFF
--- a/.github/workflows/community-issue-tagging.yml
+++ b/.github/workflows/community-issue-tagging.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     types: [opened]
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   call-central-workflow:
     uses: tenstorrent/tt-github-actions/.github/workflows/on-community-issue.yml@main


### PR DESCRIPTION
### Ticket
None

### Problem description
After move to GitHub Enterprise, we started seeing failures in this workflow, due to missing permissions.

### What's changed
Explicitly added permissions for PRs and issues.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update