### PR TITLE
Support running tests on simulator

### DIFF
--- a/tests/python_tests/conftest.py
+++ b/tests/python_tests/conftest.py
@@ -14,18 +14,12 @@ from requests.exceptions import ConnectionError, RequestException, Timeout
 from ttexalens import tt_exalens_init
 from ttexalens.tt_exalens_lib import (
     arc_msg,
-    write_words_to_device,
 )
 
-
 import helpers.device
-
 from helpers.chip_architecture import ChipArchitecture, get_chip_architecture
 from helpers.format_arg_mapping import Mailbox
 from helpers.log_utils import _format_log
-
-# Constants indicating the TRISC kernel run status
-RESET_VAL = 0  # Kernel not running and not complete
 
 
 def init_llk_home():

--- a/tests/python_tests/conftest.py
+++ b/tests/python_tests/conftest.py
@@ -232,6 +232,10 @@ def pytest_configure(config):
     else:
         tt_exalens_init.init_ttexalens()
 
+@pytest.fixture(scope="session", autouse=True)
+def run_simulator_enabled(pytestconfig):
+    RUN_SIMULATOR["enabled"] = pytestconfig.getoption("--run_simulator")
+
 
 # Skip decorators for specific architectures
 # These decorators can be used to skip tests based on the architecture

--- a/tests/python_tests/conftest.py
+++ b/tests/python_tests/conftest.py
@@ -78,11 +78,6 @@ def reset_mailboxes():
 
 
 @pytest.fixture(scope="session", autouse=True)
-def delete_perf_reports():
-    delete_reports()
-
-
-@pytest.fixture(scope="session", autouse=True)
 def download_headers():
     CHIP_ARCH = set_chip_architecture()
     if CHIP_ARCH not in [ChipArchitecture.WORMHOLE, ChipArchitecture.BLACKHOLE]:

--- a/tests/python_tests/conftest.py
+++ b/tests/python_tests/conftest.py
@@ -256,8 +256,7 @@ def pytest_configure(config):
     test_config.from_pytest_config(config)
 
     if test_config.run_simulator:
-        port = test_config.simulator_port or 5555
-        tt_exalens_init.init_ttexalens_remote(port=port)
+        tt_exalens_init.init_ttexalens_remote(port=test_config.simulator_port)
     else:
         tt_exalens_init.init_ttexalens()
 

--- a/tests/python_tests/conftest.py
+++ b/tests/python_tests/conftest.py
@@ -18,9 +18,7 @@ from ttexalens.tt_exalens_lib import (
 )
 
 from helpers.chip_architecture import ChipArchitecture, get_chip_architecture
-from helpers.config import (
-    test_config,
-)
+from helpers.config import test_config
 from helpers.format_arg_mapping import Mailbox
 from helpers.log_utils import _format_log
 

--- a/tests/python_tests/conftest.py
+++ b/tests/python_tests/conftest.py
@@ -205,10 +205,7 @@ def pytest_runtest_protocol(item, nextitem):
 
 def pytest_sessionstart(session):
     # Default LLK_HOME environment variable
-    print("BEFOREEEE")
     init_llk_home()
-
-    print(helpers.device.RUN_SIMULATOR)
 
     if not helpers.device.RUN_SIMULATOR:
         # Send ARC message for GO BUSY signal. This should increase device clock speed.

--- a/tests/python_tests/conftest.py
+++ b/tests/python_tests/conftest.py
@@ -203,6 +203,7 @@ def pytest_sessionstart(session):
     # Default LLK_HOME environment variable
     init_llk_home()
 
+    test_target = TestTargetConfig()
     if not test_target.run_simulator:
         # Send ARC message for GO BUSY signal. This should increase device clock speed.
         _send_arc_message("GO_BUSY", test_target.device_id)
@@ -217,6 +218,7 @@ def pytest_sessionfinish(session, exitstatus):
         for input_fmt, output_fmt in _format_log:
             print(f"{BOLD}{YELLOW}  {input_fmt} -> {output_fmt}{RESET}")
 
+    test_target = TestTargetConfig()
     if not test_target.run_simulator:
         # Send ARC message for GO IDLE signal. This should decrease device clock speed.
         _send_arc_message("GO_IDLE", test_target.device_id)
@@ -253,7 +255,6 @@ def pytest_addoption(parser):
 
 # Use simulator or silicon to run tests depending on the given command line options
 def pytest_configure(config):
-    global test_target
     initialize_test_target_from_pytest(config)
     test_target = TestTargetConfig()
 

--- a/tests/python_tests/conftest.py
+++ b/tests/python_tests/conftest.py
@@ -21,6 +21,7 @@ from helpers.chip_architecture import ChipArchitecture, get_chip_architecture
 from helpers.format_arg_mapping import Mailbox
 from helpers.log_utils import _format_log
 
+from helpers.device import RUN_SIMULATOR
 
 def init_llk_home():
     if "LLK_HOME" in os.environ:
@@ -224,13 +225,16 @@ def pytest_addoption(parser):
         "--run_simulator", action="store_true", help="Run tests using the simulator."
     )
 
-
 def pytest_configure(config):
     run_simulator = config.getoption("--run_simulator")
     if run_simulator:
         tt_exalens_init.init_ttexalens_remote()
     else:
         tt_exalens_init.init_ttexalens()
+
+@pytest.fixture(scope="session", autouse=True)
+def run_simulator_enabled(pytestconfig):
+    RUN_SIMULATOR["enabled"] = pytestconfig.getoption("--run_simulator")
 
 
 # Skip decorators for specific architectures

--- a/tests/python_tests/conftest.py
+++ b/tests/python_tests/conftest.py
@@ -18,7 +18,9 @@ from ttexalens.tt_exalens_lib import (
 )
 
 from helpers.chip_architecture import ChipArchitecture, get_chip_architecture
