### PR TITLE
Cleanup assertions for passed test

### DIFF
--- a/tests/python_tests/test_eltwise_unary_sfpu.py
+++ b/tests/python_tests/test_eltwise_unary_sfpu.py
@@ -28,7 +28,7 @@ from helpers.param_config import (
 )
 from helpers.stimuli_generator import generate_stimuli
 from helpers.test_config import generate_make_command
-from helpers.utils import compare_pcc, run_shell_command
+from helpers.utils import passed_test, run_shell_command
 
 
 def generate_golden(operation, operand1, data_format):
@@ -163,21 +163,4 @@ def test_eltwise_unary_sfpu(testname, formats, dest_acc, approx_mode, mathop):
         ),
     )
 
-    if formats.output_format in [
-        DataFormat.Float16_b,
-        DataFormat.Float16,
-        DataFormat.Float32,
-    ]:
-        atol = 0.05
-        rtol = 0.1
-    elif formats.output_format == DataFormat.Bfp8_b:
-        atol = 0.05
-        rtol = 0.1
-
-    for i in range(len(golden)):
-        assert torch.isclose(
-            golden_tensor[i], res_tensor[i], rtol=rtol, atol=atol
-        ), f"Failed at index {i} with values {golden[i]} and {res_from_L1[i]}"
-
-    _, pcc = compare_pcc(golden_tensor, res_tensor, pcc=0.99)
-    assert pcc > 0.99
+    assert passed_test(golden_tensor, res_tensor, formats.output_format)

