### PR TITLE
Fix instrn-buffer change breakage

### DIFF
--- a/tests/helpers/include/ckernel_helper.h
+++ b/tests/helpers/include/ckernel_helper.h
@@ -4,14 +4,12 @@
 
 #pragma once
 
-#include <cstdint>
-
-constexpr std::uint32_t INSTRN_BUF_BASE = 0xFFE40000;
-
 namespace ckernel
 {
-volatile std::uint32_t tt_reg_ptr *pc_buf_base     = reinterpret_cast<volatile std::uint32_t *>(PC_BUF_BASE);
-volatile std::uint32_t tt_reg_ptr *instrn_buffer   = reinterpret_cast<volatile std::uint32_t *>(INSTRN_BUF_BASE);
+volatile std::uint32_t tt_reg_ptr *pc_buf_base = reinterpret_cast<volatile std::uint32_t *>(PC_BUF_BASE);
+#if defined(INSTRN_BUF_BASE)
+volatile std::uint32_t tt_reg_ptr *instrn_buffer = reinterpret_cast<volatile std::uint32_t *>(INSTRN_BUF_BASE);
+#endif
 volatile std::uint32_t tt_reg_ptr *regfile         = reinterpret_cast<volatile std::uint32_t *>(REGFILE_BASE);
 volatile std::uint32_t tt_reg_ptr *mailbox_base[4] = {
     reinterpret_cast<volatile std::uint32_t tt_reg_ptr *>(TENSIX_MAILBOX0_BASE),

--- a/tests/helpers/ld/memory.blackhole.ld
+++ b/tests/helpers/ld/memory.blackhole.ld
@@ -32,4 +32,4 @@ MEMORY
     TRISC1_LOADER_CODE_MEM : ORIGIN = (90624 + (0 * 1024) + (0 * 1024) + (0 * 1024)), LENGTH = (0 * 1024)
     TRISC2_LOADER_CODE_MEM : ORIGIN = (90624 + (0 * 1024) + (0 * 1024) + (0 * 1024) + (0 * 1024)), LENGTH = (0 * 1024)
 }
-PROVIDE(__instrn_buffer = 0xFFE4000);
+PROVIDE(__instrn_buffer = 0xFFE40000);

--- a/tests/helpers/ld/memory.wormhole.ld
+++ b/tests/helpers/ld/memory.wormhole.ld
@@ -32,4 +32,4 @@ MEMORY
     TRISC1_LOADER_CODE_MEM : ORIGIN = (76288 + (0 * 1024) + (16 * 1024) + (0 * 1024)), LENGTH = (0 * 1024)
     TRISC2_LOADER_CODE_MEM : ORIGIN = (76288 + (0 * 1024) + (16 * 1024) + (0 * 1024) + (0 * 1024)), LENGTH = (0 * 1024)
 }
-PROVIDE(__instrn_buffer = 0xFFE4000);
+PROVIDE(__instrn_buffer = 0xFFE40000);

--- a/tests/python_tests/conftest.py
+++ b/tests/python_tests/conftest.py
@@ -52,7 +52,6 @@ def download_headers():
         "cfg_defines.h",
         "dev_mem_map.h",
         "tensix.h",
-        "tensix_dev_map.h",
         "tensix_types.h",
     ]
 

--- a/tt_llk_blackhole/common/inc/ckernel.h
+++ b/tt_llk_blackhole/common/inc/ckernel.h
@@ -68,7 +68,7 @@ extern volatile uint tt_reg_ptr *regfile;
 extern volatile uint32_t __instrn_buffer[];
 namespace ckernel
 {
-constexpr volatile uint32_t(tt_reg_ptr &instrn_buffer)[] = __instrn_buffer;
+constexpr inline volatile uint32_t(tt_reg_ptr &instrn_buffer)[] = __instrn_buffer;
 #else // defined(INSTRN_BUF_BASE)
 extern volatile uint tt_reg_ptr *instrn_buffer;
 #endif

--- a/tt_llk_blackhole/common/inc/ckernel.h
+++ b/tt_llk_blackhole/common/inc/ckernel.h
@@ -60,7 +60,18 @@ constexpr uint KERNEL_COMPLETE    = 1;
 extern volatile uint tt_reg_ptr *reg_base;
 extern volatile uint tt_reg_ptr *pc_buf_base;
 extern volatile uint tt_reg_ptr *regfile;
+#if !defined(INSTRN_BUF_BASE)
+// Once tt_metal's submodule use of tt_llk is updated, this shim can
+// be cleaned up.
+#define INSTRN_BUFFER_TNG
+} // namespace ckernel
+extern volatile uint32_t __instrn_buffer[];
+namespace ckernel
+{
+constexpr volatile uint32_t(tt_reg_ptr &instrn_buffer)[] = __instrn_buffer;
+#else // defined(INSTRN_BUF_BASE)
 extern volatile uint tt_reg_ptr *instrn_buffer;
+#endif
 extern volatile uint tt_reg_ptr *mailbox_base[4];
 extern volatile uint tt_reg_ptr *dbg_event_scratch;
 extern volatile uint tt_reg_ptr *trisc_l1_mailbox;

--- a/tt_llk_wormhole_b0/common/inc/ckernel.h
+++ b/tt_llk_wormhole_b0/common/inc/ckernel.h
@@ -59,7 +59,7 @@ extern volatile uint tt_reg_ptr *regfile;
 extern volatile uint32_t __instrn_buffer[];
 namespace ckernel
 {
-constexpr volatile uint32_t(tt_reg_ptr &instrn_buffer)[] = __instrn_buffer;
+constexpr inline volatile uint32_t(tt_reg_ptr &instrn_buffer)[] = __instrn_buffer;
 #else // defined(INSTRN_BUF_BASE)
 extern volatile uint tt_reg_ptr *instrn_buffer;
 #endif

--- a/tt_llk_wormhole_b0/common/inc/ckernel.h
+++ b/tt_llk_wormhole_b0/common/inc/ckernel.h
@@ -51,7 +51,18 @@ constexpr uint KERNEL_COMPLETE    = 1;
 extern volatile uint tt_reg_ptr *reg_base;
 extern volatile uint tt_reg_ptr *pc_buf_base;
 extern volatile uint tt_reg_ptr *regfile;
+#if !defined(INSTRN_BUF_BASE)
+// Once tt_metal's submodule use of tt_llk is updated, this shim can
+// be cleaned up.
+#define INSTRN_BUFFER_TNG
+} // namespace ckernel
+extern volatile uint32_t __instrn_buffer[];
+namespace ckernel
+{
+constexpr volatile uint32_t(tt_reg_ptr &instrn_buffer)[] = __instrn_buffer;
+#else // defined(INSTRN_BUF_BASE)
 extern volatile uint tt_reg_ptr *instrn_buffer;
+#endif
 extern volatile uint tt_reg_ptr *mailbox_base[4];
 extern volatile uint tt_reg_ptr *dbg_event_scratch;
 extern volatile uint tt_reg_ptr *trisc_l1_mailbox;


### PR DESCRIPTION
### Ticket
NA

### Problem description
My recent change to instrn_buffer was inadequately tested and broke things :(
https://github.com/tenstorrent/tt-llk/pull/516

### What's changed
1) Revert @fvranicTT 's pragmatic fix.  (I don;t think it necessary to copy the tensix_dev_map.h files, but we can if you think that desirable).
2) Add `inline` to the constexpr defn. In some circumstances the compiler can decide to emit this as an object, and then we get multiple definition errors.
3) I typoed the instrn_buffer address in the test harness's linker script fragments

I manually tested on IRD.

### Type of change

- [YES] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
