### PR TITLE
refactor: change the way we add new sfpu types for testing

### DIFF
--- a/tests/helpers/include/params.h
+++ b/tests/helpers/include/params.h
@@ -10,6 +10,7 @@
 // Include auto-generated build configuration
 #include "build.h"
 #include "ckernel_defs.h"
+#include "ckernel_sfpu.h"
 #include "data_format_inference.h"
 #include "perf.h"
 #include "tensix_types.h"

--- a/tests/helpers/include/params.h
+++ b/tests/helpers/include/params.h
@@ -10,13 +10,7 @@
 // Include auto-generated build configuration
 #include "build.h"
 #include "ckernel_defs.h"
-#include "ckernel_sfpu_binary.h"
-#include "ckernel_sfpu_log.h"
-#include "ckernel_sfpu_sqrt.h"
-#include "ckernel_sfpu_square.h"
 #include "data_format_inference.h"
-#include "llk_defs.h"
-#include "llk_sfpu_types.h"
 #include "perf.h"
 #include "tensix_types.h"
 
@@ -32,13 +26,6 @@ constexpr std::underlying_type_t<DataFormat> get_data_format(DataFormat format)
     return static_cast<std::underlying_type_t<DataFormat>>(format);
 }
 } // namespace
-
-constexpr bool dest_acc_en_input =
-#ifdef DEST_ACC
-    true;
-#else
-    false;
-#endif
 
 constexpr bool unpack_to_dest = UNPACKING_TO_DEST;
 
@@ -61,77 +48,4 @@ constexpr auto& formats = formats_array[0];
 #else // Not inferring formats — all formats are pre-defined. Set format configuration directly.
 constexpr bool is_fp32_dest_acc_en = dest_acc_en_input; // dest_acc doesn't require adjustment; configuration is hard-coded
 constexpr FormatConfig formats     = FormatConfig(UNPACK_A_IN, UNPACK_A_OUT, MATH, PACK_IN, PACK_OUT);
-#endif
-
-#ifdef ELTWISE_BINARY_ADD
-constexpr auto ELTWISE_BINARY_OP = ckernel::EltwiseBinaryType::ELWADD;
-#endif
-#ifdef ELTWISE_BINARY_SUB
-constexpr auto ELTWISE_BINARY_OP = ckernel::EltwiseBinaryType::ELWSUB;
-#endif
-#ifdef ELTWISE_BINARY_MUL
-constexpr auto ELTWISE_BINARY_OP = ckernel::EltwiseBinaryType::ELWMUL;
-#endif
-// TO BE IMPLEMENTED IN LLKs
-#ifdef ELTWISE_BINARY_DIV
-constexpr auto ELTWISE_BINARY_OP = ckernel::EltwiseBinaryType::ELWDIV;
-#endif
-#ifdef ELTWISE_BINARY_LESS
-constexpr auto ELTWISE_BINARY_OP = ckernel::EltwiseBinaryType::ELWLESS;
-#endif
-
-#ifdef SFPU_ELWADD
-constexpr auto SFPU_BINARY_OPERATION = ckernel::BinaryOp::ADD;
-#endif
-#ifdef SFPU_ELWSUB
-constexpr auto SFPU_BINARY_OPERATION = ckernel::BinaryOp::SUB;
-#endif
-#ifdef SFPU_ELWMUL
-constexpr auto SFPU_BINARY_OPERATION = ckernel::BinaryOp::MUL;
-#endif
-#ifdef SFPU_OP_XLOGY
-constexpr auto SFPU_BINARY_OPERATION = ckernel::BinaryOp::XLOGY;
-#endif
-#ifdef SFPU_OP_RSHFT
-constexpr auto SFPU_BINARY_OPERATION = ckernel::BinaryOp::RSHFT;
-#endif
-#ifdef SFPU_OP_LSHFT
-constexpr auto SFPU_BINARY_OPERATION = ckernel::BinaryOp::LSHFT;
-#endif
-#ifdef SFPU_OP_LOGICAL_RSHFT
-constexpr auto SFPU_BINARY_OPERATION = ckernel::BinaryOp::LOGICAL_RSHFT;
-#endif
-#ifdef SFPU_OP_NEG
-constexpr auto SFPU_OPERATION = SfpuType::neg;
-#endif
-
-#ifdef SFPU_OP_SQRT
-constexpr auto SFPU_OPERATION = SfpuType::sqrt;
-#endif
-#ifdef SFPU_OP_LOG
-constexpr auto SFPU_OPERATION = SfpuType::log;
-#endif
-#ifdef SFPU_OP_SQUARE
-constexpr auto SFPU_OPERATION = SfpuType::square;
-#endif
-#ifdef SFPU_OP_SINE
-constexpr auto SFPU_OPERATION = SfpuType::sine;
-#endif
-#ifdef SFPU_OP_COSINE
-constexpr auto SFPU_OPERATION = SfpuType::cosine;
-#endif
-#ifdef SFPU_OP_ABS
-constexpr auto SFPU_OPERATION = SfpuType::abs;
-#endif
-#ifdef SFPU_OP_RECIPROCAL
-constexpr auto SFPU_OPERATION = SfpuType::reciprocal;
-#endif
-#ifdef SFPU_OP_CELU
-constexpr auto SFPU_OPERATION = SfpuType::celu;
-#endif
-#ifdef SFPU_OP_SILU
-constexpr auto SFPU_OPERATION = SfpuType::silu;
-#endif
-#ifdef SFPU_OP_GELU
-constexpr auto SFPU_OPERATION = SfpuType::gelu;
 #endif

