### PR TITLE
Add profiler zone for measuring kernel runtime

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -114,7 +114,8 @@ $(OUTPUT_ELFS)/$(testname)_trisc2.elf: $(BUILD_DIR)/tmu-crt0.o $(BUILD_DIR)/main
 $(OUTPUT_ELFS)/brisc.elf: $(BUILD_DIR)/tmu-crt0.o $(BUILD_DIR)/brisc.o
 	$(GXX) $(OPTIONS_ALL) $(OPTIONS_LINK) $^ -T$(LINKER_SCRIPTS)/memory.$(CHIP_ARCH).ld -T$(LINKER_SCRIPTS)/brisc.ld -T$(LINKER_SCRIPTS)/sections.ld -o $@
 
-#compiling _test.pp to .o
+# force recompilation of tests per core
+# force recompilation of trisc.cpp for ZONE_SCOPED("KERNEL") to work
 .PHONY: $(BUILD_DIR)/$(testname)_unpack.o $(BUILD_DIR)/$(testname)_math.o $(BUILD_DIR)/$(testname)_pack.o \
         $(BUILD_DIR)/main_unpack.o $(BUILD_DIR)/main_math.o $(BUILD_DIR)/main_pack.o
 
@@ -124,9 +125,6 @@ $(BUILD_DIR)/$(testname)_math.o: sources/$(testname).cpp
 	$(GXX) $(OPTIONS_ALL) $(OPTIONS_COMPILE) $(OPTIONS_MATH) -DLLK_TRISC_MATH -c -o $@ $<
 $(BUILD_DIR)/$(testname)_pack.o: sources/$(testname).cpp
 	$(GXX) $(OPTIONS_ALL) $(OPTIONS_COMPILE) $(OPTIONS_PACK) -DLLK_TRISC_PACK -c -o $@ $<
-
-# force recompilation of trisc.cpp for ZONE_SCOPED("KERNEL") to work
-.PHONY: $(BUILD_DIR)/main_unpack.o $(BUILD_DIR)/main_math.o $(BUILD_DIR)/main_pack.o
 
 #compiling main for every TRISC core
 $(BUILD_DIR)/main_unpack.o : $(RISCV_SOURCES)/trisc.cpp

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -117,6 +117,9 @@ $(BUILD_DIR)/$(testname)_math.o: sources/$(testname).cpp
 $(BUILD_DIR)/$(testname)_pack.o: sources/$(testname).cpp
 	$(GXX) $(OPTIONS_ALL) $(OPTIONS_COMPILE) $(OPTIONS_PACK) -DLLK_TRISC_PACK -c -o $@ $<
 
+# force recompilation of trisc.cpp for ZONE_SCOPED("KERNEL") to work
+.PHONY: $(BUILD_DIR)/main_unpack.o $(BUILD_DIR)/main_math.o $(BUILD_DIR)/main_pack.o
+
 #compiling main for every TRISC core
 $(BUILD_DIR)/main_unpack.o : $(RISCV_SOURCES)/trisc.cpp
 	$(GXX) $(OPTIONS_ALL) $(OPTIONS_COMPILE) -DLLK_TRISC_UNPACK -c -o $@ $<

--- a/tests/helpers/src/trisc.cpp
+++ b/tests/helpers/src/trisc.cpp
@@ -54,8 +54,12 @@ int main()
     llk_profiler::reset();
 #endif
 
-    run_kernel();
-    ckernel::tensix_sync();
+    {
+        ZONE_SCOPED("KERNEL")
+        run_kernel();
+        ckernel::tensix_sync();
+    }
+
     *mailbox = ckernel::KERNEL_COMPLETE; // 0x1
 
     // Use a volatile variable to prevent the compiler from optimizing away the loop

--- a/tests/python_tests/helpers/profiler.py
+++ b/tests/python_tests/helpers/profiler.py
@@ -36,7 +36,7 @@ class ProfilerFullMarker:
     id: int
 
 
-def _process_profiler_message(line: str):
+def _parse_profiler_message(line: str):
     # ex. '#pragma message: LLK_PROFILER:sources/example.cpp:1337:MARKER'
     expr = _PROFILER_PATTERN.search(line)
     if expr is None:
@@ -51,6 +51,13 @@ def _process_profiler_message(line: str):
     )
 
 
+def _assert_no_collision(messages, message):
+    """Inserts message if no collisions, raises otherwise"""
+    collision = messages.get(message.id)
+    if collision and collision != message:
+        raise AssertionError(f'Hash collision between "{message}" and "{collision}"')
+
+
 def build_perf_test(test_config):
     make_cmd = generate_make_command(test_config, ProfilerBuild.Yes)
     result = run_shell_command(f"cd .. && {make_cmd}")
@@ -58,11 +65,8 @@ def build_perf_test(test_config):
     lines = result.stderr.splitlines()
     messages = {}
     for line in lines:
-        if message := _process_profiler_message(line):
-            if message.id in messages:
-                first = messages[message.id]
-                second = message
-                raise AssertionError(f'Hash collision between "{first}" and "{second}"')
+        if message := _parse_profiler_message(line):
+            _assert_no_collision(messages, message)
             messages[message.id] = message
     return messages
 

--- a/tests/python_tests/helpers/profiler.py
+++ b/tests/python_tests/helpers/profiler.py
@@ -53,9 +53,9 @@ def _parse_profiler_message(line: str):
 
 def _assert_no_collision(messages, message):
     """Inserts message if no collisions, raises otherwise"""
-    collision = messages.get(message.id)
-    if collision and collision != message:
-        raise AssertionError(f'Hash collision between "{message}" and "{collision}"')
+    existing = messages.get(message.id)
+    if existing is not None and existing != message:
+        raise AssertionError(f'Hash collision between "{message}" and "{existing}"')
 
 
 def build_perf_test(test_config):


### PR DESCRIPTION
### Ticket
#331 

### Problem description
This PR adds a generic zone for measuring test infra KERNEL execution time, as well as forcing the recompilation of `trisc.cpp` to make sure the `KERNEL_PROFILER:...:KERNEL` message is emitted to `stderr` every time a test is built.

### What's changed
<!-- Describe the approach used to solve the problem.
Summarize the changes made and its impact. -->

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
