### PR TITLE
ci: disable harbor as it seems to be down

### DIFF
--- a/.github/workflows/setup-and-test.yml
+++ b/.github/workflows/setup-and-test.yml
@@ -28,7 +28,7 @@ jobs:
       matrix:
         test_group: ${{ fromJSON(inputs.test_group) }}
     container:
-      image: harbor.ci.tenstorrent.net/${{ inputs.docker_image }}
+      image: ${{ inputs.docker_image }}
       options: "--rm --device /dev/tenstorrent"
     name: "🦄 Run tests (group ${{ matrix.test_group }}${{ fromJSON(inputs.test_group).length }})"
     steps:


### PR DESCRIPTION
### Ticket
None

### Problem description
Harbor service is down, disabling it for now. We use harbor as a cache server for docker images, it's an internal instance.
See an example of failed run: https://github.com/tenstorrent/tt-llk/actions/runs/16414826585/job/46378256374?pr=512

### What's changed
Harbor has been disabled.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
