### PR TITLE
test infra :test_tube:: decouple build from chip architecture

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -50,7 +50,6 @@ GXX             := $(TOOL_PATH)/riscv32-tt-elf-g++
 OBJDUMP         := $(TOOL_PATH)/riscv32-tt-elf-objdump
 OBJCOPY         := $(TOOL_PATH)/riscv32-tt-elf-objcopy
 
-
 # =========================
 # Compiler and Linker Flags
 # =========================
@@ -96,53 +95,61 @@ profiler: $(PROFILER_DIR)/unpack.meta.bin \
 # Build Rules
 # =========================
 
-# Currently only used for brisc.dis
-$(SHARED_DIS_DIR)/%.S: $(SHARED_ELF_DIR)/%.elf | $(SHARED_DIS_DIR)
-	$(OBJDUMP) -xsD $< > $@
-	$(OBJDUMP) -t $< | sort >> $@
 
+# extract profiler metadata from .elf
 $(PROFILER_DIR)/%.meta.bin: $(ELF_DIR)/%.elf | $(PROFILER_DIR)
 	$(OBJCOPY) -O binary -j .profiler_meta $< $@
 
+# disasseble unpack.elf, math.elf, pack.elf
 $(DIS_DIR)/%.S: $(ELF_DIR)/%.elf | $(DIS_DIR)
 	$(OBJDUMP) -xsD $< > $@
 	$(OBJDUMP) -t $< | sort >> $@
 
+# disassemble brisc.elf
+$(SHARED_DIS_DIR)/%.S: $(SHARED_ELF_DIR)/%.elf | $(SHARED_DIS_DIR)
+	$(OBJDUMP) -xsD $< > $@
+	$(OBJDUMP) -t $< | sort >> $@
+
+# link unpack.elf, math.elf, pack.elf
 $(ELF_DIR)/%.elf: $(SHARED_OBJ_DIR)/tmu-crt0.o $(SHARED_OBJ_DIR)/main_%.o $(OBJ_DIR)/kernel_%.o | $(ELF_DIR)
 	$(GXX) $(OPTIONS_ALL) $(OPTIONS_LINK) $^ -T$(LINKER_SCRIPTS)/memory.$(ARCH).ld -T$(LINKER_SCRIPTS)/$*.ld -T$(LINKER_SCRIPTS)/sections.ld -o $@
 
-# Building brisc.elf for BRISC core
+# link brisc.elf
 $(SHARED_ELF_DIR)/brisc.elf: $(SHARED_OBJ_DIR)/tmu-crt0.o $(SHARED_OBJ_DIR)/brisc.o | $(SHARED_ELF_DIR)
 	$(GXX) $(OPTIONS_ALL) $(OPTIONS_LINK) $^ -T$(LINKER_SCRIPTS)/memory.$(ARCH).ld -T$(LINKER_SCRIPTS)/brisc.ld -T$(LINKER_SCRIPTS)/sections.ld -o $@
 