--- a/tests/python_tests/helpers/format_arg_mapping.py
+++ b/tests/python_tests/helpers/format_arg_mapping.py
@@ -38,18 +38,24 @@ class MathOperation(Enum):
     """
     An enumeration class that holds all the math operations supported by the LLKs.
     Each enum value is an OpSpec tuple containing (cpp_enum_value, operation_type).
-    Used to avoid hardcoding the operation strings in the test scripts using strings. This avoid typos and future errors.
-    MathOperations(Enum) class instances can be compared via unique values.
-    When you have a set of related constants and you want to leverage the benefits of enumeration (unique members, comparisons, introspection, etc.).
-    It's a good choice for things like state machines, categories, or settings where values should not be changed or duplicated.
+
+    Operations are organized by type:
+    - FPU_BINARY: Floating Point Unit binary operations
+    - SFPU_UNARY: Special Function Processing Unit unary operations
+    - SFPU_BINARY: Special Function Processing Unit binary operations
+    - REDUCE: Reduction operations
     """
 
-    # FPU binary operations (sorted alphabetically)
+    # =============================================================================
+    # FPU BINARY OPERATIONS
+    # =============================================================================
     Elwadd = OpSpec("ELWADD", MathOpType.FPU_BINARY)
     Elwmul = OpSpec("ELWMUL", MathOpType.FPU_BINARY)
     Elwsub = OpSpec("ELWSUB", MathOpType.FPU_BINARY)
 
-    # SFPU unary operations (sorted alphabetically)
+    # =============================================================================
+    # SFPU UNARY OPERATIONS
+    # =============================================================================
     Abs = OpSpec("abs", MathOpType.SFPU_UNARY)
     Celu = OpSpec("celu", MathOpType.SFPU_UNARY)
     Cos = OpSpec("cosine", MathOpType.SFPU_UNARY)
@@ -62,7 +68,9 @@ class MathOperation(Enum):
     Sqrt = OpSpec("sqrt", MathOpType.SFPU_UNARY)
     Square = OpSpec("square", MathOpType.SFPU_UNARY)
 
-    # SFPU binary operations (sorted alphabetically)
+    # =============================================================================
+    # SFPU BINARY OPERATIONS
+    # =============================================================================
     SfpuElwadd = OpSpec("ADD", MathOpType.SFPU_BINARY)
     SfpuElwLeftShift = OpSpec("LSHFT", MathOpType.SFPU_BINARY)
     SfpuElwLogicalRightShift = OpSpec("LOGICAL_RSHFT", MathOpType.SFPU_BINARY)
