### PR TITLE
Sstanisic/profiler unit test

### DIFF
--- a/tests/python_tests/helpers/test_config.py
+++ b/tests/python_tests/helpers/test_config.py
@@ -11,7 +11,7 @@ from .format_arg_mapping import (
     ReduceDimension,
     ReducePool,
 )
-from .format_config import InputOutputFormat
+from .format_config import FormatConfig, InputOutputFormat
 
 
 class ProfilerBuild(Enum):
@@ -82,7 +82,7 @@ def generate_build_header(
 
     # Data format configuration
     header_content.extend(["", "// Data format configuration"])
-    formats = test_config.get("formats")
+    formats = test_config.get("formats", None)
     if isinstance(formats, InputOutputFormat):
         header_content.extend(
             [
@@ -92,7 +92,7 @@ def generate_build_header(
                 f"constexpr auto PACK_OUT = static_cast<std::underlying_type_t<DataFormat>>(DataFormat::{formats.output_format.name});",
             ]
         )
-    else:
+    elif isinstance(formats, FormatConfig):
         header_content.append(f"#define DATA_FORMAT_INFERENCE_MODEL false")
         header_content.extend(
             [

--- a/tests/python_tests/test_profiler_overhead.py
+++ b/tests/python_tests/test_profiler_overhead.py
@@ -5,8 +5,6 @@ from helpers.device import (
     run_elf_files,
     wait_for_tensix_operations_finished,
 )
-from helpers.format_config import DataFormat
-from helpers.param_config import InputOutputFormat
 from helpers.profiler import Profiler, build_with_profiler
 
 
@@ -15,9 +13,6 @@ def test_profiler_overhead():
     EXPECTED_OVERHEAD = 36
 
     test_config = {
-        "formats": InputOutputFormat(
-            DataFormat.Float16, DataFormat.Float16
-        ),  # sstanisic todo: remove need to specify the format
         "testname": "profiler_overhead_test",
     }
 

--- a/tests/python_tests/test_profiler_overhead.py
+++ b/tests/python_tests/test_profiler_overhead.py
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+from helpers.device import (
+    run_elf_files,
+    wait_for_tensix_operations_finished,
+)
+from helpers.format_config import DataFormat
+from helpers.param_config import InputOutputFormat
+from helpers.profiler import Profiler, build_with_profiler
+
+
+def test_profiler_overhead():
+
+    EXPECTED_OVERHEAD = 36
+
+    test_config = {
+        "formats": InputOutputFormat(
+            DataFormat.Float16, DataFormat.Float16
+        ),  # sstanisic todo: remove need to specify the format
+        "testname": "profiler_overhead_test",
+    }
+
+    profiler_meta = build_with_profiler(test_config)
+    assert profiler_meta is not None, "Profiler metadata should not be None"
+
+    run_elf_files("profiler_overhead_test")
+    wait_for_tensix_operations_finished()
+
+    runtime = Profiler.get_data(profiler_meta)
+
+    # filter out all zones that dont have marker "OVERHEAD"
+    overhead_zones = [x for x in runtime.unpack if x.full_marker.marker == "OVERHEAD"]
+    assert (
+        len(overhead_zones) == 32
+    ), f"Expected 32 overhead zones, got {len(overhead_zones)}"
+
+    for loop_iterations, zone in enumerate(overhead_zones, 8):
+        overhead = zone.duration - (loop_iterations * 10)
+
+        abs_err = abs(overhead - EXPECTED_OVERHEAD)
+        assert (
+            abs_err < 5
+        ), f"Expected overhead {EXPECTED_OVERHEAD}, got {overhead} cycles"

--- a/tests/sources/profiler_overhead_test.cpp
+++ b/tests/sources/profiler_overhead_test.cpp
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdio>
+#include <type_traits>
+
+#include "ckernel.h"
+#include "llk_defs.h"
+#include "profiler.h"
+
+// Globals
+uint32_t unp_cfg_context        = 0;
+uint32_t pack_sync_tile_dst_ptr = 0;
+
+#ifdef LLK_TRISC_UNPACK
+
+#include "profiler.h"
+
+void run_kernel()
+{
+    // measure length of zones of different sizes
+
+    // start with i = 8 because for i < 8, overhead is not consistent
+    for (uint32_t i = 8; i < 40; i++)
+    {
+        uint32_t cnt = i;
+        {
+            // The body of the loop without the zone should take i*10 cycles
+            // however the ZONE_SCOPED macro will add around 36 cycles of overhead
+            // so the total time should be around i*10 + 36 cycles
+            ZONE_SCOPED("OVERHEAD");
+        loop:
+            asm volatile("addi %0, %1, -1" : "=r"(cnt) : "r"(cnt));
+            asm volatile("nop");
+            asm volatile("nop");
+            asm volatile("nop");
+            asm volatile("nop");
+            asm volatile("nop");
+            asm volatile("nop");
+            asm volatile("nop");
+            asm volatile("nop");
+            asm volatile goto("bgtu %0, zero, %l1" : : "r"(cnt) : : loop);
+        }
+    }
+}
+
+#endif
+
+#ifdef LLK_TRISC_MATH
+
+void run_kernel()
+{
+    // Only unpack kernel is measuring profiler overhead
+}
+
+#endif
+
+#ifdef LLK_TRISC_PACK
+
+void run_kernel()
+{
+    // Only unpack kernel is measuring profiler overhead
+}
+
+#endif


### PR DESCRIPTION
### Ticket
<!-- Link to Github Issue -->
#308 

### Problem description
Add a unit test to sanity check the overhead of `ZONE_SCOPED` to prevent accidental decrease/increase

### What's changed
- Added `test_profiler_overhead.py` and `profiler_overhead_test.cpp`
- Made `test_config["formats"]` optional

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
