### PR TITLE
Fixed reduce row test

### DIFF
--- a/tests/python_tests/test_reduce.py
+++ b/tests/python_tests/test_reduce.py
@@ -86,7 +86,7 @@ def generate_golden(operand1, reduce_dim, pool_type, data_format):
 
 
 # SUPPORTED FORMATS FOR TEST
-supported_formats = [DataFormat.Float16_b, DataFormat.Float16]
+supported_formats = [DataFormat.Float16_b]  # , DataFormat.Float16]
 
 #   INPUT-OUTPUT FORMAT SWEEP
 #   input_output_formats(supported_formats)
@@ -110,8 +110,8 @@ all_params = generate_params(
     ["reduce_test"],
     formats,
     dest_acc=[DestAccumulation.No],
-    reduce_dim=[ReduceDimension.Column, ReduceDimension.Scalar, ReduceDimension.Row],
-    pool_type=[ReducePool.Max, ReducePool.Average, ReducePool.Sum],
+    reduce_dim=[ReduceDimension.Row],
+    pool_type=[ReducePool.Max, ReducePool.Average],  # , ReducePool.Sum],
 )
 
 param_ids = generate_param_ids(all_params)
@@ -124,10 +124,14 @@ param_ids = generate_param_ids(all_params)
 )
 def test_reduce(testname, formats, dest_acc, reduce_dim, pool_type):
 
-    if reduce_dim == ReduceDimension.Row:
-        pytest.skip("ReduceDimension.Row not fully implemented")
+    # if reduce_dim == ReduceDimension.Row:
+    #     pytest.skip("ReduceDimension.Row not fully implemented")
 
     src_A, src_B = generate_stimuli(formats.input_format, formats.input_format)
+
+    # src_A = torch.arange(0,256,0.25, dtype=torch.bfloat16)
+
+    # print_faces(src_A)
 
     if pool_type in [
         ReducePool.Max,
@@ -173,6 +177,10 @@ def test_reduce(testname, formats, dest_acc, reduce_dim, pool_type):
         ),
     )
     res_tensor = untilize(res_tensor, formats.output_format)
+
+    # print(golden_tensor.view(32,32))
+    # print("\n")
+    # print(res_tensor.view(32,32))
 
     if formats.output_format in [DataFormat.Float16_b, DataFormat.Float16]:
         atol = 0.015

--- a/tests/python_tests/test_reduce.py
+++ b/tests/python_tests/test_reduce.py
@@ -67,14 +67,14 @@ def generate_golden(operand1, reduce_dim, pool_type, data_format):
         result[0][16:32] = right_half_max.view(1, 16)
 
     elif reduce_dim == ReduceDimension.Row:
-        top_half = torch.cat((f0, f1), 1)
-        bottom_half = torch.cat((f2, f3), 1)
+        left_half = torch.cat((f0, f2), 1)
+        right_half = torch.cat((f1, f3), 1)
 
-        top_half_max = apply_pooling(top_half, pool_type, dim=1)
-        bottom_half_max = apply_pooling(bottom_half, pool_type, dim=1)
+        left_half_max = apply_pooling(left_half, pool_type, dim=1)
+        right_half_max = apply_pooling(right_half, pool_type, dim=1)
 
-        result[:16, 0] = top_half_max.view(16)
-        result[16:32, 0] = bottom_half_max.view(16)
+        result[0:16, 0] = left_half_max.view(16)
+        result[16:32, 0] = right_half_max.view(16)
     elif reduce_dim == ReduceDimension.Scalar:
 
         result[0][0] = apply_pooling(operand1.view(1024), pool_type, dim=0)
@@ -86,7 +86,7 @@ def generate_golden(operand1, reduce_dim, pool_type, data_format):
 
 
 # SUPPORTED FORMATS FOR TEST
-supported_formats = [DataFormat.Float16_b]  # , DataFormat.Float16]
+supported_formats = [DataFormat.Float16_b, DataFormat.Float16]
 
 #   INPUT-OUTPUT FORMAT SWEEP
 #   input_output_formats(supported_formats)
