### PR TITLE
ci: add Strahinja and Stefan as tests' code owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,7 +8,7 @@
 .github/ @fvranicTT @nvelickovicTT
 
 # Tests
-tests/ @fvranicTT @ldjurovicTT @nvelickovicTT @skotaracTT
+tests/ @fvranicTT @ldjurovicTT @nvelickovicTT @skotaracTT @skrsmanovicTT @sstanisicTT
 
 # Blackhole
 tt_llk_blackhole/ @amahmudTT @nvelickovicTT @rdjogoTT @rtawfik01 @ttmtrajkovic


### PR DESCRIPTION
### Ticket
<!-- Link to Github Issue -->

### Problem description
Add new code owners for testing infrastructure. Stefan and Strahinja are working on perf testing, it only makes sense to make them owners of this code.

### What's changed
Added Stefan and Strahinja as code owners.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update