-from helpers.config import TestConfig
+from helpers.config import (
+    test_config,
+)
 from helpers.format_arg_mapping import Mailbox
 from helpers.log_utils import _format_log
 
@@ -203,8 +205,8 @@ def pytest_sessionstart(session):
     # Default LLK_HOME environment variable
     init_llk_home()
 
-    if not TestConfig.run_simulator:
-        _send_arc_message("GO_BUSY", TestConfig.device_id)
+    if not test_config.run_simulator:
+        _send_arc_message("GO_BUSY", test_config.device_id)
 
 
 def pytest_sessionfinish(session, exitstatus):
@@ -216,8 +218,8 @@ def pytest_sessionfinish(session, exitstatus):
         for input_fmt, output_fmt in _format_log:
             print(f"{BOLD}{YELLOW}  {input_fmt} -> {output_fmt}{RESET}")
 
-    if not TestConfig.run_simulator:
-        _send_arc_message("GO_IDLE", TestConfig.device_id)
+    if not test_config.run_simulator:
+        _send_arc_message("GO_IDLE", test_config.device_id)
 
 
 def _send_arc_message(message_type: str, device_id: int):
@@ -251,9 +253,10 @@ def pytest_addoption(parser):
 
 # Configure pytest depending on the given command line options
 def pytest_configure(config):
-    TestConfig.from_pytest_config(config)
-    if TestConfig.run_simulator:
-        port = TestConfig.simulator_port or 5555
+    test_config.from_pytest_config(config)
+
+    if test_config.run_simulator:
+        port = test_config.simulator_port or 5555
         tt_exalens_init.init_ttexalens_remote(port=port)
     else:
         tt_exalens_init.init_ttexalens()

--- a/tests/python_tests/conftest.py
+++ b/tests/python_tests/conftest.py
@@ -204,6 +204,7 @@ def pytest_sessionstart(session):
     init_llk_home()
 
     if not test_config.run_simulator:
+        # Send ARC message for GO BUSY signal. This should increase device clock speed.
         _send_arc_message("GO_BUSY", test_config.device_id)
 
 
@@ -217,6 +218,7 @@ def pytest_sessionfinish(session, exitstatus):
             print(f"{BOLD}{YELLOW}  {input_fmt} -> {output_fmt}{RESET}")
 
     if not test_config.run_simulator:
+        # Send ARC message for GO IDLE signal. This should decrease device clock speed.
         _send_arc_message("GO_IDLE", test_config.device_id)
 
 

--- a/tests/python_tests/conftest.py
+++ b/tests/python_tests/conftest.py
@@ -11,11 +11,11 @@ from pathlib import Path
 import pytest
 import requests
 from requests.exceptions import ConnectionError, RequestException, Timeout
+from ttexalens import tt_exalens_init
 from ttexalens.tt_exalens_lib import (
     arc_msg,
     write_words_to_device,
 )
-from ttexalens import tt_exalens_init
 
 from helpers.chip_architecture import ChipArchitecture, get_chip_architecture
 from helpers.format_arg_mapping import Mailbox
@@ -235,6 +235,20 @@ def pytest_configure(config):
 @pytest.fixture(scope="session", autouse=True)
 def run_simulator_enabled(pytestconfig):
     RUN_SIMULATOR["enabled"] = pytestconfig.getoption("--run_simulator")
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--run_simulator", action="store_true", help="Run tests using the simulator."
+    )
+
+
+def pytest_configure(config):
+    run_simulator = config.getoption("--run_simulator")
+    if run_simulator:
+        tt_exalens_init.init_ttexalens_remote()
+    else:
+        tt_exalens_init.init_ttexalens()
 
 
 # Skip decorators for specific architectures

--- a/tests/python_tests/conftest.py
+++ b/tests/python_tests/conftest.py
@@ -203,9 +203,9 @@ def pytest_sessionstart(session):
     # Default LLK_HOME environment variable
     init_llk_home()
 
-    if not target_config.run_simulator:
+    if not test_target.run_simulator:
         # Send ARC message for GO BUSY signal. This should increase device clock speed.
-        _send_arc_message("GO_BUSY", target_config.device_id)
+        _send_arc_message("GO_BUSY", test_target.device_id)
 
 
 def pytest_sessionfinish(session, exitstatus):
@@ -217,9 +217,9 @@ def pytest_sessionfinish(session, exitstatus):
         for input_fmt, output_fmt in _format_log:
             print(f"{BOLD}{YELLOW}  {input_fmt} -> {output_fmt}{RESET}")
 
-    if not target_config.run_simulator:
+    if not test_target.run_simulator:
         # Send ARC message for GO IDLE signal. This should decrease device clock speed.
-        _send_arc_message("GO_IDLE", target_config.device_id)
+        _send_arc_message("GO_IDLE", test_target.device_id)
 
 
 def _send_arc_message(message_type: str, device_id: int):
@@ -253,9 +253,9 @@ def pytest_addoption(parser):
 
 # Use simulator or silicon to run tests depending on the given command line options
 def pytest_configure(config):
-    global target_config
+    global test_target
     initialize_test_target_from_pytest(config)
-    target_config = TestTargetConfig()
+    test_target = TestTargetConfig()
 
     if test_target.run_simulator:
         tt_exalens_init.init_ttexalens_remote(port=test_target.simulator_port)

--- a/tests/python_tests/conftest.py
+++ b/tests/python_tests/conftest.py
@@ -205,15 +205,6 @@ def pytest_sessionstart(session):
     # Send ARC message for GO BUSY signal. This should increase device clock speed.
     ARC_COMMON_PREFIX = 0xAA00
     GO_BUSY_MESSAGE_CODE = 0x52
-    arc_msg(
-        device_id=0,
-        msg_code=ARC_COMMON_PREFIX | GO_BUSY_MESSAGE_CODE,
-        wait_for_done=True,
-        arg0=0,
-        arg1=0,
-        timeout=10,
-    )
-
 
 def pytest_sessionfinish(session, exitstatus):
     BOLD = "\033[1m"