@@ -71,11 +79,16 @@ class MathOperation(Enum):
     SfpuElwsub = OpSpec("SUB", MathOpType.SFPU_BINARY)
     SfpuXlogy = OpSpec("XLOGY", MathOpType.SFPU_BINARY)
 
-    # Reduce operations (sorted alphabetically)
+    # =============================================================================
+    # REDUCE OPERATIONS
+    # =============================================================================
     ReduceColumn = OpSpec("REDUCE_COL", MathOpType.REDUCE)
     ReduceRow = OpSpec("REDUCE_ROW", MathOpType.REDUCE)
     ReduceScalar = OpSpec("REDUCE_SCALAR", MathOpType.REDUCE)
 
+    # =============================================================================
+    # PROPERTIES AND UTILITY METHODS
+    # =============================================================================
     @property
     def cpp_enum_value(self):
         """Get the C++ enum value for this operation."""
@@ -86,17 +99,36 @@ class MathOperation(Enum):
         """Get the operation type for this operation."""
         return self.value.operation_type
 
+    @classmethod
+    def _get_operations_by_type(cls, op_type: MathOpType):
+        """Get all operations of a specific type."""
+        return {op for op in cls if op.operation_type == op_type}
 
-# Dynamically generate operation type sets
-def _get_operations_by_type(op_type: MathOpType):
-    """Get all operations of a specific type."""
-    return {op for op in MathOperation if op.operation_type == op_type}
+    @classmethod
+    def get_fpu_binary_operations(cls):
+        """Get all FPU binary operations."""
+        return cls._get_operations_by_type(MathOpType.FPU_BINARY)
+
+    @classmethod
+    def get_sfpu_unary_operations(cls):
+        """Get all SFPU unary operations."""
+        return cls._get_operations_by_type(MathOpType.SFPU_UNARY)
+
+    @classmethod
+    def get_sfpu_binary_operations(cls):
+        """Get all SFPU binary operations."""
+        return cls._get_operations_by_type(MathOpType.SFPU_BINARY)
+
+    @classmethod
+    def get_reduce_operations(cls):
+        """Get all reduce operations."""
+        return cls._get_operations_by_type(MathOpType.REDUCE)
 
 
-SFPU_UNARY_OPERATIONS = _get_operations_by_type(MathOpType.SFPU_UNARY)
-SFPU_BINARY_OPERATIONS = _get_operations_by_type(MathOpType.SFPU_BINARY)
-FPU_BINARY_OPERATIONS = _get_operations_by_type(MathOpType.FPU_BINARY)
-REDUCE_OPERATIONS = _get_operations_by_type(MathOpType.REDUCE)
+SFPU_UNARY_OPERATIONS = MathOperation.get_sfpu_unary_operations()
+SFPU_BINARY_OPERATIONS = MathOperation.get_sfpu_binary_operations()
+FPU_BINARY_OPERATIONS = MathOperation.get_fpu_binary_operations()
+REDUCE_OPERATIONS = MathOperation.get_reduce_operations()
 
 
 class ReduceDimension(Enum):
@@ -112,8 +144,8 @@ class ReducePool(Enum):
 
 
 class DestAccumulation(Enum):
-    Yes = "DEST_ACC"
-    No = ""
+    Yes = "true"
+    No = "false"
 
 
 class ApproximationMode(Enum):

--- a/tests/python_tests/helpers/format_arg_mapping.py
+++ b/tests/python_tests/helpers/format_arg_mapping.py
@@ -158,7 +158,6 @@ class MathFidelity(Enum):
     HiFi2 = 2
     HiFi3 = 3
     HiFi4 = 4
-    Invalid = 5
 
 
 class Mailbox(Enum):

--- a/tests/python_tests/helpers/format_arg_mapping.py
+++ b/tests/python_tests/helpers/format_arg_mapping.py
@@ -30,14 +30,14 @@ class MathOpType(Enum):
     REDUCE = auto()
 
 
