### PR TITLE
profiler ⌛: refactor how metadata is passed

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -13,6 +13,7 @@ SHARED_DIR       := $(BUILD_DIR)/shared
 TEST_DIR        := $(BUILD_DIR)/tests/$(testname)
 OBJ_DIR         := $(TEST_DIR)/obj
 DIS_DIR         := $(TEST_DIR)/dis
+PROFILER_DIR    := $(TEST_DIR)/profiler
 ELF_DIR         := $(TEST_DIR)/elf
 
 HELPERS         := helpers
@@ -23,6 +24,7 @@ RMDIR           := rm -rf
 
 GXX             := $(TOOL_PATH)/riscv32-tt-elf-g++
 OBJDUMP         := $(TOOL_PATH)/riscv32-tt-elf-objdump
+OBJCOPY         := $(TOOL_PATH)/riscv32-tt-elf-objcopy
 
 # =========================
 # Architecture Selection
@@ -61,7 +63,7 @@ TO_UPPER = $(shell echo $(1) | tr '[:lower:]' '[:upper:]')
 # =========================
 # Targets
 # =========================
-.PHONY: all dis clean
+.PHONY: all dis profiler clean
 
 all: $(ELF_DIR)/unpack.elf \
 	 $(ELF_DIR)/math.elf \
@@ -73,6 +75,9 @@ dis: $(DIS_DIR)/unpack.S \
 	 $(DIS_DIR)/pack.S \
 	 $(SHARED_DIR)/brisc.S
 
+profiler: $(PROFILER_DIR)/unpack.meta.bin \
+	      $(PROFILER_DIR)/math.meta.bin \
+	      $(PROFILER_DIR)/pack.meta.bin
 # =========================
 # Build Rules
 # =========================
@@ -81,6 +86,9 @@ dis: $(DIS_DIR)/unpack.S \
 $(SHARED_DIR)/%.S: $(SHARED_DIR)/%.elf | $(SHARED_DIR)
 	$(OBJDUMP) -xsD $< > $@
 	$(OBJDUMP) -t $< | sort >> $@
+
+$(PROFILER_DIR)/%.meta.bin: $(ELF_DIR)/%.elf | $(PROFILER_DIR)
+	$(OBJCOPY) -O binary -j .profiler_meta $< $@
 
 $(DIS_DIR)/%.S: $(ELF_DIR)/%.elf | $(DIS_DIR)
 	$(OBJDUMP) -xsD $< > $@
@@ -107,7 +115,7 @@ $(SHARED_DIR)/tmu-crt0.o: $(HELPERS)/tmu-crt0.S | $(SHARED_DIR)
 	$(GXX) $(OPTIONS_ALL) $(OPTIONS_COMPILE) -MMD -MP -MF $(@:.o=.d) -c -o $@ $<
 
 # required folder structure
-$(DIS_DIR) $(ELF_DIR) $(OBJ_DIR) $(SHARED_DIR):
+$(PROFILER_DIR) $(DIS_DIR) $(ELF_DIR) $(OBJ_DIR) $(SHARED_DIR):
 	mkdir -p $@
 
 # =========================

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -76,8 +76,8 @@ dis: $(DIS_DIR)/unpack.S \
 	 $(SHARED_DIR)/brisc.S
 
 profiler: $(PROFILER_DIR)/unpack.meta.bin \
-	      $(PROFILER_DIR)/math.meta.bin \
-	      $(PROFILER_DIR)/pack.meta.bin
+	  $(PROFILER_DIR)/math.meta.bin \
+	  $(PROFILER_DIR)/pack.meta.bin
 # =========================
 # Build Rules
 # =========================

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -44,7 +44,7 @@ endif
 # =========================
 # Compiler and Linker Flags
 # =========================
-OPTIONS_ALL	:= -O3 -mabi=ilp32 -std=$(CXX_VERSION) -ffast-math $(ARCH_CPU)
+OPTIONS_ALL	:= -g -O3 -mabi=ilp32 -std=$(CXX_VERSION) -ffast-math $(ARCH_CPU)
 OPTIONS_COMPILE := -fno-use-cxa-atexit -Wall -fpermissive -fno-exceptions -fno-rtti -Werror \
 				   -Wno-unknown-pragmas -Wno-error=multistatement-macros -Wno-error=parentheses \
 				   -Wno-error=unused-but-set-variable -Wno-unused-variable -DTENSIX_FIRMWARE \

