### PR TITLE
Added uint typecasts to LLK for WH BH

### DIFF
--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_typecast.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_typecast.h
@@ -262,8 +262,41 @@ inline void _calculate_typecast_uint16_to_uint32_()
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++)
     {
-        TTI_SFPLOAD(0, 9, ADDR_MOD_7, 0);
+        TTI_SFPLOAD(0, 6, ADDR_MOD_7, 0);
         TTI_SFPSTORE(0, 12, ADDR_MOD_7, 0);
+        sfpi::dst_reg++;
+    }
+}
+
+template <bool APPROXIMATION_MODE, int ITERATIONS>
+inline void _calculate_typecast_uint32_to_uint16_()
+{
+    //Packer will read HI16 bits from DEST if DEST is in 32bit mode but pck is configured for uint16
+#pragma GCC unroll 0
+    for (int d = 0; d < ITERATIONS; d++)
+    {
+        TTI_SFPLOAD(p_sfpu::LREG0, 12, ADDR_MOD_7, 0); //Load 32bit datums from DEST
+        TTI_SFPLOADI(p_sfpu::LREG1, 2, 0xFFFF); //Load Lo16 of LREG1 with 0xFFFF (65535)
+        TTI_SFPSETCC(0, p_sfpu::LREG0, 0, 4); //If sign bit of LREG0 is 0, set CC
+        TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG1, 1); //Put smaller of LREG0 & 1 into LREG1
+        TTI_SFPENCC(0, 0, 0, 0); //Clear CC bits
+        TTI_SFPSTORE(p_sfpu::LREG1, 6, ADDR_MOD_7, 0); //Store output
+        sfpi::dst_reg++;
+    }
+}
+
+template <bool APPROXIMATION_MODE, int ITERATIONS>
+inline void _calculate_typecast_int32_to_uint16_()
+{
+#pragma GCC unroll 0
+    for (int d = 0; d < ITERATIONS; d++)
+    {
+        TTI_SFPLOAD(0, 12, ADDR_MOD_7, 0);
+        TTI_SFPLOADI(1, 2, 0);
+        TTI_SFPSWAP(0, 0, 1, 1);
+        TTI_SFPLOADI(2, 2, 0xFFFF);
+        TTI_SFPSWAP(0, 2, 0, 1);
+        TTI_SFPSTORE(0, 6, ADDR_MOD_7, 0);
         sfpi::dst_reg++;
     }
 }

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_typecast.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_typecast.h
@@ -243,5 +243,38 @@ inline void _calculate_typecast_uint16_to_uint32_()
     }
 }
 
+template <bool APPROXIMATION_MODE, int ITERATIONS>
+inline void _calculate_typecast_uint32_to_uint16_()
+{
+    //Packer will read HI16 bits from DEST if DEST is in 32bit mode but pck is configured for uint16
+#pragma GCC unroll 0
+    for (int d = 0; d < ITERATIONS; d++)
+    {
+        TTI_SFPLOAD(p_sfpu::LREG0, 4, ADDR_MOD_3, 0); //Load 32bit datums from DEST
+        TTI_SFPLOADI(p_sfpu::LREG1, 2, 0xFFFF); //Load Lo16 of LREG1 with 0xFFFF (65535)
+        TTI_SFPSETCC(0, p_sfpu::LREG0, 0, 4); //If sign bit of LREG0 is 0, set CC
+        TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG1, 1); //Put smaller of LREG0 & 1 into LREG1
+        TTI_SFPENCC(0, 0, 0, 0); //Clear CC bits
+        TTI_SFPSTORE(p_sfpu::LREG1, 6, ADDR_MOD_3, 0); //Store output
+        sfpi::dst_reg++;
+    }
+}
+
+template <bool APPROXIMATION_MODE, int ITERATIONS>
+inline void _calculate_typecast_int32_to_uint16_()
+{
+#pragma GCC unroll 0
+    for (int d = 0; d < ITERATIONS; d++)
+    {
+        TTI_SFPLOAD(0, 4, ADDR_MOD_3, 0);
+        TTI_SFPLOADI(1, 2, 0);
+        TTI_SFPSWAP(0, 0, 1, 1);
+        TTI_SFPLOADI(2, 2, 0xFFFF);
+        TTI_SFPSWAP(0, 2, 0, 1);
+        TTI_SFPSTORE(0, 6, ADDR_MOD_3, 0);
+        sfpi::dst_reg++;
+    }
+}
+
 } // namespace sfpu
 } // namespace ckernel


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/21435
https://github.com/tenstorrent/tt-metal/issues/21436

### Problem description
Missing int to int typecasts

### What's changed
Added these int to int typecast on WH and BH:

- int32 to uint16
- uint32 to uint16
- uint16 to int32

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