-# Named tuple for operation specification
-OpSpec = namedtuple("OpSpec", ["cpp_name", "operation_type"])
+# Operation specification
+OpSpec = namedtuple("OpSpec", ["cpp_enum_value", "operation_type"])
 
 
 class MathOperation(Enum):
     """
     An enumeration class that holds all the math operations supported by the LLKs.
-    Each enum value is an OpSpec namedtuple containing (cpp_name, operation_type).
+    Each enum value is an OpSpec tuple containing (cpp_enum_value, operation_type).
     Used to avoid hardcoding the operation strings in the test scripts using strings. This avoid typos and future errors.
     MathOperations(Enum) class instances can be compared via unique values.
     When you have a set of related constants and you want to leverage the benefits of enumeration (unique members, comparisons, introspection, etc.).
@@ -73,13 +73,13 @@ class MathOperation(Enum):
 
     # Reduce operations (sorted alphabetically)
     ReduceColumn = OpSpec("REDUCE_COL", MathOpType.REDUCE)
-    ReduceRow = OpSpec("REDUCE_ROW_", MathOpType.REDUCE)
+    ReduceRow = OpSpec("REDUCE_ROW", MathOpType.REDUCE)
     ReduceScalar = OpSpec("REDUCE_SCALAR", MathOpType.REDUCE)
 
     @property
-    def cpp_name(self):
-        """Get the C++ constant for this operation."""
-        return self.value.cpp_name
+    def cpp_enum_value(self):
+        """Get the C++ enum value for this operation."""
+        return self.value.cpp_enum_value
 
     @property
     def operation_type(self):
@@ -100,17 +100,15 @@ REDUCE_OPERATIONS = _get_operations_by_type(MathOpType.REDUCE)
 
 
 class ReduceDimension(Enum):
-    Column = "ReduceDim::REDUCE_COL"
-    Row = "ReduceDim::REDUCE_ROW"
-    Scalar = "ReduceDim::REDUCE_SCALAR"
-    No = " "
+    Column = auto()
+    Row = auto()
+    Scalar = auto()
 
 
 class ReducePool(Enum):
-    Max = "PoolType::MAX"
-    Sum = "PoolType::SUM"
-    Average = "PoolType::AVG"
-    No = " "
+    Max = "MAX"
+    Sum = "SUM"
+    Average = "AVG"
 
 
 class DestAccumulation(Enum):

--- a/tests/python_tests/helpers/format_arg_mapping.py
+++ b/tests/python_tests/helpers/format_arg_mapping.py
@@ -29,30 +29,75 @@ class MathOperation(Enum):
     It's a good choice for things like state machines, categories, or settings where values should not be changed or duplicated.
     """
 
