### PR TITLE
Relocate the TRISC kernel running write to mailbox

### DIFF
--- a/tests/helpers/src/trisc.cpp
+++ b/tests/helpers/src/trisc.cpp
@@ -43,7 +43,6 @@ int main()
     std::uint64_t wall_clock = ckernel::read_wall_clock();
 
     *(TIMESTAMP_ADDRESS + core_idx * 2) = wall_clock;
-    *mailbox                            = 0x2; // write value different than 1 to mailbox to indicate kernel is running
 
     std::fill(ckernel::regfile, ckernel::regfile + 64, 0);
     ckernel::reset_cfg_state_id();

--- a/tests/helpers/src/trisc.cpp
+++ b/tests/helpers/src/trisc.cpp
@@ -43,7 +43,6 @@ int main()
     std::uint64_t wall_clock = ckernel::read_wall_clock();
 
     *(TIMESTAMP_ADDRESS + core_idx * 2) = wall_clock;
-    *mailbox                            = ckernel::KERNEL_IN_PROGRESS; // 0xf
 
     std::fill(ckernel::regfile, ckernel::regfile + 64, 0);
     ckernel::reset_cfg_state_id();

--- a/tests/helpers/src/trisc.cpp
+++ b/tests/helpers/src/trisc.cpp
@@ -43,6 +43,7 @@ int main()
     std::uint64_t wall_clock = ckernel::read_wall_clock();
 
     *(TIMESTAMP_ADDRESS + core_idx * 2) = wall_clock;
+    *mailbox                            = ckernel::KERNEL_IN_PROGRESS; // 0xf
 
     std::fill(ckernel::regfile, ckernel::regfile + 64, 0);
     ckernel::reset_cfg_state_id();

--- a/tests/python_tests/conftest.py
+++ b/tests/python_tests/conftest.py
@@ -21,9 +21,6 @@ from helpers.format_arg_mapping import Mailbox
 from helpers.log_utils import _format_log
 from helpers.perf import delete_reports
 
-# Constant - indicates the TRISC kernel run status
-RESET_VAL = 0  # Kernel not running and not complete
-
 
 def init_llk_home():
     if "LLK_HOME" in os.environ:
@@ -69,10 +66,13 @@ def set_chip_architecture():
 
 
 @pytest.fixture(autouse=True)
-def setup_all_mailboxes_before_test():
-    write_words_to_device(core_loc="0, 0", addr=Mailbox.Packer.value, data=RESET_VAL)
-    write_words_to_device(core_loc="0, 0", addr=Mailbox.Math.value, data=RESET_VAL)
-    write_words_to_device(core_loc="0, 0", addr=Mailbox.Unpacker.value, data=RESET_VAL)
+def reset_mailboxes():
+    """Reset all core mailboxes before each test."""
+    core_loc = "0, 0"
+    reset_value = 0  # Constant - indicates the TRISC kernel run status
+    mailboxes = [Mailbox.Packer, Mailbox.Math, Mailbox.Unpacker]
+    for mailbox in mailboxes:
+        write_words_to_device(core_loc=core_loc, addr=mailbox.value, data=reset_value)
     yield
 
 

--- a/tests/python_tests/conftest.py
+++ b/tests/python_tests/conftest.py
@@ -11,11 +11,18 @@ from pathlib import Path
 import pytest
 import requests
 from requests.exceptions import ConnectionError, RequestException, Timeout
-from ttexalens.tt_exalens_lib import arc_msg
+from ttexalens.tt_exalens_lib import (
+    arc_msg,
+    write_words_to_device,
+)
 
 from helpers.chip_architecture import ChipArchitecture, get_chip_architecture
+from helpers.format_arg_mapping import Mailbox
 from helpers.log_utils import _format_log
 from helpers.perf import delete_reports
+
+# Constant - indicates the TRISC kernel run status
+RESET_VAL = 0  # Kernel not running and not complete
 
 
 def init_llk_home():
@@ -59,6 +66,14 @@ def set_chip_architecture():
         sys.exit(1)
     os.environ["CHIP_ARCH"] = architecture.value
     return architecture
