### PR TITLE
Add instr_mod support for binary shift

### DIFF
--- a/tests/sources/sfpu_binary_test.cpp
+++ b/tests/sources/sfpu_binary_test.cpp
@@ -58,10 +58,10 @@ void call_binary_sfpu_operation(BinaryOp operation)
             _calculate_sfpu_binary_<false, SFPU_BINARY_OPERATION, 32>(1);
             break;
         case BinaryOp::RSHFT:
-            _calculate_binary_right_shift_<false, 32>(1);
+            _calculate_binary_right_shift_<false, 32, INT32, false>(1);
             break;
         case BinaryOp::LSHFT:
-            _calculate_binary_left_shift_<false, 32>(1);
+            _calculate_binary_left_shift_<false, 32, INT32, false>(1);
             break;
         default:
             return;

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_shift.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_shift.h
@@ -18,6 +18,8 @@ namespace sfpu
 template <bool APPROXIMATION_MODE, int ITERATIONS, InstrModLoadStore INSTRUCTION_MODE, bool SIGN_MAGNITUDE_FORMAT>
 inline void _calculate_binary_left_shift_(const uint dst_offset)
 {
+    static_assert(is_valid_instruction_mode(INSTRUCTION_MODE), "INSTRUCTION_MODE must be one of: INT32_2S_COMP, INT32, LO16.");
+
     constexpr int sfpload_instr_mod = SIGN_MAGNITUDE_FORMAT ? INT32_2S_COMP : static_cast<std::underlying_type_t<InstrModLoadStore>>(INSTRUCTION_MODE);
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++)
@@ -43,6 +45,8 @@ inline void _calculate_binary_left_shift_(const uint dst_offset)
 template <bool APPROXIMATION_MODE, int ITERATIONS, InstrModLoadStore INSTRUCTION_MODE, bool SIGN_MAGNITUDE_FORMAT>
 inline void _calculate_binary_right_shift_(const uint dst_offset)
 {
+    static_assert(is_valid_instruction_mode(INSTRUCTION_MODE), "INSTRUCTION_MODE must be one of: INT32_2S_COMP, INT32, LO16.");
+
     constexpr int sfpload_instr_mod = SIGN_MAGNITUDE_FORMAT ? INT32_2S_COMP : static_cast<std::underlying_type_t<InstrModLoadStore>>(INSTRUCTION_MODE);
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++)

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_shift.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_shift.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <type_traits>
+
 #include "ckernel_addrmod.h"
 #include "ckernel_ops.h"
 #include "sfpi.h"

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_shift.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_shift.h
@@ -22,18 +22,18 @@ inline void _calculate_binary_left_shift_(const uint dst_offset)
     {
         constexpr uint dst_tile_size = 64;
         // load
-        TTI_SFPLOAD(0, sfpload_instr_mod, ADDR_MOD_7, 0);
-        TT_SFPLOAD(1, sfpload_instr_mod, ADDR_MOD_7, dst_offset * dst_tile_size);
+        TTI_SFPLOAD(p_sfpu::LREG0, sfpload_instr_mod, ADDR_MOD_7, 0);
+        TT_SFPLOAD(p_sfpu::LREG1, sfpload_instr_mod, ADDR_MOD_7, dst_offset * dst_tile_size);
         // if (shift_amount < 0 OR shift_amount >= 32) -> result should be 0
-        TTI_SFPSETCC(0, 1, 0, 4);
-        TTI_SFPIADD(0xFE0, 1, 2, 1); // 0xFE0 = -32
-        TTI_SFPCOMPC(0, 0, 0, 0);
-        TTI_SFPMOV(0, 9, 0, 0);
-        TTI_SFPENCC(0, 0, 0, 0);
+        TTI_SFPSETCC(0, p_sfpu::LREG1, p_sfpu::LREG0, 4);
+        TTI_SFPIADD(0xFE0, p_sfpu::LREG1, p_sfpu::LREG2, 1); // 0xFE0 = -32
+        TTI_SFPCOMPC(0, p_sfpu::LREG0, p_sfpu::LREG0, 0);
+        TTI_SFPMOV(0, 9, p_sfpu::LREG0, 0);
+        TTI_SFPENCC(0, p_sfpu::LREG0, p_sfpu::LREG0, 0);
         // shift left
-        TTI_SFPSHFT(0, 1, 0, 0);
+        TTI_SFPSHFT(0, p_sfpu::LREG1, p_sfpu::LREG0, 0);
         // store result
-        TTI_SFPSTORE(0, sfpload_instr_mod, ADDR_MOD_7, 0);
+        TTI_SFPSTORE(p_sfpu::LREG0, sfpload_instr_mod, ADDR_MOD_7, 0);
         sfpi::dst_reg++;
     }
 }
