### PR TITLE
ci: use harbor for faster fetching of Docker images

### DIFF
--- a/.github/workflows/setup-and-test.yml
+++ b/.github/workflows/setup-and-test.yml
@@ -28,7 +28,7 @@ jobs:
       matrix:
         test_group: ${{ fromJSON(inputs.test_group) }}
     container:
-      image: ${{ inputs.docker_image }}
+      image: harbor.ci.tenstorrent.net/${{ inputs.docker_image }}
       options: "--rm --device /dev/tenstorrent"
     name: "🦄 Run tests (group ${{ matrix.test_group }}${{ fromJSON(inputs.test_group).length }})"
     steps:


### PR DESCRIPTION
### Ticket
None

### Problem description
We disabled harbor last week in #416 due to service being down, to unblock our development. Since harbor is back in service, we should restore this setting, as it speeds up execution of our jobs.

### What's changed
Use `harbor.ci.tenstorrent.net` to fetch docker images.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update