### PR TITLE
Improve gathering asms

### DIFF
--- a/tt_llk_blackhole/common/inc/ckernel.h
+++ b/tt_llk_blackhole/common/inc/ckernel.h
@@ -644,21 +644,12 @@ inline void set_ttsync_enables()
 template <bool add_nops = true>
 inline void disable_gathering()
 {
+    asm("csrrs zero, 0x7c0, %0" : : "r"(1 << 1));
+    asm("fence");
     // Disable gathering: set bit 18
-    asm(R"ASM(
-        .option push
-        li   t1, 0x2
-        csrrs zero, 0x7c0, t1
-        li   t1, 0x1
-        slli t1, t1, 18
-        fence
-        csrrs zero, 0x7c0, t1
-        li   t1, 0x2
-        csrrc zero, 0x7c0, t1
-        fence
-        .option pop
-         )ASM" ::
-            : "t1");
+    asm("csrrs zero, 0x7c0, %0" : : "r"(1 << 18));
+    asm("csrrc zero, 0x7c0, %0" : : "r"(1 << 1));
+    asm("fence");
 
     // Gathering is done early in the pipeline, so we need to make sure
     // the above csrrw gets processed before the load-replay instructions
@@ -673,14 +664,7 @@ inline void disable_gathering()
 inline void enable_gathering()
 {
     // Enable gathering: clear bit 18
-    asm(R"ASM(
-        .option push
-        li   t1, 0x1
-        slli t1, t1, 18
-        csrrc zero, 0x7c0, t1
-        .option pop
-         )ASM" ::
-            : "t1");
+    asm("csrrc zero, 0x7c0, %0" : : "r"(1 << 18));
 }
 
 // Pass a lambda function (or a regular function pointer) that takes void,


### PR DESCRIPTION
### Ticket
NA

### Problem description
In working on TT_REPLAY changes, I notice this asm wasn't the best
* the option push/pop does nothing
* Explicitly constructing constants in the asm forces clobbers and requires us to rematerialize a value.

### What's changed
* Remove the option push/pop
* making the '1<<18' and '1<<1' inputs means the compiler can now choose as to whether to use 2 regs (and no rematerialization), or a single reg and do a rematerialization.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [YES] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [YES] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