@@ -47,9 +47,9 @@ inline void _calculate_binary_right_shift_(const uint dst_offset)
     {
         constexpr uint dst_tile_size = 64;
         // load
-        TTI_SFPLOAD(0, sfpload_instr_mod, ADDR_MOD_7, 0);
-        TT_SFPLOAD(1, sfpload_instr_mod, ADDR_MOD_7, dst_offset * dst_tile_size);
-        TTI_SFPMOV(0, 0, 4, 0); // save shift_value for later
+        TTI_SFPLOAD(p_sfpu::LREG0, sfpload_instr_mod, ADDR_MOD_7, 0);
+        TT_SFPLOAD(p_sfpu::LREG1, sfpload_instr_mod, ADDR_MOD_7, dst_offset * dst_tile_size);
+        TTI_SFPMOV(0, p_sfpu::LREG0, p_sfpu::LREG4, 0); // save shift_value for later
         // if (shift_amount < 0 OR shift_amount >= 32) -> result should be 0
         TTI_SFPSETCC(0, p_sfpu::LREG1, p_sfpu::LREG0, 4);
         TTI_SFPIADD(0xFE0, p_sfpu::LREG1, p_sfpu::LREG2, p_sfpu::LCONST_0); // 0xFE0 = -32
@@ -57,17 +57,17 @@ inline void _calculate_binary_right_shift_(const uint dst_offset)
         TTI_SFPENCC(0, p_sfpu::LREG0, p_sfpu::LREG0, 0);
         TTI_SFPIADD(0, p_sfpu::LCONST_0, p_sfpu::LREG1, 6); // take negative of shift_amount to shift right
         // shift right
-        TTI_SFPSHFT(0, 1, 0, 0);
+        TTI_SFPSHFT(0, p_sfpu::LREG1, p_sfpu::LREG0, 0);
         // if shift_value was negative, need to shift in 1's manually
-        TTI_SFPSETCC(0, 4, 0, 0);    // only run if shift_value is negative
-        TTI_SFPSETCC(0, 1, 0, 2);    // only needed if shift_amount>0
-        TTI_SFPIADD(0x020, 1, 2, 5); // take 32-shift_amount (0x020 = 32)
-        TTI_SFPNOT(0, 9, 3, 0);      // put all 1's into LREG3
-        TTI_SFPSHFT(0, 2, 3, 0);     // shift all 1's by 32-shift_amount
-        TTI_SFPOR(0, 3, 0, 0);       // OR in the 1's
-        TTI_SFPENCC(0, 0, 0, 0);
+        TTI_SFPSETCC(0, p_sfpu::LREG4, p_sfpu::LREG0, 0);    // only run if shift_value is negative
+        TTI_SFPSETCC(0, p_sfpu::LREG1, p_sfpu::LREG0, 2);    // only needed if shift_amount>0
+        TTI_SFPIADD(0x020, p_sfpu::LREG1, p_sfpu::LREG2, 5); // take 32-shift_amount (0x020 = 32)
+        TTI_SFPNOT(0, 9, p_sfpu::LREG3, 0);                  // put all 1's into LREG3
+        TTI_SFPSHFT(0, p_sfpu::LREG2, p_sfpu::LREG3, 0);     // shift all 1's by 32-shift_amount
+        TTI_SFPOR(0, p_sfpu::LREG3, p_sfpu::LREG0, 0);       // OR in the 1's
+        TTI_SFPENCC(0, p_sfpu::LREG0, p_sfpu::LREG0, 0);
         // store result
-        TTI_SFPSTORE(0, sfpload_instr_mod, ADDR_MOD_7, 0);
+        TTI_SFPSTORE(p_sfpu::LREG0, sfpload_instr_mod, ADDR_MOD_7, 0);
         sfpi::dst_reg++;
     }
 }

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_shift.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_shift.h
@@ -15,7 +15,7 @@ namespace ckernel
 namespace sfpu
 {
 
-template <bool APPROXIMATION_MODE, int ITERATIONS, InstrModLoadStore INSTRUCTION_MODE = INT32, bool SIGN_MAGNITUDE_FORMAT = false>
+template <bool APPROXIMATION_MODE, int ITERATIONS, InstrModLoadStore INSTRUCTION_MODE, bool SIGN_MAGNITUDE_FORMAT>
 inline void _calculate_binary_left_shift_(const uint dst_offset)
 {
     constexpr int sfpload_instr_mod = SIGN_MAGNITUDE_FORMAT ? INT32_2S_COMP : static_cast<std::underlying_type_t<InstrModLoadStore>>(INSTRUCTION_MODE);
@@ -30,7 +30,7 @@ inline void _calculate_binary_left_shift_(const uint dst_offset)
         TTI_SFPSETCC(0, p_sfpu::LREG1, p_sfpu::LREG0, 4);
         TTI_SFPIADD(0xFE0, p_sfpu::LREG1, p_sfpu::LREG2, 1); // 0xFE0 = -32
         TTI_SFPCOMPC(0, p_sfpu::LREG0, p_sfpu::LREG0, 0);
-        TTI_SFPMOV(0, 9, p_sfpu::LREG0, 0);
+        TTI_SFPMOV(0, p_sfpu::LCONST_0, p_sfpu::LREG0, 0);
         TTI_SFPENCC(0, p_sfpu::LREG0, p_sfpu::LREG0, 0);
         // shift left
         TTI_SFPSHFT(0, p_sfpu::LREG1, p_sfpu::LREG0, 0);
@@ -40,7 +40,7 @@ inline void _calculate_binary_left_shift_(const uint dst_offset)
     }
 }
 