@@ -227,15 +218,6 @@ def pytest_sessionfinish(session, exitstatus):
     # Send ARC message for GO IDLE signal. This should decrease device clock speed.
     ARC_COMMON_PREFIX = 0xAA00
     GO_IDLE_MESSAGE_CODE = 0x54
-    arc_msg(
-        device_id=0,
-        msg_code=ARC_COMMON_PREFIX | GO_IDLE_MESSAGE_CODE,
-        wait_for_done=True,
-        arg0=0,
-        arg1=0,
-        timeout=10,
-    )
-
 
 def pytest_addoption(parser):
     parser.addoption(

--- a/tests/python_tests/conftest.py
+++ b/tests/python_tests/conftest.py
@@ -18,7 +18,7 @@ from ttexalens.tt_exalens_lib import (
 )
 
 from helpers.chip_architecture import ChipArchitecture, get_chip_architecture
-from helpers.config import test_config
+from helpers.config import TestConfig
 from helpers.format_arg_mapping import Mailbox
 from helpers.log_utils import _format_log
 
@@ -203,7 +203,7 @@ def pytest_sessionstart(session):
     # Default LLK_HOME environment variable
     init_llk_home()
 
-    if not test_config.run_simulator:
+    if not TestConfig.run_simulator:
         _send_arc_message("GO_BUSY", test_config.device_id)
 
 
@@ -251,10 +251,9 @@ def pytest_addoption(parser):
 
 # Configure pytest depending on the given command line options
 def pytest_configure(config):
-    test_config.run_simulator = config.getoption("--run_simulator")
-    test_config.simulator_port = config.getoption("--port")
-    if test_config.run_simulator:
-        port = test_config.simulator_port or 5555
+    TestConfig.from_pytest_config(config)
+    if TestConfig.run_simulator:
+        port = TestConfig.simulator_port or 5555
         tt_exalens_init.init_ttexalens_remote(port=port)
     else:
         tt_exalens_init.init_ttexalens()

--- a/tests/python_tests/conftest.py
+++ b/tests/python_tests/conftest.py
@@ -204,7 +204,7 @@ def pytest_sessionstart(session):
     init_llk_home()
 
     if not TestConfig.run_simulator:
-        _send_arc_message("GO_BUSY", test_config.device_id)
+        _send_arc_message("GO_BUSY", TestConfig.device_id)
 
 
 def pytest_sessionfinish(session, exitstatus):
@@ -216,8 +216,8 @@ def pytest_sessionfinish(session, exitstatus):
         for input_fmt, output_fmt in _format_log:
             print(f"{BOLD}{YELLOW}  {input_fmt} -> {output_fmt}{RESET}")
 
-    if not test_config.run_simulator:
-        _send_arc_message("GO_IDLE", test_config.device_id)
+    if not TestConfig.run_simulator:
+        _send_arc_message("GO_IDLE", TestConfig.device_id)
 
 
 def _send_arc_message(message_type: str, device_id: int):

--- a/tests/python_tests/conftest.py
+++ b/tests/python_tests/conftest.py
@@ -15,6 +15,7 @@ from ttexalens.tt_exalens_lib import (
     arc_msg,
     write_words_to_device,
 )
+from ttexalens import tt_exalens_init
 
 from helpers.chip_architecture import ChipArchitecture, get_chip_architecture
 from helpers.format_arg_mapping import Mailbox
@@ -234,6 +235,20 @@ def pytest_sessionfinish(session, exitstatus):
         arg1=0,
         timeout=10,
     )
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--run_simulator", action="store_true", help="Run tests using the simulator."
+    )
+
+
+def pytest_configure(config):
+    run_simulator = config.getoption("--run_simulator")
+    if run_simulator:
+        tt_exalens_init.init_ttexalens_remote()
+    else:
+        tt_exalens_init.init_ttexalens()
 
 
 # Skip decorators for specific architectures

--- a/tests/python_tests/conftest.py
+++ b/tests/python_tests/conftest.py
@@ -14,6 +14,7 @@ from requests.exceptions import ConnectionError, RequestException, Timeout
 from ttexalens import tt_exalens_init
 from ttexalens.tt_exalens_lib import (
     arc_msg,
+    write_words_to_device,
 )
 
 import helpers.device

--- a/tests/python_tests/conftest.py
+++ b/tests/python_tests/conftest.py
@@ -18,7 +18,7 @@ from ttexalens.tt_exalens_lib import (
 )
 
 from helpers.chip_architecture import ChipArchitecture, get_chip_architecture
-from helpers.config import test_config
+from helpers.config import TestConfig, initialize_test_config_from_pytest
 from helpers.format_arg_mapping import Mailbox
 from helpers.log_utils import _format_log
 
@@ -249,9 +249,11 @@ def pytest_addoption(parser):
     )
 
 
-# Configure pytest depending on the given command line options
+# Use simulator or silicon to run tests depending on the given command line options
 def pytest_configure(config):
-    test_config.from_pytest_config(config)
+    global test_config
+    initialize_test_config_from_pytest(config)
+    test_config = TestConfig()
 
     if test_config.run_simulator:
         tt_exalens_init.init_ttexalens_remote(port=test_config.simulator_port)

--- a/tests/python_tests/conftest.py
+++ b/tests/python_tests/conftest.py
@@ -232,24 +232,6 @@ def pytest_configure(config):
     else:
         tt_exalens_init.init_ttexalens()
 
-@pytest.fixture(scope="session", autouse=True)
-def run_simulator_enabled(pytestconfig):
-    RUN_SIMULATOR["enabled"] = pytestconfig.getoption("--run_simulator")
-
-
-def pytest_addoption(parser):
-    parser.addoption(
-        "--run_simulator", action="store_true", help="Run tests using the simulator."
-    )
-
-
-def pytest_configure(config):
-    run_simulator = config.getoption("--run_simulator")
-    if run_simulator:
-        tt_exalens_init.init_ttexalens_remote()
-    else:
-        tt_exalens_init.init_ttexalens()
-
 
 # Skip decorators for specific architectures
 # These decorators can be used to skip tests based on the architecture

