### PR TITLE
chore: remove Milos as code owner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,7 +2,7 @@
 # precedence.
 
 # Top-level files
-/* @amahmudTT @nvelickovicTT @rtawfik01 @ttmtrajkovic
+/* @amahmudTT @nvelickovicTT @rdjogoTT @rtawfik01
 
 # CI/CD
 .github/ @fvranicTT @nvelickovicTT
@@ -11,7 +11,7 @@
 tests/ @fvranicTT @ldjurovicTT @nvelickovicTT @skotaracTT @skrsmanovicTT @sstanisicTT
 
 # Blackhole
-tt_llk_blackhole/ @amahmudTT @nvelickovicTT @rdjogoTT @rtawfik01 @ttmtrajkovic
+tt_llk_blackhole/ @amahmudTT @nvelickovicTT @rdjogoTT @rtawfik01
 
 # Wormhole
-tt_llk_wormhole_b0/ @amahmudTT @nvelickovicTT @rdjogoTT @rtawfik01 @ttmtrajkovic
+tt_llk_wormhole_b0/ @amahmudTT @nvelickovicTT @rdjogoTT @rtawfik01


### PR DESCRIPTION
### Ticket
<!-- Link to Github Issue -->

### Problem description
Milos is not actively working on LLK repo. I spoke with him, and we agreed to remove him, to reduce impact on his mailbox. If needed, we could always ask him explicitly to review something.

### What's changed
Removing Milos Trajkovic as code owner.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