+
+
+@pytest.fixture(autouse=True)
+def setup_all_mailboxes_before_test():
+    write_words_to_device(core_loc="0, 0", addr=Mailbox.Packer.value, data=RESET_VAL)
+    write_words_to_device(core_loc="0, 0", addr=Mailbox.Math.value, data=RESET_VAL)
+    write_words_to_device(core_loc="0, 0", addr=Mailbox.Unpacker.value, data=RESET_VAL)
+    yield
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/python_tests/helpers/device.py
+++ b/tests/python_tests/helpers/device.py
@@ -275,6 +275,8 @@ def wait_until_tensix_complete(core_loc, mailbox_addr, timeout=30, max_backoff=5
 
     while time.time() - start_time < timeout:
         if read_word_from_device(core_loc, mailbox_addr.value) == 1:
+            # write value different than 1 to mailbox to indicate kernel is running
+            write_words_to_device(core_loc, mailbox_addr.value, 2)
             return
 
         time.sleep(backoff)

--- a/tests/python_tests/helpers/device.py
+++ b/tests/python_tests/helpers/device.py
@@ -84,18 +84,17 @@ def perform_tensix_soft_reset(core_loc="0,0"):
 
 
 def run_elf_files(testname, core_loc="0,0"):
-    BUILD = "../build"
+    build_dir = Path("../build")
 
     # Perform soft reset
     perform_tensix_soft_reset(core_loc)
 
     # Load TRISC ELF files
-    TRISC = ["unpack", "math", "pack"]
-    for i in range(3):
+    trisc_names = ["unpack", "math", "pack"]
+    for i, trisc_name in enumerate(trisc_names):
+        elf_path = build_dir / "tests" / testname / "elf" / f"{trisc_name}.elf"
         load_elf(
-            elf_file=str(
-                Path(f"{BUILD}/tests/{testname}/elf/{TRISC[i]}.elf").absolute()
-            ),
+            elf_file=str(elf_path.absolute()),
             core_loc=core_loc,
             risc_name=f"trisc{i}",
         )
@@ -105,9 +104,8 @@ def run_elf_files(testname, core_loc="0,0"):
     write_words_to_device(core_loc, TRISC_PROFILER_BARRIE_ADDRESS, [0, 0, 0])
 
     # Run BRISC
-    run_elf(
-        str(Path(f"{BUILD}/shared/brisc.elf").absolute()), core_loc, risc_name="brisc"
-    )
+    brisc_elf_path = build_dir / "shared" / "brisc.elf"
+    run_elf(str(brisc_elf_path.absolute()), core_loc, risc_name="brisc")
 
 
 def write_stimuli_to_l1(

--- a/tests/python_tests/helpers/device.py
+++ b/tests/python_tests/helpers/device.py
@@ -51,6 +51,11 @@ MAX_READ_BYTE_SIZE_16BIT = 2048
 # Constants for soft reset operation
 TRISC_SOFT_RESET_MASK = 0x7800  # Reset mask for TRISCs (unpack, math, pack) and BRISC
 
+# Constants indicating the TRISC kernel run status
+RESET_VAL = 0  # Kernel not running and not complete
+KERNEL_COMPLETE = 1  # Kernel completed its run
+KERNEL_IN_PROGRESS = 15  # Kernel running
+
 
 def collect_results(
     formats: FormatConfig,
@@ -274,9 +279,9 @@ def wait_until_tensix_complete(core_loc, mailbox_addr, timeout=30, max_backoff=5
     backoff = 0.1  # Initial backoff time in seconds
 
     while time.time() - start_time < timeout:
-        if read_word_from_device(core_loc, mailbox_addr.value) == 1:
+        if read_word_from_device(core_loc, mailbox_addr.value) == KERNEL_COMPLETE:
             # write value different than 1 to mailbox to indicate kernel is running
-            write_words_to_device(core_loc, mailbox_addr.value, 2)
+            write_words_to_device(core_loc, mailbox_addr.value, RESET_VAL)
             return
 
         time.sleep(backoff)


### PR DESCRIPTION
Write to the mailbox that the TRISC kernel is running immediately after detecting that tensix is complete, instead of doing it in trisc.cpp

### Ticket


### Problem description
When running multiple tests one after the other on simulator, only the first one passes, and the following ones fail. This is because at the end of the first test there is a 1 written to the mailbox. This value gets read, instead of the 2 which is supposed to be written into the mailbox by trisc.cpp. This results in the second test getting interpreted as already finished, when it has not even started yet. 

### What's changed
Instead of trisc.cpp writing the 2 into the mailbox, it is now done inside of device.py, right after detecting that Tensix operations are complete. 

### Type of change

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