--- a/tests/python_tests/conftest.py
+++ b/tests/python_tests/conftest.py
@@ -18,9 +18,9 @@ from ttexalens.tt_exalens_lib import (
 )
 
 from helpers.chip_architecture import ChipArchitecture, get_chip_architecture
-from helpers.config import TestConfig, initialize_test_config_from_pytest
 from helpers.format_arg_mapping import Mailbox
 from helpers.log_utils import _format_log
+from helpers.target_config import TestTargetConfig, initialize_test_target_from_pytest
 
 
 def init_llk_home():
@@ -203,9 +203,9 @@ def pytest_sessionstart(session):
     # Default LLK_HOME environment variable
     init_llk_home()
 
-    if not test_config.run_simulator:
+    if not target_config.run_simulator:
         # Send ARC message for GO BUSY signal. This should increase device clock speed.
-        _send_arc_message("GO_BUSY", test_config.device_id)
+        _send_arc_message("GO_BUSY", target_config.device_id)
 
 
 def pytest_sessionfinish(session, exitstatus):
@@ -217,9 +217,9 @@ def pytest_sessionfinish(session, exitstatus):
         for input_fmt, output_fmt in _format_log:
             print(f"{BOLD}{YELLOW}  {input_fmt} -> {output_fmt}{RESET}")
 
-    if not test_config.run_simulator:
+    if not target_config.run_simulator:
         # Send ARC message for GO IDLE signal. This should decrease device clock speed.
-        _send_arc_message("GO_IDLE", test_config.device_id)
+        _send_arc_message("GO_IDLE", target_config.device_id)
 
 
 def _send_arc_message(message_type: str, device_id: int):
@@ -253,12 +253,12 @@ def pytest_addoption(parser):
 
 # Use simulator or silicon to run tests depending on the given command line options
 def pytest_configure(config):
-    global test_config
-    initialize_test_config_from_pytest(config)
-    test_config = TestConfig()
+    global target_config
+    initialize_test_target_from_pytest(config)
+    target_config = TestTargetConfig()
 
-    if test_config.run_simulator:
-        tt_exalens_init.init_ttexalens_remote(port=test_config.simulator_port)
+    if test_target.run_simulator:
+        tt_exalens_init.init_ttexalens_remote(port=test_target.simulator_port)
     else:
         tt_exalens_init.init_ttexalens()
 

--- a/tests/python_tests/helpers/config.py
+++ b/tests/python_tests/helpers/config.py
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class TestConfig:
+    run_simulator: bool = False
+    simulator_port: Optional[int] = None
+    log_level: str = "INFO"
+
+
+# Global instance
+test_config = TestConfig()

--- a/tests/python_tests/helpers/config.py
+++ b/tests/python_tests/helpers/config.py
@@ -3,13 +3,13 @@
 
 
 class TestConfig:
-    """TestConfig class represents the test configuration set by command line options."""
+    """TestConfig class represents the test configuration set by command line options related to simulator use."""
 
     def __init__(
         self, run_simulator=False, simulator_port=5555, device_id=0, log_level="INFO"
     ):
         """
-            Initializes the test configuration.
+            Initializes the test configuration in regards to using the simulator.
         Args:
             run_simulator (bool): True if the test is run on simulator, False if on silicon
             simulator_port (int): Simulator server port number
@@ -32,5 +32,5 @@ class TestConfig:
         self.simulator_port = port if port is not None else 5555
 
 
-# Global instance
+# Global instance used to share simulator settings
 test_config = TestConfig()

--- a/tests/python_tests/helpers/config.py
+++ b/tests/python_tests/helpers/config.py
@@ -11,6 +11,8 @@ class TestConfig:
     device_id: int = 0
     log_level: str = "INFO"
 
-
-# Global instance
-test_config = TestConfig()
+    @classmethod
+    def from_pytest_config(cls, config):
+        cls.run_simulator = (config.getoption("--run_simulator"),)
+        cls.simulator_port = config.getoption("--port")
+        return cls

--- a/tests/python_tests/helpers/config.py
+++ b/tests/python_tests/helpers/config.py
@@ -3,17 +3,33 @@
 
 
 class TestConfig:
-    run_simulator: bool = False
-    simulator_port: int = 5555
-    device_id: int = 0
-    log_level: str = "INFO"
+    """TestConfig class represents the test configuration set by command line options."""
 
-    @classmethod
-    def from_pytest_config(cls, config):
+    def __init__(
+        self, run_simulator=False, simulator_port=5555, device_id=0, log_level="INFO"
+    ):
+        """
+            Initializes the test configuration.
+        Args:
+            run_simulator (bool): True if the test is run on simulator, False if on silicon
+            simulator_port (int): Simulator server port number
+            device_id (int): ID number of the device to send message to.
+            log_level (str): Log level
+        """
+        self.run_simulator: bool = run_simulator
+        self.simulator_port: int = simulator_port
+        self.device_id: int = device_id
+        self.log_level: str = log_level
+
+    def from_pytest_config(self, config):
+        """
+            Fetches the options set in the command line.
+        Args:
+            config: An instance of pytest.Config. It represents the configuration state for a test session.
+        """
         port = config.getoption("--port")
-        cls.run_simulator = config.getoption("--run_simulator")
-        cls.simulator_port = port if port is not None else 5555
-        return cls
+        self.run_simulator = config.getoption("--run_simulator")
+        self.simulator_port = port if port is not None else 5555
 
 
 # Global instance

--- a/tests/python_tests/helpers/config.py
+++ b/tests/python_tests/helpers/config.py
@@ -1,20 +1,21 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 from dataclasses import dataclass
-from typing import ClassVar, Optional
+from typing import ClassVar
 
 
 @dataclass
 class TestConfig:
     run_simulator: ClassVar[bool] = False
-    simulator_port: ClassVar[Optional[int]] = None
+    simulator_port: ClassVar[int] = 5555
     device_id: int = 0
     log_level: str = "INFO"
 
     @classmethod
     def from_pytest_config(cls, config):
+        port = config.getoption("--port")
         cls.run_simulator = config.getoption("--run_simulator")
-        cls.simulator_port = config.getoption("--port")
+        cls.simulator_port = port if port is not None else 5555
         return cls
 
 

--- a/tests/python_tests/helpers/config.py
+++ b/tests/python_tests/helpers/config.py
@@ -13,6 +13,6 @@ class TestConfig:
 
     @classmethod
     def from_pytest_config(cls, config):
-        cls.run_simulator = (config.getoption("--run_simulator"),)
+        cls.run_simulator = config.getoption("--run_simulator")
         cls.simulator_port = config.getoption("--port")
         return cls

--- a/tests/python_tests/helpers/config.py
+++ b/tests/python_tests/helpers/config.py
@@ -1,13 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
-from dataclasses import dataclass
-from typing import ClassVar
 
 
-@dataclass
 class TestConfig:
-    run_simulator: ClassVar[bool] = False
-    simulator_port: ClassVar[int] = 5555
+    run_simulator: bool = False
+    simulator_port: int = 5555
     device_id: int = 0
     log_level: str = "INFO"
 

--- a/tests/python_tests/helpers/config.py
+++ b/tests/python_tests/helpers/config.py
@@ -5,6 +5,14 @@
 class TestConfig:
     """TestConfig class represents the test configuration set by command line options related to simulator use."""
 
+    _instance = None
+    _initialized = False
+
+    def __new__(cls):
+        if cls._instance is None:
+            cls._instance = super(TestConfig, cls).__new__(cls)
+        return cls._instance
+
     def __init__(
         self, run_simulator=False, simulator_port=5555, device_id=0, log_level="INFO"
     ):
@@ -16,21 +24,21 @@ class TestConfig:
             device_id (int): ID number of the device to send message to.
             log_level (str): Log level
         """
