### PR TITLE
tooling 🧑‍💻: add script to generate compile_flags.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ compile_commands.json
 
 # Ignore generated build.h
 tests/helpers/include/build.h
+
+# Ignore generated compile_flags.txt
+tests/compile_flags.txt

--- a/tests/setup_clangd.sh
+++ b/tests/setup_clangd.sh
@@ -7,32 +7,38 @@ set -e  # Exit immediately if a command exits with a non-zero status
 set -o pipefail  # Fail if any command in a pipeline fails
 
 ARCH=$1
-if [[ "$ARCH" == "wormhole" ]]; then
-    ARCH_LLK_ROOT="tt_llk_wormhole_b0"
-    ARCH_DEFINE="ARCH_WORMHOLE"
-    CHIP_ARCH="wormhole"
-elif [[ "$ARCH" == "blackhole" ]]; then
-    ARCH_LLK_ROOT="tt_llk_blackhole"
-    ARCH_DEFINE="ARCH_BLACKHOLE"
-    CHIP_ARCH="blackhole"
-else
-    echo "Usage: $0 [wormhole|blackhole]"
-    exit 1
-fi
+case "$ARCH" in
+    wormhole)
+        ARCH_LLK_ROOT="tt_llk_wormhole_b0"
+        ARCH_DEFINE="ARCH_WORMHOLE"
+        CHIP_ARCH="wormhole"
+        ;;
+    blackhole)
+        ARCH_LLK_ROOT="tt_llk_blackhole"
+        ARCH_DEFINE="ARCH_BLACKHOLE"
+        CHIP_ARCH="blackhole"
+        ;;
+    *)
+        echo "Usage: $0 [wormhole|blackhole]"
+        exit 1
+        ;;
+esac
 
-echo -D$ARCH_DEFINE                         > compile_flags.txt
-echo                                        >> compile_flags.txt
-echo -DLLK_TRISC_UNPACK                     >> compile_flags.txt
-echo -DLLK_TRISC_MATH                       >> compile_flags.txt
-echo -DLLK_TRISC_PACK                       >> compile_flags.txt
-echo                                        >> compile_flags.txt
-echo -I../$ARCH_LLK_ROOT/llk_lib            >> compile_flags.txt
-echo -I../$ARCH_LLK_ROOT/common/inc         >> compile_flags.txt
-echo -I../$ARCH_LLK_ROOT/common/inc/sfpu    >> compile_flags.txt
-echo -Ihw_specific/inc                      >> compile_flags.txt
-echo -Ifirmware/riscv/common                >> compile_flags.txt
-echo -Ifirmware/riscv/$CHIP_ARCH            >> compile_flags.txt
-echo -Isfpi/include                         >> compile_flags.txt
-echo -Ihelpers/include                      >> compile_flags.txt
+cat > compile_flags.txt <<EOF
+-D$ARCH_DEFINE
+
+-DLLK_TRISC_UNPACK
+-DLLK_TRISC_MATH
+-DLLK_TRISC_PACK
+
+-I../$ARCH_LLK_ROOT/llk_lib
+-I../$ARCH_LLK_ROOT/common/inc
+-I../$ARCH_LLK_ROOT/common/inc/sfpu
+-Ihw_specific/inc
+-Ifirmware/riscv/common
+-Ifirmware/riscv/$CHIP_ARCH
+-Isfpi/include
+-Ihelpers/include
+EOF
 
 (pkill clangd && clangd >/dev/null 2>&1 &) || true  # restart clang if it's running

--- a/tests/setup_clangd.sh
+++ b/tests/setup_clangd.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -e  # Exit immediately if a command exits with a non-zero status
+set -o pipefail  # Fail if any command in a pipeline fails
+
+ARCH=$1
+if [[ "$ARCH" == "wormhole" ]]; then
+    ARCH_LLK_ROOT="tt_llk_wormhole_b0"
+    ARCH_DEFINE="ARCH_WORMHOLE"
+    CHIP_ARCH="wormhole"
+elif [[ "$ARCH" == "blackhole" ]]; then
+    ARCH_LLK_ROOT="tt_llk_blackhole"
+    ARCH_DEFINE="ARCH_BLACKHOLE"
+    CHIP_ARCH="blackhole"
+else
+    echo "Usage: $0 [wormhole|blackhole]"
+    exit 1
+fi
+
+echo -D$ARCH_DEFINE                         > compile_flags.txt
+echo                                        >> compile_flags.txt
+echo -DLLK_TRISC_UNPACK                     >> compile_flags.txt
+echo -DLLK_TRISC_MATH                       >> compile_flags.txt
+echo -DLLK_TRISC_PACK                       >> compile_flags.txt
+echo                                        >> compile_flags.txt
+echo -I../$ARCH_LLK_ROOT/llk_lib            >> compile_flags.txt
+echo -I../$ARCH_LLK_ROOT/common/inc         >> compile_flags.txt
+echo -I../$ARCH_LLK_ROOT/common/inc/sfpu    >> compile_flags.txt
+echo -Ihw_specific/inc                      >> compile_flags.txt
+echo -Ifirmware/riscv/common                >> compile_flags.txt
+echo -Ifirmware/riscv/$CHIP_ARCH            >> compile_flags.txt
+echo -Isfpi/include                         >> compile_flags.txt
+echo -Ihelpers/include                      >> compile_flags.txt
+
+(pkill clangd && clangd >/dev/null 2>&1 &) || true  # restart clang if it's running


### PR DESCRIPTION
### Ticket

### Problem description
Currently, IDEs have a hard time indexing LLK code becaue they don't have information about:
- Include directories 
- Defines

### What's changed
Added a `tests/setup_clangd.sh` that does the following:
- Generates sensible `compile_flags.txt` based on provided architecture 
- Restarts `clangd` to force it to reload the file

This will allow all IDEs that can parse `compile_flags.txt` to index the codebase, and will work by default in all IDEs that rely on `clangd` for hints.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
