### PR TITLE
[ Test Infra ]Upgrade test infra to support multiple tiles and random tensor shape as input ( first iteration )

### DIFF
--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -39,6 +39,7 @@ jobs:
       tests: ${{ steps.filter.outputs.tests }}
       github: ${{ steps.filter.outputs.github }}
       documentation: ${{ steps.filter.outputs.documentation }}
+      performance: ${{ steps.filter.outputs.performance }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -62,6 +63,9 @@ jobs:
                 - 'docs/**'
                 - '**/*.md'
                 - '**/*.rst'
+              performance:
+                - '**/*perf**'
+                - '**/*profiler**'
 
   label-pr:
     name: "🏷️ Label PR"
@@ -82,6 +86,7 @@ jobs:
             if ("${{ needs.detect-changes.outputs.tests }}" === "true") expectedLabels.add("test-infra");
             if ("${{ needs.detect-changes.outputs.github }}" === "true") expectedLabels.add("ci");
             if ("${{ needs.detect-changes.outputs.documentation }}" === "true") expectedLabels.add("documentation");
+            if ("${{ needs.detect-changes.outputs.performance }}" === "true") expectedLabels.add("performance");
 
             // Get current labels
             const {data: currentLabels} = await github.rest.issues.listLabelsOnIssue({
@@ -91,7 +96,8 @@ jobs:
             });
 
             // Create sets for comparison
-            const managedLabels = new Set(["blackhole", "ci", "documentation", "test-infra", "wormhole"]);
+            const managedLabels = new Set(["blackhole", "ci", "documentation",
+                                           "performance", "test-infra", "wormhole"]);
             const currentLabelSet = new Set(currentLabels.map(label => label.name));
 
             // Calculate labels to add and remove

--- a/tests/sources/sfpu_binary_test.cpp
+++ b/tests/sources/sfpu_binary_test.cpp
@@ -58,10 +58,10 @@ void call_binary_sfpu_operation(BinaryOp operation)
             _calculate_sfpu_binary_<false, SFPU_BINARY_OPERATION, 32>(1);
             break;
         case BinaryOp::RSHFT:
-            _calculate_binary_right_shift_<false, 32>(1);
+            _calculate_binary_right_shift_<false, 32, INT32, false>(1);
             break;
         case BinaryOp::LSHFT:
-            _calculate_binary_left_shift_<false, 32>(1);
+            _calculate_binary_left_shift_<false, 32, INT32, false>(1);
             break;
         default:
             return;

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_shift.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_shift.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <type_traits>
+
 #include "ckernel_addrmod.h"
 #include "ckernel_ops.h"
 #include "sfpi.h"
@@ -13,41 +15,47 @@ namespace ckernel
 namespace sfpu
 {
 
-template <bool APPROXIMATION_MODE, int ITERATIONS>
+template <bool APPROXIMATION_MODE, int ITERATIONS, InstrModLoadStore INSTRUCTION_MODE, bool SIGN_MAGNITUDE_FORMAT>
 inline void _calculate_binary_left_shift_(const uint dst_offset)
 {
+    static_assert(is_valid_instruction_mode(INSTRUCTION_MODE), "INSTRUCTION_MODE must be one of: INT32_2S_COMP, INT32, LO16.");
+
+    constexpr int sfpload_instr_mod = SIGN_MAGNITUDE_FORMAT ? INT32_2S_COMP : static_cast<std::underlying_type_t<InstrModLoadStore>>(INSTRUCTION_MODE);
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++)
     {
         constexpr uint dst_tile_size = 64;
         // load
-        TTI_SFPLOAD(0, 12, ADDR_MOD_7, 0);
-        TT_SFPLOAD(1, 12, ADDR_MOD_7, dst_offset * dst_tile_size);
+        TTI_SFPLOAD(p_sfpu::LREG0, sfpload_instr_mod, ADDR_MOD_7, 0);
+        TT_SFPLOAD(p_sfpu::LREG1, sfpload_instr_mod, ADDR_MOD_7, dst_offset * dst_tile_size);
         // if (shift_amount < 0 OR shift_amount >= 32) -> result should be 0
-        TTI_SFPSETCC(0, 1, 0, 4);
-        TTI_SFPIADD(0xFE0, 1, 2, 1); // 0xFE0 = -32
-        TTI_SFPCOMPC(0, 0, 0, 0);
-        TTI_SFPMOV(0, 9, 0, 0);
-        TTI_SFPENCC(0, 0, 0, 0);
+        TTI_SFPSETCC(0, p_sfpu::LREG1, p_sfpu::LREG0, 4);
+        TTI_SFPIADD(0xFE0, p_sfpu::LREG1, p_sfpu::LREG2, 1); // 0xFE0 = -32
+        TTI_SFPCOMPC(0, p_sfpu::LREG0, p_sfpu::LREG0, 0);
+        TTI_SFPMOV(0, p_sfpu::LCONST_0, p_sfpu::LREG0, 0);
+        TTI_SFPENCC(0, p_sfpu::LREG0, p_sfpu::LREG0, 0);
         // shift left
-        TTI_SFPSHFT(0, 1, 0, 0);
+        TTI_SFPSHFT(0, p_sfpu::LREG1, p_sfpu::LREG0, 0);
         // store result
-        TTI_SFPSTORE(0, 12, ADDR_MOD_7, 0);
+        TTI_SFPSTORE(p_sfpu::LREG0, sfpload_instr_mod, ADDR_MOD_7, 0);
         sfpi::dst_reg++;
     }
 }
 
-template <bool APPROXIMATION_MODE, int ITERATIONS>
+template <bool APPROXIMATION_MODE, int ITERATIONS, InstrModLoadStore INSTRUCTION_MODE, bool SIGN_MAGNITUDE_FORMAT>
 inline void _calculate_binary_right_shift_(const uint dst_offset)
 {
+    static_assert(is_valid_instruction_mode(INSTRUCTION_MODE), "INSTRUCTION_MODE must be one of: INT32_2S_COMP, INT32, LO16.");
+
+    constexpr int sfpload_instr_mod = SIGN_MAGNITUDE_FORMAT ? INT32_2S_COMP : static_cast<std::underlying_type_t<InstrModLoadStore>>(INSTRUCTION_MODE);
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++)
     {
         constexpr uint dst_tile_size = 64;
         // load
-        TTI_SFPLOAD(0, 12, ADDR_MOD_7, 0);
-        TT_SFPLOAD(1, 12, ADDR_MOD_7, dst_offset * dst_tile_size);
-        TTI_SFPMOV(0, 0, 4, 0); // save shift_value for later
+        TTI_SFPLOAD(p_sfpu::LREG0, sfpload_instr_mod, ADDR_MOD_7, 0);
+        TT_SFPLOAD(p_sfpu::LREG1, sfpload_instr_mod, ADDR_MOD_7, dst_offset * dst_tile_size);
+        TTI_SFPMOV(0, p_sfpu::LREG0, p_sfpu::LREG4, 0); // save shift_value for later
         // if (shift_amount < 0 OR shift_amount >= 32) -> result should be 0
         TTI_SFPSETCC(0, p_sfpu::LREG1, p_sfpu::LREG0, 4);
         TTI_SFPIADD(0xFE0, p_sfpu::LREG1, p_sfpu::LREG2, p_sfpu::LCONST_0); // 0xFE0 = -32
@@ -55,17 +63,17 @@ inline void _calculate_binary_right_shift_(const uint dst_offset)
         TTI_SFPENCC(0, p_sfpu::LREG0, p_sfpu::LREG0, 0);
         TTI_SFPIADD(0, p_sfpu::LCONST_0, p_sfpu::LREG1, 6); // take negative of shift_amount to shift right
         // shift right
-        TTI_SFPSHFT(0, 1, 0, 0);
+        TTI_SFPSHFT(0, p_sfpu::LREG1, p_sfpu::LREG0, 0);
         // if shift_value was negative, need to shift in 1's manually
-        TTI_SFPSETCC(0, 4, 0, 0);    // only run if shift_value is negative
-        TTI_SFPSETCC(0, 1, 0, 2);    // only needed if shift_amount>0
-        TTI_SFPIADD(0x020, 1, 2, 5); // take 32-shift_amount (0x020 = 32)
-        TTI_SFPNOT(0, 9, 3, 0);      // put all 1's into LREG3
-        TTI_SFPSHFT(0, 2, 3, 0);     // shift all 1's by 32-shift_amount
-        TTI_SFPOR(0, 3, 0, 0);       // OR in the 1's
-        TTI_SFPENCC(0, 0, 0, 0);
+        TTI_SFPSETCC(0, p_sfpu::LREG4, p_sfpu::LREG0, 0);    // only run if shift_value is negative
+        TTI_SFPSETCC(0, p_sfpu::LREG1, p_sfpu::LREG0, 2);    // only needed if shift_amount>0
+        TTI_SFPIADD(0x020, p_sfpu::LREG1, p_sfpu::LREG2, 5); // take 32-shift_amount (0x020 = 32)
+        TTI_SFPNOT(0, p_sfpu::LCONST_0, p_sfpu::LREG3, 0);   // put all 1's into LREG3
+        TTI_SFPSHFT(0, p_sfpu::LREG2, p_sfpu::LREG3, 0);     // shift all 1's by 32-shift_amount
+        TTI_SFPOR(0, p_sfpu::LREG3, p_sfpu::LREG0, 0);       // OR in the 1's
+        TTI_SFPENCC(0, p_sfpu::LREG0, p_sfpu::LREG0, 0);
         // store result
-        TTI_SFPSTORE(0, 12, ADDR_MOD_7, 0);
+        TTI_SFPSTORE(p_sfpu::LREG0, sfpload_instr_mod, ADDR_MOD_7, 0);
         sfpi::dst_reg++;
     }
 }

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_shift.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_shift.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <type_traits>
+
 #include "ckernel_ops.h"
 #include "sfpi.h"
 