-    Elwadd = "ELTWISE_BINARY_ADD"
-    Elwsub = "ELTWISE_BINARY_SUB"
-    Elwmul = "ELTWISE_BINARY_MUL"
-    Abs = "SFPU_OP_ABS"
-    Sqrt = "SFPU_OP_SQRT"
-    Square = "SFPU_OP_SQUARE"
-    Log = "SFPU_OP_LOG"
-    Sin = "SFPU_OP_SINE"
-    Cos = "SFPU_OP_COSINE"
-    Reciprocal = "SFPU_OP_RECIPROCAL"
-    Celu = "SFPU_OP_CELU"
-    ReduceColumn = "REDUCE_COL_OPERATION"
-    ReduceRow = "REDUCE_ROW_OPERATION"
-    ReduceScalar = "REDUCE_SCALAR_OPERATION"
-    SfpuElwadd = "SFPU_ELWADD"
-    SfpuElwsub = "SFPU_ELWSUB"
-    SfpuElwmul = "SFPU_ELWMUL"
-    SfpuXlogy = "SFPU_OP_XLOGY"
-    SfpuElwRightShift = "SFPU_OP_RSHFT"
-    SfpuElwLeftShift = "SFPU_OP_LSHFT"
-    SfpuElwLogicalRightShift = "SFPU_OP_LOGICAL_RSHFT"
-    Silu = "SFPU_OP_SILU"
-    Gelu = "SFPU_OP_GELU"
-    Neg = "SFPU_OP_NEG"
+    # FPU binary operations
+    Elwadd = "ELWADD"
+    Elwsub = "ELWSUB"
+    Elwmul = "ELWMUL"
+
+    # SFPU unary operations
+    Abs = "abs"
+    Sqrt = "sqrt"
+    Square = "square"
+    Log = "log"
+    Sin = "sine"
+    Cos = "cosine"
+    Reciprocal = "reciprocal"
+    Celu = "celu"
+    Silu = "silu"
+    Gelu = "gelu"
+    Neg = "neg"
+
+    # SFPU binary operations
+    SfpuElwadd = "ADD"
+    SfpuElwsub = "SUB"
+    SfpuElwmul = "MUL"
+    SfpuXlogy = "XLOGY"
+    SfpuElwRightShift = "RSHFT"
+    SfpuElwLeftShift = "LSHFT"
+    SfpuElwLogicalRightShift = "LOGICAL_RSHFT"
+
+    # Reduce operations
+    ReduceColumn = "REDUCE_COL"
+    ReduceRow = "REDUCE_ROW_"
+    ReduceScalar = "REDUCE_SCALAR"
+
+
+# Operation type sets for easy categorization
+SFPU_UNARY_OPERATIONS = {
+    MathOperation.Abs,
+    MathOperation.Sqrt,
+    MathOperation.Square,
+    MathOperation.Log,
+    MathOperation.Sin,
+    MathOperation.Cos,
+    MathOperation.Reciprocal,
+    MathOperation.Celu,
+    MathOperation.Silu,
+    MathOperation.Gelu,
+    MathOperation.Neg,
+}
+
+SFPU_BINARY_OPERATIONS = {
+    MathOperation.SfpuElwadd,
+    MathOperation.SfpuElwsub,
+    MathOperation.SfpuElwmul,
+    MathOperation.SfpuXlogy,
+    MathOperation.SfpuElwRightShift,
+    MathOperation.SfpuElwLeftShift,
+    MathOperation.SfpuElwLogicalRightShift,
+}
+
+FPU_BINARY_OPERATIONS = {
+    MathOperation.Elwadd,
+    MathOperation.Elwsub,
+    MathOperation.Elwmul,
+}
+
+REDUCE_OPERATIONS = {
+    MathOperation.ReduceColumn,
+    MathOperation.ReduceRow,
+    MathOperation.ReduceScalar,
+}
 
 
 class ReduceDimension(Enum):

--- a/tests/python_tests/helpers/test_config.py
+++ b/tests/python_tests/helpers/test_config.py
@@ -124,7 +124,7 @@ def generate_build_header(
         f"constexpr std::uint32_t MATH_FIDELITY = {test_config.get('math_fidelity', MathFidelity.LoFi).value};"
     )
     header_content.append(
-        f"constexpr bool APPROX_MODE ={test_config.get('approx_mode', ApproximationMode.No).value};"
+        f"constexpr bool APPROX_MODE = {test_config.get('approx_mode', ApproximationMode.No).value};"
     )
 
     # Data format configuration
