### PR TITLE
Skipping tests that are not elwmul and sweep fidelity

### DIFF
--- a/tests/python_tests/helpers/test_config.py
+++ b/tests/python_tests/helpers/test_config.py
@@ -76,5 +76,4 @@ def generate_make_command(
 
             make_cmd += f"kern_cnt={kern_cnt} pack_addr_cnt={pack_addr_cnt} pack_addrs={pack_addrs} "
 
-    print(make_cmd)
     return make_cmd

--- a/tests/python_tests/test_multiple_tiles_eltwise.py
+++ b/tests/python_tests/test_multiple_tiles_eltwise.py
@@ -109,6 +109,10 @@ param_ids = generate_param_ids(all_params)
     ids=param_ids,
 )
 def test_multiple_tiles(testname, formats, dest_acc, mathop, math_fidelity, tile_cnt):
+
+    if mathop != MathOperation.Elwmul and math_fidelity != MathFidelity.LoFi:
+        pytest.skip("Fidelity does not affect Elwadd and Elwsub operations")
+
     pack_start_address = 0x1A000 + 2 * 4096 * tile_cnt.value
     pack_addresses = [pack_start_address + 0x1000 * i for i in range(tile_cnt.value)]
     pack_addresses_formatted = format_kernel_list(pack_addresses, as_hex=True)
@@ -120,9 +124,6 @@ def test_multiple_tiles(testname, formats, dest_acc, mathop, math_fidelity, tile
     write_stimuli_to_l1(
         src_A, src_B, formats.input_format, formats.input_format, "0,0", tile_cnt
     )
-
-    if mathop != MathOperation.Elwmul:
-        math_fidelity = MathFidelity.LoFi
 
     test_config = {
         "formats": formats,


### PR DESCRIPTION
### Ticket
#300 

### Problem description
Some tests are running fidelity sweep for operations not affected by math fidelity

### What's changed
Skipped those tests

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