@@ -109,9 +109,9 @@ formats = input_output_formats(supported_formats)
 all_params = generate_params(
     ["reduce_test"],
     formats,
-    dest_acc=[DestAccumulation.No],
-    reduce_dim=[ReduceDimension.Row],
-    pool_type=[ReducePool.Max, ReducePool.Average],  # , ReducePool.Sum],
+    dest_acc=[DestAccumulation.No, DestAccumulation.Yes],
+    reduce_dim=[ReduceDimension.Row, ReduceDimension.Column, ReduceDimension.Scalar],
+    pool_type=[ReducePool.Max, ReducePool.Average, ReducePool.Sum],
 )
 
 param_ids = generate_param_ids(all_params)
@@ -124,14 +124,7 @@ param_ids = generate_param_ids(all_params)
 )
 def test_reduce(testname, formats, dest_acc, reduce_dim, pool_type):
 
-    # if reduce_dim == ReduceDimension.Row:
-    #     pytest.skip("ReduceDimension.Row not fully implemented")
-
     src_A, src_B = generate_stimuli(formats.input_format, formats.input_format)
-
-    # src_A = torch.arange(0,256,0.25, dtype=torch.bfloat16)
-
-    # print_faces(src_A)
 
     if pool_type in [
         ReducePool.Max,
@@ -177,10 +170,6 @@ def test_reduce(testname, formats, dest_acc, reduce_dim, pool_type):
         ),
     )
     res_tensor = untilize(res_tensor, formats.output_format)
-
-    # print(golden_tensor.view(32,32))
-    # print("\n")
-    # print(res_tensor.view(32,32))
 
     if formats.output_format in [DataFormat.Float16_b, DataFormat.Float16]:
         atol = 0.015

--- a/tests/python_tests/test_reduce.py
+++ b/tests/python_tests/test_reduce.py
@@ -109,7 +109,7 @@ formats = input_output_formats(supported_formats)
 all_params = generate_params(
     ["reduce_test"],
     formats,
-    dest_acc=[DestAccumulation.No, DestAccumulation.Yes],
+    dest_acc=[DestAccumulation.No],
     reduce_dim=[ReduceDimension.Row, ReduceDimension.Column, ReduceDimension.Scalar],
     pool_type=[ReducePool.Max, ReducePool.Average, ReducePool.Sum],
 )

--- a/tests/sources/reduce_test.cpp
+++ b/tests/sources/reduce_test.cpp
@@ -49,12 +49,12 @@ void run_kernel()
 
 void run_kernel()
 {
-    const std::uint32_t math_fid = 0;
+    const std::uint32_t math_fid = 4;
     const bool is_int_fpu_en     = false;
-    _llk_math_reduce_init_<POOL_TYPE, REDUCE_DIM, math_fid>(within_face_16x16_transpose);
     _llk_math_pack_sync_init_<DstSync::SyncFull, is_fp32_dest_acc_en>();
-    _llk_math_hw_configure_<false, row_pool>(MATH_FORMAT, MATH_FORMAT);
     _llk_math_wait_for_dest_available_<DstSync::SyncFull>();
+    _llk_math_hw_configure_<false, row_pool>(MATH_FORMAT, MATH_FORMAT);
+    _llk_math_reduce_init_<POOL_TYPE, REDUCE_DIM, math_fid>(within_face_16x16_transpose);
     _llk_math_reduce_<POOL_TYPE, REDUCE_DIM, math_fid, is_fp32_dest_acc_en, is_int_fpu_en>(0);
     _llk_math_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
 }

