### PR TITLE
doc: update contributing guideline with merging instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ A breaking change is any change that:
    - Do **not merge** the change into the submodule’s main branch until:
      - The `tt-metal` PR is **approved**.
      - **All checks are passing**.
-     - Reviewers from both repos have signed off.
+     - Reviewers from both repositories have approved your changes.
 
 
 ## 🔁 Submodule Update Guidelines


### PR DESCRIPTION
### Ticket
None

### Problem description
In the past few weeks, we’ve encountered numerous integration issues caused by breaking changes. In several cases, we had to revert merged changes, sometimes even reverting multiple stacked changes one on top of the other. Updating the contribution guide should help prevent such situations by discouraging uncoordinated breaking changes and providing clear guidance on how to make necessary ones easier to adopt.

### What's changed
This PR contains changes in the contribution guidelines.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update