@@ -12,41 +14,49 @@ namespace ckernel
 namespace sfpu
 {
 
-template <bool APPROXIMATION_MODE, int ITERATIONS>
+template <bool APPROXIMATION_MODE, int ITERATIONS, InstrModLoadStore INSTRUCTION_MODE, bool SIGN_MAGNITUDE_FORMAT>
 inline void _calculate_binary_left_shift_(const uint dst_offset)
 {
+    static_assert(is_valid_instruction_mode(INSTRUCTION_MODE), "INSTRUCTION_MODE must be one of: INT32_2S_COMP, INT32, LO16.");
+
+    constexpr int sfpload_instr_mod = SIGN_MAGNITUDE_FORMAT ? INT32_2S_COMP : static_cast<std::underlying_type_t<InstrModLoadStore>>(INSTRUCTION_MODE);
+
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++)
     {
         constexpr uint dst_tile_size = 64;
         // load
-        TTI_SFPLOAD(0, 4, 3, 0);
-        TT_SFPLOAD(1, 4, 3, dst_offset * dst_tile_size);
+        TTI_SFPLOAD(p_sfpu::LREG0, sfpload_instr_mod, 3, 0);
+        TT_SFPLOAD(p_sfpu::LREG1, sfpload_instr_mod, 3, dst_offset * dst_tile_size);
         // if (shift_amount < 0 OR shift_amount >= 32) -> result should be 0
-        TTI_SFPSETCC(0, 1, 0, 4);
-        TTI_SFPIADD(0xFE0, 1, 2, 1); // 0xFE0 = -32
-        TTI_SFPCOMPC(0, 0, 0, 0);
-        TTI_SFPMOV(0, 9, 0, 0);
-        TTI_SFPENCC(0, 0, 0, 0);
+        TTI_SFPSETCC(0, p_sfpu::LREG1, p_sfpu::LREG0, 4);
+        TTI_SFPIADD(0xFE0, p_sfpu::LREG1, p_sfpu::LREG2, 1); // 0xFE0 = -32
+        TTI_SFPCOMPC(0, p_sfpu::LREG0, p_sfpu::LREG0, 0);
+        TTI_SFPMOV(0, p_sfpu::LCONST_0, p_sfpu::LREG0, 0);
+        TTI_SFPENCC(0, p_sfpu::LREG0, p_sfpu::LREG0, 0);
         // shift left
-        TTI_SFPSHFT(0, 1, 0, 0);
+        TTI_SFPSHFT(0, p_sfpu::LREG1, p_sfpu::LREG0, 0);
         // store result
-        TTI_SFPSTORE(0, 4, 3, 0);
+        TTI_SFPSTORE(p_sfpu::LREG0, sfpload_instr_mod, 3, 0);
         sfpi::dst_reg++;
     }
 }
 