--- a/tests/helpers/include/profiler.h
+++ b/tests/helpers/include/profiler.h
@@ -36,6 +36,14 @@ constexpr std::uint16_t hashString16(const char (&s)[N])
 
 #define MARKER_ID(marker) hashString16(MARKER_FULL(marker))
 
+#define PROFILER_META(full_marker)                          \
+    {                                                       \
+        asm volatile(                                     \
+            ".pushsection .profiler_meta,\"a\"\n\t"       \
+            ".asciz " ExpandStringize(full_marker) "\n\t" \
+            ".popsection\n\t"); \
+    }
+
 #if defined(LLK_PROFILER)
 
 namespace llk_profiler
@@ -193,14 +201,17 @@ __attribute__((always_inline)) inline void write_timestamp(uint16_t id16, uint64
 } // namespace llk_profiler
 
 #define ZONE_SCOPED(marker)                 \
+    PROFILER_META(MARKER_FULL(marker))      \
     DO_PRAGMA(message(MARKER_FULL(marker))) \
     const auto _zone_scoped_ = llk_profiler::zone_scoped<MARKER_ID(marker)>();
 
 #define TIMESTAMP(marker)                   \
+    PROFILER_META(MARKER_FULL(marker))      \
     DO_PRAGMA(message(MARKER_FULL(marker))) \
     llk_profiler::write_timestamp(MARKER_ID(marker));
 
 #define TIMESTAMP_DATA(marker, data)        \
+    PROFILER_META(MARKER_FULL(marker))      \
     DO_PRAGMA(message(MARKER_FULL(marker))) \
     llk_profiler::write_timestamp(MARKER_ID(marker), data);
 

--- a/tests/helpers/include/profiler.h
+++ b/tests/helpers/include/profiler.h
@@ -11,8 +11,6 @@
 #include "build.h"
 #include "ckernel.h"
 
-#define DO_PRAGMA(x) _Pragma(#x)
-
 // Logic to convert zone name -> 16bit numeric id
 #define Stringize(L)       #L
 #define ExpandStringize(L) Stringize(L)
@@ -200,19 +198,16 @@ __attribute__((always_inline)) inline void write_timestamp(uint16_t id16, uint64
 
 } // namespace llk_profiler
 
-#define ZONE_SCOPED(marker)                 \
-    PROFILER_META(MARKER_FULL(marker))      \
-    DO_PRAGMA(message(MARKER_FULL(marker))) \
+#define ZONE_SCOPED(marker)            \
+    PROFILER_META(MARKER_FULL(marker)) \
     const auto _zone_scoped_ = llk_profiler::zone_scoped<MARKER_ID(marker)>();
 
-#define TIMESTAMP(marker)                   \
-    PROFILER_META(MARKER_FULL(marker))      \
-    DO_PRAGMA(message(MARKER_FULL(marker))) \
+#define TIMESTAMP(marker)              \
+    PROFILER_META(MARKER_FULL(marker)) \
     llk_profiler::write_timestamp(MARKER_ID(marker));
 
-#define TIMESTAMP_DATA(marker, data)        \
-    PROFILER_META(MARKER_FULL(marker))      \
-    DO_PRAGMA(message(MARKER_FULL(marker))) \
+#define TIMESTAMP_DATA(marker, data)   \
+    PROFILER_META(MARKER_FULL(marker)) \
     llk_profiler::write_timestamp(MARKER_ID(marker), data);
 
 #else

--- a/tests/helpers/include/profiler.h
+++ b/tests/helpers/include/profiler.h
@@ -38,13 +38,7 @@ constexpr std::uint16_t hashString16(const char (&s)[N])
  * This section will be processed by the host code to construct a mapping
  * MARKER_ID -> { filename, line, marker } for parsing the profiler buffer.
  */
-#define PROFILER_META(full_marker)                          \
-    {                                                       \
-        asm volatile(                                     \
-            ".pushsection .profiler_meta,\"a\"\n\t"       \
-            ".asciz " ExpandStringize(full_marker) "\n\t" \
-            ".popsection\n\t"); \
-    }
+#define PROFILER_META(full_marker) __attribute__((section(".profiler_meta"), used)) static const char _profiler_meta_##__COUNTER__[] = full_marker;
 
 #if defined(LLK_PROFILER)
 

--- a/tests/helpers/include/profiler.h
+++ b/tests/helpers/include/profiler.h
@@ -34,6 +34,10 @@ constexpr std::uint16_t hashString16(const char (&s)[N])
 
 #define MARKER_ID(marker) hashString16(MARKER_FULL(marker))
 
