### PR TITLE
23591: Move gelu implementation and tests to llk repo 

### DIFF
--- a/tests/helpers/include/params.h
+++ b/tests/helpers/include/params.h
@@ -114,6 +114,9 @@ constexpr auto SFPU_OPERATION = SfpuType::reciprocal;
 #ifdef SFPU_OP_CELU
 constexpr auto SFPU_OPERATION = SfpuType::celu;
 #endif
+#ifdef SFPU_OP_GELU
+constexpr auto SFPU_OPERATION = SfpuType::gelu;
+#endif
 
 inline void process_addresses(volatile uint32_t* buffer_Dest[], int n, int first, ...)
 {

--- a/tests/python_tests/helpers/format_arg_mapping.py
+++ b/tests/python_tests/helpers/format_arg_mapping.py
@@ -49,6 +49,7 @@ class MathOperation(Enum):
     SfpuXlogy = "SFPU_OP_XLOGY"
     SfpuElwRightShift = "SFPU_OP_RSHFT"
     SfpuElwLeftShift = "SFPU_OP_LSHFT"
+    Gelu = "SFPU_OP_GELU"
 
 
 class ReduceDimension(Enum):

--- a/tests/python_tests/helpers/golden_generators.py
+++ b/tests/python_tests/helpers/golden_generators.py
@@ -85,6 +85,7 @@ class UnarySFPUGolden:
             MathOperation.Sqrt: self._sqrt,
             MathOperation.Square: self._square,
             MathOperation.Celu: self._celu,
+            MathOperation.Gelu: self._gelu,
         }
         self.data_format = None
 
@@ -125,6 +126,14 @@ class UnarySFPUGolden:
             else torch.tensor(x, dtype=format_dict[self.data_format])
         )
         return torch.nn.functional.celu(input_tensor, alpha=1.0).item()
+    
+    def _gelu(self, x):
+        input_tensor = (
+            x
+            if isinstance(x, torch.Tensor)
+            else torch.tensor(x, dtype=format_dict[self.data_format])
+        )
+        return torch.nn.functional.gelu(input_tensor).item()
 
 
 @register_golden

--- a/tests/python_tests/test_eltwise_unary_sfpu.py
+++ b/tests/python_tests/test_eltwise_unary_sfpu.py
@@ -65,6 +65,7 @@ all_params = generate_params(
         MathOperation.Sqrt,
         MathOperation.Square,
         MathOperation.Celu,
+        MathOperation.Gelu,
     ],
 )
 param_ids = generate_param_ids(all_params)

--- a/tests/sources/eltwise_unary_sfpu_test.cpp
+++ b/tests/sources/eltwise_unary_sfpu_test.cpp
@@ -77,6 +77,14 @@ void call_sfpu_operation(SfpuType operation)
         case SfpuType::celu:
             ckernel::sfpu::_calculate_activation_<APPROX_MODE, ActivationType::Celu, iterations>(10, 1 / 10);
             break;