-        self.run_simulator: bool = run_simulator
-        self.simulator_port: int = simulator_port
-        self.device_id: int = device_id
-        self.log_level: str = log_level
+        # Only initialize once
+        if not TestConfig._initialized:
+            self.run_simulator: bool = run_simulator
+            self.simulator_port: int = simulator_port
+            self.device_id: int = device_id
+            self.log_level: str = log_level
+            TestConfig._initialized = True
 
-    def from_pytest_config(self, config):
-        """
-            Fetches the options set in the command line.
-        Args:
-            config: An instance of pytest.Config. It represents the configuration state for a test session.
-        """
-        port = config.getoption("--port")
-        self.run_simulator = config.getoption("--run_simulator")
-        self.simulator_port = port if port is not None else 5555
+    def update_from_pytest_config(self, config):
+        """Update only the simulator related settings from pytest config"""
+        self.run_simulator = config.getoption("--run_simulator", default=False)
+        self.simulator_port = config.getoption("--port", default=5555)
 
 
-# Global instance used to share simulator settings
-test_config = TestConfig()
+def initialize_test_config_from_pytest(config):
+    """Initialize the global test configuration from pytest command line options."""
+    test_config = TestConfig()
+    test_config.update_from_pytest_config(config)

--- a/tests/python_tests/helpers/config.py
+++ b/tests/python_tests/helpers/config.py
@@ -8,6 +8,7 @@ from typing import Optional
 class TestConfig:
     run_simulator: bool = False
     simulator_port: Optional[int] = None
+    device_id: int = 0
     log_level: str = "INFO"
 
 

--- a/tests/python_tests/helpers/config.py
+++ b/tests/python_tests/helpers/config.py
@@ -1,13 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 from dataclasses import dataclass
-from typing import Optional
+from typing import ClassVar, Optional
 
 
 @dataclass
 class TestConfig:
-    run_simulator: bool = False
-    simulator_port: Optional[int] = None
+    run_simulator: ClassVar[bool] = False
+    simulator_port: ClassVar[Optional[int]] = None
     device_id: int = 0
     log_level: str = "INFO"
 
@@ -16,3 +16,7 @@ class TestConfig:
         cls.run_simulator = config.getoption("--run_simulator")
         cls.simulator_port = config.getoption("--port")
         return cls
+
+
+# Global instance
+test_config = TestConfig()

--- a/tests/python_tests/helpers/device.py
+++ b/tests/python_tests/helpers/device.py
@@ -16,7 +16,7 @@ from ttexalens.tt_exalens_lib import (
     write_words_to_device,
 )
 