-# makes sure that make doesn't automatically delete intermediate files (didn't know this was a feature)
+# disable make automatically deleting important intermediate files
 .SECONDARY: $(SHARED_OBJ_DIR)/*.o $(OBJ_DIR)/*.o
 
+# build kernel_unpack.o, kernel_math.o, kernel_pack.o
 $(OBJ_DIR)/kernel_%.o: sources/$(testname).cpp | $(OBJ_DIR) $(DEPS_DIR)
 	$(GXX) $(OPTIONS_ALL) $(TEST_KERNEL_FLAG) $(OPTIONS_COMPILE) \
 	-MMD -MP -MF $(patsubst $(OBJ_DIR)/%.o,$(DEPS_DIR)/%.d,$@) \
 	-DLLK_TRISC_$(call TO_UPPER, $*) -c -o $@ $<
 
-# compiling main for every TRISC core
+# build main_unpack.o, main_math.o, main_pack.o
 $(SHARED_OBJ_DIR)/main_%.o: $(RISCV_SOURCES)/trisc.cpp | $(SHARED_OBJ_DIR) $(SHARED_DEPS_DIR)
 	$(GXX) $(OPTIONS_ALL) $(OPTIONS_COMPILE) \
 	-MMD -MP -MF $(patsubst $(SHARED_OBJ_DIR)/%.o,$(SHARED_DEPS_DIR)/%.d,$@) \
 	-DLLK_TRISC_$(call TO_UPPER, $*) -c -o $@ $<
 
+# build brisc.o
 $(SHARED_OBJ_DIR)/brisc.o: $(RISCV_SOURCES)/brisc.cpp | $(SHARED_OBJ_DIR) $(SHARED_DEPS_DIR)
 	$(GXX) $(OPTIONS_ALL) $(OPTIONS_COMPILE) \
 	-MMD -MP -MF $(patsubst $(SHARED_OBJ_DIR)/%.o,$(SHARED_DEPS_DIR)/%.d,$@) \
 	-c -o $@ $<
 
+# build c runtime library
 $(SHARED_OBJ_DIR)/tmu-crt0.o: $(HELPERS)/tmu-crt0.S | $(SHARED_OBJ_DIR) $(SHARED_DEPS_DIR)
 	$(GXX) $(OPTIONS_ALL) $(OPTIONS_COMPILE) \
 	-MMD -MP -MF $(patsubst $(SHARED_OBJ_DIR)/%.o,$(SHARED_DEPS_DIR)/%.d,$@) \
 	-c -o $@ $<
 
-# required folder structure
+# create folder structure for shared files
 $(SHARED_OBJ_DIR) $(SHARED_DEPS_DIR) $(SHARED_DIS_DIR) $(SHARED_ELF_DIR):
 	mkdir -p $@
 
+# create folder structure for test specific files
 $(OBJ_DIR) $(DEPS_DIR) $(DIS_DIR) $(ELF_DIR) $(PROFILER_DIR):
 	mkdir -p $@
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -8,38 +8,48 @@
 CXX_VERSION     := c++17
 TOOL_PATH       ?= sfpi/compiler/bin
 
-BUILD_DIR       ?= build
-SHARED_DIR       := $(BUILD_DIR)/shared
+# =========================
+# Architecture Selection
+# =========================
+ARCH            := $(if $(archname),$(archname),$(CHIP_ARCH))
+ifeq ($(ARCH),wormhole)
+	ARCH_CPU        := -mcpu=tt-wh
+	ARCH_DEFINE     := -DARCH_WORMHOLE
+	ARCH_LLK_ROOT   := tt_llk_wormhole_b0
+else ifeq ($(ARCH),blackhole)
+	ARCH_CPU        := -mcpu=tt-bh
+	ARCH_DEFINE     := -DARCH_BLACKHOLE
+	ARCH_LLK_ROOT   := tt_llk_blackhole
+else
+$(error must provide archname or CHIP_ARCH environment variable (wormhole / blackhole))
+endif
+
+BUILD_DIR       ?= build/$(ARCH)
+
+SHARED_DIR      := $(BUILD_DIR)/shared
+SHARED_OBJ_DIR  := $(SHARED_DIR)/obj
+SHARED_DEPS_DIR := $(SHARED_DIR)/deps
+SHARED_DIS_DIR  := $(SHARED_DIR)/dis
+SHARED_ELF_DIR  := $(SHARED_DIR)/elf
+
 TEST_DIR        := $(BUILD_DIR)/tests/$(testname)
 OBJ_DIR         := $(TEST_DIR)/obj
+DEPS_DIR        := $(TEST_DIR)/deps
 DIS_DIR         := $(TEST_DIR)/dis
-PROFILER_DIR    := $(TEST_DIR)/profiler
 ELF_DIR         := $(TEST_DIR)/elf
+
+PROFILER_DIR    := $(TEST_DIR)/profiler
 
 HELPERS         := helpers
 RISCV_SOURCES   := $(HELPERS)/src
 LINKER_SCRIPTS  := $(HELPERS)/ld
-HEADER_DIR      := hw_specific/inc
+HEADER_DIR      := hw_specific/$(ARCH)/inc
 RMDIR           := rm -rf
 
 GXX             := $(TOOL_PATH)/riscv32-tt-elf-g++
 OBJDUMP         := $(TOOL_PATH)/riscv32-tt-elf-objdump
 OBJCOPY         := $(TOOL_PATH)/riscv32-tt-elf-objcopy
 
-# =========================
-# Architecture Selection
-# =========================
-ifeq ($(CHIP_ARCH),wormhole)
-	ARCH_CPU	:= -mcpu=tt-wh
-	ARCH_DEFINE     := -DARCH_WORMHOLE
-	ARCH_LLK_ROOT   := tt_llk_wormhole_b0
-else ifeq ($(CHIP_ARCH),blackhole)
-	ARCH_CPU	:= -mcpu=tt-bh
-	ARCH_DEFINE     := -DARCH_BLACKHOLE
-	ARCH_LLK_ROOT   := tt_llk_blackhole
-else
-	$(error CHIP_ARCH must be either 'wormhole' or 'blackhole')
-endif
 
 # =========================
 # Compiler and Linker Flags
@@ -53,7 +63,7 @@ OPTIONS_LINK	:= -fexceptions -Wl,-z,max-page-size=16 -Wl,-z,common-page-size=16 
 
 INCLUDES := -I../$(ARCH_LLK_ROOT)/llk_lib -I../$(ARCH_LLK_ROOT)/common/inc \
 			-I../$(ARCH_LLK_ROOT)/common/inc/sfpu -I$(HEADER_DIR) \
-			-Ifirmware/riscv/common -Ifirmware/riscv/$(CHIP_ARCH) \
+			-Ifirmware/riscv/common -Ifirmware/riscv/$(ARCH) \
 			-Isfpi/include -Ihelpers/include
 
 OPTIONS_COMPILE += $(INCLUDES)
@@ -70,22 +80,24 @@ TEST_KERNEL_FLAG := -DTEST_KERNEL
 all: $(ELF_DIR)/unpack.elf \
 	 $(ELF_DIR)/math.elf \
 	 $(ELF_DIR)/pack.elf \
-	 $(SHARED_DIR)/brisc.elf
+	 $(SHARED_ELF_DIR)/brisc.elf
 
 dis: $(DIS_DIR)/unpack.S \
 	 $(DIS_DIR)/math.S \
 	 $(DIS_DIR)/pack.S \
-	 $(SHARED_DIR)/brisc.S
+	 $(SHARED_DIS_DIR)/brisc.S
 
 profiler: $(PROFILER_DIR)/unpack.meta.bin \
 	  $(PROFILER_DIR)/math.meta.bin \
 	  $(PROFILER_DIR)/pack.meta.bin
+
+
 # =========================
 # Build Rules
 # =========================
 
 # Currently only used for brisc.dis
-$(SHARED_DIR)/%.S: $(SHARED_DIR)/%.elf | $(SHARED_DIR)
+$(SHARED_DIS_DIR)/%.S: $(SHARED_ELF_DIR)/%.elf | $(SHARED_DIS_DIR)
 	$(OBJDUMP) -xsD $< > $@
 	$(OBJDUMP) -t $< | sort >> $@
 
@@ -96,38 +108,53 @@ $(DIS_DIR)/%.S: $(ELF_DIR)/%.elf | $(DIS_DIR)
 	$(OBJDUMP) -xsD $< > $@
 	$(OBJDUMP) -t $< | sort >> $@
 
-$(ELF_DIR)/%.elf: $(SHARED_DIR)/tmu-crt0.o $(SHARED_DIR)/main_%.o $(OBJ_DIR)/kernel_%.o | $(ELF_DIR)
-	$(GXX) $(OPTIONS_ALL) $(OPTIONS_LINK) $^ -T$(LINKER_SCRIPTS)/memory.$(CHIP_ARCH).ld -T$(LINKER_SCRIPTS)/$*.ld -T$(LINKER_SCRIPTS)/sections.ld -o $@
+$(ELF_DIR)/%.elf: $(SHARED_OBJ_DIR)/tmu-crt0.o $(SHARED_OBJ_DIR)/main_%.o $(OBJ_DIR)/kernel_%.o | $(ELF_DIR)
+	$(GXX) $(OPTIONS_ALL) $(OPTIONS_LINK) $^ -T$(LINKER_SCRIPTS)/memory.$(ARCH).ld -T$(LINKER_SCRIPTS)/$*.ld -T$(LINKER_SCRIPTS)/sections.ld -o $@
 
 # Building brisc.elf for BRISC core
-$(SHARED_DIR)/brisc.elf: $(SHARED_DIR)/tmu-crt0.o $(SHARED_DIR)/brisc.o | $(SHARED_DIR)
-	$(GXX) $(OPTIONS_ALL) $(OPTIONS_LINK) $^ -T$(LINKER_SCRIPTS)/memory.$(CHIP_ARCH).ld -T$(LINKER_SCRIPTS)/brisc.ld -T$(LINKER_SCRIPTS)/sections.ld -o $@
+$(SHARED_ELF_DIR)/brisc.elf: $(SHARED_OBJ_DIR)/tmu-crt0.o $(SHARED_OBJ_DIR)/brisc.o | $(SHARED_ELF_DIR)
+	$(GXX) $(OPTIONS_ALL) $(OPTIONS_LINK) $^ -T$(LINKER_SCRIPTS)/memory.$(ARCH).ld -T$(LINKER_SCRIPTS)/brisc.ld -T$(LINKER_SCRIPTS)/sections.ld -o $@
 
-$(OBJ_DIR)/kernel_%.o: sources/$(testname).cpp | $(OBJ_DIR)
-	$(GXX) $(OPTIONS_ALL)  $(TEST_KERNEL_FLAG) $(OPTIONS_COMPILE) -MMD -MP -MF $(@:.o=.d) -DLLK_TRISC_$(call TO_UPPER, $*) -c -o $@ $<
+# makes sure that make doesn't automatically delete intermediate files (didn't know this was a feature)
+.SECONDARY: $(SHARED_OBJ_DIR)/*.o $(OBJ_DIR)/*.o
+
+$(OBJ_DIR)/kernel_%.o: sources/$(testname).cpp | $(OBJ_DIR) $(DEPS_DIR)
+	$(GXX) $(OPTIONS_ALL) $(TEST_KERNEL_FLAG) $(OPTIONS_COMPILE) \
+	-MMD -MP -MF $(patsubst $(OBJ_DIR)/%.o,$(DEPS_DIR)/%.d,$@) \
+	-DLLK_TRISC_$(call TO_UPPER, $*) -c -o $@ $<
 
 # compiling main for every TRISC core
-$(SHARED_DIR)/main_%.o: $(RISCV_SOURCES)/trisc.cpp | $(SHARED_DIR)
-	$(GXX) $(OPTIONS_ALL) $(OPTIONS_COMPILE) -MMD -MP -MF $(@:.o=.d) -DLLK_TRISC_$(call TO_UPPER, $*) -c -o $@ $<
+$(SHARED_OBJ_DIR)/main_%.o: $(RISCV_SOURCES)/trisc.cpp | $(SHARED_OBJ_DIR) $(SHARED_DEPS_DIR)
+	$(GXX) $(OPTIONS_ALL) $(OPTIONS_COMPILE) \
+	-MMD -MP -MF $(patsubst $(SHARED_OBJ_DIR)/%.o,$(SHARED_DEPS_DIR)/%.d,$@) \
+	-DLLK_TRISC_$(call TO_UPPER, $*) -c -o $@ $<
 
-$(SHARED_DIR)/brisc.o: $(RISCV_SOURCES)/brisc.cpp | $(SHARED_DIR)
-	$(GXX) $(OPTIONS_ALL) $(OPTIONS_COMPILE) -MMD -MP -MF $(@:.o=.d) -c -o $@ $<
+$(SHARED_OBJ_DIR)/brisc.o: $(RISCV_SOURCES)/brisc.cpp | $(SHARED_OBJ_DIR) $(SHARED_DEPS_DIR)
+	$(GXX) $(OPTIONS_ALL) $(OPTIONS_COMPILE) \
+	-MMD -MP -MF $(patsubst $(SHARED_OBJ_DIR)/%.o,$(SHARED_DEPS_DIR)/%.d,$@) \
+	-c -o $@ $<
 
-$(SHARED_DIR)/tmu-crt0.o: $(HELPERS)/tmu-crt0.S | $(SHARED_DIR)
-	$(GXX) $(OPTIONS_ALL) $(OPTIONS_COMPILE) -MMD -MP -MF $(@:.o=.d) -c -o $@ $<
+$(SHARED_OBJ_DIR)/tmu-crt0.o: $(HELPERS)/tmu-crt0.S | $(SHARED_OBJ_DIR) $(SHARED_DEPS_DIR)
+	$(GXX) $(OPTIONS_ALL) $(OPTIONS_COMPILE) \
+	-MMD -MP -MF $(patsubst $(SHARED_OBJ_DIR)/%.o,$(SHARED_DEPS_DIR)/%.d,$@) \
+	-c -o $@ $<
 
 # required folder structure
-$(PROFILER_DIR) $(DIS_DIR) $(ELF_DIR) $(OBJ_DIR) $(SHARED_DIR):
+$(SHARED_OBJ_DIR) $(SHARED_DEPS_DIR) $(SHARED_DIS_DIR) $(SHARED_ELF_DIR):
 	mkdir -p $@
+
+$(OBJ_DIR) $(DEPS_DIR) $(DIS_DIR) $(ELF_DIR) $(PROFILER_DIR):
+	mkdir -p $@
+
 
 # =========================
 # Clean
 # =========================
 clean:
-	$(RMDIR) $(BUILD_DIR)
+	$(RMDIR) build
 	$(RMDIR) __pycache__
 	$(RMDIR) .pytest_cache
 	$(MAKE) -C python_tests clean
 
--include $(wildcard $(OBJ_DIR)/*.d)
--include $(wildcard $(SHARED_DIR)/*.d)
+-include $(wildcard $(SHARED_DEPS_DIR)/*.d)
+-include $(wildcard $(DEPS_DIR)/*.d)

--- a/tests/python_tests/helpers/device.py
+++ b/tests/python_tests/helpers/device.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import inspect
+import os
 import time
 from pathlib import Path
 
@@ -15,6 +16,8 @@ from ttexalens.tt_exalens_lib import (
     write_to_device,
     write_words_to_device,
 )
+
+from helpers.chip_architecture import get_chip_architecture
 
 from .format_arg_mapping import (
     DestAccumulation,
@@ -85,7 +88,9 @@ def perform_tensix_soft_reset(core_loc="0,0"):
 
 
 def run_elf_files(testname, core_loc="0,0"):
-    build_dir = Path("../build")
+    CHIP_ARCH = get_chip_architecture()
+    LLK_HOME = os.environ.get("LLK_HOME")
+    BUILD_DIR = Path(LLK_HOME) / "tests" / "build" / CHIP_ARCH.value
 
     # Perform soft reset
     perform_tensix_soft_reset(core_loc)
@@ -93,7 +98,7 @@ def run_elf_files(testname, core_loc="0,0"):
     # Load TRISC ELF files
     trisc_names = ["unpack", "math", "pack"]
     for i, trisc_name in enumerate(trisc_names):
-        elf_path = build_dir / "tests" / testname / "elf" / f"{trisc_name}.elf"
+        elf_path = BUILD_DIR / "tests" / testname / "elf" / f"{trisc_name}.elf"
         load_elf(
             elf_file=str(elf_path.absolute()),
             core_loc=core_loc,
@@ -105,7 +110,7 @@ def run_elf_files(testname, core_loc="0,0"):
     write_words_to_device(core_loc, TRISC_PROFILER_BARRIE_ADDRESS, [0, 0, 0])
 
     # Run BRISC
-    brisc_elf_path = build_dir / "shared" / "brisc.elf"
+    brisc_elf_path = BUILD_DIR / "shared" / "elf" / "brisc.elf"
     run_elf(str(brisc_elf_path.absolute()), core_loc, risc_name="brisc")
 
 

--- a/tests/python_tests/helpers/profiler.py
+++ b/tests/python_tests/helpers/profiler.py
@@ -12,6 +12,7 @@ from typing import Optional
 
 from ttexalens.tt_exalens_lib import read_words_from_device
 
+from helpers.chip_architecture import get_chip_architecture
 from helpers.test_config import ProfilerBuild, generate_make_command
 from helpers.utils import run_shell_command
 
@@ -178,11 +179,13 @@ class Profiler:
 
     @staticmethod
     def _get_meta(testname: str) -> dict[id, ProfilerFullMarker]:
-        root = os.environ.get("LLK_HOME")
-        if not root:
+        CHIP_ARCH = get_chip_architecture()
+        LLK_HOME = os.environ.get("LLK_HOME")
+        if not LLK_HOME:
             raise AssertionError("Environment variable LLK_HOME is not set")
 
-        profiler = Path(root) / "tests" / "build" / "tests" / testname / "profiler"
+        BUILD_DIR = Path(LLK_HOME) / "tests" / "build" / CHIP_ARCH.value
+        profiler = BUILD_DIR / "tests" / testname / "profiler"
 
         files = [
             profiler / "unpack.meta.bin",


### PR DESCRIPTION
### Ticket
<!-- Link to Github Issue -->

### Problem description
This PR is supposed to fix two issues:
- Improve the solution in https://github.com/tenstorrent/tt-llk/pull/473
- The previous Makefile would handle `.d` files incorrectly, leading to errors and redundant rebuilds @lpremovicTT 

### What's changed
- `build` and `hw_specific` are now split into two subfolders for Wormhole and Blackhole files
- All intermediate files in the build process now get their own subfolders instead of getting mixed together
- Adds make variable `archname` to provide a way to override what arch you're building for

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