-template <bool APPROXIMATION_MODE, int ITERATIONS>
+template <bool APPROXIMATION_MODE, int ITERATIONS, InstrModLoadStore INSTRUCTION_MODE, bool SIGN_MAGNITUDE_FORMAT>
 inline void _calculate_binary_right_shift_(const uint dst_offset)
 {
+    static_assert(is_valid_instruction_mode(INSTRUCTION_MODE), "INSTRUCTION_MODE must be one of: INT32_2S_COMP, INT32, LO16.");
+
+    constexpr int sfpload_instr_mod = SIGN_MAGNITUDE_FORMAT ? INT32_2S_COMP : static_cast<std::underlying_type_t<InstrModLoadStore>>(INSTRUCTION_MODE);
+
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++)
     {
         constexpr uint dst_tile_size = 64;
         // load
-        TTI_SFPLOAD(0, 4, 3, 0);
-        TT_SFPLOAD(1, 4, 3, dst_offset * dst_tile_size);
-        TTI_SFPMOV(0, 0, 4, 0); // save shift_value for later
+        TTI_SFPLOAD(p_sfpu::LREG0, sfpload_instr_mod, 3, 0);
+        TT_SFPLOAD(p_sfpu::LREG1, sfpload_instr_mod, 3, dst_offset * dst_tile_size);
+        TTI_SFPMOV(0, p_sfpu::LREG0, p_sfpu::LREG4, 0); // save shift_value for later
         // if (shift_amount < 0 OR shift_amount >= 32) -> result should be 0
         TTI_SFPSETCC(0, p_sfpu::LREG1, p_sfpu::LREG0, 4);
         TTI_SFPIADD(0xFE0, p_sfpu::LREG1, p_sfpu::LREG2, p_sfpu::LCONST_0); // 0xFE0 = -32
@@ -54,17 +64,17 @@ inline void _calculate_binary_right_shift_(const uint dst_offset)
         TTI_SFPENCC(0, p_sfpu::LREG0, p_sfpu::LREG0, 0);
         TTI_SFPIADD(0, p_sfpu::LCONST_0, p_sfpu::LREG1, 6); // take negative of shift_amount to shift right
         // shift right
-        TTI_SFPSHFT(0, 1, 0, 0);
+        TTI_SFPSHFT(0, p_sfpu::LREG1, p_sfpu::LREG0, 0);
         // if shift_value was negative, need to shift in 1's manually
-        TTI_SFPSETCC(0, 4, 0, 0);    // only run if shift_value is negative
-        TTI_SFPSETCC(0, 1, 0, 2);    // only needed if shift_amount>0
-        TTI_SFPIADD(0x020, 1, 2, 5); // take 32-shift_amount (0x020 = 32)
-        TTI_SFPNOT(0, 9, 3, 0);      // put all 1's into LREG3
-        TTI_SFPSHFT(0, 2, 3, 0);     // shift all 1's by 32-shift_amount
-        TTI_SFPOR(0, 3, 0, 0);       // OR in the 1's
-        TTI_SFPENCC(0, 0, 0, 0);
+        TTI_SFPSETCC(0, p_sfpu::LREG4, p_sfpu::LREG0, 0);    // only run if shift_value is negative
+        TTI_SFPSETCC(0, p_sfpu::LREG1, p_sfpu::LREG0, 2);    // only needed if shift_amount>0
+        TTI_SFPIADD(0x020, p_sfpu::LREG1, p_sfpu::LREG2, 5); // take 32-shift_amount (0x020 = 32)
+        TTI_SFPNOT(0, p_sfpu::LCONST_0, p_sfpu::LREG3, 0);   // put all 1's into LREG3
+        TTI_SFPSHFT(0, p_sfpu::LREG2, p_sfpu::LREG3, 0);     // shift all 1's by 32-shift_amount
+        TTI_SFPOR(0, p_sfpu::LREG3, p_sfpu::LREG0, 0);       // OR in the 1's
+        TTI_SFPENCC(0, p_sfpu::LREG0, p_sfpu::LREG0, 0);
         // store result
-        TTI_SFPSTORE(0, 4, 3, 0);
+        TTI_SFPSTORE(p_sfpu::LREG0, sfpload_instr_mod, 3, 0);
         sfpi::dst_reg++;
     }
 }


### PR DESCRIPTION
### Ticket
#235 

### Problem description
LLK test in infra are hardcoded for running on single tile and have hardcoded addresses for L1 input and output buffers.

### What's changed
Addresses for L1 operands and result are generated in build.h ( still needs a bit of polishing ), some of tests are uplifted to work on custom tensor input shape ( for example [32,64] ). Based on that tile_cnt is generated and data is stored in L1 in contignuous manner aware of data format and it's length. 

Golden generation for tilize ( untilize in progress ) is now treated as tilize/untilize_block which operate on multiple tiles of data. 

All cpp tests changed to accept parameters from build.h

Fill_dest is treated as an edge case of multiple_tiles these ( where it gets filld with 16 (16 bit formats) or 8 (fp32 int32) tiles) so is removed as redundant.

Tests that are fully converted to new approach:
- eltwise unary datacopy
- eltwise unary sfpu
- Unpack tilize
- multiple tiles eltwise

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