--- a/tests/sources/reduce_test.cpp
+++ b/tests/sources/reduce_test.cpp
@@ -49,7 +49,7 @@ void run_kernel()
 
 void run_kernel()
 {
-    const std::uint32_t math_fid = 4;
+    const std::uint32_t math_fid = 0;
     const bool is_int_fpu_en     = false;
     _llk_math_reduce_init_<POOL_TYPE, REDUCE_DIM, math_fid>(within_face_16x16_transpose);
     _llk_math_pack_sync_init_<DstSync::SyncFull, is_fp32_dest_acc_en>();

--- a/tt_llk_wormhole_b0/llk_lib/llk_math_reduce.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_math_reduce.h
@@ -13,6 +13,16 @@
 #include "cmath_common.h"
 #include "llk_math_common.h"
 
+inline void dbg_thread()
+{
+    tensix_sync();
+    volatile uint32_t temp = mailbox_read(ThreadId::UnpackThreadId);
+    // Wait for previous packs to finish
+    while (semaphore_read(semaphore::MATH_PACK) > 0)
+    {
+    };
+}
+
 using namespace ckernel;
 
 // local function declarations
@@ -34,6 +44,7 @@ inline void _llk_math_reduce_(const uint dst_index, bool narrow_tile = false, co
         if constexpr (type == PoolType::MAX)
         {
             TTI_GMPOOL(p_setrwc::CLR_AB, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, 0);
+            TTI_SETRWC(p_setrwc::CLR_AB, 0, 0, 0, 0, p_setrwc::SET_A);
         }
         else if constexpr (HIGH_FIDELITY)
         {
@@ -43,6 +54,7 @@ inline void _llk_math_reduce_(const uint dst_index, bool narrow_tile = false, co
         else
         {
             TTI_GAPOOL(p_setrwc::CLR_AB, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, 0);
+            TTI_SETRWC(p_setrwc::CLR_AB, 0, 0, 0, 0, p_setrwc::SET_A);
         }
 
         if constexpr (type == PoolType::MAX)
@@ -124,6 +136,7 @@ inline void _llk_math_reduce_(const uint dst_index, bool narrow_tile = false, co
             if constexpr (type == PoolType::MAX)
             {
                 TTI_GMPOOL(p_setrwc::CLR_AB, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, 0);
+                TTI_SETRWC(p_setrwc::CLR_AB, 0, 0, 0, 0, p_setrwc::SET_A);
             }
             else if constexpr (HIGH_FIDELITY)
             {
@@ -133,6 +146,7 @@ inline void _llk_math_reduce_(const uint dst_index, bool narrow_tile = false, co
             else
             {
                 TTI_GAPOOL(p_setrwc::CLR_AB, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, 0);
+                TTI_SETRWC(p_setrwc::CLR_AB, 0, 0, 0, 0, p_setrwc::SET_A);
             }
 
             if constexpr (type == PoolType::MAX)

--- a/tt_llk_wormhole_b0/llk_lib/llk_math_reduce.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_math_reduce.h
@@ -13,16 +13,6 @@
 #include "cmath_common.h"
 #include "llk_math_common.h"
 
-inline void dbg_thread()
-{
-    tensix_sync();
-    volatile uint32_t temp = mailbox_read(ThreadId::UnpackThreadId);
-    // Wait for previous packs to finish
-    while (semaphore_read(semaphore::MATH_PACK) > 0)
-    {
-    };
-}
-
 using namespace ckernel;
 
 // local function declarations
@@ -44,7 +34,6 @@ inline void _llk_math_reduce_(const uint dst_index, bool narrow_tile = false, co
         if constexpr (type == PoolType::MAX)
         {
             TTI_GMPOOL(p_setrwc::CLR_AB, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, 0);
-            TTI_SETRWC(p_setrwc::CLR_AB, 0, 0, 0, 0, p_setrwc::SET_A);
         }
         else if constexpr (HIGH_FIDELITY)
         {
@@ -54,7 +43,6 @@ inline void _llk_math_reduce_(const uint dst_index, bool narrow_tile = false, co
         else
         {
             TTI_GAPOOL(p_setrwc::CLR_AB, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, 0);
-            TTI_SETRWC(p_setrwc::CLR_AB, 0, 0, 0, 0, p_setrwc::SET_A);
         }
 
         if constexpr (type == PoolType::MAX)
@@ -136,7 +124,6 @@ inline void _llk_math_reduce_(const uint dst_index, bool narrow_tile = false, co
             if constexpr (type == PoolType::MAX)
             {
                 TTI_GMPOOL(p_setrwc::CLR_AB, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, 0);
-                TTI_SETRWC(p_setrwc::CLR_AB, 0, 0, 0, 0, p_setrwc::SET_A);
             }
             else if constexpr (HIGH_FIDELITY)
             {
@@ -146,7 +133,6 @@ inline void _llk_math_reduce_(const uint dst_index, bool narrow_tile = false, co
             else
             {
                 TTI_GAPOOL(p_setrwc::CLR_AB, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, 0);
-                TTI_SETRWC(p_setrwc::CLR_AB, 0, 0, 0, 0, p_setrwc::SET_A);
             }
 
             if constexpr (type == PoolType::MAX)


### PR DESCRIPTION
### Ticket
#234 

### Problem description
Reduce test was failing for any pool type and row dimension

### What's changed
Changed golden generation for reduce row op to match one from tt-metal

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

