### PR TITLE
Returning to old cosine implementation

### DIFF
--- a/tests/sources/eltwise_unary_sfpu_test.cpp
+++ b/tests/sources/eltwise_unary_sfpu_test.cpp
@@ -53,7 +53,7 @@ void call_sfpu_operation(SfpuType operation)
             ckernel::sfpu::_calculate_abs_<APPROX_MODE, 10>(10);
             break;
         case SfpuType::cosine:
-            ckernel::sfpu::_calculate_cosine_<APPROX_MODE, 10>();
+            ckernel::sfpu::_calculate_cosine_<APPROX_MODE, 10>(10);
             break;
         case SfpuType::log:
             ckernel::sfpu::_init_log_<APPROX_MODE>();


### PR DESCRIPTION
### Ticket
#262 

### Problem description
It was observed that cosine tests fail in isolation when run without reset between

### What's changed
Returned to using old cosine implementation from `tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_trigonometry.h`

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
