### PR TITLE
Fixup `profiler_overhead_test.py`

### DIFF
--- a/tests/python_tests/test_profiler_overhead.py
+++ b/tests/python_tests/test_profiler_overhead.py
@@ -50,7 +50,7 @@ def test_profiler_overhead():
         calculated_duration = 10 * loop_iterations
         overhead = zone.duration - calculated_duration
 
-        expected = get_expected_overhead()
+        expected_overhead = get_expected_overhead()
         assert overhead == pytest.approx(
-            expected, abs=5
-        ), f"iterations: {loop_iterations}, runtime: {zone.duration}/{calculated_duration} (actual/calculated), overhead {overhead}/{expected} (actual/expected) "
+            expected_overhead, abs=5
+        ), f"iterations: {i}, runtime: {zone.duration}/{calculated_duration} (actual/calculated), overhead {overhead}/{expected_overhead} (actual/expected) "

--- a/tests/python_tests/test_profiler_overhead.py
+++ b/tests/python_tests/test_profiler_overhead.py
@@ -38,10 +38,10 @@ def test_profiler_overhead():
     # filter out all zones that dont have marker "OVERHEAD"
     overhead_zones = [x for x in runtime.unpack if x.full_marker.marker == "OVERHEAD"]
     assert (
-        len(overhead_zones) == 30
+        len(overhead_zones) == 32
     ), f"Expected 32 overhead zones, got {len(overhead_zones)}"
 
-    for loop_iterations, zone in enumerate(overhead_zones, 10):
+    for loop_iterations, zone in enumerate(overhead_zones, 8):
         calculated_duration = 10 * loop_iterations
         overhead = zone.duration - calculated_duration
 

--- a/tests/python_tests/test_profiler_overhead.py
+++ b/tests/python_tests/test_profiler_overhead.py
@@ -45,6 +45,7 @@ def test_profiler_overhead():
         calculated_duration = 10 * loop_iterations
         overhead = zone.duration - calculated_duration
 
+        expected = get_expected_overhead()
         assert overhead == pytest.approx(
-            get_expected_overhead(), abs=5
-        ), f"iterations: {loop_iterations}, runtime: {zone.duration}/{calculated_duration} (actual/calculated), overhead {overhead}/{EXPECTED_OVERHEAD} (actual/expected) "
+            expected, abs=5
+        ), f"iterations: {loop_iterations}, runtime: {zone.duration}/{calculated_duration} (actual/calculated), overhead {overhead}/{expected} (actual/expected) "

--- a/tests/python_tests/test_profiler_overhead.py
+++ b/tests/python_tests/test_profiler_overhead.py
@@ -41,7 +41,12 @@ def test_profiler_overhead():
         len(overhead_zones) == 32
     ), f"Expected 32 overhead zones, got {len(overhead_zones)}"
 
-    for loop_iterations, zone in enumerate(overhead_zones, 8):
+    # the first iteration is inconsistent, because code is not in icache
+    overhead_zones.pop(0)
+
+    for loop_iterations, zone in enumerate(
+        overhead_zones, 9
+    ):  # enumerate from 9 because the first iteration is ignored
         calculated_duration = 10 * loop_iterations
         overhead = zone.duration - calculated_duration
 

--- a/tests/python_tests/test_profiler_overhead.py
+++ b/tests/python_tests/test_profiler_overhead.py
@@ -44,13 +44,14 @@ def test_profiler_overhead():
     # the first iteration is inconsistent, because code is not in icache
     overhead_zones.pop(0)
 
-    for loop_iterations, zone in enumerate(
+    for i, zone in enumerate(
         overhead_zones, 9
     ):  # enumerate from 9 because the first iteration is ignored
-        calculated_duration = 10 * loop_iterations
+        calculated_duration = 10 * i
         overhead = zone.duration - calculated_duration
 
         expected_overhead = get_expected_overhead()
-        assert overhead == pytest.approx(
-            expected_overhead, abs=5
-        ), f"iterations: {i}, runtime: {zone.duration}/{calculated_duration} (actual/calculated), overhead {overhead}/{expected_overhead} (actual/expected) "
+        assert overhead == pytest.approx(expected_overhead, abs=5), (
+            f"iterations: {i}, runtime: {zone.duration}/{i * 10} "
+            f"(actual/calculated), overhead {overhead}/{expected_overhead} (actual/expected)"
+        )

--- a/tests/sources/profiler_overhead_test.cpp
+++ b/tests/sources/profiler_overhead_test.cpp
@@ -16,8 +16,8 @@ void run_kernel()
 {
     // measure length of zones of different sizes
 
-    // start with i = 10 because for i < 10, overhead is not consistent
-    for (uint32_t i = 10; i < 40; i++)
+    // start with i = 8 because for i < 8, overhead is not consistent
+    for (uint32_t i = 8; i < 40; i++)
     {
         uint32_t cnt = i;
         {


### PR DESCRIPTION
### Ticket

### Problem description
`profiler_overhead_test.py` tests how much overhead is added by putting a zone around code. It seems to sometimes fail on first iteration. My guess is that it performs inconsistently because the code is not in icache during the first iteration.

### What's changed
Ignore the result from the first iteration because it's inconsistent. All the other iterations should be OK because the first iteration will pull the code into cache. 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
