### PR TITLE
ci: trigger metal bump only if blackhole or wormhole code has been changed

### DIFF
--- a/.github/workflows/trigger-tt-metal-bump.yml
+++ b/.github/workflows/trigger-tt-metal-bump.yml
@@ -3,6 +3,9 @@ name: Trigger tt-metal CI
 on:
   push:
     branches: [main]
+    paths:
+      - 'tt_llk_blackhole/**'
+      - 'tt_llk_wormhole_b0/**'
 
 permissions:
   contents: read


### PR DESCRIPTION
### Problem description
Without this change, the integration flow to TT-metal is triggered regardless of what changes are made in this repository. Changes to the testing framework, documentation, or CI configuration all trigger the TT-metal integration flow. Even though this integration step checks whether to run post-commit workflows of TT-metal, it still creates unnecessary pressure on the code owners.

### What's changed
With this change, TT-metal’s workflow will be triggered only if the blackhole or wormhole headers are updated.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update