### PR TITLE
dead code elimination :coffin:: PERF_DUMP and related

### DIFF
--- a/tt_llk_blackhole/common/inc/ckernel_instr_params.h
+++ b/tt_llk_blackhole/common/inc/ckernel_instr_params.h
@@ -4,10 +4,6 @@
 
 #pragma once
 
-#ifdef PERF_DUMP
-#include "perf_res_decouple.h"
-#endif
-
 // MT: This should be dissolved and moved to the appropriate place
 #include "tensix.h"
 
@@ -17,23 +13,9 @@ namespace ckernel
 
 struct p_setrwc
 {
-#ifdef PERF_DUMP
-
-#if SKIP_UNP == 1
-    constexpr static uint CLR_A  = 0x0;
-    constexpr static uint CLR_B  = 0x0;
-    constexpr static uint CLR_AB = 0x0;
-#else
-    constexpr static uint CLR_A  = 0x1;
-    constexpr static uint CLR_B  = 0x2;
-    constexpr static uint CLR_AB = 0x3;
-#endif
-
-#else
-    constexpr static uint CLR_A  = 0x1;
-    constexpr static uint CLR_B  = 0x2;
-    constexpr static uint CLR_AB = 0x3;
-#endif
+    constexpr static uint CLR_A    = 0x1;
+    constexpr static uint CLR_B    = 0x2;
+    constexpr static uint CLR_AB   = 0x3;
     constexpr static uint CLR_NONE = 0x0;
 
     constexpr static uint SET_A     = 0x1;

--- a/tt_llk_blackhole/common/inc/cunpack_common.h
+++ b/tt_llk_blackhole/common/inc/cunpack_common.h
@@ -10,10 +10,6 @@
 #include "ckernel.h"
 #include "ckernel_globals.h"
 
-#ifdef PERF_DUMP
-#include "perf_res_decouple.h"
-#endif
-
 namespace ckernel::unpacker
 {
 constexpr uint32_t TILE_DESC_SIZE = 2; // Unpacker descriptor size in dwords

--- a/tt_llk_blackhole/llk_lib/llk_math_common.h
+++ b/tt_llk_blackhole/llk_lib/llk_math_common.h
@@ -10,9 +10,6 @@
 #include "ckernel_include.h"
 #include "ckernel_ops.h"
 #include "cmath_common.h"
-#ifdef PERF_DUMP
-#include "ckernel_perf_api.h"
-#endif
 
 using namespace ckernel::math;
 
@@ -48,26 +45,12 @@ inline void _llk_math_wait_for_dest_available_()
 {
     // These lightweight functions for sync with packer imply
     // no mode change - entire epoch is either double buffer or single buffer
-#ifdef PERF_DUMP
-    if constexpr (MATH_PACK_DECOUPLE == 0)
-    {
-        math_dest_wait();
-    }
-#else
     math_dest_wait();
-#endif
 }
 
 template <DstSync Dst, bool is_fp32_dest_acc_en>
 inline void _llk_math_dest_section_done_()
 {
-#ifdef PERF_DUMP
-    if constexpr (MATH_PACK_DECOUPLE)
-    {
-        return;
-    }
-#endif
-
     set_math_semaphores();
     if constexpr (Dst == DstSync::SyncHalf)
     {
@@ -79,12 +62,6 @@ inline void _llk_math_dest_section_done_()
 template <DstSync Dst, bool is_fp32_dest_acc_en>
 inline void _llk_math_pack_sync_init_()
 {
-#ifdef PERF_DUMP
-    if constexpr (MATH_PACK_DECOUPLE)
-    {
-        return;
-    }
-#endif
     tensix_sync();
     while (semaphore_read(semaphore::MATH_PACK) > 0)
     {

--- a/tt_llk_blackhole/llk_lib/llk_math_eltwise_unary_datacopy.h
+++ b/tt_llk_blackhole/llk_lib/llk_math_eltwise_unary_datacopy.h
@@ -30,8 +30,6 @@ inline void _llk_math_eltwise_unary_datacopy_(const std::uint32_t dst_index, con
 
     if (unpack_to_dest && is_32bit_input(src_format, dst_format))
     {
-#if SKIP_UNP == 1
-#else
         math_unpack_to_dest_math_ready();
         math::set_dst_write_addr<DstTileLayout::Default, DstTileShape::Tile32x32, true>(dst_index);
         math::math_unpack_to_dest_tile_ready();
@@ -48,7 +46,6 @@ inline void _llk_math_eltwise_unary_datacopy_(const std::uint32_t dst_index, con
             // Clears zero flags in DEST for one face.
             TT_ZEROACC(p_zeroacc::CLR_16, 0, 1 /*clear zero flags*/, ADDR_MOD_3, dest_base_offset_in_faces + dst_index_in_faces + i);
         }
-#endif
     }
     else
     {

--- a/tt_llk_blackhole/llk_lib/llk_pack_common.h
+++ b/tt_llk_blackhole/llk_lib/llk_pack_common.h
@@ -15,21 +15,10 @@
 using namespace ckernel;
 using namespace ckernel::packer;
 
-#ifdef PERF_DUMP
-#include "ckernel_perf_api.h"
-#endif
-
 // wait until math is done and has produced something to pack
 inline void _llk_packer_wait_for_math_done_()
 {
-#ifdef PERF_DUMP
-    if constexpr (MATH_PACK_DECOUPLE == 0)
-    {
-        TTI_SEMWAIT(p_stall::STALL_TDMA, semaphore::t6_sem(semaphore::MATH_PACK), p_stall::STALL_ON_ZERO);
-    }
-#else
     TTI_SEMWAIT(p_stall::STALL_TDMA, semaphore::t6_sem(semaphore::MATH_PACK), p_stall::STALL_ON_ZERO);
-#endif
 }
 
 // Tell math that it can write again
@@ -45,13 +34,6 @@ inline void _llk_packer_set_math_semaphore_()
 template <DstSync Dst, bool is_fp32_dest_acc_en>
 inline void _llk_pack_dest_section_done_()
 {
-#ifdef PERF_DUMP
-    if constexpr (MATH_PACK_DECOUPLE)
-    {
-        return;
-    }
-#endif
-
     TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::PACK); // wait for pack to finish
 
     if constexpr (Dst == DstSync::SyncFull)

--- a/tt_llk_blackhole/llk_lib/llk_unpack_AB.h
+++ b/tt_llk_blackhole/llk_lib/llk_unpack_AB.h
@@ -19,13 +19,8 @@ using namespace ckernel::unpacker;
 template <BroadcastType BType = BroadcastType::NONE>
 inline void _llk_unpack_AB_mop_config_(const bool transpose_of_faces = false, const std::uint32_t num_faces = 4, const bool narrow_tile = false)
 {
-#if SKIP_UNP == 1
-    static constexpr uint unpack_srca = TT_OP_NOP;
-    static constexpr uint unpack_srcb = TT_OP_NOP;
-#else
     static constexpr uint unpack_srca = TT_OP_UNPACR(SrcA, 0b1, 0, 0, 0, 1, 1, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
     static constexpr uint unpack_srcb = TT_OP_UNPACR(SrcB, 0b1, 0, 0, 0, 1, 1, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
-#endif
 
     if constexpr (BType == BroadcastType::COL)
     {
@@ -155,8 +150,4 @@ inline void _llk_unpack_AB_(const std::uint32_t address_a, const std::uint32_t a
 
     // Switch unpacker config context
     switch_config_context(unp_cfg_context);
-
-#ifdef PERF_DUMP
-    first_unpack_recorded = true;
-#endif
 }

--- a/tt_llk_blackhole/llk_lib/llk_unpack_common.h
+++ b/tt_llk_blackhole/llk_lib/llk_unpack_common.h
@@ -11,10 +11,6 @@
 #include "ckernel_ops.h"
 #include "cunpack_common.h"
 
-#ifdef PERF_DUMP
-#include "ckernel_perf_api.h"
-#endif
-
 using namespace ckernel;
 using namespace ckernel::unpacker;
 

--- a/tt_llk_blackhole/llk_lib/llk_unpack_reduce.h
+++ b/tt_llk_blackhole/llk_lib/llk_unpack_reduce.h
@@ -19,17 +19,10 @@ using namespace ckernel::unpacker;
 template <PoolType type, ReduceDim dim>
 inline void _llk_unpack_reduce_mop_config_()
 {
-#if SKIP_UNP == 1
-    static constexpr uint unpack_srca = TT_OP_NOP;
-#else
-    static constexpr uint unpack_srca = TT_OP_UNPACR(SrcA, 0b1, 0, 0, 0, 1, 1, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
-#endif
+    static constexpr uint unpack_srca     = TT_OP_UNPACR(SrcA, 0b1, 0, 0, 0, 1, 1, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
     static constexpr uint unpack_zerosrca = TT_OP_UNPACR_NOP(p_unpacr_nop::UNP0, 0, 0, 0, 0, 0, 0, p_unpacr_nop::CLR_SRC_0, p_unpacr_nop::CLR_SRC);
-#if SKIP_UNP == 1
-    static constexpr uint unpack_srcb = TT_OP_NOP;
-#else
-    static constexpr uint unpack_srcb = TT_OP_UNPACR(SrcB, 0b0, 0, 0, 0, 1, 1, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
-#endif
+    static constexpr uint unpack_srcb     = TT_OP_UNPACR(SrcB, 0b0, 0, 0, 0, 1, 1, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
+
     ckernel_unpack_template tmp = ckernel_unpack_template(
         true, // src B
         true, // halo - just used for 4 unpacks
@@ -126,8 +119,4 @@ inline void _llk_unpack_reduce_(const std::uint32_t address)
 
     // Switch unpacker config context
     switch_config_context(unp_cfg_context);
-
-#ifdef PERF_DUMP
-    first_unpack_recorded = true;
-#endif
 }

--- a/tt_llk_blackhole/llk_lib/llk_unpack_tilize.h
+++ b/tt_llk_blackhole/llk_lib/llk_unpack_tilize.h
@@ -18,18 +18,12 @@ using namespace ckernel::unpacker;
 
 inline void _llk_unpack_tilize_mop_config_(const bool narrow_tile = false, const bool unpack_to_dest = false)
 {
-#if SKIP_UNP == 1
-    static constexpr uint unpack_srca            = TT_OP_NOP;
-    static constexpr uint unpack_srca_to_dest    = TT_OP_NOP;
-    static constexpr uint unpack_srcb_zerosrc    = TT_OP_NOP;
-    static constexpr uint unpack_srcb_set_dvalid = TT_OP_NOP;
-#else
     static constexpr uint unpack_srca =
         TT_OP_UNPACR(SrcA, 0b1 /*Z inc*/, 0, 0, 0, 1 /* Set OvrdThreadId*/, 1 /*Set Dvalid*/, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
     static constexpr uint unpack_srca_to_dest =
         TT_OP_UNPACR(0, 0b00010001 /*Z inc*/, 0, 0, 0, 1 /* Set OvrdThreadId*/, 0, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
     static constexpr uint unpack_srcb_set_dvalid = TT_OP_UNPACR_NOP(SrcB, 0, 0, p_unpacr_nop::SET_DVALID, 0, 0, 0, 0, p_unpacr_nop::UNP_ZEROSRC);
-#endif
+
     const uint32_t outerloop = 1;
     const uint32_t innerloop = 1;
 
@@ -179,10 +173,6 @@ inline void _llk_unpack_tilize_(
 
     // Switch unpacker config context
     switch_config_context(unp_cfg_context);
-
-#ifdef PERF_DUMP
-    first_unpack_recorded = true;
-#endif
 }
 
 inline void _llk_unpack_tilize_uninit_(const std::uint32_t unpack_dst_format, const std::uint32_t num_faces = 4, const std::uint32_t face_r_dim = FACE_R_DIM)

--- a/tt_llk_wormhole_b0/common/inc/ckernel.h
+++ b/tt_llk_wormhole_b0/common/inc/ckernel.h
@@ -31,45 +31,11 @@
 #define GPR_DEBUG_REGFILE 0
 #endif
 
-#ifdef PERF_DUMP
-#define DECOUPLINGS_EN (SKIP_UNP || MATH_PACK_DECOUPLE)
-#else
-#define SKIP_UNP           0
-#define MATH_PACK_DECOUPLE 0
-#define DECOUPLINGS_EN     0
-#define OVERLAY_DECOUPLE   0
-#endif
-
-#if defined(EN_KERNEL_SLOWDOWN)
-#include "kernel_slowdown_config.h"
-#endif
-
-#ifndef INSERT_UNPACK_DELAY
-#define INSERT_UNPACK_DELAY 0
-#endif
-
-#ifndef INSERT_MATH_DELAY
-#define INSERT_MATH_DELAY 0
-#endif
-
-#ifndef INSERT_PACK_DELAY
-#define INSERT_PACK_DELAY 0
-#endif
-
-#define DELAY_EN (INSERT_UNPACK_DELAY || INSERT_PACK_DELAY || INSERT_MATH_DELAY)
-
 #define TT_ALWAYS_INLINE inline __attribute__((always_inline))
 
 #include <cstdint>
 
 #include "ckernel_include.h"
-
-// #include <cstring>
-#if defined(PERF_DUMP) || DELAY_EN > 0
-#include <l1_address_map.h>
-
-#include "perf_lib/scratch_api.h"
-#endif
 
 namespace ckernel
 {
@@ -511,115 +477,6 @@ inline void record_kernel_runtime(uint64_t kernel_runtime)
 
 void debug_dump(const uint8_t *data, uint32_t byte_size);
 void debug_dump_seek(uint8_t offset);
-
-inline void stall_kernel(uint32_t num_cycles)
-{
-#if DELAY_EN > 0
-    TT_LLK_DUMP("stall_kernel({})", num_cycles);
-    uint32_t start_clk_l  = reg_read(RISCV_DEBUG_REG_WALL_CLOCK_L);
-    uint32_t elapsed_time = 0;
-    while (elapsed_time <= num_cycles)
-    {
-        uint32_t current_clk_l = reg_read(RISCV_DEBUG_REG_WALL_CLOCK_L);
-        if (current_clk_l >= start_clk_l)
-        {
-            elapsed_time = current_clk_l - start_clk_l;
-        }
-        else
-        {
-            elapsed_time = 0xffffffff - (start_clk_l - current_clk_l);
-        }
-    }
-#endif
-}
-
-#if defined(PERF_DUMP) || DELAY_EN > 0
-extern bool record_perf_events;
-#endif
-
-// This api is inserted in the beginning of each input loop
-// Wait for all instructions of previous loop to finish before starting the next loop
-// If PERF_DUMP is enabled, always wait but only for the inputs that perf dump is enabled for
-// If PERF_DUMP is enabled, and delay is not, no need to insert these apis for unpack and math
-template <int thread_id>
-inline void serialize_input_loop_start()
-{
-#if defined(PERF_DUMP) || DELAY_EN > 0
-    TT_LLK_DUMP("serialize_input_loop_start<{}>()", thread_id);
-    if constexpr (thread_id == 0)
-    {
-#if DELAY_EN > 0
-        t6_semaphore_post(semaphore::UNPACK_MATH_DONE);
-        while (semaphore_read(semaphore::UNPACK_MATH_DONE) == 0)
-        {
-        }
-#endif
-    }
-    else if (thread_id == 1)
-    {
-#if DELAY_EN > 0
-        t6_semaphore_post(semaphore::UNPACK_MATH_DONE);
-        while (semaphore_read(semaphore::UNPACK_MATH_DONE) == 0)
-        {
-        }
-#endif
-    }
-    else if (thread_id == 2)
-    {
-#if DELAY_EN == 0
-        if (record_perf_events)
-        {
-#endif
-            t6_semaphore_post(semaphore::PACK_DONE);
-            while (semaphore_read(semaphore::PACK_DONE) == 0)
-            {
-            }
-#if DELAY_EN == 0
-        }
-#endif
-    }
-#endif
-}
-
-template <int thread_id>
-inline void serialize_input_loop_end()
-{
-#if defined(PERF_DUMP) || DELAY_EN > 0
-    TT_LLK_DUMP("serialize_input_loop_end<{}>()", thread_id);
-    if constexpr (thread_id == 0)
-    {
-#if DELAY_EN > 0
-        t6_semaphore_get<p_stall::UNPACK>(semaphore::UNPACK_MATH_DONE);
-        while (semaphore_read(semaphore::UNPACK_MATH_DONE) > 0)
-        {
-        }
-#endif
-    }
-    else if (thread_id == 1)
-    {
-#if DELAY_EN > 0
-        t6_semaphore_get<p_stall::MATH>(semaphore::UNPACK_MATH_DONE);
-        while (semaphore_read(semaphore::UNPACK_MATH_DONE) > 0)
-        {
-        }
-#endif
-    }
-    else if (thread_id == 2)
-    {
-#if DELAY_EN == 0
-        if (record_perf_events)
-        {
-#endif
-            t6_semaphore_get<p_stall::PACK>(semaphore::PACK_DONE);
-            while (semaphore_read(semaphore::PACK_DONE) > 0)
-            {
-            }
-#if DELAY_EN == 0
-        }
-#endif
-    }
-#endif
-}
 
 inline void init_prng_seed(const uint seed)
 {

--- a/tt_llk_wormhole_b0/common/inc/ckernel_instr_params.h
+++ b/tt_llk_wormhole_b0/common/inc/ckernel_instr_params.h
@@ -4,10 +4,6 @@
 
 #pragma once
 
-#ifdef PERF_DUMP
-#include "perf_res_decouple.h"
-#endif
-
 // MT: This should be dissolved and moved to the appropriate place
 #include "tensix.h"
 
@@ -17,23 +13,9 @@ namespace ckernel
 
 struct p_setrwc
 {
-#ifdef PERF_DUMP
-
-#if SKIP_UNP == 1
-    constexpr static uint CLR_A  = 0x0;
-    constexpr static uint CLR_B  = 0x0;
-    constexpr static uint CLR_AB = 0x0;
-#else
-    constexpr static uint CLR_A  = 0x1;
-    constexpr static uint CLR_B  = 0x2;
-    constexpr static uint CLR_AB = 0x3;
-#endif
-
-#else
-    constexpr static uint CLR_A  = 0x1;
-    constexpr static uint CLR_B  = 0x2;
-    constexpr static uint CLR_AB = 0x3;
-#endif
+    constexpr static uint CLR_A    = 0x1;
+    constexpr static uint CLR_B    = 0x2;
+    constexpr static uint CLR_AB   = 0x3;
     constexpr static uint CLR_NONE = 0x0;
 
     constexpr static uint SET_A     = 0x1;

--- a/tt_llk_wormhole_b0/common/inc/cunpack_common.h
+++ b/tt_llk_wormhole_b0/common/inc/cunpack_common.h
@@ -10,10 +10,6 @@
 #include "ckernel.h"
 #include "ckernel_globals.h"
 
-#ifdef PERF_DUMP
-#include "perf_res_decouple.h"
-#endif
-
 namespace ckernel::unpacker
 {
 constexpr uint32_t TILE_DESC_SIZE = 2; // Unpacker descriptor size in dwords

--- a/tt_llk_wormhole_b0/llk_lib/llk_math_common.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_math_common.h
@@ -10,9 +10,6 @@
 #include "ckernel_include.h"
 #include "ckernel_ops.h"
 #include "cmath_common.h"
-#ifdef PERF_DUMP
-#include "ckernel_perf_api.h"
-#endif
 
 using namespace ckernel::math;
 
@@ -35,26 +32,12 @@ inline void _llk_math_wait_for_dest_available_()
 {
     // These lightweight functions for sync with packer imply
     // no mode change - entire epoch is either double buffer or single buffer
-#ifdef PERF_DUMP
-    if constexpr (MATH_PACK_DECOUPLE == 0)
-    {
-        math_dest_wait();
-    }
-#else
     math_dest_wait();
-#endif
 }
 
 template <DstSync Dst, bool is_fp32_dest_acc_en>
 inline void _llk_math_dest_section_done_()
 {
-#ifdef PERF_DUMP
-    if constexpr (MATH_PACK_DECOUPLE)
-    {
-        return;
-    }
-#endif
-
     set_math_semaphores();
     if constexpr (Dst == DstSync::SyncHalf)
     {
@@ -66,12 +49,6 @@ inline void _llk_math_dest_section_done_()
 template <DstSync Dst, bool is_fp32_dest_acc_en>
 inline void _llk_math_pack_sync_init_()
 {
-#ifdef PERF_DUMP
-    if constexpr (MATH_PACK_DECOUPLE)
-    {
-        return;
-    }
-#endif
     tensix_sync();
     while (semaphore_read(semaphore::MATH_PACK) > 0)
     {

--- a/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_unary_datacopy.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_unary_datacopy.h
@@ -23,12 +23,9 @@ inline void _llk_math_eltwise_unary_datacopy_(const std::uint32_t dst_index, con
 {
     if (unpack_to_dest && is_32bit_input(src_format, dst_format))
     {
-#if SKIP_UNP == 1
-#else
         math_unpack_to_dest_math_ready();
         math::set_dst_write_addr<DstTileLayout::Default, DstTileShape::Tile32x32, true>(dst_index);
         math::math_unpack_to_dest_tile_ready();
-#endif
     }
     else
     {

--- a/tt_llk_wormhole_b0/llk_lib/llk_pack_common.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_pack_common.h
@@ -15,21 +15,10 @@
 using namespace ckernel;
 using namespace ckernel::packer;
 
-#ifdef PERF_DUMP
-#include "ckernel_perf_api.h"
-#endif
-
 // wait until math is done and has produced something to pack
 inline void _llk_packer_wait_for_math_done_()
 {
-#ifdef PERF_DUMP
-    if constexpr (MATH_PACK_DECOUPLE == 0)
-    {
-        TTI_SEMWAIT(p_stall::STALL_TDMA, semaphore::t6_sem(semaphore::MATH_PACK), p_stall::STALL_ON_ZERO);
-    }
-#else
     TTI_SEMWAIT(p_stall::STALL_TDMA, semaphore::t6_sem(semaphore::MATH_PACK), p_stall::STALL_ON_ZERO);
-#endif
 }
 
 // Tell math that it can write again
@@ -45,13 +34,6 @@ inline void _llk_packer_set_math_semaphore_()
 template <DstSync Dst, bool is_fp32_dest_acc_en>
 inline void _llk_pack_dest_section_done_()
 {
-#ifdef PERF_DUMP
-    if constexpr (MATH_PACK_DECOUPLE)
-    {
-        return;
-    }
-#endif
-
     TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::PACK); // wait for pack to finish
 
     if constexpr (Dst == DstSync::SyncFull)

--- a/tt_llk_wormhole_b0/llk_lib/llk_unpack_A.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_unpack_A.h
@@ -18,10 +18,6 @@
 using namespace ckernel;
 using namespace ckernel::unpacker;
 
-#ifndef SKIP_UNP
-#define SKIP_UNP 0
-#endif
-
 template <
     BroadcastType BType                          = BroadcastType::NONE,
     bool acc_to_dest                             = false,
@@ -36,21 +32,6 @@ inline void _llk_unpack_A_mop_config_(
         (((BType == BroadcastType::NONE) && (!acc_to_dest) && (binary_reuse_dest == EltwiseBinaryReuseDestType::NONE)) || (!unpack_to_dest)),
         "Not supported configuration when unpacking to dest!");
 
-#if SKIP_UNP == 1
-    static constexpr uint unpack_srca            = TT_OP_NOP;
-    static constexpr uint unpack_srca_to_dest    = TT_OP_NOP;
-    static constexpr uint unpack_srca_set_dvalid = TT_OP_NOP;
-    static constexpr uint unpack_srcb            = TT_OP_NOP;
-    static constexpr uint unpack_srcb_inc_z_0    = TT_OP_NOP;
-    static constexpr uint unpack_srcb_zerosrc    = TT_OP_NOP;
-    static constexpr uint unpack_srcb_set_dvalid = TT_OP_NOP;
-    static constexpr uint srca_set_z_1           = TT_OP_NOP;
-    static constexpr uint srcb_set_z_2           = TT_OP_NOP;
-    static constexpr uint srcb_clear_z           = TT_OP_NOP;
-    constexpr uint replay_buf_len                = 1;
-    lltt::record(0, 1);
-    TTI_NOP;
-#else
     static constexpr uint unpack_srca =
         TT_OP_UNPACR(SrcA, 0b1 /*Z inc*/, 0, 0, 0, 1 /* Set OvrdThreadId*/, 1 /*Set Dvalid*/, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
     static constexpr uint unpack_srca_to_dest =
@@ -75,7 +56,6 @@ inline void _llk_unpack_A_mop_config_(
     TTI_UNPACR(SrcB, 0b1 /*Z inc*/, 0, 0, 0, 1 /* Set OvrdThreadId*/, 1 /*Set Dvalid*/, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
     static constexpr uint unpack_srca_zerosrc_set_dvalid = lltt::replay_insn(0, 2);
     static constexpr uint unpack_srcb_unpack_srcb        = lltt::replay_insn(2, 2);
-#endif
 
     if (unpack_to_dest && is_32bit_input(unpack_src_format, unpack_dst_format))
     {
@@ -131,7 +111,6 @@ inline void _llk_unpack_A_mop_config_(
     {
         if (transpose_of_faces)
         {
-#if SKIP_UNP == 0
             constexpr uint replay_buf_len = 3;
             lltt::record(4, replay_buf_len);
             TTI_UNPACR_NOP(SrcB, p_unpacr_nop::UNP_ZEROSRC);
@@ -144,7 +123,7 @@ inline void _llk_unpack_A_mop_config_(
             {
                 TTI_UNPACR(SrcA, 0b01, 0, 0, 0, 1, 1, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1); // inc srcA ch0_z+=1
             }
-#endif
+
             const uint32_t outerloop = num_faces < 4 ? 1 : 2;
             const uint32_t innerloop = num_faces < 2 ? 1 : 2;
             ckernel_template tmp(outerloop, innerloop, lltt::replay_insn(4, replay_buf_len)); // Unpack faces 0/2 && 1/3 to srcA
@@ -302,8 +281,4 @@ inline void _llk_unpack_A_(
 
     // Switch unpacker config context
     switch_config_context(unp_cfg_context);
-
-#ifdef PERF_DUMP
-    first_unpack_recorded = true;
-#endif
 }

--- a/tt_llk_wormhole_b0/llk_lib/llk_unpack_AB.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_unpack_AB.h
@@ -20,13 +20,8 @@ using namespace ckernel::unpacker;
 template <BroadcastType BType = BroadcastType::NONE>
 inline void _llk_unpack_AB_mop_config_(const bool transpose_of_faces = false, const std::uint32_t num_faces = 4, const bool narrow_tile = false)
 {
-#if SKIP_UNP == 1
-    static constexpr uint unpack_srca = TT_OP_NOP;
-    static constexpr uint unpack_srcb = TT_OP_NOP;
-#else
     static constexpr uint unpack_srca = TT_OP_UNPACR(SrcA, 0b1, 0, 0, 0, 1, 1, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
     static constexpr uint unpack_srcb = TT_OP_UNPACR(SrcB, 0b1, 0, 0, 0, 1, 1, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
-#endif
 
     if constexpr (BType == BroadcastType::COL)
     {
@@ -156,8 +151,4 @@ inline void _llk_unpack_AB_(const std::uint32_t address_a, const std::uint32_t a
 
     // Switch unpacker config context
     switch_config_context(unp_cfg_context);
-
-#ifdef PERF_DUMP
-    first_unpack_recorded = true;
-#endif
 }

--- a/tt_llk_wormhole_b0/llk_lib/llk_unpack_AB_matmul.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_unpack_AB_matmul.h
@@ -37,10 +37,6 @@ inline void _llk_unpack_AB_matmul_mop_config_(
 
     if (reuse_a)
     {
-#if SKIP_UNP == 1
-        lltt::record(0, 1);
-        TTI_NOP;
-#else
         static_assert(kernel_broadcast_b <= 1, "kernel_broadcast>1 on matmul input 1 is not supported with reuse enabled!");
         lltt::record(0, replay_buf_prog_len);
         if (unpA_partial_face)
@@ -91,14 +87,9 @@ inline void _llk_unpack_AB_matmul_mop_config_(
             TTI_REG2FLOP(1, 0, 0, 0, THCON_SEC0_REG3_Base_cntx1_address_ADDR32 - THCON_CFGREG_BASE_ADDR32, p_gpr_unpack::TMP0);
         }
         TTI_NOP;
-#endif
     }
     else
     {
-#if SKIP_UNP == 1
-        lltt::record(0, 1);
-        TTI_NOP;
-#else
         static_assert(kernel_broadcast_a <= 1, "kernel_broadcast>1 on matmul input 0 is not supported with reuse enabled!");
         lltt::record(0, replay_buf_prog_len);
         if (unpB_partial_face)
@@ -149,7 +140,6 @@ inline void _llk_unpack_AB_matmul_mop_config_(
             TTI_REG2FLOP(1, 0, 0, 0, THCON_SEC1_REG3_Base_cntx1_address_ADDR32 - THCON_CFGREG_BASE_ADDR32, p_gpr_unpack::TMP0);
         }
         TTI_NOP;
-#endif
     }
 
     ckernel_unpack_template tmp = ckernel_unpack_template(
@@ -333,9 +323,6 @@ inline void _llk_unpack_AB_matmul_(
 
         if (reuse_a)
         {
-#if SKIP_UNP == 1
-            TTI_NOP;
-#else
             if (unpB_partial_face)
             {
                 TTI_UNPACR_NOP(SrcB, p_unpacr_nop::UNP_ZEROSRC);
@@ -380,13 +367,9 @@ inline void _llk_unpack_AB_matmul_(
                 }
                 t++;
             }
-#endif
         }
         else
         {
-#if SKIP_UNP == 1
-            TTI_NOP;
-#else
             if (unpA_partial_face)
             {
                 // Do face by face unpacking
@@ -431,7 +414,6 @@ inline void _llk_unpack_AB_matmul_(
                 }
                 t++;
             }
-#endif
         }
 
         TT_MOP(0, (reuse_a ? ct_dim : rt_dim) - 1, unp_cfg_context == 0 ? 0 : 0xff); // Run the MOP
@@ -442,8 +424,4 @@ inline void _llk_unpack_AB_matmul_(
         // Switch unpacker config context
         switch_config_context(unp_cfg_context);
     }
-
-#ifdef PERF_DUMP
-    first_unpack_recorded = true;
-#endif
 }

--- a/tt_llk_wormhole_b0/llk_lib/llk_unpack_common.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_unpack_common.h
@@ -12,10 +12,6 @@
 #include "ckernel_ops.h"
 #include "cunpack_common.h"
 
-#ifdef PERF_DUMP
-#include "ckernel_perf_api.h"
-#endif
-
 using namespace ckernel;
 using namespace ckernel::unpacker;
 

--- a/tt_llk_wormhole_b0/llk_lib/llk_unpack_reduce.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_unpack_reduce.h
@@ -19,17 +19,10 @@ using namespace ckernel::unpacker;
 template <PoolType type, ReduceDim dim>
 inline void _llk_unpack_reduce_mop_config_(const std::uint32_t num_faces)
 {
-#if SKIP_UNP == 1
-    static constexpr uint unpack_srca = TT_OP_NOP;
-#else
-    static constexpr uint unpack_srca = TT_OP_UNPACR(SrcA, 0b1, 0, 0, 0, 1, 1, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
-#endif
+    static constexpr uint unpack_srca     = TT_OP_UNPACR(SrcA, 0b1, 0, 0, 0, 1, 1, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
     static constexpr uint unpack_zerosrca = TT_OP_UNPACR_NOP(p_unpacr_nop::UNP0, p_unpacr_nop::UNP_ZEROSRC);
-#if SKIP_UNP == 1
-    static constexpr uint unpack_srcb = TT_OP_NOP;
-#else
-    static constexpr uint unpack_srcb = TT_OP_UNPACR(SrcB, 0b0, 0, 0, 0, 1, 1, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
-#endif
+    static constexpr uint unpack_srcb     = TT_OP_UNPACR(SrcB, 0b0, 0, 0, 0, 1, 1, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
+
     const uint32_t outerloop     = num_faces;
     constexpr uint32_t innerloop = 1;
     ckernel_template tmp(outerloop, innerloop, unpack_zerosrca, unpack_srca);
@@ -115,8 +108,4 @@ inline void _llk_unpack_reduce_(const std::uint32_t address)
 
     // Switch unpacker config context
     switch_config_context(unp_cfg_context);
-
-#ifdef PERF_DUMP
-    first_unpack_recorded = true;
-#endif
 }

--- a/tt_llk_wormhole_b0/llk_lib/llk_unpack_tilize.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_unpack_tilize.h
@@ -18,19 +18,12 @@ using namespace ckernel::unpacker;
 
 inline void _llk_unpack_tilize_mop_config_(const bool narrow_tile = false, const bool unpack_to_dest = false)
 {
-#if SKIP_UNP == 1
-    static constexpr uint unpack_srca            = TT_OP_NOP;
-    static constexpr uint unpack_srca_to_dest    = TT_OP_NOP;
-    static constexpr uint unpack_srcb_zerosrc    = TT_OP_NOP;
-    static constexpr uint unpack_srcb_set_dvalid = TT_OP_NOP;
-#else
     static constexpr uint unpack_srca =
         TT_OP_UNPACR(SrcA, 0b1 /*Z inc*/, 0, 0, 0, 1 /* Set OvrdThreadId*/, 1 /*Set Dvalid*/, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
     static constexpr uint unpack_srca_to_dest =
         TT_OP_UNPACR(SrcA, 0b00010001 /*CH0/CH1 Z inc*/, 0, 0, 0, 1 /* Set OvrdThreadId*/, 0, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
     static constexpr uint unpack_srcb_zerosrc    = TT_OP_UNPACR_NOP(SrcB, p_unpacr_nop::UNP_ZEROSRC);
     static constexpr uint unpack_srcb_set_dvalid = TT_OP_UNPACR_NOP(SrcB, p_unpacr_nop::UNP_SET_DVALID); // WA for tenstorrent/budabackend#1230
-#endif
 
     const uint32_t outerloop     = narrow_tile ? 1 : 2;
     constexpr uint32_t innerloop = 1;
@@ -237,10 +230,6 @@ inline void _llk_unpack_tilize_(
         reset_config_context();
         unpack_tilize_to_dest_impl(base_address, unpack_src_format, num_loops, top_face_offset_address, bot_face_offset_address);
     }
-
-#ifdef PERF_DUMP
-    first_unpack_recorded = true;
-#endif
 }
 
 /*************************************************************************


### PR DESCRIPTION
### Ticket
<!-- Link to Github Issue -->

### Problem description
There is a lot of unused defines and logic connected to PERF_DUMP define. From what I found, this hasn't been used for the last 2+ years.

### What's changed
Removes dead code

Removed Defines:
- `PERF_DUMP`
- `SKIP_UNP`
- `MATH_PACK_DECOUPLE`
- `DECOUPLINGS_EN`
- `OVERLAY_DECOUPLE`
- `INSERT_UNPACK_DELAY`
- `INSERT_MATH_DELAY`
- `INSERT_PACK_DELAY`
- `DELAY_EN`

Removed functions:
- `stall_kernel`
- `serialize_input_loop_start`
- `serialize_input_loop_end`

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