+        case SfpuType::gelu:
+            ckernel::sfpu::_init_gelu_<APPROX_MODE>();
+            if(APPROX_MODE){
+                ckernel::sfpu::_calculate_gelu_<APPROX_MODE, iterations>(iterations);
+            }else{
+                ckernel::sfpu::_calculate_gelu_accurate_(iterations);
+            }
+            break;
         default:
             return;
     }

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_cdf.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_cdf.h
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ckernel_defs.h"
+#include "ckernel.h"
+#include "noc_nonblocking_api.h"
+
+#include "sfpi.h"
+
+namespace ckernel {
+namespace sfpu {
+
+#define POLYVAL5(coef4, coef3, coef2, coef1, coef0, val) \
+    ((((coef4 * val + coef3) * val + coef2) * val + coef1) * val + coef0)
+
+inline sfpi::vFloat _calculate_pos_cdf_appx_(sfpi::vFloat val) {
+    //(0,2.5) interpolation polynomial coeffs  [ 0.0122792,  -0.05281024, -0.03048313,  0.41314081,  0.49866379]
+    //(2.5,5) interpolation polynomial coeffs  [0.44656975,  0.58216001]
+
+    // FIXME:
+    // reuse LREG0-3 for storing coefficients and do product computation
+    // const float coef_2dot5_to_5[4] = {-0.00221304f, -0.03253934f, -0.18027954f, -0.44656975f };
+    // TTI_SFPLOADI(p_sfpu::LREG0, 0, 0xbb1108a6);
+    // TTI_SFPLOADI(p_sfpu::LREG1, 0, 0xbd0547f9);
+    // TTI_SFPLOADI(p_sfpu::LREG2, 0, 0xbe389b33);
+    // TTI_SFPLOADI(p_sfpu::LREG2, 0, 0xbee4a4ca);
+
+    sfpi::vFloat result;
+    v_if(val < 2.5f) { result = POLYVAL5(0.0122792f, -0.05281024f, -0.03048313f, 0.41314081f, 0.49866379f, val); }
+    v_else {
+        // assume v >= 2.5f - 5
+        // result = POLYVAL5(result,-0.00221304f,  0.03253934f, -0.18027954f,  0.44656975f,  0.58216001f, val);
+        // result = ((sfpi::vFloat)l_reg[LRegs::LReg0])*val + (sfpi::vFloat)l_reg[LRegs::LReg1];
+        // result = result*val + (sfpi::vFloat)l_reg[LRegs::LReg2];
+        // result = result*val + (sfpi::vFloat)l_reg[LRegs::LReg3];
+        result = 0.44656975f * val + 0.58216001f;
+    }
+    v_endif;
+
+    v_if(result > 1.0f) { result = 1.0f; }
+    v_endif;
+    return result;
+}
+
+// compute the approximate value of CDF of normal distribution
+inline sfpi::vFloat _calculate_cdf_appx_(sfpi::vFloat val, bool scaled = false) {
+    sfpi::vFloat result = 0.0f;
+    sfpi::vFloat val2 = 0.0;
+    v_if(val < 0.0f) { val2 = -val; }
+    v_else { val2 = val; }
+    v_endif;
+
+    result = _calculate_pos_cdf_appx_(val2);
+
+    v_if(val < 0.0f) { result = 1.0f - result; }
+    v_endif;
+
+    if (scaled) {
+        result *= val;  // scale
+    }
+    return result;
+}
+
+}  // namespace sfpu
+}  // namespace ckernel

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_cdf.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_cdf.h
@@ -1,22 +1,22 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
 
-#include "ckernel_defs.h"
 #include "ckernel.h"
-#include "noc_nonblocking_api.h"
-
+#include "ckernel_defs.h"
 #include "sfpi.h"
 
