### PR TITLE
chore: change path of the deployed page

### DIFF
--- a/.github/workflows/sort-issues.yml
+++ b/.github/workflows/sort-issues.yml
@@ -36,10 +36,18 @@ jobs:
           node .github/scripts/sort-issues.js
           node .github/scripts/list-pending-prs.js
 
-      - name: Create index page
+      - name: Organize files for deployment
         run: |
+          # Create reports directory structure
+          mkdir -p reports
+
+          # Move generated reports to reports directory
+          mv sorted-issues.html reports/
+          mv pending-prs.html reports/
+
+          # Create dashboard in reports directory
           TIMESTAMP=$(date '+%B %d, %Y at %H:%M UTC')
-          cat > index.html << EOF
+          cat > reports/index.html << EOF
           <!DOCTYPE html>
           <html>
           <head>


### PR DESCRIPTION
### Ticket
<!-- Link to Github Issue -->

### Problem description
At the moment, our deployment goes to tt-llk root page on docs.tenstorrent.com. We'd like to "hide" these reports a bit deeper.

### What's changed
Page gets deployed to docs.tenstorrent.com/tt-llk/reports now.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update