--- a/tests/python_tests/test_matmul.py
+++ b/tests/python_tests/test_matmul.py
@@ -21,7 +21,7 @@ from helpers.param_config import (
 from helpers.stimuli_generator import generate_stimuli
 from helpers.test_config import generate_make_command
 from helpers.tilize_untilize import tilize
-from helpers.utils import compare_pcc, run_shell_command
+from helpers.utils import passed_test, run_shell_command
 
 
 def generate_golden(operand1, operand2, data_format, math_fidelity):
@@ -123,16 +123,4 @@ def test_matmul(testname, formats, dest_acc, math_fidelity):
 
     res_tensor = torch.tensor(res_from_L1, dtype=(torch_format))
 
-    atol = 0.1
-    rtol = 0.05
-    if formats.output_format == DataFormat.Bfp8_b:
-        atol = 0.1
-        rtol = 0.2
-
-    for i in range(len(golden_tensor)):
-        assert torch.isclose(
-            golden_tensor[i], res_tensor[i], rtol=rtol, atol=atol
-        ), f"Failed at index {i} with values {golden_tensor[i]} and {res_from_L1[i]}"
-
-    _, pcc = compare_pcc(golden_tensor, res_tensor, pcc=0.99)
-    assert pcc > 0.98
+    assert passed_test(golden_tensor, res_tensor, formats.output_format)

--- a/tests/python_tests/test_matmul_and_unary_sfpu.py
+++ b/tests/python_tests/test_matmul_and_unary_sfpu.py
@@ -30,7 +30,7 @@ from helpers.param_config import (
 from helpers.stimuli_generator import generate_stimuli
 from helpers.test_config import generate_make_command
 from helpers.tilize_untilize import tilize
-from helpers.utils import compare_pcc, run_shell_command
+from helpers.utils import passed_test, run_shell_command
 
 
 def generate_matmul_golden(operand1, operand2, data_format, math_fidelity):
@@ -187,16 +187,4 @@ def test_matmul_and_unary_sfpu(
         dtype=(torch_format),
     )
 
-    atol = 0.1
-    rtol = 0.05
-    if formats.output_format == DataFormat.Bfp8_b:
-        atol = 0.1
-        rtol = 0.2
-
-    for i in range(len(golden_tensor)):
-        assert torch.isclose(
-            golden_tensor[i], res_tensor[i], rtol=rtol, atol=atol
-        ), f"Failed at index {i} with values {golden_tensor[i]} and {res_from_L1[i]}"
-
-    _, pcc = compare_pcc(golden_tensor, res_tensor, pcc=0.99)
-    assert pcc > 0.98
+    assert passed_test(golden_tensor, res_tensor, formats.output_format)

--- a/tests/python_tests/test_matmul_pack_untilize.py
+++ b/tests/python_tests/test_matmul_pack_untilize.py
@@ -22,22 +22,11 @@ from helpers.param_config import (
 from helpers.stimuli_generator import generate_stimuli
 from helpers.test_config import generate_make_command
 from helpers.tilize_untilize import tilize
-from helpers.utils import compare_pcc, run_shell_command
-
-torch.set_printoptions(linewidth=500, sci_mode=False, precision=2, threshold=10000)
+from helpers.utils import passed_test, run_shell_command
 
 
 def generate_golden(operand1, operand2, data_format, math_fidelity):
     torch_format = format_dict.get(data_format, format_dict[DataFormat.Float16_b])
-
-    if math_fidelity in [MathFidelity.LoFi, MathFidelity.HiFi2]:  # LoFi or HiFi2
-        for element in operand2:
-            element = element.to(torch.int32)
-            element &= 0xFFFE
-    if math_fidelity == MathFidelity.LoFi:  # LoFi
-        for element in operand1:
-            element = element.to(torch.int32)
-            element &= 0xFFF8
 
     operand1_matrix = operand1.view(32, 32).to(torch_format)
     operand2_matrix = operand2.view(32, 32).to(torch_format)
@@ -130,16 +119,4 @@ def test_matmul_pack_untilize(testname, formats, dest_acc, math_fidelity):
 
     res_tensor = torch.tensor(res_from_L1, dtype=(torch_format))
 
-    atol = 0.1
-    rtol = 0.05
-    if formats.output_format == DataFormat.Bfp8_b:
-        atol = 0.1
-        rtol = 0.2
-
-    for i in range(len(golden_tensor)):
-        assert torch.isclose(
-            golden_tensor[i], res_tensor[i], rtol=rtol, atol=atol
-        ), f"Failed at index {i} with values {golden_tensor[i]} and {res_from_L1[i]}"
-
-    _, pcc = compare_pcc(golden_tensor, res_tensor, pcc=0.99)
-    assert pcc > 0.98
+    assert passed_test(golden_tensor, res_tensor, formats.output_format)

--- a/tests/python_tests/test_matmul_unpack_tilize.py
+++ b/tests/python_tests/test_matmul_unpack_tilize.py
@@ -21,7 +21,7 @@ from helpers.param_config import (
 from helpers.stimuli_generator import generate_stimuli
 from helpers.test_config import generate_make_command
 from helpers.tilize_untilize import tilize
-from helpers.utils import compare_pcc, run_shell_command
+from helpers.utils import passed_test, run_shell_command
 
 
 def generate_golden(operand1, operand2, data_format, math_fidelity):
@@ -127,16 +127,4 @@ def test_matmul_unpack_tilize(testname, formats, dest_acc, math_fidelity):
 
     res_tensor = torch.tensor(res_from_L1, dtype=(torch_format))
 
-    atol = 0.1
-    rtol = 0.05
-    if formats.output_format == DataFormat.Bfp8_b:
-        atol = 0.1
-        rtol = 0.2
-
-    for i in range(len(golden_tensor)):
-        assert torch.isclose(
-            golden_tensor[i], res_tensor[i], rtol=rtol, atol=atol
-        ), f"Failed at index {i} with values {golden_tensor[i]} and {res_from_L1[i]}"
-
-    _, pcc = compare_pcc(golden_tensor, res_tensor, pcc=0.99)
-    assert pcc > 0.98
+    assert passed_test(golden_tensor, res_tensor, formats.output_format)

--- a/tests/python_tests/test_multiple_tiles_eltwise.py
+++ b/tests/python_tests/test_multiple_tiles_eltwise.py
@@ -26,7 +26,7 @@ from helpers.param_config import (
 )
 from helpers.stimuli_generator import flatten_list, generate_stimuli
 from helpers.test_config import generate_make_command
-from helpers.utils import compare_pcc, format_kernel_list, run_shell_command
+from helpers.utils import format_kernel_list, passed_test, run_shell_command
 
 
 def generate_golden(op, operand1, operand2, data_format, math_fidelity):
@@ -109,20 +109,21 @@ param_ids = generate_param_ids(all_params)
     ids=param_ids,
 )
 def test_multiple_tiles(testname, formats, dest_acc, mathop, math_fidelity, tile_cnt):
+
+    if mathop != MathOperation.Elwmul and math_fidelity != MathFidelity.LoFi:
+        pytest.skip("Fidelity does not affect Elwadd and Elwsub operations")
+
     pack_start_address = 0x1A000 + 2 * 4096 * tile_cnt.value
     pack_addresses = [pack_start_address + 0x1000 * i for i in range(tile_cnt.value)]
     pack_addresses_formatted = format_kernel_list(pack_addresses, as_hex=True)
 
     src_A, src_B = generate_stimuli(
         formats.input_format, formats.input_format, tile_cnt=tile_cnt
-    )  # , const_face=True, const_value_A=3, const_value_B=2)
+    )
     golden = generate_golden(mathop, src_A, src_B, formats.output_format, math_fidelity)
     write_stimuli_to_l1(
         src_A, src_B, formats.input_format, formats.input_format, "0,0", tile_cnt
     )
-
-    if mathop != MathOperation.Elwmul:
-        math_fidelity = MathFidelity.LoFi
 
     test_config = {
         "formats": formats,
@@ -170,17 +171,4 @@ def test_multiple_tiles(testname, formats, dest_acc, mathop, math_fidelity, tile
         ),
     )
 
-    if formats.output_format in [DataFormat.Float16_b, DataFormat.Float16]:
-        atol = 0.05
-        rtol = 0.1
-    elif formats.output_format == DataFormat.Bfp8_b:
-        atol = 0.1
-        rtol = 0.2
-
-    for i in range(len(golden_tensor)):
-        assert torch.isclose(
-            golden_tensor[i], res_tensor[i], rtol=rtol, atol=atol
-        ), f"Failed at index {i} with values {golden_tensor[i]} and {res_from_L1[i]}"
-
-    _, pcc = compare_pcc(golden_tensor, res_tensor, pcc=0.99)
-    assert pcc > 0.99
+    assert passed_test(golden_tensor, res_tensor, formats.output_format)

--- a/tests/python_tests/test_pack_untilize.py
+++ b/tests/python_tests/test_pack_untilize.py
@@ -21,9 +21,7 @@ from helpers.param_config import (
 from helpers.stimuli_generator import generate_stimuli
 from helpers.test_config import generate_make_command
 from helpers.tilize_untilize import untilize
-from helpers.utils import compare_pcc, run_shell_command
-
-torch.set_printoptions(linewidth=500, sci_mode=False, precision=2, threshold=10000)
+from helpers.utils import passed_test, run_shell_command
 
 
 def generate_golden(operand1, data_format):
@@ -99,17 +97,4 @@ def test_pack_untilize(testname, formats):
         ),
     )
 
-    if formats.output_format in [DataFormat.Float16_b, DataFormat.Float16]:
-        atol = 0.1
-        rtol = 0.05
-    elif formats.output_format == DataFormat.Bfp8_b:
-        atol = 0.1
-        rtol = 0.2
-
-    for i in range(len(golden_tensor)):
-        assert torch.isclose(
-            golden_tensor[i], res_tensor[i], rtol=rtol, atol=atol
-        ), f"Failed at index {i} with values {golden_tensor[i]} and {res_from_L1[i]}"
-
-    _, pcc = compare_pcc(golden_tensor, res_tensor, pcc=0.99)
-    assert pcc > 0.98
+    assert passed_test(golden_tensor, res_tensor, formats.output_format)

--- a/tests/python_tests/test_pack_untilize.py
+++ b/tests/python_tests/test_pack_untilize.py
@@ -74,7 +74,6 @@ def test_pack_untilize(testname, formats):
     test_config = {
         "formats": formats,
         "testname": testname,
-        "unpack_to_dest": True,  # This test does a datacopy and unpacks input into dest register
     }
 
     make_cmd = generate_make_command(test_config)

--- a/tests/python_tests/test_reduce.py
+++ b/tests/python_tests/test_reduce.py
@@ -27,7 +27,7 @@ from helpers.param_config import (
 from helpers.stimuli_generator import generate_stimuli
 from helpers.test_config import generate_make_command
 from helpers.tilize_untilize import untilize
-from helpers.utils import compare_pcc, run_shell_command
+from helpers.utils import passed_test, run_shell_command
 
 # Helper dictionary to map reduce dimensions to math operations
 mathop_mapping = {
@@ -171,19 +171,6 @@ def test_reduce(testname, formats, dest_acc, reduce_dim, pool_type):
     )
     res_tensor = untilize(res_tensor, formats.output_format)
 
-    if formats.output_format in [DataFormat.Float16_b, DataFormat.Float16]:
-        atol = 0.015
-        rtol = 0.015
-    elif formats.output_format == DataFormat.Bfp8_b:
-        atol = 0.1
-        rtol = 0.2
-
     run_shell_command(f"cd .. && make clean")
 
-    _, pcc = compare_pcc(golden_tensor, res_tensor, pcc=0.99)
-    assert pcc > 0.99
-
-    for i in range(len(golden_tensor)):
-        assert torch.isclose(
-            golden_tensor[i], res_tensor[i], rtol=rtol, atol=atol
-        ), f"Failed at index {i} with values {golden_tensor[i]} and {res_from_L1[i]}"
+    assert passed_test(golden_tensor, res_tensor, formats.output_format)

--- a/tests/python_tests/test_sfpu_binary.py
+++ b/tests/python_tests/test_sfpu_binary.py
@@ -21,7 +21,7 @@ from helpers.param_config import (
 )
 from helpers.stimuli_generator import generate_stimuli
 from helpers.test_config import generate_make_command
-from helpers.utils import compare_pcc, run_shell_command
+from helpers.utils import passed_test, run_shell_command
 
 
 def generate_golden(operation, operand1, operand2, data_format):
@@ -96,12 +96,16 @@ def test_all(testname, formats, dest_acc, mathop):
     golden = generate_golden(mathop, src_A, src_B, formats.output_format)
     write_stimuli_to_l1(src_A, src_B, formats.input_format, formats.input_format)
 
+    unpack_to_dest = False
+    if formats.input_format == DataFormat.Float32:
+        unpack_to_dest = True
+
     test_config = {
         "formats": formats,
         "testname": testname,
         "dest_acc": dest_acc,
         "mathop": mathop,
-        "unpack_to_dest": True,  # This test does a datacopy and unpacks input into dest register
+        "unpack_to_dest": unpack_to_dest,
     }
 
     make_cmd = generate_make_command(test_config)
@@ -113,17 +117,6 @@ def test_all(testname, formats, dest_acc, mathop):
     res_from_L1 = collect_results(formats, tensor_size=len(src_A))
 
     assert len(res_from_L1) == len(golden)
-
-    if formats.output_format in [
-        DataFormat.Float16_b,
-        DataFormat.Float16,
-        DataFormat.Float32,
-    ]:
-        atol = 0.05
-        rtol = 0.1
-    elif formats.output_format == DataFormat.Bfp8_b:
-        atol = 0.1
-        rtol = 0.2
 
     golden_tensor = torch.tensor(
         golden,
@@ -144,10 +137,4 @@ def test_all(testname, formats, dest_acc, mathop):
         ),
     )
 
-    for i in range(len(golden)):
-        assert torch.isclose(
-            golden_tensor[i], res_tensor[i], rtol=rtol, atol=atol
-        ), f"Failed at index {i} with values {golden[i]} and {res_from_L1[i]}"
-
-    _, pcc = compare_pcc(golden_tensor, res_tensor, pcc=0.99)
-    assert pcc > 0.99
+    assert passed_test(golden_tensor, res_tensor, formats.output_format)

--- a/tests/python_tests/test_unpack_tilize.py
+++ b/tests/python_tests/test_unpack_tilize.py
@@ -67,7 +67,6 @@ def test_unpack_tilize(testname, formats):
     test_config = {
         "formats": formats,
         "testname": testname,
-        "unpack_to_dest": False,
     }
 
     make_cmd = generate_make_command(test_config)

--- a/tests/python_tests/test_unpack_tilize.py
+++ b/tests/python_tests/test_unpack_tilize.py
@@ -20,7 +20,7 @@ from helpers.param_config import (
 from helpers.stimuli_generator import generate_stimuli
 from helpers.test_config import generate_make_command
 from helpers.tilize_untilize import tilize
-from helpers.utils import compare_pcc, run_shell_command
+from helpers.utils import passed_test, run_shell_command
 
 
 def generate_golden(operand1, data_format):
@@ -67,7 +67,7 @@ def test_unpack_tilize(testname, formats):
     test_config = {
         "formats": formats,
         "testname": testname,
-        "unpack_to_dest": True,  # This test does a datacopy and unpacks input into dest register
+        "unpack_to_dest": False,
     }
 
     make_cmd = generate_make_command(test_config)
@@ -76,9 +76,7 @@ def test_unpack_tilize(testname, formats):
     run_elf_files(testname)
     wait_for_tensix_operations_finished()
 
-    res_from_L1 = collect_results(
-        formats, tensor_size=len(src_A)
-    )  # Bug patchup in (unpack.py): passing formats struct to check unpack_src with pack_dst and distinguish when input and output formats have different exponent widths then reading from L1 changes
+    res_from_L1 = collect_results(formats, tensor_size=len(src_A))
     assert len(res_from_L1) == len(golden_tensor)
 
     res_tensor = torch.tensor(
@@ -90,17 +88,4 @@ def test_unpack_tilize(testname, formats):
         ),
     )
 
-    if formats.output_format in [DataFormat.Float16_b, DataFormat.Float16]:
-        atol = 0.1
-        rtol = 0.05
-    elif formats.output_format == DataFormat.Bfp8_b:
-        atol = 0.1
-        rtol = 0.2
-
-    for i in range(len(golden_tensor)):
-        assert torch.isclose(
-            golden_tensor[i], res_tensor[i], rtol=rtol, atol=atol
-        ), f"Failed at index {i} with values {golden_tensor[i]} and {res_from_L1[i]}"
-
-    _, pcc = compare_pcc(golden_tensor, res_tensor, pcc=0.99)
-    assert pcc > 0.98
+    assert passed_test(golden_tensor, res_tensor, formats.output_format)

--- a/tests/python_tests/test_unpack_untilize.py
+++ b/tests/python_tests/test_unpack_untilize.py
@@ -21,9 +21,7 @@ from helpers.param_config import (
 from helpers.stimuli_generator import generate_stimuli
 from helpers.test_config import generate_make_command
 from helpers.tilize_untilize import untilize
-from helpers.utils import compare_pcc, run_shell_command
-
-torch.set_printoptions(linewidth=500, sci_mode=False, precision=2, threshold=10000)
+from helpers.utils import passed_test, run_shell_command
 
 
 def generate_golden(operand1, data_format):
@@ -70,7 +68,7 @@ def test_unpack_untilze(testname, formats):
     test_config = {
         "formats": formats,
         "testname": testname,
-        "unpack_to_dest": True,  # This test does a datacopy and unpacks input into dest register
+        "unpack_to_dest": False,
     }
 
     make_cmd = generate_make_command(test_config)
@@ -78,9 +76,7 @@ def test_unpack_untilze(testname, formats):
 
     run_elf_files(testname)
     wait_for_tensix_operations_finished()
-    res_from_L1 = collect_results(
-        formats, tensor_size=len(src_A)
-    )  # Bug patchup in (unpack.py): passing formats struct to check unpack_src with pack_dst and distinguish when input and output formats have different exponent widths then reading from L1 changes
+    res_from_L1 = collect_results(formats, tensor_size=len(src_A))
     assert len(res_from_L1) == len(golden_tensor)
 
     res_tensor = torch.tensor(
@@ -92,17 +88,4 @@ def test_unpack_untilze(testname, formats):
         ),
     )
 
-    if formats.output_format in [DataFormat.Float16_b, DataFormat.Float16]:
-        atol = 0.1
-        rtol = 0.05
-    elif formats.output_format == DataFormat.Bfp8_b:
-        atol = 0.1
-        rtol = 0.2
-
-    for i in range(len(golden_tensor)):
-        assert torch.isclose(
-            golden_tensor[i], res_tensor[i], rtol=rtol, atol=atol
-        ), f"Failed at index {i} with values {golden_tensor[i]} and {res_from_L1[i]}"
-
-    _, pcc = compare_pcc(golden_tensor, res_tensor, pcc=0.99)
-    assert pcc > 0.98
+    assert passed_test(golden_tensor, res_tensor, formats.output_format)

--- a/tests/python_tests/test_unpack_untilize.py
+++ b/tests/python_tests/test_unpack_untilize.py
@@ -68,7 +68,6 @@ def test_unpack_untilze(testname, formats):
     test_config = {
         "formats": formats,
         "testname": testname,
-        "unpack_to_dest": False,
     }
 
     make_cmd = generate_make_command(test_config)


### PR DESCRIPTION
### Ticket
None

### Problem description
Every pyhon test contained same code for checking if test has passed with relative, absolute error and pcc

### What's changed
Moved that checking to utils.py. Every test now just has 
`assert passed_test(golden_tensor, res_tensor, formats.output_format)`

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