-namespace ckernel {
-namespace sfpu {
+namespace ckernel
+{
+namespace sfpu
+{
 
-#define POLYVAL5(coef4, coef3, coef2, coef1, coef0, val) \
-    ((((coef4 * val + coef3) * val + coef2) * val + coef1) * val + coef0)
+#define POLYVAL5(coef4, coef3, coef2, coef1, coef0, val) ((((coef4 * val + coef3) * val + coef2) * val + coef1) * val + coef0)
 
-inline sfpi::vFloat _calculate_pos_cdf_appx_(sfpi::vFloat val) {
+inline sfpi::vFloat _calculate_pos_cdf_appx_(sfpi::vFloat val)
+{
     //(0,2.5) interpolation polynomial coeffs  [ 0.0122792,  -0.05281024, -0.03048313,  0.41314081,  0.49866379]
     //(2.5,5) interpolation polynomial coeffs  [0.44656975,  0.58216001]
 
@@ -29,8 +29,12 @@ inline sfpi::vFloat _calculate_pos_cdf_appx_(sfpi::vFloat val) {
     // TTI_SFPLOADI(p_sfpu::LREG2, 0, 0xbee4a4ca);
 
     sfpi::vFloat result;
-    v_if(val < 2.5f) { result = POLYVAL5(0.0122792f, -0.05281024f, -0.03048313f, 0.41314081f, 0.49866379f, val); }
-    v_else {
+    v_if (val < 2.5f)
+    {
+        result = POLYVAL5(0.0122792f, -0.05281024f, -0.03048313f, 0.41314081f, 0.49866379f, val);
+    }
+    v_else
+    {
         // assume v >= 2.5f - 5
         // result = POLYVAL5(result,-0.00221304f,  0.03253934f, -0.18027954f,  0.44656975f,  0.58216001f, val);
         // result = ((sfpi::vFloat)l_reg[LRegs::LReg0])*val + (sfpi::vFloat)l_reg[LRegs::LReg1];
@@ -40,29 +44,43 @@ inline sfpi::vFloat _calculate_pos_cdf_appx_(sfpi::vFloat val) {
     }
     v_endif;
 
-    v_if(result > 1.0f) { result = 1.0f; }
+    v_if (result > 1.0f)
+    {
+        result = 1.0f;
+    }
     v_endif;
     return result;
 }
 
 // compute the approximate value of CDF of normal distribution
-inline sfpi::vFloat _calculate_cdf_appx_(sfpi::vFloat val, bool scaled = false) {
+inline sfpi::vFloat _calculate_cdf_appx_(sfpi::vFloat val, bool scaled = false)
+{
     sfpi::vFloat result = 0.0f;
-    sfpi::vFloat val2 = 0.0;
-    v_if(val < 0.0f) { val2 = -val; }
-    v_else { val2 = val; }
+    sfpi::vFloat val2   = 0.0;
+    v_if (val < 0.0f)
+    {
+        val2 = -val;
+    }
+    v_else
+    {
+        val2 = val;
+    }
     v_endif;
 
     result = _calculate_pos_cdf_appx_(val2);
 
-    v_if(val < 0.0f) { result = 1.0f - result; }
+    v_if (val < 0.0f)
+    {
+        result = 1.0f - result;
+    }
     v_endif;
 
-    if (scaled) {
-        result *= val;  // scale
+    if (scaled)
+    {
+        result *= val; // scale
     }
     return result;
 }
 
-}  // namespace sfpu
-}  // namespace ckernel
+} // namespace sfpu
+} // namespace ckernel

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_gelu.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_gelu.h
@@ -4,9 +4,9 @@
 
 #pragma once
 
+#include "ckernel_sfpu_cdf.h"
 #include "ckernel_sfpu_exp.h"
 #include "ckernel_sfpu_load_config.h"
-#include "ckernel_sfpu_cdf.h"
 #include "sfpi.h"
 #include "sfpi_fp16.h"
 
@@ -239,14 +239,14 @@ inline void _init_gelu_derivative_()
 }
 
 inline void _calculate_gelu_accurate_(const int iterations)
-{   
+{
     constexpr bool scaled = true;
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
     {
-        sfpi::vFloat in = sfpi::dst_reg[0];
+        sfpi::vFloat in     = sfpi::dst_reg[0];
         sfpi::vFloat result = _calculate_cdf_appx_(in, scaled);
-        sfpi::dst_reg[0] = result;
+        sfpi::dst_reg[0]    = result;
         sfpi::dst_reg++;
     }
 }

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_gelu.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_gelu.h
@@ -6,6 +6,7 @@
 
 #include "ckernel_sfpu_exp.h"
 #include "ckernel_sfpu_load_config.h"
+#include "ckernel_sfpu_cdf.h"
 #include "sfpi.h"
 #include "sfpi_fp16.h"
 
@@ -234,6 +235,19 @@ inline void _init_gelu_derivative_()
         imm1 = 0x3020;
         _sfpu_load_imm16_(0, imm0);
         _sfpu_load_imm16_(1, imm1);
+    }
+}
+
+inline void _calculate_gelu_accurate_(const int iterations)
+{   
+    constexpr bool scaled = true;
+#pragma GCC unroll 8
+    for (int d = 0; d < iterations; d++)
+    {
+        sfpi::vFloat in = sfpi::dst_reg[0];
+        sfpi::vFloat result = _calculate_cdf_appx_(in, scaled);
+        sfpi::dst_reg[0] = result;
+        sfpi::dst_reg++;
     }
 }
 

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_cdf.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_cdf.h
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ckernel_defs.h"
+#include "ckernel.h"
+#include "noc_nonblocking_api.h"
+
+#include "sfpi.h"
+
+namespace ckernel {
+namespace sfpu {
+
+#define POLYVAL5(coef4, coef3, coef2, coef1, coef0, val) \
+    ((((coef4 * val + coef3) * val + coef2) * val + coef1) * val + coef0)
+
+inline sfpi::vFloat _calculate_pos_cdf_appx_(sfpi::vFloat val) {
+    //(0,2.5) interpolation polynomial coeffs  [ 0.0122792,  -0.05281024, -0.03048313,  0.41314081,  0.49866379]
+    //(2.5,5) interpolation polynomial coeffs  [0.44656975,  0.58216001]
+
+    // FIXME:
+    // reuse LREG0-3 for storing coefficients and do product computation
+    // const float coef_2dot5_to_5[4] = {-0.00221304f, -0.03253934f, -0.18027954f, -0.44656975f };
+    // TTI_SFPLOADI(p_sfpu::LREG0, 0, 0xbb1108a6);
+    // TTI_SFPLOADI(p_sfpu::LREG1, 0, 0xbd0547f9);
+    // TTI_SFPLOADI(p_sfpu::LREG2, 0, 0xbe389b33);
+    // TTI_SFPLOADI(p_sfpu::LREG2, 0, 0xbee4a4ca);
+
+    sfpi::vFloat result;
+    v_if(val < 2.5f) { result = POLYVAL5(0.0122792f, -0.05281024f, -0.03048313f, 0.41314081f, 0.49866379f, val); }
+    v_else {
+        // assume v >= 2.5f - 5
+        // result = POLYVAL5(result,-0.00221304f,  0.03253934f, -0.18027954f,  0.44656975f,  0.58216001f, val);
+        // result = ((sfpi::vFloat)l_reg[LRegs::LReg0])*val + (sfpi::vFloat)l_reg[LRegs::LReg1];
+        // result = result*val + (sfpi::vFloat)l_reg[LRegs::LReg2];
+        // result = result*val + (sfpi::vFloat)l_reg[LRegs::LReg3];
+        result = 0.44656975f * val + 0.58216001f;
+    }
+    v_endif;
+
+    v_if(result > 1.0f) { result = 1.0f; }
+    v_endif;
+    return result;
+}
+
+// compute the approximate value of CDF of normal distribution
+inline sfpi::vFloat _calculate_cdf_appx_(sfpi::vFloat val, bool scaled = false) {
+    sfpi::vFloat result = 0.0f;
+    sfpi::vFloat val2 = 0.0;
+    v_if(val < 0.0f) { val2 = -val; }
+    v_else { val2 = val; }
+    v_endif;
+
+    result = _calculate_pos_cdf_appx_(val2);
+
+    v_if(val < 0.0f) { result = 1.0f - result; }
+    v_endif;
+
+    if (scaled) {
+        result *= val;  // scale
+    }
+    return result;
+}
+
+}  // namespace sfpu
+}  // namespace ckernel

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_cdf.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_cdf.h
@@ -1,22 +1,22 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
 
-#include "ckernel_defs.h"
 #include "ckernel.h"
-#include "noc_nonblocking_api.h"
-
+#include "ckernel_defs.h"
 #include "sfpi.h"
 
-namespace ckernel {
-namespace sfpu {
+namespace ckernel
+{
+namespace sfpu
+{
 
-#define POLYVAL5(coef4, coef3, coef2, coef1, coef0, val) \
-    ((((coef4 * val + coef3) * val + coef2) * val + coef1) * val + coef0)
+#define POLYVAL5(coef4, coef3, coef2, coef1, coef0, val) ((((coef4 * val + coef3) * val + coef2) * val + coef1) * val + coef0)
 
-inline sfpi::vFloat _calculate_pos_cdf_appx_(sfpi::vFloat val) {
+inline sfpi::vFloat _calculate_pos_cdf_appx_(sfpi::vFloat val)
+{
     //(0,2.5) interpolation polynomial coeffs  [ 0.0122792,  -0.05281024, -0.03048313,  0.41314081,  0.49866379]
     //(2.5,5) interpolation polynomial coeffs  [0.44656975,  0.58216001]
 
@@ -29,8 +29,12 @@ inline sfpi::vFloat _calculate_pos_cdf_appx_(sfpi::vFloat val) {
     // TTI_SFPLOADI(p_sfpu::LREG2, 0, 0xbee4a4ca);
 
     sfpi::vFloat result;
-    v_if(val < 2.5f) { result = POLYVAL5(0.0122792f, -0.05281024f, -0.03048313f, 0.41314081f, 0.49866379f, val); }
-    v_else {
+    v_if (val < 2.5f)
+    {
+        result = POLYVAL5(0.0122792f, -0.05281024f, -0.03048313f, 0.41314081f, 0.49866379f, val);
+    }
+    v_else
+    {
         // assume v >= 2.5f - 5
         // result = POLYVAL5(result,-0.00221304f,  0.03253934f, -0.18027954f,  0.44656975f,  0.58216001f, val);
         // result = ((sfpi::vFloat)l_reg[LRegs::LReg0])*val + (sfpi::vFloat)l_reg[LRegs::LReg1];
@@ -40,29 +44,43 @@ inline sfpi::vFloat _calculate_pos_cdf_appx_(sfpi::vFloat val) {
     }
     v_endif;
 
-    v_if(result > 1.0f) { result = 1.0f; }
+    v_if (result > 1.0f)
+    {
+        result = 1.0f;
+    }
     v_endif;
     return result;
 }
 
 // compute the approximate value of CDF of normal distribution
-inline sfpi::vFloat _calculate_cdf_appx_(sfpi::vFloat val, bool scaled = false) {
+inline sfpi::vFloat _calculate_cdf_appx_(sfpi::vFloat val, bool scaled = false)
+{
     sfpi::vFloat result = 0.0f;
-    sfpi::vFloat val2 = 0.0;
-    v_if(val < 0.0f) { val2 = -val; }
-    v_else { val2 = val; }
+    sfpi::vFloat val2   = 0.0;
+    v_if (val < 0.0f)
+    {
+        val2 = -val;
+    }
+    v_else
+    {
+        val2 = val;
+    }
     v_endif;
 
     result = _calculate_pos_cdf_appx_(val2);
 
-    v_if(val < 0.0f) { result = 1.0f - result; }
+    v_if (val < 0.0f)
+    {
+        result = 1.0f - result;
+    }
     v_endif;
 
-    if (scaled) {
-        result *= val;  // scale
+    if (scaled)
+    {
+        result *= val; // scale
     }
     return result;
 }
 
-}  // namespace sfpu
-}  // namespace ckernel
+} // namespace sfpu
+} // namespace ckernel

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_gelu.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_gelu.h
@@ -4,9 +4,9 @@
 
 #pragma once
 
+#include "ckernel_sfpu_cdf.h"
 #include "ckernel_sfpu_exp.h"
 #include "ckernel_sfpu_load_config.h"
-#include "ckernel_sfpu_cdf.h"
 #include "sfpi.h"
 #include "sfpi_fp16.h"
 
@@ -239,14 +239,14 @@ inline void _init_gelu_derivative_()
 }
 
 inline void _calculate_gelu_accurate_(const int iterations)
-{   
+{
     constexpr bool scaled = true;
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
     {
-        sfpi::vFloat in = sfpi::dst_reg[0];
+        sfpi::vFloat in     = sfpi::dst_reg[0];
         sfpi::vFloat result = _calculate_cdf_appx_(in, scaled);
-        sfpi::dst_reg[0] = result;
+        sfpi::dst_reg[0]    = result;
         sfpi::dst_reg++;
     }
 }

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_gelu.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_gelu.h
@@ -6,6 +6,7 @@
 
 #include "ckernel_sfpu_exp.h"
 #include "ckernel_sfpu_load_config.h"
+#include "ckernel_sfpu_cdf.h"
 #include "sfpi.h"
 #include "sfpi_fp16.h"
 
@@ -234,6 +235,19 @@ inline void _init_gelu_derivative_()
         imm1 = 0x3020;
         _sfpu_load_imm16_(0, imm0);
         _sfpu_load_imm16_(1, imm1);
+    }
+}
+
+inline void _calculate_gelu_accurate_(const int iterations)
+{   
+    constexpr bool scaled = true;
+#pragma GCC unroll 8
+    for (int d = 0; d < iterations; d++)
+    {
+        sfpi::vFloat in = sfpi::dst_reg[0];
+        sfpi::vFloat result = _calculate_cdf_appx_(in, scaled);
+        sfpi::dst_reg[0] = result;
+        sfpi::dst_reg++;
     }
 }
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/23591

### Problem description
Move gelu accurate implementation from tt-metal to tt-llk.

### What's changed
- Moved Gelu accurate implementation to tt-llk.
- Tests: Integrated Gelu tests in tt-llk (as part of eltwise unary sfpu test infra)

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
- [ ] [All post commit]() 
- [ ] [Blackhole Post commit]() 
