### PR TITLE
ci: fix permissions of check-stale workflow

### DIFF
--- a/.github/workflows/check-stale.yml
+++ b/.github/workflows/check-stale.yml
@@ -3,7 +3,6 @@ name: Close stale issues and PRs
 on:
   schedule:
     - cron: '0 3 * * *'  # Runs daily at 3:00 UTC
-  workflow_dispatch:
 
 jobs:
   stale:
@@ -17,19 +16,19 @@ jobs:
       - uses: actions/stale@v9
         with:
           # Issue settings
-          days-before-stale: 700
-          days-before-close: 10
+          days-before-stale: 360
+          days-before-close: 20
           stale-issue-message: >
-            This issue has been automatically marked as stale due to inactivity for 100 days.
-            It will be closed in 10 days if no further activity occurs.
+            This issue has been automatically marked as stale due to inactivity for 360 days.
+            It will be closed in 20 days if no further activity occurs.
           close-issue-message: >
             This issue was closed due to prolonged inactivity. Feel free to reopen if needed.
 
           # PR settings
-          days-before-pr-stale: 30
+          days-before-pr-stale: 90
           days-before-pr-close: 10
           stale-pr-message: >
-            This pull request has been automatically marked as stale due to 30 days of inactivity.
+            This pull request has been automatically marked as stale due to 90 days of inactivity.
             It will be closed in 10 days if no further activity occurs.
           close-pr-message: >
             This pull request was closed due to inactivity. Please reopen or create a new one if still relevant.

--- a/.github/workflows/check-stale.yml
+++ b/.github/workflows/check-stale.yml
@@ -3,16 +3,21 @@ name: Close stale issues and PRs
 on:
   schedule:
     - cron: '0 3 * * *'  # Runs daily at 3:00 UTC
+  workflow_dispatch:
 
 jobs:
   stale:
     runs-on: ubuntu-latest
-
+    permissions:
+      contents: read
+      actions: write
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/stale@v9
         with:
           # Issue settings
-          days-before-stale: 100
+          days-before-stale: 700
           days-before-close: 10
           stale-issue-message: >
             This issue has been automatically marked as stale due to inactivity for 100 days.


### PR DESCRIPTION
### Ticket
None

### Problem description
We have some stale PRs that we'd like to automatically label as stale. This workflow has been added some time ago, but after moving to GH enterprise, it stopped working as expected since it was missing permissions.

### What's changed
- Added missing permissions to the check-stale workflow.
- Increased number of days before issue becomes stale to 700, since I wasn't sure about the number already in place (100 days)

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update