### PR TITLE
exp_init: reset LoadMacroConfig[Lane].Misc for all lanes.

### DIFF
--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_exp.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_exp.h
@@ -352,6 +352,9 @@ inline void _init_exponential_()
                      // : 8'b0_______0_______010_____110          = 0x16 slot4 : STORE  UNIT, want STORE instruction which is in macro instruction mux[3],
                      // delayed by 4 ;     using staging flop as src ;     using                  : 8'b0_______1_______100_____011          = 0x63
         TTI_SFPCONFIG(0, 4, 0); // Load it into macro sequence register 0 (destination = 4)
+
+        // Reset LoadMacroConfig[Lane].Misc for all lanes, in case it has been previously set by another use of macros.
+        TTI_SFPCONFIG(0, 8, 1);
     }
     else if constexpr (APPROXIMATION_MODE)
     {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_exp.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_exp.h
@@ -351,6 +351,9 @@ inline void _init_exponential_()
                      // : 8'b0_______0_______010_____110          = 0x16 slot4 : STORE  UNIT, want STORE instruction which is in macro instruction mux[3],
                      // delayed by 4 ;     using staging flop as src ;     using                  : 8'b0_______1_______100_____011          = 0x63
         TTI_SFPCONFIG(0, 4, 0); // Load it into macro sequence register 0 (destination = 4)
+
+        // Reset LoadMacroConfig[Lane].Misc for all lanes, in case it has been previously set by another use of macros.
+        TTI_SFPCONFIG(0, 8, 1);
     }
     else if constexpr (APPROXIMATION_MODE)
     {


### PR DESCRIPTION
### Ticket

Closes #340

### Problem description

Insufficient macro config reset results in hang when using exp with fast_and_approx mode.

### What's changed

Reset macro config to the default during exp init.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
