### PR TITLE
Enable BRISC TRISC synchronisation

### DIFF
--- a/tests/helpers/src/brisc.cpp
+++ b/tests/helpers/src/brisc.cpp
@@ -4,6 +4,7 @@
 
 #include <cstdint>
 
+#include "ckernel.h"
 #include "ckernel_instr_params.h"
 #include "ckernel_ops.h"
 #include "ckernel_structs.h"
@@ -35,9 +36,20 @@ void device_setup()
     TTI_SEMINIT(1, 0, ckernel::semaphore::PACK_DONE);
 }
 
+void clear_trisc_soft_reset()
+{
+    uint32_t soft_reset = ckernel::reg_read(RISCV_DEBUG_REG_SOFT_RESET_0);
+    soft_reset &= ~0x7000;
+    ckernel::reg_write(RISCV_DEBUG_REG_SOFT_RESET_0, soft_reset);
+}
+
 int main()
 {
     device_setup();
+
+    // Reset triscs here in order to achieve brisc <-> trisc synchronization
+    clear_trisc_soft_reset();
+
     // Use a volatile variable to prevent the compiler from optimizing away the loop
     volatile bool run = true;
 

--- a/tests/python_tests/helpers/device.py
+++ b/tests/python_tests/helpers/device.py
@@ -60,9 +60,6 @@ def collect_results(
 def run_elf_files(testname, core_loc="0,0", run_brisc=True):
     BUILD = "../build"
 
-    if run_brisc:
-        run_elf(f"{BUILD}/shared/brisc.elf", core_loc, risc_id=0)
-
     context = check_context()
     device = context.devices[0]
     RISC_DBG_SOFT_RESET0 = device.get_tensix_register_address(
@@ -85,9 +82,8 @@ def run_elf_files(testname, core_loc="0,0", run_brisc=True):
     TRISC_PROFILER_BARRIER = 0x16AFF4
     write_words_to_device(core_loc, TRISC_PROFILER_BARRIER, [0, 0, 0])
 
-    # Clear soft reset
-    soft_reset &= ~0x7800
-    write_words_to_device(core_loc, RISC_DBG_SOFT_RESET0, soft_reset)
+    if run_brisc:
+        run_elf(f"{BUILD}/shared/brisc.elf", core_loc, risc_id=0)
 
 
 def write_stimuli_to_l1(


### PR DESCRIPTION
BRISC handles the soft reset of the TRISCs, which ensures that dst is zeroed properly via TTI_ZEROACC.

### Ticket

### Problem description
When tests are run in simulation, the BRISC does not start executing on time, and therefore the dst register is not zeroed. Do to the lack of synchronisation, TRISC executes and takes garbage values from dst and produces incorrect results.

### What's changed
The problem is solved by introducing BRISC <-> TRISC synchronisation. The BRISC is taken out of reset first, and then the BRISC is responsible for taking the TRISCs out of reset. This ensures that the dst register is zeroed before TRISCs start running.

### Type of change

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
