### PR TITLE
ci: remove special case handling for private runner

### DIFF
--- a/.github/workflows/setup-and-test.yml
+++ b/.github/workflows/setup-and-test.yml
@@ -28,7 +28,7 @@ jobs:
       matrix:
         test_group: ${{ fromJSON(inputs.test_group) }}
     container:
-      image: ${{ inputs.runs_on != 'P150' && 'harbor.ci.tenstorrent.net/' || '' }}${{ inputs.docker_image }}
+      image: harbor.ci.tenstorrent.net/${{ inputs.docker_image }}
       options: "--rm --device /dev/tenstorrent"
     name: "🦄 Run tests (group ${{ matrix.test_group }}${{ fromJSON(inputs.test_group).length }})"
     steps:


### PR DESCRIPTION
### Ticket
None

### Problem description
Historically, we used a private runner that couldn't access the Tenstorrent Harbor. To handle this, we had conditional logic in place to avoid using Harbor with that runner. As of last week, we're no longer using this runner, so the check can be removed and the code simplified.

### What's changed
Removed a scenario that is no longer possible.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
