### PR TITLE
initial debug functions for halting tensix ( from tt-metal )

### DIFF
--- a/tests/helpers/include/dbg_halt.h
+++ b/tests/helpers/include/dbg_halt.h
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+template <ckernel::ThreadId thread_id>
+inline void dbg_thread_halt()
+{
+    static_assert(
+        (thread_id == ckernel::ThreadId::MathThreadId) || (thread_id == ckernel::ThreadId::UnpackThreadId) || (thread_id == ckernel::ThreadId::PackThreadId),
+        "Invalid thread id set in dbg_wait_for_thread_idle(...)");
+
+    if constexpr (thread_id == ckernel::ThreadId::UnpackThreadId)
+    {
+        // Wait for all instructions on the running thread to complete
+        ckernel::tensix_sync();
+        // Notify math thread that unpack thread is idle
+        ckernel::mailbox_write(ckernel::ThreadId::MathThreadId, 1);
+        // Wait for math thread to complete debug dump
+        volatile uint32_t temp = ckernel::mailbox_read(ckernel::ThreadId::MathThreadId);
+    }
+    else if constexpr (thread_id == ckernel::ThreadId::MathThreadId)
+    {
+        // Wait for all instructions on the running thread to complete
+        ckernel::tensix_sync();
+        // Wait for unpack thread to complete
+        volatile uint32_t temp = ckernel::mailbox_read(ckernel::ThreadId::UnpackThreadId);
+        // Wait for previous packs to finish
+        while (ckernel::semaphore_read(ckernel::semaphore::MATH_PACK) > 0)
+        {
+        };
+    }
+}
+
+void dbg_halt_math()
+{
+    dbg_thread_halt<ckernel::MathThreadId>();
+}
+
+void dbg_halt_unpack()
+{
+    dbg_thread_halt<ckernel::UnpackThreadId>();
+}
+
+void dbg_halt_pack()
+{
+    dbg_thread_halt<ckernel::PackThreadId>();
+}
+
+void dbg_halt_tensix()
+{
+    dbg_halt_unpack();
+    dbg_halt_math();
+    dbg_halt_pack();
+}


### PR DESCRIPTION
### Ticket
None

### Problem description
We want to be able to halt single and all threads on Tensix to see what is src and dst registers while debugging

### What's changed
Added header file that extracts some tt-metal functions and adapted it to be LLK standalone

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
