### PR TITLE
#22456: Cleanup Binary max min

### DIFF
--- a/tt_llk_blackhole/common/inc/ckernel_sfpu.h
+++ b/tt_llk_blackhole/common/inc/ckernel_sfpu.h
@@ -14,6 +14,7 @@
 #include "sfpu/ckernel_sfpu_add_int32.h"
 #include "sfpu/ckernel_sfpu_binary.h"
 #include "sfpu/ckernel_sfpu_binary_bitwise.h"
+#include "sfpu/ckernel_sfpu_binary_max_min.h"
 #include "sfpu/ckernel_sfpu_cast_fp32_to_fp16a.h"
 #include "sfpu/ckernel_sfpu_clamp.h"
 #include "sfpu/ckernel_sfpu_comp.h"

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_binary_max_min.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_binary_max_min.h
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ckernel.h"
+#include "ckernel_defs.h"
+
+namespace ckernel
+{
+namespace sfpu
+{
+
+template <InstrModLoadStore INSTRUCTION_MODE, bool IS_MAX_OP = true, int ITERATIONS = 8>
+inline void _calculate_binary_max_min_(const uint dst_offset)
+{
+    constexpr auto INSTR_MOD_CAST = InstrModCast::INT_SIGN_MAGN_TO_INT32_2S_COMP;
+#pragma GCC unroll 0
+    for (int d = 0; d < ITERATIONS; d++)
+    {
+        constexpr uint dst_tile_size = 64;
+
+        TTI_SFPLOAD(p_sfpu::LREG0, INSTRUCTION_MODE, ADDR_MOD_7, 0); // a
+        if constexpr (INSTRUCTION_MODE == InstrModLoadStore::INT32_2S_COMP)
+        {
+            TTI_SFPCAST(p_sfpu::LREG0, p_sfpu::LREG2, INSTR_MOD_CAST);
+            TTI_SFPSETSGN(0, p_sfpu::LREG2, p_sfpu::LREG0, 0);
+        }
+
+        TT_SFPLOAD(p_sfpu::LREG1, INSTRUCTION_MODE, ADDR_MOD_7, dst_offset * dst_tile_size); // b
+        if constexpr (INSTRUCTION_MODE == InstrModLoadStore::INT32_2S_COMP)
+        {
+            TTI_SFPCAST(p_sfpu::LREG1, p_sfpu::LREG2, INSTR_MOD_CAST);
+            TTI_SFPSETSGN(0, p_sfpu::LREG2, p_sfpu::LREG1, 0);
+        }
+
+        // Swap and store maximum in lreg1, minimum in lreg0
+        TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG0, 1);
+
+        if constexpr (IS_MAX_OP)
+        {
+            if constexpr (INSTRUCTION_MODE == InstrModLoadStore::INT32_2S_COMP)
+            {
+                TTI_SFPCAST(p_sfpu::LREG1, p_sfpu::LREG2, INSTR_MOD_CAST);
+                TTI_SFPSETSGN(0, p_sfpu::LREG2, p_sfpu::LREG1, 0);
+            }
+            TTI_SFPSTORE(p_sfpu::LREG1, INSTRUCTION_MODE, ADDR_MOD_7, 0);
+        }
+        else
+        {
+            if constexpr (INSTRUCTION_MODE == InstrModLoadStore::INT32_2S_COMP)
+            {
+                TTI_SFPCAST(p_sfpu::LREG0, p_sfpu::LREG2, INSTR_MOD_CAST);
+                TTI_SFPSETSGN(0, p_sfpu::LREG2, p_sfpu::LREG0, 0);
+            }
+            TTI_SFPSTORE(p_sfpu::LREG0, INSTRUCTION_MODE, ADDR_MOD_7, 0);
+        }
+        dst_reg++;
+    }
+}
+
+} // namespace sfpu
+} // namespace ckernel

--- a/tt_llk_wormhole_b0/common/inc/ckernel_sfpu.h
+++ b/tt_llk_wormhole_b0/common/inc/ckernel_sfpu.h
@@ -14,6 +14,7 @@
 #include "sfpu/ckernel_sfpu_add_int32.h"
 #include "sfpu/ckernel_sfpu_binary.h"
 #include "sfpu/ckernel_sfpu_binary_bitwise.h"
+#include "sfpu/ckernel_sfpu_binary_max_min.h"
 #include "sfpu/ckernel_sfpu_cast_fp32_to_fp16a.h"
 #include "sfpu/ckernel_sfpu_clamp.h"
 #include "sfpu/ckernel_sfpu_comp.h"

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_binary_max_min.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_binary_max_min.h
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ckernel.h"
+#include "ckernel_defs.h"
+
+namespace ckernel
+{
+namespace sfpu
+{
+
+template <InstrModLoadStore INSTRUCTION_MODE, bool IS_MAX_OP = true, int ITERATIONS = 8>
+inline void _calculate_binary_max_min_(const uint dst_offset)
+{
+#pragma GCC unroll 0
+    for (int d = 0; d < ITERATIONS; d++)
+    {
+        constexpr uint dst_tile_size = 64;
+
+        TTI_SFPLOAD(p_sfpu::LREG0, INSTRUCTION_MODE, ADDR_MOD_3, 0);                         // a
+        TT_SFPLOAD(p_sfpu::LREG1, INSTRUCTION_MODE, ADDR_MOD_3, dst_offset * dst_tile_size); // b
+
+        // Swap and store maximum in lreg1, minimum in lreg0
+        TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG0, 1);
+
+        if constexpr (IS_MAX_OP)
+        {
+            TTI_SFPSTORE(p_sfpu::LREG1, INSTRUCTION_MODE, ADDR_MOD_3, 0);
+        }
+        else
+        {
+            TTI_SFPSTORE(p_sfpu::LREG0, INSTRUCTION_MODE, ADDR_MOD_3, 0);
+        }
+        sfpi::dst_reg++;
+    }
+}
+
+} // namespace sfpu
+} // namespace ckernel


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/22456

### Problem description
Need to include bf16,fp32,int32 support for max min in LLK 

### What's changed
<!-- Describe the approach used to solve the problem.
Summarize the changes made and its impact. -->

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