@@ -224,8 +224,10 @@ def generate_build_header(
 
     header_content.extend(
         [
+            "#if defined(TEST_KERNEL)",
             f"constexpr uint32_t BLOCK_CT_DIM = {block_ct_dim};",
             f"constexpr uint32_t BLOCK_RT_DIM = {block_rt_dim};",
+            "#endif",
         ]
     )
 

--- a/tests/python_tests/helpers/test_config.py
+++ b/tests/python_tests/helpers/test_config.py
@@ -39,15 +39,15 @@ def _generate_operation_constants(mathop: MathOperation) -> list[str]:
 
     if mathop in SFPU_UNARY_OPERATIONS:
         constants.append(
-            f"constexpr auto SFPU_UNARY_OPERATION = SfpuType::{mathop.value};"
+            f"constexpr auto SFPU_UNARY_OPERATION = SfpuType::{mathop.cpp_name};"
         )
     elif mathop in SFPU_BINARY_OPERATIONS:
         constants.append(
-            f"constexpr auto SFPU_BINARY_OPERATION = ckernel::BinaryOp::{mathop.value};"
+            f"constexpr auto SFPU_BINARY_OPERATION = ckernel::BinaryOp::{mathop.cpp_name};"
         )
     elif mathop in FPU_BINARY_OPERATIONS:
         constants.append(
-            f"constexpr auto ELTWISE_BINARY_OP = ckernel::EltwiseBinaryType::{mathop.value};"
+            f"constexpr auto ELTWISE_BINARY_OP = ckernel::EltwiseBinaryType::{mathop.cpp_name};"
         )
 
     return constants

--- a/tests/python_tests/helpers/test_config.py
+++ b/tests/python_tests/helpers/test_config.py
@@ -39,15 +39,15 @@ def _generate_operation_constants(mathop: MathOperation) -> list[str]:
 
     if mathop in SFPU_UNARY_OPERATIONS:
         constants.append(
-            f"constexpr auto SFPU_UNARY_OPERATION = SfpuType::{mathop.cpp_name};"
+            f"constexpr auto SFPU_UNARY_OPERATION = SfpuType::{mathop.cpp_enum_value};"
         )
     elif mathop in SFPU_BINARY_OPERATIONS:
         constants.append(
-            f"constexpr auto SFPU_BINARY_OPERATION = ckernel::BinaryOp::{mathop.cpp_name};"
+            f"constexpr auto SFPU_BINARY_OPERATION = ckernel::BinaryOp::{mathop.cpp_enum_value};"
         )
     elif mathop in FPU_BINARY_OPERATIONS:
         constants.append(
-            f"constexpr auto ELTWISE_BINARY_OP = ckernel::EltwiseBinaryType::{mathop.cpp_name};"
+            f"constexpr auto ELTWISE_BINARY_OP = ckernel::EltwiseBinaryType::{mathop.cpp_enum_value};"
         )
 
     return constants
@@ -165,11 +165,13 @@ def generate_build_header(
         # Handle reduce operations
         if mathop in REDUCE_OPERATIONS:
             header_content.append(
-                f"#define REDUCE_DIM {test_config.get('reduce_dim', ReduceDimension.No).value}"
+                f"constexpr auto REDUCE_DIM = ckernel::ReduceDim::{mathop.cpp_enum_value};"
             )
-            header_content.append(
-                f"#define POOL_TYPE {test_config.get('pool_type', ReducePool.No).value}"
-            )
+            pool_type = test_config.get("pool_type", None)
+            if pool_type is not None:
+                header_content.append(
+                    f"constexpr auto POOL_TYPE = ckernel::PoolType::{pool_type.value};"
+                )
 
     tile_cnt = test_config.get("tile_cnt", 1)
 

--- a/tests/python_tests/helpers/test_config.py
+++ b/tests/python_tests/helpers/test_config.py
@@ -20,8 +20,6 @@ from .format_arg_mapping import (
     L1BufferLocations,
     MathFidelity,
     MathOperation,
-    ReduceDimension,
-    ReducePool,
     format_tile_sizes,
 )
 from .format_config import FormatConfig, InputOutputFormat

--- a/tests/python_tests/helpers/test_config.py
+++ b/tests/python_tests/helpers/test_config.py
@@ -72,7 +72,9 @@ def _generate_operation_constants(mathop):
 
     if mathop in SFPU_UNARY_OPERATION_MAP:
         sfpu_type = SFPU_UNARY_OPERATION_MAP[mathop]
-        constants.append(f"constexpr auto SFPU_OPERATION = SfpuType::{sfpu_type};")
+        constants.append(
+            f"constexpr auto SFPU_UNARY_OPERATION = SfpuType::{sfpu_type};"
+        )
     elif mathop in SFPU_BINARY_OPERATION_MAP:
         binary_op = SFPU_BINARY_OPERATION_MAP[mathop]
         constants.append(

--- a/tests/python_tests/helpers/test_config.py
+++ b/tests/python_tests/helpers/test_config.py
@@ -139,7 +139,7 @@ def generate_build_header(
 
     # Dest accumulation
     dest_acc = test_config.get("dest_acc", DestAccumulation.No)
-    dest_acc_enabled = dest_acc == DestAccumulation.Yes or dest_acc == "DEST_ACC"
+    dest_acc_enabled = dest_acc == DestAccumulation.Yes
     header_content.append(
         f"constexpr bool dest_acc_en_input = {str(dest_acc_enabled).lower()};"
     )

--- a/tests/sources/eltwise_unary_sfpu_test.cpp
+++ b/tests/sources/eltwise_unary_sfpu_test.cpp
@@ -123,11 +123,11 @@ void run_kernel()
             i, formats.math, formats.math);
 
         // calculation of sfpu operation on dest
-        _llk_math_eltwise_unary_sfpu_init_<SFPU_OPERATION>();
+        _llk_math_eltwise_unary_sfpu_init_<SFPU_UNARY_OPERATION>();
         _llk_math_eltwise_unary_sfpu_start_<DstSync::SyncHalf>(i);
         // calling sfpu function from ckernel
         // this part is where parametrization of operation takes part
-        call_sfpu_operation(SFPU_OPERATION, formats.math);
+        call_sfpu_operation(SFPU_UNARY_OPERATION, formats.math);
 
         _llk_math_eltwise_unary_sfpu_done_();
     }

--- a/tests/sources/matmul_and_unary_sfpu_test.cpp
+++ b/tests/sources/matmul_and_unary_sfpu_test.cpp
@@ -126,11 +126,11 @@ void run_kernel()
         0, formats_array[run].math, formats_array[run].math);
 
     // calculation of sfpu operation on dest
-    _llk_math_eltwise_unary_sfpu_init_<SFPU_OPERATION>();
+    _llk_math_eltwise_unary_sfpu_init_<SFPU_UNARY_OPERATION>();
     _llk_math_eltwise_unary_sfpu_start_<DstSync::SyncHalf>(0);
     // calling sfpu function from ckernel
     // this part is where parametrization of operation takes part
-    call_sfpu_operation(SFPU_OPERATION);
+    call_sfpu_operation(SFPU_UNARY_OPERATION);
 
     _llk_math_eltwise_unary_sfpu_done_();
     _llk_math_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();

--- a/tests/sources/reduce_test.cpp
+++ b/tests/sources/reduce_test.cpp
@@ -10,15 +10,13 @@
 #include "llk_defs.h"
 #include "params.h"
 
-using namespace ckernel;
-
 // Globals
 uint32_t unp_cfg_context          = 0;
 uint32_t pack_sync_tile_dst_ptr   = 0;
 uint32_t math_sync_tile_dst_index = 0;
 
-constexpr std::uint32_t within_face_16x16_transpose = (REDUCE_DIM == ReduceDim::REDUCE_ROW) ? 1 : 0;
-constexpr bool row_pool                             = (REDUCE_DIM == ReduceDim::REDUCE_ROW);
+constexpr std::uint32_t within_face_16x16_transpose = (REDUCE_DIM == ckernel::ReduceDim::REDUCE_ROW) ? 1 : 0;
+constexpr bool row_pool                             = (REDUCE_DIM == ckernel::ReduceDim::REDUCE_ROW);
 
 #ifdef LLK_TRISC_UNPACK
 

--- a/tests/sources/reduce_test.cpp
+++ b/tests/sources/reduce_test.cpp
@@ -10,18 +10,15 @@
 #include "llk_defs.h"
 #include "params.h"
 
+using namespace ckernel;
+
 // Globals
 uint32_t unp_cfg_context          = 0;
 uint32_t pack_sync_tile_dst_ptr   = 0;
 uint32_t math_sync_tile_dst_index = 0;
 
-#ifdef REDUCE_ROW_OPERATION
-const std::uint32_t within_face_16x16_transpose = 1;
-const bool row_pool                             = true;
-#else
-const std::uint32_t within_face_16x16_transpose = 0;
-const bool row_pool                             = false;
-#endif
+constexpr std::uint32_t within_face_16x16_transpose = (REDUCE_DIM == ReduceDim::REDUCE_ROW) ? 1 : 0;
+constexpr bool row_pool                             = (REDUCE_DIM == ReduceDim::REDUCE_ROW);
 
 #ifdef LLK_TRISC_UNPACK
 


### PR DESCRIPTION
### Ticket
None

### Problem description
This aims to simplify how we pass defines, especially for SFPU and other math operations.

### What's changed
This code change leans more towards autogeneration than cumbersome manual handling of #ifdefs 

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
