### PR TITLE
ci: cancel ongoing integration tests after a new commit

### DIFF
--- a/.github/workflows/run-metal-tests-on-label.yml
+++ b/.github/workflows/run-metal-tests-on-label.yml
@@ -4,6 +4,16 @@ on:
   pull_request:
     types: [labeled, synchronize]
 
+concurrency:
+  # Use github.run_id on main branch (or any protected branch)
+  # This ensures that no runs get cancelled on main.
+  # Use github.event.pull_request.number on pull requests, so it's unique per pull request
+  # and will cancel obsolete runs.
+  # Use github.ref on other branches, so it's unique per branch.
+  group: ${{ github.workflow }}-${{ github.ref_protected && github.run_id ||
+    github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test-tt-metal-wormhole:
     name: "🌀 Running tests (Wormhole)"


### PR DESCRIPTION
### Ticket
None

### Problem description
If test infra label is set, new commits don't cancel the old runs, they just pile up.

### What's changed
Implemented cancellation of run in progress when new run is scheduled

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
