### PR TITLE
Make instrn_buffer an array

### DIFF
--- a/tests/helpers/include/ckernel_helper.h
+++ b/tests/helpers/include/ckernel_helper.h
@@ -6,8 +6,10 @@
 
 namespace ckernel
 {
-volatile std::uint32_t tt_reg_ptr *pc_buf_base     = reinterpret_cast<volatile std::uint32_t *>(PC_BUF_BASE);
-volatile std::uint32_t tt_reg_ptr *instrn_buffer   = reinterpret_cast<volatile std::uint32_t *>(INSTRN_BUF_BASE);
+volatile std::uint32_t tt_reg_ptr *pc_buf_base = reinterpret_cast<volatile std::uint32_t *>(PC_BUF_BASE);
+#if defined(INSTRN_BUF_BASE)
+volatile std::uint32_t tt_reg_ptr *instrn_buffer = reinterpret_cast<volatile std::uint32_t *>(INSTRN_BUF_BASE);
+#endif
 volatile std::uint32_t tt_reg_ptr *regfile         = reinterpret_cast<volatile std::uint32_t *>(REGFILE_BASE);
 volatile std::uint32_t tt_reg_ptr *mailbox_base[4] = {
     reinterpret_cast<volatile std::uint32_t tt_reg_ptr *>(TENSIX_MAILBOX0_BASE),

--- a/tests/helpers/ld/memory.blackhole.ld
+++ b/tests/helpers/ld/memory.blackhole.ld
@@ -32,3 +32,4 @@ MEMORY
     TRISC1_LOADER_CODE_MEM : ORIGIN = (90624 + (0 * 1024) + (0 * 1024) + (0 * 1024)), LENGTH = (0 * 1024)
     TRISC2_LOADER_CODE_MEM : ORIGIN = (90624 + (0 * 1024) + (0 * 1024) + (0 * 1024) + (0 * 1024)), LENGTH = (0 * 1024)
 }
+PROVIDE(__instrn_buffer = 0xFFE4000);

--- a/tests/helpers/ld/memory.wormhole.ld
+++ b/tests/helpers/ld/memory.wormhole.ld
@@ -32,3 +32,4 @@ MEMORY
     TRISC1_LOADER_CODE_MEM : ORIGIN = (76288 + (0 * 1024) + (16 * 1024) + (0 * 1024)), LENGTH = (0 * 1024)
     TRISC2_LOADER_CODE_MEM : ORIGIN = (76288 + (0 * 1024) + (16 * 1024) + (0 * 1024) + (0 * 1024)), LENGTH = (0 * 1024)
 }
+PROVIDE(__instrn_buffer = 0xFFE4000);

--- a/tt_llk_blackhole/common/inc/ckernel.h
+++ b/tt_llk_blackhole/common/inc/ckernel.h
@@ -94,7 +94,18 @@ constexpr uint KERNEL_COMPLETE    = 1;
 extern volatile uint tt_reg_ptr *reg_base;
 extern volatile uint tt_reg_ptr *pc_buf_base;
 extern volatile uint tt_reg_ptr *regfile;
+#if !defined(INSTRN_BUF_BASE)
+// Once tt_metal's submodule use of tt_llk is updated, this shim can
+// be cleaned up.
+#define INSTRN_BUFFER_TNG
+} // namespace ckernel
+extern volatile uint32_t __instrn_buffer[];
+namespace ckernel
+{
+constexpr volatile uint32_t(tt_reg_ptr &instrn_buffer)[] = __instrn_buffer;
+#else // defined(INSTRN_BUF_BASE)
 extern volatile uint tt_reg_ptr *instrn_buffer;
+#endif
 extern volatile uint tt_reg_ptr *mailbox_base[4];
 extern volatile uint tt_reg_ptr *dbg_event_scratch;
 extern volatile uint tt_reg_ptr *trisc_l1_mailbox;

--- a/tt_llk_wormhole_b0/common/inc/ckernel.h
+++ b/tt_llk_wormhole_b0/common/inc/ckernel.h
@@ -85,7 +85,18 @@ constexpr uint KERNEL_COMPLETE    = 1;
 extern volatile uint tt_reg_ptr *reg_base;
 extern volatile uint tt_reg_ptr *pc_buf_base;
 extern volatile uint tt_reg_ptr *regfile;
+#if !defined(INSTRN_BUF_BASE)
+// Once tt_metal's submodule use of tt_llk is updated, this shim can
+// be cleaned up.
+#define INSTRN_BUFFER_TNG
+} // namespace ckernel
+extern volatile uint32_t __instrn_buffer[];
+namespace ckernel
+{
+constexpr volatile uint32_t(tt_reg_ptr &instrn_buffer)[] = __instrn_buffer;
+#else // defined(INSTRN_BUF_BASE)
 extern volatile uint tt_reg_ptr *instrn_buffer;
+#endif
 extern volatile uint tt_reg_ptr *mailbox_base[4];
 extern volatile uint tt_reg_ptr *dbg_event_scratch;
 extern volatile uint tt_reg_ptr *trisc_l1_mailbox;


### PR DESCRIPTION
### Ticket
NA

### Problem description
`ckernel::instrn_buffer` is a pointer.  It is more efficient to declare it as an array and have the linker script provide the symbol. (although the compiler doesn't yet take full advantage of that, but future updates will).

### What's changed

This change requires care, as the (non-test) linker scripts are provided by tt-metal, and we can't rely on that and tt_llk being updated atomically.  This change has been tested both with and without the tt-metal change.  In the without case `instrn_buffer` remains a pointer.

We have temporary shim code here and in tt-metal, to allow asynchronous updating.  Once both are updated and tt-metal updates it's tt_llk submodule, this shim code can be removed (asynchronously).

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [Yes] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [YES ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [YES] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
