### PR TITLE
fix: add more sfpu unary ops to mm fused test

### DIFF
--- a/tests/python_tests/test_matmul_and_unary_sfpu.py
+++ b/tests/python_tests/test_matmul_and_unary_sfpu.py
@@ -66,9 +66,12 @@ all_params = generate_params(
     approx_mode=[ApproximationMode.No, ApproximationMode.Yes],
     mathop=[
         MathOperation.Abs,
+        MathOperation.Celu,
         MathOperation.Cos,
+        MathOperation.Gelu,
         MathOperation.Log,
         MathOperation.Reciprocal,
+        MathOperation.Silu,
         MathOperation.Sin,
         MathOperation.Sqrt,
         MathOperation.Square,


### PR DESCRIPTION
### Ticket
None

### Problem description
Adding more sfpu unary ops to fused matmul test.

### What's changed
Added more ops.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update