+/* Push a string containing the full marker into the .profiler_meta section.
+ * This section will be processed by the host code to construct a mapping
+ * MARKER_ID -> { filename, line, marker } for parsing the profiler buffer.
+ */
 #define PROFILER_META(full_marker)                          \
     {                                                       \
         asm volatile(                                     \

--- a/tests/helpers/ld/sections.ld
+++ b/tests/helpers/ld/sections.ld
@@ -138,6 +138,7 @@ SECTIONS
    . += __firmware_stack_size;
     __stack_top = .;
   } > REGION_STACK
+  .profiler_meta 0 : { *(.profiler_meta) }
   .stab 0 : { *(.stab) }
   .stabstr 0 : { *(.stabstr) }
   .stab.excl 0 : { *(.stab.excl) }

--- a/tests/python_tests/helpers/perf.py
+++ b/tests/python_tests/helpers/perf.py
@@ -127,14 +127,14 @@ def perf_benchmark(test_config, run_types: list[PerfRunType], run_count=8):
         get_timing = RUN_CONFIGURATIONS[type]
 
         test_config["perf_run_type"] = type
-        profiler_meta = build_with_profiler(test_config)
+        build_with_profiler(test_config)
 
         runs = []
         for _ in range(run_count):
             run_elf_files(test_config["testname"])
             wait_for_tensix_operations_finished()
 
-            profiler_data = Profiler.get_data(profiler_meta)
+            profiler_data = Profiler.get_data(test_config["testname"])
             perf_data = process_profiler_data(profiler_data)
 
             runs.append(get_timing(perf_data))

--- a/tests/python_tests/helpers/test_config.py
+++ b/tests/python_tests/helpers/test_config.py
@@ -180,6 +180,9 @@ def generate_make_command(
         write_build_header(test_config, profiler_build=profiler_build)
 
     # Simplified make command - only basic build parameters
-    make_cmd = f"make -j 6 --silent testname={test_config.get('testname')} "
+    make_cmd = f"make -j 6 --silent testname={test_config.get('testname')} all "
+
+    if profiler_build == ProfilerBuild.Yes:
+        make_cmd += "profiler "
 
     return make_cmd

--- a/tests/python_tests/test_profiler_overhead.py
+++ b/tests/python_tests/test_profiler_overhead.py
@@ -27,13 +27,12 @@ def test_profiler_overhead():
         "testname": "profiler_overhead_test",
     }
 
-    profiler_meta = build_with_profiler(test_config)
-    assert profiler_meta is not None, "Profiler metadata should not be None"
+    build_with_profiler(test_config)
 
     run_elf_files("profiler_overhead_test")
     wait_for_tensix_operations_finished()
 
-    runtime = Profiler.get_data(profiler_meta)
+    runtime = Profiler.get_data(test_config["testname"])
 
     # filter out all zones that dont have marker "OVERHEAD"
     overhead_zones = [x for x in runtime.unpack if x.full_marker.marker == "OVERHEAD"]

--- a/tests/python_tests/test_profiler_primitives.py
+++ b/tests/python_tests/test_profiler_primitives.py
@@ -32,13 +32,12 @@ def test_profiler_primitives():
         "testname": "profiler_primitives_test",
     }
 
-    profiler_meta = build_with_profiler(test_config)
-    assert profiler_meta is not None, "Profiler metadata should not be None"
+    build_with_profiler(test_config)
 
     run_elf_files("profiler_primitives_test")
     wait_for_tensix_operations_finished()
 
-    runtime = Profiler.get_data(profiler_meta)
+    runtime = Profiler.get_data(test_config["testname"])
 
     # ZONE_SCOPED
     zone = runtime.unpack[0]


### PR DESCRIPTION
### Ticket

### Problem description
The metadata that is needed for the profiler to properly function is currently passed compile time from `gcc` to the python infra using `#pragma message`. The `stderr` stream is then parsed on the python side for this metadata. This has already caused issues when files containing profiler primitives are not recompiled every run, because the message wouldn't get written to `stderr` 

### What's changed
This refactor changes how profiler metadata is passed to python infra. The profiler metadata will get pushed into the `.profiler_meta` section, which will get parsed after linking is done. Because meta is kept in the intermediate `.o` files, we have a guarantee that all metadata will end up in the final `.elf` of the corresponding thread.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