-from .config import test_config
+from .config import TestConfig
 from .format_arg_mapping import (
     DestAccumulation,
     L1BufferLocations,
@@ -277,7 +277,7 @@ def wait_until_tensix_complete(core_loc, mailbox_addr, timeout=30, max_backoff=5
         timeout: Maximum time to wait (in seconds) before timing out. Default is 30 seconds.
         max_backoff: Maximum backoff time (in seconds) between polls. Default is 5 seconds.
     """
-    timeout = 600 if test_config.run_simulator else timeout
+    timeout = 600 if TestConfig.run_simulator else timeout
 
     start_time = time.time()
     backoff = 0.1  # Initial backoff time in seconds
@@ -287,7 +287,7 @@ def wait_until_tensix_complete(core_loc, mailbox_addr, timeout=30, max_backoff=5
             return
 
         time.sleep(backoff)
-        if not test_config.run_simulator:
+        if not TestConfig.run_simulator:
             backoff = min(backoff * 2, max_backoff)  # Exponential backoff with a cap
 
     raise TimeoutError(

--- a/tests/python_tests/helpers/device.py
+++ b/tests/python_tests/helpers/device.py
@@ -16,7 +16,7 @@ from ttexalens.tt_exalens_lib import (
     write_words_to_device,
 )
 
-from .config import TestConfig
+from .config import test_config
 from .format_arg_mapping import (
     DestAccumulation,
     L1BufferLocations,
@@ -277,7 +277,7 @@ def wait_until_tensix_complete(core_loc, mailbox_addr, timeout=30, max_backoff=5
         timeout: Maximum time to wait (in seconds) before timing out. Default is 30 seconds. If running on a simulator it is 600 seconds.
         max_backoff: Maximum backoff time (in seconds) between polls. Default is 5 seconds.
     """
-    timeout = 600 if TestConfig.run_simulator else timeout
+    timeout = 600 if test_config.run_simulator else timeout
 
     start_time = time.time()
     backoff = 0.1  # Initial backoff time in seconds
@@ -289,7 +289,7 @@ def wait_until_tensix_complete(core_loc, mailbox_addr, timeout=30, max_backoff=5
         time.sleep(backoff)
         # Disable exponential backoff if running on simulator
         # The simulator sits idle due to no polling - If it is idle for too long, it gets stuck
-        if not TestConfig.run_simulator:
+        if not test_config.run_simulator:
             backoff = min(backoff * 2, max_backoff)  # Exponential backoff with a cap
 
     raise TimeoutError(

--- a/tests/python_tests/helpers/device.py
+++ b/tests/python_tests/helpers/device.py
@@ -70,7 +70,13 @@ def collect_results(
     return res_from_L1
 
 
+<<<<<<< Updated upstream
 def perform_tensix_soft_reset(core_loc="0,0"):
+=======
+def run_elf_files(testname, core_loc="0,0", run_brisc=True):
+    ELF_LOCATION = "../build/elf/"
+
+>>>>>>> Stashed changes
     context = check_context()
     device = context.devices[0]
     chip_coordinate = OnChipCoordinate.create(core_loc, device=device)
@@ -103,10 +109,20 @@ def run_elf_files(testname, core_loc="0,0"):
     TRISC_PROFILER_BARRIE_ADDRESS = 0x16AFF4
     write_words_to_device(core_loc, TRISC_PROFILER_BARRIE_ADDRESS, [0, 0, 0])
 
+<<<<<<< Updated upstream
     # Run BRISC
+<<<<<<< HEAD
     brisc_elf_path = build_dir / "shared" / "brisc.elf"
     run_elf(str(brisc_elf_path.absolute()), core_loc, risc_name="brisc")
+=======
+    run_elf(f"{BUILD}/shared/brisc.elf", core_loc, risc_name="brisc")
+=======
+    if run_brisc:
+        run_elf(f"{ELF_LOCATION}brisc.elf", core_loc, risc_id=0)
+>>>>>>> Stashed changes
+>>>>>>> 2b6e05e (Update with changes from main, brisc trisc sync)
 
+    print("RUN ELF FILES")
 
 def write_stimuli_to_l1(
     buffer_A,
@@ -266,7 +282,7 @@ def read_dest_register(dest_acc: DestAccumulation, num_tiles: int = 1):
     return dest_reg
 
 
-def wait_until_tensix_complete(core_loc, mailbox_addr, timeout=30, max_backoff=5):
+def wait_until_tensix_complete(core_loc, mailbox_addr, timeout=600, max_backoff=5):
     """
     Polls a value from the device with an exponential backoff timer and fails if it doesn't read 1 within the timeout.
 
@@ -284,7 +300,7 @@ def wait_until_tensix_complete(core_loc, mailbox_addr, timeout=30, max_backoff=5
             return
 
         time.sleep(backoff)
-        backoff = min(backoff * 2, max_backoff)  # Exponential backoff with a cap
+      #  backoff = min(backoff * 2, max_backoff)  # Exponential backoff with a cap
 
     assert False, f"Timeout reached: waited {timeout} seconds for {mailbox_addr.name}"
 

--- a/tests/python_tests/helpers/device.py
+++ b/tests/python_tests/helpers/device.py
@@ -47,7 +47,7 @@ from .unpack import (
     unpack_uint32,
 )
 
-RUN_SIMULATOR = {"enabled": False}
+RUN_SIMULATOR = False
 
 MAX_READ_BYTE_SIZE_16BIT = 2048
 
@@ -289,10 +289,12 @@ def wait_until_tensix_complete(core_loc, mailbox_addr, timeout=30, max_backoff=5
             return
 
         time.sleep(backoff)
-        if RUN_SIMULATOR == False:
+        if not RUN_SIMULATOR:
             backoff = min(backoff * 2, max_backoff)  # Exponential backoff with a cap
 
-    assert False, f"Timeout reached: waited {timeout} seconds for {mailbox_addr.name}"
+    raise TimeoutError(
+        f"Timeout reached: waited {timeout} seconds for {mailbox_addr.name}"
+    )
 
 
 def wait_for_tensix_operations_finished(core_loc: str = "0,0"):

--- a/tests/python_tests/helpers/device.py
+++ b/tests/python_tests/helpers/device.py
@@ -274,7 +274,7 @@ def wait_until_tensix_complete(core_loc, mailbox_addr, timeout=30, max_backoff=5
     Args:
         core_loc: The location of the core to poll.
         mailbox_addr: The mailbox address to read from.
-        timeout: Maximum time to wait (in seconds) before timing out. Default is 30 seconds.
+        timeout: Maximum time to wait (in seconds) before timing out. Default is 30 seconds. If running on a simulator it is 600 seconds.
         max_backoff: Maximum backoff time (in seconds) between polls. Default is 5 seconds.
     """
     timeout = 600 if TestConfig.run_simulator else timeout
@@ -287,6 +287,8 @@ def wait_until_tensix_complete(core_loc, mailbox_addr, timeout=30, max_backoff=5
             return
 
         time.sleep(backoff)
+        # Disable exponential backoff if running on simulator
+        # The simulator sits idle due to no polling - If it is idle for too long, it gets stuck
         if not TestConfig.run_simulator:
             backoff = min(backoff * 2, max_backoff)  # Exponential backoff with a cap
 

--- a/tests/python_tests/helpers/device.py
+++ b/tests/python_tests/helpers/device.py
@@ -16,7 +16,6 @@ from ttexalens.tt_exalens_lib import (
     write_words_to_device,
 )
 
-from .config import TestConfig
 from .format_arg_mapping import (
     DestAccumulation,
     L1BufferLocations,
@@ -35,6 +34,7 @@ from .pack import (
     pack_uint16,
     pack_uint32,
 )
+from .target_config import TestTargetConfig
 from .unpack import (
     unpack_bfp8_b,
     unpack_bfp16,
@@ -277,8 +277,8 @@ def wait_until_tensix_complete(core_loc, mailbox_addr, timeout=30, max_backoff=5
         timeout: Maximum time to wait (in seconds) before timing out. Default is 30 seconds. If running on a simulator it is 600 seconds.
         max_backoff: Maximum backoff time (in seconds) between polls. Default is 5 seconds.
     """
-    test_config = TestConfig()
-    timeout = 600 if test_config.run_simulator else timeout
+    test_target = TestTargetConfig()
+    timeout = 600 if test_target.run_simulator else timeout
 
     start_time = time.time()
     backoff = 0.1  # Initial backoff time in seconds
@@ -290,7 +290,7 @@ def wait_until_tensix_complete(core_loc, mailbox_addr, timeout=30, max_backoff=5
         time.sleep(backoff)
         # Disable exponential backoff if running on simulator
         # The simulator sits idle due to no polling - If it is idle for too long, it gets stuck
-        if not test_config.run_simulator:
+        if not test_target.run_simulator:
             backoff = min(backoff * 2, max_backoff)  # Exponential backoff with a cap
 
     raise TimeoutError(

--- a/tests/python_tests/helpers/device.py
+++ b/tests/python_tests/helpers/device.py
@@ -47,6 +47,8 @@ from .unpack import (
     unpack_uint32,
 )
 
+RUN_SIMULATOR = {"enabled": False}
+
 MAX_READ_BYTE_SIZE_16BIT = 2048
 
 # Constants for soft reset operation
@@ -70,13 +72,7 @@ def collect_results(
     return res_from_L1
 
 
-<<<<<<< Updated upstream
 def perform_tensix_soft_reset(core_loc="0,0"):
-=======
-def run_elf_files(testname, core_loc="0,0", run_brisc=True):
-    ELF_LOCATION = "../build/elf/"
-
->>>>>>> Stashed changes
     context = check_context()
     device = context.devices[0]
     chip_coordinate = OnChipCoordinate.create(core_loc, device=device)
@@ -109,20 +105,10 @@ def run_elf_files(testname, core_loc="0,0"):
     TRISC_PROFILER_BARRIE_ADDRESS = 0x16AFF4
     write_words_to_device(core_loc, TRISC_PROFILER_BARRIE_ADDRESS, [0, 0, 0])
 
-<<<<<<< Updated upstream
     # Run BRISC
-<<<<<<< HEAD
     brisc_elf_path = build_dir / "shared" / "brisc.elf"
     run_elf(str(brisc_elf_path.absolute()), core_loc, risc_name="brisc")
-=======
-    run_elf(f"{BUILD}/shared/brisc.elf", core_loc, risc_name="brisc")
-=======
-    if run_brisc:
-        run_elf(f"{ELF_LOCATION}brisc.elf", core_loc, risc_id=0)
->>>>>>> Stashed changes
->>>>>>> 2b6e05e (Update with changes from main, brisc trisc sync)
 
-    print("RUN ELF FILES")
 
 def write_stimuli_to_l1(
     buffer_A,
@@ -282,7 +268,7 @@ def read_dest_register(dest_acc: DestAccumulation, num_tiles: int = 1):
     return dest_reg
 
 
-def wait_until_tensix_complete(core_loc, mailbox_addr, timeout=600, max_backoff=5):
+def wait_until_tensix_complete(core_loc, mailbox_addr, timeout=30, max_backoff=5):
     """
     Polls a value from the device with an exponential backoff timer and fails if it doesn't read 1 within the timeout.
 
@@ -292,6 +278,9 @@ def wait_until_tensix_complete(core_loc, mailbox_addr, timeout=600, max_backoff=
         timeout: Maximum time to wait (in seconds) before timing out. Default is 30 seconds.
         max_backoff: Maximum backoff time (in seconds) between polls. Default is 5 seconds.
     """
+    if RUN_SIMULATOR:
+        timeout = 600
+
     start_time = time.time()
     backoff = 0.1  # Initial backoff time in seconds
 
@@ -300,7 +289,8 @@ def wait_until_tensix_complete(core_loc, mailbox_addr, timeout=600, max_backoff=
             return
 
         time.sleep(backoff)
-      #  backoff = min(backoff * 2, max_backoff)  # Exponential backoff with a cap
+        if RUN_SIMULATOR == False:
+            backoff = min(backoff * 2, max_backoff)  # Exponential backoff with a cap
 
     assert False, f"Timeout reached: waited {timeout} seconds for {mailbox_addr.name}"
 

--- a/tests/python_tests/helpers/device.py
+++ b/tests/python_tests/helpers/device.py
@@ -72,13 +72,7 @@ def collect_results(
     return res_from_L1
 
 
-<<<<<<< Updated upstream
 def perform_tensix_soft_reset(core_loc="0,0"):
-=======
-def run_elf_files(testname, core_loc="0,0", run_brisc=True):
-    ELF_LOCATION = "../build/elf/"
-
->>>>>>> Stashed changes
     context = check_context()
     device = context.devices[0]
     chip_coordinate = OnChipCoordinate.create(core_loc, device=device)
@@ -274,7 +268,7 @@ def read_dest_register(dest_acc: DestAccumulation, num_tiles: int = 1):
     return dest_reg
 
 
-def wait_until_tensix_complete(core_loc, mailbox_addr, timeout=600, max_backoff=5):
+def wait_until_tensix_complete(core_loc, mailbox_addr, timeout=30, max_backoff=5):
     """
     Polls a value from the device with an exponential backoff timer and fails if it doesn't read 1 within the timeout.
 

--- a/tests/python_tests/helpers/device.py
+++ b/tests/python_tests/helpers/device.py
@@ -16,6 +16,7 @@ from ttexalens.tt_exalens_lib import (
     write_words_to_device,
 )
 
+from .config import test_config
 from .format_arg_mapping import (
     DestAccumulation,
     L1BufferLocations,
@@ -46,8 +47,6 @@ from .unpack import (
     unpack_uint16,
     unpack_uint32,
 )
-
-RUN_SIMULATOR = False
 
 MAX_READ_BYTE_SIZE_16BIT = 2048
 
@@ -278,8 +277,7 @@ def wait_until_tensix_complete(core_loc, mailbox_addr, timeout=30, max_backoff=5
         timeout: Maximum time to wait (in seconds) before timing out. Default is 30 seconds.
         max_backoff: Maximum backoff time (in seconds) between polls. Default is 5 seconds.
     """
-    if RUN_SIMULATOR:
-        timeout = 600
+    timeout = 600 if test_config.run_simulator else timeout
 
     start_time = time.time()
     backoff = 0.1  # Initial backoff time in seconds
@@ -289,7 +287,7 @@ def wait_until_tensix_complete(core_loc, mailbox_addr, timeout=30, max_backoff=5
             return
 
         time.sleep(backoff)
-        if not RUN_SIMULATOR:
+        if not test_config.run_simulator:
             backoff = min(backoff * 2, max_backoff)  # Exponential backoff with a cap
 
     raise TimeoutError(

--- a/tests/python_tests/helpers/device.py
+++ b/tests/python_tests/helpers/device.py
@@ -16,7 +16,7 @@ from ttexalens.tt_exalens_lib import (
     write_words_to_device,
 )
 
-from .config import test_config
+from .config import TestConfig
 from .format_arg_mapping import (
     DestAccumulation,
     L1BufferLocations,
@@ -277,6 +277,7 @@ def wait_until_tensix_complete(core_loc, mailbox_addr, timeout=30, max_backoff=5
         timeout: Maximum time to wait (in seconds) before timing out. Default is 30 seconds. If running on a simulator it is 600 seconds.
         max_backoff: Maximum backoff time (in seconds) between polls. Default is 5 seconds.
     """
+    test_config = TestConfig()
     timeout = 600 if test_config.run_simulator else timeout
 
     start_time = time.time()

--- a/tests/python_tests/helpers/device.py
+++ b/tests/python_tests/helpers/device.py
@@ -72,7 +72,13 @@ def collect_results(
     return res_from_L1
 
 
+<<<<<<< Updated upstream
 def perform_tensix_soft_reset(core_loc="0,0"):
+=======
+def run_elf_files(testname, core_loc="0,0", run_brisc=True):
+    ELF_LOCATION = "../build/elf/"
+
+>>>>>>> Stashed changes
     context = check_context()
     device = context.devices[0]
     chip_coordinate = OnChipCoordinate.create(core_loc, device=device)
@@ -268,7 +274,7 @@ def read_dest_register(dest_acc: DestAccumulation, num_tiles: int = 1):
     return dest_reg
 
 
-def wait_until_tensix_complete(core_loc, mailbox_addr, timeout=30, max_backoff=5):
+def wait_until_tensix_complete(core_loc, mailbox_addr, timeout=600, max_backoff=5):
     """
     Polls a value from the device with an exponential backoff timer and fails if it doesn't read 1 within the timeout.
 

--- a/tests/python_tests/helpers/target_config.py
+++ b/tests/python_tests/helpers/target_config.py
@@ -2,15 +2,15 @@
 # SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 
-class TestConfig:
-    """TestConfig class represents the test configuration set by command line options related to simulator use."""
+class TestTargetConfig:
+    """TestTargetConfig class represents where the test will be run: simulator or silicon."""
 
     _instance = None
     _initialized = False
 
     def __new__(cls):
         if cls._instance is None:
-            cls._instance = super(TestConfig, cls).__new__(cls)
+            cls._instance = super(TestTargetConfig, cls).__new__(cls)
         return cls._instance
 
     def __init__(
@@ -25,12 +25,12 @@ class TestConfig:
             log_level (str): Log level
         """
         # Only initialize once
-        if not TestConfig._initialized:
+        if not TestTargetConfig._initialized:
             self.run_simulator: bool = run_simulator
             self.simulator_port: int = simulator_port
             self.device_id: int = device_id
             self.log_level: str = log_level
-            TestConfig._initialized = True
+            TestTargetConfig._initialized = True
 
     def update_from_pytest_config(self, config):
         """Update only the simulator related settings from pytest config"""
@@ -38,7 +38,7 @@ class TestConfig:
         self.simulator_port = config.getoption("--port", default=5555)
 
 
-def initialize_test_config_from_pytest(config):
+def initialize_test_target_from_pytest(config):
     """Initialize the global test configuration from pytest command line options."""
-    test_config = TestConfig()
-    test_config.update_from_pytest_config(config)
+    test_target = TestTargetConfig()
+    test_target.update_from_pytest_config(config)


### PR DESCRIPTION
### Ticket

### Problem description
Enable LLK tests to be ran on VCS simulator.

### What's changed
Add command line options for running the simulator and defining the simulator server port. Using these flags, adjust the test configuration: run the server, do not use arc_msg, calculate backoff and timeout differently when the simulator is used.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
