### PR TITLE
ci: create CODEOWNERS file and distribute ownership between LLK reviewers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,17 @@
+# Order is important; the last matching pattern takes the most
+# precedence.
+
+# Top-level files
+/* @ttmtrajkovic @nvelickovicTT @amahmudTT @rtawfik01
+
+# CI/CD
+.github/ @fvranicTT @nvelickovicTT
+
+# Tests
+tests/ @fvranicTT @ldjurovicTT @nvelickovicTT @skotaracTT
+
+# Blackhole
+tt_llk_blackhole/ @amahmudTT @nvelickovicTT @rdjogoTT @rtawfik01 @ttmtrajkovic
+
+# Wormhole
+tt_llk_wormhole_b0/ @amahmudTT @nvelickovicTT @rdjogoTT @rtawfik01 @ttmtrajkovic

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,7 +2,7 @@
 # precedence.
 
 # Top-level files
-/* @ttmtrajkovic @nvelickovicTT @amahmudTT @rtawfik01
+/* @amahmudTT @nvelickovicTT @rtawfik01 @ttmtrajkovic
 
 # CI/CD
 .github/ @fvranicTT @nvelickovicTT


### PR DESCRIPTION
### Ticket
None

### Problem description
So far, we haven't had clearly defined ownership in this repository. With the increased number of pull requests, it is taking us longer to process them, and some people with relevant knowledge might not be involved in the review process, leading to potential regressions in behavior. This is a problem with our review process that we might be able to address by defining code ownership. GitHub offers a tool in the form of the CODEOWNERS plugin, which is an industry standard these days and is already widely used throughout Tenstorrent in other repositories.

Using a CODEOWNERS file in a repository offers several advantages:
- The right people review the right parts of the code.
- No PRs fall through the cracks.
- Gatekeepers must review critical code sections, not just anyone.
- Helps contributors know who to contact with questions.
- Effectively documents the team’s structure and responsibilities.

### What's changed
<!-- Describe the approach used to solve the problem.
Summarize the changes made and its impact. -->

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
