### PR TITLE
perf :zap:: reset_mailboxes in wrong place

### DIFF
--- a/tests/python_tests/helpers/perf.py
+++ b/tests/python_tests/helpers/perf.py
@@ -139,9 +139,9 @@ def perf_benchmark(test_config, run_types: list[PerfRunType], run_count=8):
 
         runs = []
         for _ in range(run_count):
+            reset_mailboxes()
             run_elf_files(test_config["testname"])
             wait_for_tensix_operations_finished()
-            reset_mailboxes()
 
             profiler_data = Profiler.get_data(test_config["testname"])
             perf_data = process_profiler_data(profiler_data)


### PR DESCRIPTION
### Ticket
<!-- Link to Github Issue -->

### Problem description
Mailboxes aren't reset correctly for first of the performance runs

### What's changed
<!-- Describe the approach used to solve the problem.
Summarize the changes made and its impact. -->

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