-template <bool APPROXIMATION_MODE, int ITERATIONS, InstrModLoadStore INSTRUCTION_MODE = INT32, bool SIGN_MAGNITUDE_FORMAT = false>
+template <bool APPROXIMATION_MODE, int ITERATIONS, InstrModLoadStore INSTRUCTION_MODE, bool SIGN_MAGNITUDE_FORMAT>
 inline void _calculate_binary_right_shift_(const uint dst_offset)
 {
     constexpr int sfpload_instr_mod = SIGN_MAGNITUDE_FORMAT ? INT32_2S_COMP : static_cast<std::underlying_type_t<InstrModLoadStore>>(INSTRUCTION_MODE);
@@ -64,7 +64,7 @@ inline void _calculate_binary_right_shift_(const uint dst_offset)
         TTI_SFPSETCC(0, p_sfpu::LREG4, p_sfpu::LREG0, 0);    // only run if shift_value is negative
         TTI_SFPSETCC(0, p_sfpu::LREG1, p_sfpu::LREG0, 2);    // only needed if shift_amount>0
         TTI_SFPIADD(0x020, p_sfpu::LREG1, p_sfpu::LREG2, 5); // take 32-shift_amount (0x020 = 32)
-        TTI_SFPNOT(0, 9, p_sfpu::LREG3, 0);                  // put all 1's into LREG3
+        TTI_SFPNOT(0, p_sfpu::LCONST_0, p_sfpu::LREG3, 0);   // put all 1's into LREG3
         TTI_SFPSHFT(0, p_sfpu::LREG2, p_sfpu::LREG3, 0);     // shift all 1's by 32-shift_amount
         TTI_SFPOR(0, p_sfpu::LREG3, p_sfpu::LREG0, 0);       // OR in the 1's
         TTI_SFPENCC(0, p_sfpu::LREG0, p_sfpu::LREG0, 0);

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_shift.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_shift.h
@@ -14,7 +14,7 @@ namespace ckernel
 namespace sfpu
 {
 
-template <bool APPROXIMATION_MODE, int ITERATIONS, InstrModLoadStore INSTRUCTION_MODE = INT32, bool SIGN_MAGNITUDE_FORMAT = false>
+template <bool APPROXIMATION_MODE, int ITERATIONS, InstrModLoadStore INSTRUCTION_MODE, bool SIGN_MAGNITUDE_FORMAT>
 inline void _calculate_binary_left_shift_(const uint dst_offset)
 {
     constexpr int sfpload_instr_mod = SIGN_MAGNITUDE_FORMAT ? INT32_2S_COMP : static_cast<std::underlying_type_t<InstrModLoadStore>>(INSTRUCTION_MODE);
@@ -30,7 +30,7 @@ inline void _calculate_binary_left_shift_(const uint dst_offset)
         TTI_SFPSETCC(0, p_sfpu::LREG1, p_sfpu::LREG0, 4);
         TTI_SFPIADD(0xFE0, p_sfpu::LREG1, p_sfpu::LREG2, 1); // 0xFE0 = -32
         TTI_SFPCOMPC(0, p_sfpu::LREG0, p_sfpu::LREG0, 0);
-        TTI_SFPMOV(0, 9, p_sfpu::LREG0, 0);
+        TTI_SFPMOV(0, p_sfpu::LCONST_0, p_sfpu::LREG0, 0);
         TTI_SFPENCC(0, p_sfpu::LREG0, p_sfpu::LREG0, 0);
         // shift left
         TTI_SFPSHFT(0, p_sfpu::LREG1, p_sfpu::LREG0, 0);
@@ -40,7 +40,7 @@ inline void _calculate_binary_left_shift_(const uint dst_offset)
     }
 }
 
-template <bool APPROXIMATION_MODE, int ITERATIONS, InstrModLoadStore INSTRUCTION_MODE = INT32, bool SIGN_MAGNITUDE_FORMAT = false>
+template <bool APPROXIMATION_MODE, int ITERATIONS, InstrModLoadStore INSTRUCTION_MODE, bool SIGN_MAGNITUDE_FORMAT>
 inline void _calculate_binary_right_shift_(const uint dst_offset)
 {
     constexpr int sfpload_instr_mod = SIGN_MAGNITUDE_FORMAT ? INT32_2S_COMP : static_cast<std::underlying_type_t<InstrModLoadStore>>(INSTRUCTION_MODE);
@@ -65,7 +65,7 @@ inline void _calculate_binary_right_shift_(const uint dst_offset)
         TTI_SFPSETCC(0, p_sfpu::LREG4, p_sfpu::LREG0, 0);    // only run if shift_value is negative
         TTI_SFPSETCC(0, p_sfpu::LREG1, p_sfpu::LREG0, 2);    // only needed if shift_amount>0
         TTI_SFPIADD(0x020, p_sfpu::LREG1, p_sfpu::LREG2, 5); // take 32-shift_amount (0x020 = 32)
-        TTI_SFPNOT(0, 9, p_sfpu::LREG3, 0);                  // put all 1's into LREG3
+        TTI_SFPNOT(0, p_sfpu::LCONST_0, p_sfpu::LREG3, 0);   // put all 1's into LREG3
         TTI_SFPSHFT(0, p_sfpu::LREG2, p_sfpu::LREG3, 0);     // shift all 1's by 32-shift_amount
         TTI_SFPOR(0, p_sfpu::LREG3, p_sfpu::LREG0, 0);       // OR in the 1's
         TTI_SFPENCC(0, p_sfpu::LREG0, p_sfpu::LREG0, 0);

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_shift.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_shift.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <type_traits>
+
 #include "ckernel_ops.h"
 #include "sfpi.h"
 

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_shift.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_shift.h
@@ -22,18 +22,18 @@ inline void _calculate_binary_left_shift_(const uint dst_offset)
     {
         constexpr uint dst_tile_size = 64;
         // load
-        TTI_SFPLOAD(0, sfpload_instr_mod, 3, 0);
-        TT_SFPLOAD(1, sfpload_instr_mod, 3, dst_offset * dst_tile_size);
+        TTI_SFPLOAD(p_sfpu::LREG0, sfpload_instr_mod, 3, 0);
+        TT_SFPLOAD(p_sfpu::LREG1, sfpload_instr_mod, 3, dst_offset * dst_tile_size);
         // if (shift_amount < 0 OR shift_amount >= 32) -> result should be 0
-        TTI_SFPSETCC(0, 1, 0, 4);
-        TTI_SFPIADD(0xFE0, 1, 2, 1); // 0xFE0 = -32
-        TTI_SFPCOMPC(0, 0, 0, 0);
-        TTI_SFPMOV(0, 9, 0, 0);
-        TTI_SFPENCC(0, 0, 0, 0);
+        TTI_SFPSETCC(0, p_sfpu::LREG1, p_sfpu::LREG0, 4);
+        TTI_SFPIADD(0xFE0, p_sfpu::LREG1, p_sfpu::LREG2, 1); // 0xFE0 = -32
+        TTI_SFPCOMPC(0, p_sfpu::LREG0, p_sfpu::LREG0, 0);
+        TTI_SFPMOV(0, 9, p_sfpu::LREG0, 0);
+        TTI_SFPENCC(0, p_sfpu::LREG0, p_sfpu::LREG0, 0);
         // shift left
-        TTI_SFPSHFT(0, 1, 0, 0);
+        TTI_SFPSHFT(0, p_sfpu::LREG1, p_sfpu::LREG0, 0);
         // store result
-        TTI_SFPSTORE(0, sfpload_instr_mod, 3, 0);
+        TTI_SFPSTORE(p_sfpu::LREG0, sfpload_instr_mod, 3, 0);
         sfpi::dst_reg++;
     }
 }
@@ -48,9 +48,9 @@ inline void _calculate_binary_right_shift_(const uint dst_offset)
     {
         constexpr uint dst_tile_size = 64;
         // load
-        TTI_SFPLOAD(0, sfpload_instr_mod, 3, 0);
-        TT_SFPLOAD(1, sfpload_instr_mod, 3, dst_offset * dst_tile_size);
-        TTI_SFPMOV(0, 0, 4, 0); // save shift_value for later
+        TTI_SFPLOAD(p_sfpu::LREG0, sfpload_instr_mod, 3, 0);
+        TT_SFPLOAD(p_sfpu::LREG1, sfpload_instr_mod, 3, dst_offset * dst_tile_size);
+        TTI_SFPMOV(0, p_sfpu::LREG0, p_sfpu::LREG4, 0); // save shift_value for later
         // if (shift_amount < 0 OR shift_amount >= 32) -> result should be 0
         TTI_SFPSETCC(0, p_sfpu::LREG1, p_sfpu::LREG0, 4);
         TTI_SFPIADD(0xFE0, p_sfpu::LREG1, p_sfpu::LREG2, p_sfpu::LCONST_0); // 0xFE0 = -32
@@ -58,17 +58,17 @@ inline void _calculate_binary_right_shift_(const uint dst_offset)
         TTI_SFPENCC(0, p_sfpu::LREG0, p_sfpu::LREG0, 0);
         TTI_SFPIADD(0, p_sfpu::LCONST_0, p_sfpu::LREG1, 6); // take negative of shift_amount to shift right
         // shift right
-        TTI_SFPSHFT(0, 1, 0, 0);
+        TTI_SFPSHFT(0, p_sfpu::LREG1, p_sfpu::LREG0, 0);
         // if shift_value was negative, need to shift in 1's manually
-        TTI_SFPSETCC(0, 4, 0, 0);    // only run if shift_value is negative
-        TTI_SFPSETCC(0, 1, 0, 2);    // only needed if shift_amount>0
-        TTI_SFPIADD(0x020, 1, 2, 5); // take 32-shift_amount (0x020 = 32)
-        TTI_SFPNOT(0, 9, 3, 0);      // put all 1's into LREG3
-        TTI_SFPSHFT(0, 2, 3, 0);     // shift all 1's by 32-shift_amount
-        TTI_SFPOR(0, 3, 0, 0);       // OR in the 1's
-        TTI_SFPENCC(0, 0, 0, 0);
+        TTI_SFPSETCC(0, p_sfpu::LREG4, p_sfpu::LREG0, 0);    // only run if shift_value is negative
+        TTI_SFPSETCC(0, p_sfpu::LREG1, p_sfpu::LREG0, 2);    // only needed if shift_amount>0
+        TTI_SFPIADD(0x020, p_sfpu::LREG1, p_sfpu::LREG2, 5); // take 32-shift_amount (0x020 = 32)
+        TTI_SFPNOT(0, 9, p_sfpu::LREG3, 0);                  // put all 1's into LREG3
+        TTI_SFPSHFT(0, p_sfpu::LREG2, p_sfpu::LREG3, 0);     // shift all 1's by 32-shift_amount
+        TTI_SFPOR(0, p_sfpu::LREG3, p_sfpu::LREG0, 0);       // OR in the 1's
+        TTI_SFPENCC(0, p_sfpu::LREG0, p_sfpu::LREG0, 0);
         // store result
-        TTI_SFPSTORE(0, sfpload_instr_mod, 3, 0);
+        TTI_SFPSTORE(p_sfpu::LREG0, sfpload_instr_mod, 3, 0);
         sfpi::dst_reg++;
     }
 }

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_shift.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_shift.h
@@ -17,6 +17,8 @@ namespace sfpu
 template <bool APPROXIMATION_MODE, int ITERATIONS, InstrModLoadStore INSTRUCTION_MODE, bool SIGN_MAGNITUDE_FORMAT>
 inline void _calculate_binary_left_shift_(const uint dst_offset)
 {
+    static_assert(is_valid_instruction_mode(INSTRUCTION_MODE), "INSTRUCTION_MODE must be one of: INT32_2S_COMP, INT32, LO16.");
+
     constexpr int sfpload_instr_mod = SIGN_MAGNITUDE_FORMAT ? INT32_2S_COMP : static_cast<std::underlying_type_t<InstrModLoadStore>>(INSTRUCTION_MODE);
 
     // SFPU microcode
@@ -43,6 +45,8 @@ inline void _calculate_binary_left_shift_(const uint dst_offset)
 template <bool APPROXIMATION_MODE, int ITERATIONS, InstrModLoadStore INSTRUCTION_MODE, bool SIGN_MAGNITUDE_FORMAT>
 inline void _calculate_binary_right_shift_(const uint dst_offset)
 {
+    static_assert(is_valid_instruction_mode(INSTRUCTION_MODE), "INSTRUCTION_MODE must be one of: INT32_2S_COMP, INT32, LO16.");
+
     constexpr int sfpload_instr_mod = SIGN_MAGNITUDE_FORMAT ? INT32_2S_COMP : static_cast<std::underlying_type_t<InstrModLoadStore>>(INSTRUCTION_MODE);
 
     // SFPU microcode

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_shift.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_shift.h
@@ -12,16 +12,18 @@ namespace ckernel
 namespace sfpu
 {
 
-template <bool APPROXIMATION_MODE, int ITERATIONS>
+template <bool APPROXIMATION_MODE, int ITERATIONS, InstrModLoadStore INSTRUCTION_MODE = INT32, bool SIGN_MAGNITUDE_FORMAT = false>
 inline void _calculate_binary_left_shift_(const uint dst_offset)
 {
+    constexpr int sfpload_instr_mod = SIGN_MAGNITUDE_FORMAT ? INT32_2S_COMP : static_cast<std::underlying_type_t<InstrModLoadStore>>(INSTRUCTION_MODE);
+
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++)
     {
         constexpr uint dst_tile_size = 64;
         // load
-        TTI_SFPLOAD(0, 4, 3, 0);
-        TT_SFPLOAD(1, 4, 3, dst_offset * dst_tile_size);
+        TTI_SFPLOAD(0, sfpload_instr_mod, 3, 0);
+        TT_SFPLOAD(1, sfpload_instr_mod, 3, dst_offset * dst_tile_size);
         // if (shift_amount < 0 OR shift_amount >= 32) -> result should be 0
         TTI_SFPSETCC(0, 1, 0, 4);
         TTI_SFPIADD(0xFE0, 1, 2, 1); // 0xFE0 = -32
@@ -31,21 +33,23 @@ inline void _calculate_binary_left_shift_(const uint dst_offset)
         // shift left
         TTI_SFPSHFT(0, 1, 0, 0);
         // store result
-        TTI_SFPSTORE(0, 4, 3, 0);
+        TTI_SFPSTORE(0, sfpload_instr_mod, 3, 0);
         sfpi::dst_reg++;
     }
 }
 
-template <bool APPROXIMATION_MODE, int ITERATIONS>
+template <bool APPROXIMATION_MODE, int ITERATIONS, InstrModLoadStore INSTRUCTION_MODE = INT32, bool SIGN_MAGNITUDE_FORMAT = false>
 inline void _calculate_binary_right_shift_(const uint dst_offset)
 {
+    constexpr int sfpload_instr_mod = SIGN_MAGNITUDE_FORMAT ? INT32_2S_COMP : static_cast<std::underlying_type_t<InstrModLoadStore>>(INSTRUCTION_MODE);
+
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++)
     {
         constexpr uint dst_tile_size = 64;
         // load
-        TTI_SFPLOAD(0, 4, 3, 0);
-        TT_SFPLOAD(1, 4, 3, dst_offset * dst_tile_size);
+        TTI_SFPLOAD(0, sfpload_instr_mod, 3, 0);
+        TT_SFPLOAD(1, sfpload_instr_mod, 3, dst_offset * dst_tile_size);
         TTI_SFPMOV(0, 0, 4, 0); // save shift_value for later
         // if (shift_amount < 0 OR shift_amount >= 32) -> result should be 0
         TTI_SFPSETCC(0, p_sfpu::LREG1, p_sfpu::LREG0, 4);
@@ -64,7 +68,7 @@ inline void _calculate_binary_right_shift_(const uint dst_offset)
         TTI_SFPOR(0, 3, 0, 0);       // OR in the 1's
         TTI_SFPENCC(0, 0, 0, 0);
         // store result
-        TTI_SFPSTORE(0, 4, 3, 0);
+        TTI_SFPSTORE(0, sfpload_instr_mod, 3, 0);
         sfpi::dst_reg++;
     }
 }


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/22866

### Problem description
instruction modifier support not added for binary shift ops

### What's changed
Add ins mod support

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
