### PR TITLE
fix: remove build dir if chip arch has changed

### DIFF
--- a/tests/python_tests/conftest.py
+++ b/tests/python_tests/conftest.py
@@ -84,8 +84,9 @@ def download_headers():
     if CHIP_ARCH not in [ChipArchitecture.WORMHOLE, ChipArchitecture.BLACKHOLE]:
         sys.exit(f"Unsupported CHIP_ARCH detected: {CHIP_ARCH}")
 
-    HEADER_DIR = "../hw_specific/inc"
-    BUILD_DIR = "../build"
+    LLK_HOME = os.environ.get("LLK_HOME")
+    HEADER_DIR = os.path.join(LLK_HOME, "tests", "hw_specific", "inc")
+    BUILD_DIR = os.path.join(LLK_HOME, "tests", "build")
     ARCH_FILE = os.path.join(HEADER_DIR, ".architecture")
 
     # Check if architecture has changed
@@ -102,9 +103,9 @@ def download_headers():
                 f"Architecture changed from {stored_arch} to {CHIP_ARCH.value}. Clearing headers and build directory."
             )
             if os.path.exists(HEADER_DIR):
-                shutil.rmtree(HEADER_DIR)
+                shutil.rmtree(HEADER_DIR, ignore_errors=True)
             if os.path.exists(BUILD_DIR):
-                shutil.rmtree(BUILD_DIR)
+                shutil.rmtree(BUILD_DIR, ignore_errors=True)
     else:
         print(
             f"No architecture file found. Will download headers for {CHIP_ARCH.value}."


### PR DESCRIPTION
### Ticket
None

### Problem description
This is a follow up on #471. As @sstanisicTT noted, tests might still not work, if intermediate files that don't get recompiled automatically aren't removed.

### What's changed
On top of current changes, we would be removing build directory, too. That should fix the problem with the intermediate binaries that were built for BH not working on WH and vise versa. They would be removed completely and rebuilt from scratch every time different architecture has been detected.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
