### PR TITLE
[Test Infra] Enable Reading from Dest Register, Supporting Integer formats

### DIFF
--- a/tests/python_tests/helpers/device.py
+++ b/tests/python_tests/helpers/device.py
@@ -215,7 +215,7 @@ def read_dest_register(dest_acc: DestAccumulation, num_tiles: int = 1):
     location = RiscLoc(loc=coordinate, noc_id=noc_id, risc_id=risc_id)
     debug_risc = RiscDebug(location=location, context=context, verbose=False)
 
-    assert num_tiles <= 8 if dest_acc == DestAccumulation.Yes else num_tiles <= 16
+    assert num_tiles <= (8 if dest_acc == DestAccumulation.Yes else 16)
 
     word_size = 4  # bytes per 32-bit integer
     num_words = num_tiles * 1024


### PR DESCRIPTION
### Ticket
<!-- Link to Github Issue -->
https://github.com/orgs/tenstorrent/projects/123/views/1?pane=issue&itemId=116276317&issue=tenstorrent%7Ctt-llk%7C392
### Problem description
<!-- Provide context for the problem. -->
It’s currently difficult to debug and understand why certain test cases are failing because exalens tool doesn't support reading from src and dest registers when the data format is any type of integer. As a result, running tests with integer format combinations that fail becomes a black box — we get a failure, but not much insight into why.

### What's changed
<!-- Describe the approach used to solve the problem.
Summarize the changes made and its impact. -->
Generated a wrapper function that will use existing exalens functions to read from the device using TRISC at a given address. Enables printing the dest register contents and is supported for all Tensix integer formats, which should provide some much-needed visibility until native support for integer format reads is implemented.
### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
