### PR TITLE
Rd/topk 32bit

### DIFF
--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_topk.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_topk.h
@@ -39,7 +39,7 @@ inline void bitonic_topk_load8(uint offset, uint dist)
     TT_SFPLOAD(p_sfpu::LREG1, 0, ADDR_MOD_7, ld_offset + dist);
 
     // Load 16 consecutive indices
-    TT_SFPLOAD(p_sfpu::LREG4, instr_mod_index, ADDR_MOD_7, dst_indices_offset + ld_offset); // How to load indices ? This is unpacked directly to dest!
+    TT_SFPLOAD(p_sfpu::LREG4, instr_mod_index, ADDR_MOD_7, dst_indices_offset + ld_offset);
     TT_SFPLOAD(p_sfpu::LREG5, instr_mod_index, ADDR_MOD_7, dst_indices_offset + ld_offset + dist);
 }
 
@@ -57,7 +57,7 @@ inline void bitonic_topk_store8(uint offset, uint dist)
     TT_SFPSTORE(p_sfpu::LREG1, 0, ADDR_MOD_7, ld_offset + dist);
 
     // Load 16 consecutive indices
-    TT_SFPSTORE(p_sfpu::LREG4, instr_mod_index, ADDR_MOD_7, dst_indices_offset + ld_offset + 0); // How to load indices ? This is unpacked directly to dest!
+    TT_SFPSTORE(p_sfpu::LREG4, instr_mod_index, ADDR_MOD_7, dst_indices_offset + ld_offset + 0);
     TT_SFPSTORE(p_sfpu::LREG5, instr_mod_index, ADDR_MOD_7, dst_indices_offset + ld_offset + dist);
 }
 
@@ -83,7 +83,7 @@ inline void bitonic_topk_load16(uint dist0, uint dist1)
     }
 
     // Load 16 consecutive indices
-    TTI_SFPLOAD(p_sfpu::LREG4, instr_mod_index, ADDR_MOD_7, dst_indices_offset + 0); // How to load indices ? This is unpacked directly to dest!
+    TTI_SFPLOAD(p_sfpu::LREG4, instr_mod_index, ADDR_MOD_7, dst_indices_offset + 0);
     if ((dist0 == 4) && (dist1 == 8))
     {
         TTI_SFPLOAD(p_sfpu::LREG5, instr_mod_index, ADDR_MOD_7, dst_indices_offset + 4);
@@ -120,7 +120,7 @@ inline void bitonic_topk_store16(uint dist0, uint dist1)
     }
 
     // Load 16 consecutive indices
-    TTI_SFPSTORE(p_sfpu::LREG4, instr_mod_index, ADDR_MOD_7, dst_indices_offset + 0); // How to load indices ? This is unpacked directly to dest!
+    TTI_SFPSTORE(p_sfpu::LREG4, instr_mod_index, ADDR_MOD_7, dst_indices_offset + 0);
     if ((dist0 == 4) && (dist1 == 8))
     {
         TTI_SFPSTORE(p_sfpu::LREG5, instr_mod_index, ADDR_MOD_7, dst_indices_offset + 4);

--- a/tt_llk_blackhole/llk_lib/llk_math_transpose_dest.h
+++ b/tt_llk_blackhole/llk_lib/llk_math_transpose_dest.h
@@ -47,7 +47,7 @@ inline void _llk_math_transpose_dest_(const std::uint32_t dst_index)
     {
         if constexpr (is_fp32_dest_acc_en)
         {
-            // Needs to be disabled for MOVD2B/B2D on BH
+            // Needs to be disabled for MOVD2B/B2D on BH (Issue ##449)
             cfg_reg_rmw_tensix<ALU_ACC_CTRL_Fp32_enabled_RMW>(0);
         }
         if constexpr (transpose_of_faces)

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_topk.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_topk.h
@@ -39,7 +39,7 @@ inline void bitonic_topk_load8(uint offset, uint dist)
     TT_SFPLOAD(p_sfpu::LREG1, 0, ADDR_MOD_3, ld_offset + dist);
 
     // Load 16 consecutive indices
-    TT_SFPLOAD(p_sfpu::LREG4, instr_mod_index, ADDR_MOD_3, dst_indices_offset + ld_offset); // How to load indices ? This is unpacked directly to dest!
+    TT_SFPLOAD(p_sfpu::LREG4, instr_mod_index, ADDR_MOD_3, dst_indices_offset + ld_offset);
     TT_SFPLOAD(p_sfpu::LREG5, instr_mod_index, ADDR_MOD_3, dst_indices_offset + ld_offset + dist);
 }
 
@@ -57,7 +57,7 @@ inline void bitonic_topk_store8(uint offset, uint dist)
     TT_SFPSTORE(p_sfpu::LREG1, 0, ADDR_MOD_3, ld_offset + dist);
 
     // Load 16 consecutive indices
-    TT_SFPSTORE(p_sfpu::LREG4, instr_mod_index, ADDR_MOD_3, dst_indices_offset + ld_offset + 0); // How to load indices ? This is unpacked directly to dest!
+    TT_SFPSTORE(p_sfpu::LREG4, instr_mod_index, ADDR_MOD_3, dst_indices_offset + ld_offset + 0);
     TT_SFPSTORE(p_sfpu::LREG5, instr_mod_index, ADDR_MOD_3, dst_indices_offset + ld_offset + dist);
 }
 
@@ -83,7 +83,7 @@ inline void bitonic_topk_load16(uint dist0, uint dist1)
     }
 
     // Load 16 consecutive indices
-    TTI_SFPLOAD(p_sfpu::LREG4, instr_mod_index, ADDR_MOD_3, dst_indices_offset + 0); // How to load indices ? This is unpacked directly to dest!
+    TTI_SFPLOAD(p_sfpu::LREG4, instr_mod_index, ADDR_MOD_3, dst_indices_offset + 0);
     if ((dist0 == 4) && (dist1 == 8))
     {
         TTI_SFPLOAD(p_sfpu::LREG5, instr_mod_index, ADDR_MOD_3, dst_indices_offset + 4);
@@ -120,7 +120,7 @@ inline void bitonic_topk_store16(uint dist0, uint dist1)
     }
 
     // Load 16 consecutive indices
-    TTI_SFPSTORE(p_sfpu::LREG4, instr_mod_index, ADDR_MOD_3, dst_indices_offset + 0); // How to load indices ? This is unpacked directly to dest!
+    TTI_SFPSTORE(p_sfpu::LREG4, instr_mod_index, ADDR_MOD_3, dst_indices_offset + 0);
     if ((dist0 == 4) && (dist1 == 8))
     {
         TTI_SFPSTORE(p_sfpu::LREG5, instr_mod_index, ADDR_MOD_3, dst_indices_offset + 4);


### PR DESCRIPTION
### Ticket
[<!-- Link to Github Issue -->](https://github.com/tenstorrent/tt-metal/issues/20294)

### Problem description
TopK LLK did not support use of 32bit indices

### What's changed
Pass down fp32 flag to kernel to decide whether to load indices as int32 or uint16 depending on Dest acc mode.
Also for BH, the fp32 cfg reg must be 0 for MOVD2B/B2D to work correctly, so an added cfg call was put before and after the transpose_wh llk call.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16034058666) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16034060157) CI passes (if applicable)
