### PR TITLE
Fixing sfpi expected LREG11 value of -1

### DIFF
--- a/tests/helpers/src/brisc.cpp
+++ b/tests/helpers/src/brisc.cpp
@@ -27,8 +27,7 @@ void device_setup()
     TTI_NOP;
 
     // Set default sfpu constant register state
-    TTI_SFPLOADI(ckernel::p_sfpu::LREG0, 0xA, 0xbf80); // -1.0f -> LREG0
-    TTI_SFPCONFIG(0, 11, 0);                           // LREG0 -> LREG11
+    TTI_SFPCONFIG(0, 11, 1); // loading -1 to LREG11 where sfpi expects it
 
     // Initialize tensix semaphores
     TTI_SEMINIT(1, 0, ckernel::semaphore::UNPACK_TO_DEST);


### PR DESCRIPTION
### Ticket
#333 

### Problem description
Sfpi generated code wasn't able to get inside of v_if because value in LREG11 wasn't -1 as it expected it to be.

### What's changed
Changed brsic.cpp file to load -1 into register using TI_SFPCONFIG with modifier 1.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update