### PR TITLE
ci: mirror fork branch workflow

### DIFF
--- a/.github/workflows/mirror-fork-branches.yml
+++ b/.github/workflows/mirror-fork-branches.yml
@@ -1,0 +1,133 @@
+name: 🪞 Mirror Fork Branch to Origin
+
+on:
+  workflow_call:
+    inputs:
+      source:
+        description: 'Source in format <fork_owner>:<branch>'
+        required: true
+        type: string
+      target_branch:
+        description: >
+          Optional. Target branch name in origin. If not provided, the branch will be named
+          `mirror/<fork_owner>/<branch>`.
+        required: false
+        type: string
+  workflow_dispatch:
+    inputs:
+      source:
+        description: 'Source in format <fork_owner>:<branch>'
+        required: true
+      target_branch:
+        description: >
+          Optional. Target branch name in origin. If not provided, the branch will be named
+          `mirror/<fork_owner>/<branch>`.
+        required: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  mirror-fork-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Parse input
+        id: parse_input
+        shell: bash
+        run: |
+          # Expect input format: <fork_owner>:<branch>
+          IFS=":" read -r FORK_OWNER SRC_BRANCH <<< "${{ github.event.inputs.source }}"
+          if [ -z "$FORK_OWNER" ] || [ -z "$SRC_BRANCH" ]; then
+            echo "Error: Input must be in the format <fork_owner>:<branch>"
+            exit 1
+          fi
+          # Derive the fork repository name from the current repository.
+          ORIGIN_REPO_NAME=$(echo "${{ github.repository }}" | cut -d'/' -f2)
+          FORK_REPO="${FORK_OWNER}/${ORIGIN_REPO_NAME}"
+          echo "FORK_OWNER: $FORK_OWNER"
+          echo "Source branch: $SRC_BRANCH"
+          echo "Fork repository: $FORK_REPO"
+          echo "fork_owner=$FORK_OWNER" >> $GITHUB_OUTPUT
+          echo "src_branch=$SRC_BRANCH" >> $GITHUB_OUTPUT
+          echo "fork_repo=$FORK_REPO" >> $GITHUB_OUTPUT
+
+      - name: Checkout base repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Add fork remote and fetch branch
+        run: |
+          echo "Adding remote for fork: ${{ steps.parse_input.outputs.fork_repo }}"
+          git remote add fork https://github.com/${{ steps.parse_input.outputs.fork_repo }}.git \
+            || echo "Remote 'fork' already exists"
+          echo "Fetching branch: ${{ steps.parse_input.outputs.src_branch }}"
+          git fetch fork ${{ steps.parse_input.outputs.src_branch }}
+
+      - name: Create or update local branch from fork branch
+        id: create_branch
+        shell: bash
+        run: |
+          # Determine the target branch name.
+          if [ -n "${{ github.event.inputs.target_branch }}" ]; then
+            TARGET_BRANCH="${{ github.event.inputs.target_branch }}"
+          else
+            FORK_OWNER="${{ steps.parse_input.outputs.fork_owner }}"
+            SRC_BRANCH="${{ steps.parse_input.outputs.src_branch }}"
+            TARGET_BRANCH="mirror/${FORK_OWNER}/${SRC_BRANCH}"
+          fi
+          echo "Using target branch: $TARGET_BRANCH"
+          # If the branch exists locally, update it; if not, create it.
+          if git show-ref --verify --quiet "refs/heads/$TARGET_BRANCH"; then
+            echo "Branch '$TARGET_BRANCH' exists. Updating with latest commits from fork."
+            git checkout "$TARGET_BRANCH"
+            git reset --hard "fork/${{ steps.parse_input.outputs.src_branch }}"
+          else
+            echo "Branch '$TARGET_BRANCH' does not exist. Creating it from fork branch."
+            git checkout -b "$TARGET_BRANCH" "fork/${{ steps.parse_input.outputs.src_branch }}"
+          fi
+          echo "target_branch=$TARGET_BRANCH" >> $GITHUB_OUTPUT
+
+      - name: Push branch to origin
+        run: |
+          TARGET_BRANCH="${{ steps.create_branch.outputs.target_branch }}"
+          echo "Pushing branch '$TARGET_BRANCH' to origin"
+          git push origin "$TARGET_BRANCH" --force
+
+      - name: Find PR
+        id: pr
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Look for a PR with head "fork_owner:src_branch"
+          HEAD_QUERY="${{ steps.parse_input.outputs.fork_owner }}:${{ steps.parse_input.outputs.src_branch }}"
+          echo "Searching for PR with head: ${HEAD_QUERY}"
+          PR_JSON=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${{ github.repository }}/pulls?head=${HEAD_QUERY}")
+          PR_NUMBER=$(echo "$PR_JSON" | jq '.[0].number // empty')
+          if [ -z "$PR_NUMBER" ]; then
+            echo "No PR found"
+            echo "issue=" >> $GITHUB_OUTPUT
+          else
+            echo "Found PR #$PR_NUMBER"
+            echo "issue=$PR_NUMBER" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Post comment on PR
+        if: steps.pr.outputs.issue != ''
+        uses: mshick/add-pr-comment@v2
+        with:
+          issue: ${{ steps.pr.outputs.issue }}
+          message: >
+            ✨ A mirror branch has been created/updated for this PR:
+            [`${{ steps.create_branch.outputs.target_branch }}`](
+              https://github.com/${{ github.repository }}/tree/${{ steps.create_branch.outputs.target_branch }}
+            )

--- a/.github/workflows/mirror-fork-branches.yml
+++ b/.github/workflows/mirror-fork-branches.yml
@@ -37,7 +37,9 @@ jobs:
         shell: bash
         run: |
           # Expect input format: <fork_owner>:<branch>
-          IFS=":" read -r FORK_OWNER SRC_BRANCH <<< "${{ github.event.inputs.source }}"
+          source="${{ github.event.inputs.source }}"
+          FORK_OWNER="${source%%:*}"
+          SRC_BRANCH="${source#*:}"
           if [ -z "$FORK_OWNER" ] || [ -z "$SRC_BRANCH" ]; then
             echo "Error: Input must be in the format <fork_owner>:<branch>"
             exit 1
@@ -64,22 +66,25 @@ jobs:
 
       - name: Add fork remote and fetch branch
         run: |
+          FORK_OWNER="${{ steps.parse_input.outputs.fork_owner }}"
+          REMOTE_NAME="fork-${FORK_OWNER}"
           echo "Adding remote for fork: ${{ steps.parse_input.outputs.fork_repo }}"
-          git remote add fork https://github.com/${{ steps.parse_input.outputs.fork_repo }}.git \
-            || echo "Remote 'fork' already exists"
+          git remote add "$REMOTE_NAME" https://github.com/${{ steps.parse_input.outputs.fork_repo }}.git \
+            || echo "Remote '$REMOTE_NAME' already exists"
           echo "Fetching branch: ${{ steps.parse_input.outputs.src_branch }}"
-          git fetch fork ${{ steps.parse_input.outputs.src_branch }}
+          git fetch "$REMOTE_NAME" ${{ steps.parse_input.outputs.src_branch }}
 
       - name: Create or update local branch from fork branch
         id: create_branch
         shell: bash
         run: |
+          FORK_OWNER="${{ steps.parse_input.outputs.fork_owner }}"
+          SRC_BRANCH="${{ steps.parse_input.outputs.src_branch }}"
+          REMOTE_NAME="fork-${FORK_OWNER}"
           # Determine the target branch name.
           if [ -n "${{ github.event.inputs.target_branch }}" ]; then
             TARGET_BRANCH="${{ github.event.inputs.target_branch }}"
           else
-            FORK_OWNER="${{ steps.parse_input.outputs.fork_owner }}"
-            SRC_BRANCH="${{ steps.parse_input.outputs.src_branch }}"
             TARGET_BRANCH="mirror/${FORK_OWNER}/${SRC_BRANCH}"
           fi
           echo "Using target branch: $TARGET_BRANCH"
@@ -87,10 +92,10 @@ jobs:
           if git show-ref --verify --quiet "refs/heads/$TARGET_BRANCH"; then
             echo "Branch '$TARGET_BRANCH' exists. Updating with latest commits from fork."
             git checkout "$TARGET_BRANCH"
-            git reset --hard "fork/${{ steps.parse_input.outputs.src_branch }}"
+            git reset --hard "$REMOTE_NAME/$SRC_BRANCH"
           else
             echo "Branch '$TARGET_BRANCH' does not exist. Creating it from fork branch."
-            git checkout -b "$TARGET_BRANCH" "fork/${{ steps.parse_input.outputs.src_branch }}"
+            git checkout -b "$TARGET_BRANCH" "$REMOTE_NAME/$SRC_BRANCH"
           fi
           echo "target_branch=$TARGET_BRANCH" >> $GITHUB_OUTPUT
 
@@ -98,7 +103,7 @@ jobs:
         run: |
           TARGET_BRANCH="${{ steps.create_branch.outputs.target_branch }}"
           echo "Pushing branch '$TARGET_BRANCH' to origin"
-          git push origin "$TARGET_BRANCH" --force
+          git push origin "$TARGET_BRANCH" --force-with-lease
 
       - name: Find PR
         id: pr
@@ -109,10 +114,8 @@ jobs:
           # Look for a PR with head "fork_owner:src_branch"
           HEAD_QUERY="${{ steps.parse_input.outputs.fork_owner }}:${{ steps.parse_input.outputs.src_branch }}"
           echo "Searching for PR with head: ${HEAD_QUERY}"
-          PR_JSON=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
-            -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/repos/${{ github.repository }}/pulls?head=${HEAD_QUERY}")
-          PR_NUMBER=$(echo "$PR_JSON" | jq '.[0].number // empty')
+          PR_NUMBER=$(gh pr list --repo "${{ github.repository }}" \
+            --head "${HEAD_QUERY}" --json number --jq '.[0].number // empty')
           if [ -z "$PR_NUMBER" ]; then
             echo "No PR found"
             echo "issue=" >> $GITHUB_OUTPUT

--- a/.github/workflows/mirror-fork-branches.yml
+++ b/.github/workflows/mirror-fork-branches.yml
@@ -113,6 +113,7 @@ jobs:
         run: |
           # Look for a PR with head "fork_owner:src_branch"
           HEAD_QUERY="${{ steps.parse_input.outputs.fork_owner }}:${{ steps.parse_input.outputs.src_branch }}"
+          echo "HEAD_QUERY: $HEAD_QUERY"
           echo "Searching for PR with head: ${HEAD_QUERY}"
           PR_NUMBER=$(gh pr list --repo "${{ github.repository }}" \
             --head "${HEAD_QUERY}" --json number --jq '.[0].number // empty')

--- a/.github/workflows/mirror-fork-branches.yml
+++ b/.github/workflows/mirror-fork-branches.yml
@@ -115,8 +115,10 @@ jobs:
           HEAD_QUERY="${{ steps.parse_input.outputs.fork_owner }}:${{ steps.parse_input.outputs.src_branch }}"
           echo "HEAD_QUERY: $HEAD_QUERY"
           echo "Searching for PR with head: ${HEAD_QUERY}"
-          PR_NUMBER=$(gh pr list --repo "${{ github.repository }}" \
-            --head "${HEAD_QUERY}" --json number --jq '.[0].number // empty')
+          PR_JSON=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${{ github.repository }}/pulls?head=${HEAD_QUERY}")
+          PR_NUMBER=$(echo "$PR_JSON" | jq '.[0].number // empty')
           if [ -z "$PR_NUMBER" ]; then
             echo "No PR found"
             echo "issue=" >> $GITHUB_OUTPUT

--- a/.github/workflows/sort-issues.yml
+++ b/.github/workflows/sort-issues.yml
@@ -1,139 +1,136 @@
-name: 🪞 Mirror Fork Branch to Origin
+name: 📋 List Open Issues and Pull Requests
 
 on:
-  workflow_call:
-    inputs:
-      source:
-        description: 'Source in format <fork_owner>:<branch>'
-        required: true
-        type: string
-      target_branch:
-        description: >
-          Optional. Target branch name in origin. If not provided, the branch will be named
-          `mirror/<fork_owner>/<branch>`.
-        required: false
-        type: string
   workflow_dispatch:
-    inputs:
-      source:
-        description: 'Source in format <fork_owner>:<branch>'
-        required: true
-      target_branch:
-        description: >
-          Optional. Target branch name in origin. If not provided, the branch will be named
-          `mirror/<fork_owner>/<branch>`.
-        required: false
+  schedule:
+    - cron: '0 * * * *'
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
+  pages: write
+  id-token: write
 
 jobs:
-  mirror-fork-branch:
+  generate_reports:
     runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - name: Parse input
-        id: parse_input
-        shell: bash
-        run: |
-          # Expect input format: <fork_owner>:<branch>
-          source="${{ github.event.inputs.source }}"
-          FORK_OWNER="${source%%:*}"
-          SRC_BRANCH="${source#*:}"
-          if [ -z "$FORK_OWNER" ] || [ -z "$SRC_BRANCH" ]; then
-            echo "Error: Input must be in the format <fork_owner>:<branch>"
-            exit 1
-          fi
-          # Derive the fork repository name from the current repository.
-          ORIGIN_REPO_NAME=$(echo "${{ github.repository }}" | cut -d'/' -f2)
-          FORK_REPO="${FORK_OWNER}/${ORIGIN_REPO_NAME}"
-          echo "FORK_OWNER: $FORK_OWNER"
-          echo "Source branch: $SRC_BRANCH"
-          echo "Fork repository: $FORK_REPO"
-          echo "fork_owner=$FORK_OWNER" >> $GITHUB_OUTPUT
-          echo "src_branch=$SRC_BRANCH" >> $GITHUB_OUTPUT
-          echo "fork_repo=$FORK_REPO" >> $GITHUB_OUTPUT
-
-      - name: Checkout base repository
+      - name: Checkout repo
         uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
         with:
-          fetch-depth: 0
+          node-version: '20'
 
-      - name: Configure Git
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+      - name: Install dependencies
+        run: npm install
 
-      - name: Add fork remote and fetch branch
-        run: |
-          FORK_OWNER="${{ steps.parse_input.outputs.fork_owner }}"
-          REMOTE_NAME="fork-${FORK_OWNER}"
-          echo "Adding remote for fork: ${{ steps.parse_input.outputs.fork_repo }}"
-          git remote add "$REMOTE_NAME" https://github.com/${{ steps.parse_input.outputs.fork_repo }}.git \
-            || echo "Remote '$REMOTE_NAME' already exists"
-          echo "Fetching branch: ${{ steps.parse_input.outputs.src_branch }}"
-          git fetch "$REMOTE_NAME" ${{ steps.parse_input.outputs.src_branch }}
-
-      - name: Create or update local branch from fork branch
-        id: create_branch
-        shell: bash
-        run: |
-          FORK_OWNER="${{ steps.parse_input.outputs.fork_owner }}"
-          SRC_BRANCH="${{ steps.parse_input.outputs.src_branch }}"
-          REMOTE_NAME="fork-${FORK_OWNER}"
-          # Determine the target branch name.
-          if [ -n "${{ github.event.inputs.target_branch }}" ]; then
-            TARGET_BRANCH="${{ github.event.inputs.target_branch }}"
-          else
-            TARGET_BRANCH="mirror/${FORK_OWNER}/${SRC_BRANCH}"
-          fi
-          echo "Using target branch: $TARGET_BRANCH"
-          # If the branch exists locally, update it; if not, create it.
-          if git show-ref --verify --quiet "refs/heads/$TARGET_BRANCH"; then
-            echo "Branch '$TARGET_BRANCH' exists. Updating with latest commits from fork."
-            git checkout "$TARGET_BRANCH"
-            git reset --hard "$REMOTE_NAME/$SRC_BRANCH"
-          else
-            echo "Branch '$TARGET_BRANCH' does not exist. Creating it from fork branch."
-            git checkout -b "$TARGET_BRANCH" "$REMOTE_NAME/$SRC_BRANCH"
-          fi
-          echo "target_branch=$TARGET_BRANCH" >> $GITHUB_OUTPUT
-
-      - name: Push branch to origin
-        run: |
-          TARGET_BRANCH="${{ steps.create_branch.outputs.target_branch }}"
-          echo "Pushing branch '$TARGET_BRANCH' to origin"
-          git push origin "$TARGET_BRANCH" --force-with-lease
-
-      - name: Find PR
-        id: pr
-        shell: bash
+      - name: Run information collection scripts
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
-          # Look for a PR with head "fork_owner:src_branch"
-          HEAD_QUERY="${{ steps.parse_input.outputs.fork_owner }}:${{ steps.parse_input.outputs.src_branch }}"
-          echo "HEAD_QUERY: $HEAD_QUERY"
-          echo "Searching for PR with head: ${HEAD_QUERY}"
-          PR_JSON=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
-            -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/repos/${{ github.repository }}/pulls?head=${HEAD_QUERY}")
-          PR_NUMBER=$(echo "$PR_JSON" | jq '.[0].number // empty')
-          if [ -z "$PR_NUMBER" ]; then
-            echo "No PR found"
-            echo "issue=" >> $GITHUB_OUTPUT
-          else
-            echo "Found PR #$PR_NUMBER"
-            echo "issue=$PR_NUMBER" >> $GITHUB_OUTPUT
-          fi
+          node .github/scripts/sort-issues.js
+          node .github/scripts/list-pending-prs.js
 
-      - name: Post comment on PR
-        if: steps.pr.outputs.issue != ''
-        uses: mshick/add-pr-comment@v2
+      - name: Organize files for deployment
+        run: |
+          # Create reports directory structure
+          mkdir -p reports
+
+          # Move generated reports to reports directory
+          mv sorted-issues.html reports/
+          mv pending-prs.html reports/
+
+          # Create dashboard in reports directory
+          TIMESTAMP=$(date '+%B %d, %Y at %H:%M UTC')
+          cat > reports/index.html << EOF
+          <!DOCTYPE html>
+          <html>
+          <head>
+              <meta charset="UTF-8">
+              <title>LLK GitHub Reports</title>
+              <style>
+                  body {
+                      font-family: "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+                      background-color: #f4f6f9;
+                      color: #333;
+                      padding: 40px;
+                      text-align: center;
+                  }
+                  h1 {
+                      color: #007bff;
+                      margin-bottom: 30px;
+                  }
+                  .report-links {
+                      display: flex;
+                      justify-content: center;
+                      gap: 30px;
+                      margin-top: 30px;
+                  }
+                  .report-card {
+                      background: white;
+                      border-radius: 8px;
+                      padding: 30px;
+                      box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+                      text-decoration: none;
+                      color: #333;
+                      transition: transform 0.2s;
+                      min-width: 250px;
+                  }
+                  .report-card:hover {
+                      transform: translateY(-2px);
+                      box-shadow: 0 4px 15px rgba(0,0,0,0.15);
+                  }
+                  .report-card h2 {
+                      color: #007bff;
+                      margin-bottom: 15px;
+                  }
+                  .report-card p {
+                      margin: 0;
+                      color: #666;
+                  }
+                  .last-updated {
+                      margin-top: 40px;
+                      color: #666;
+                      font-size: 14px;
+                  }
+              </style>
+          </head>
+          <body>
+              <h1>LLK GitHub Reports Dashboard</h1>
+              <p>Automatically generated reports for repository insights</p>
+
+              <div class="report-links">
+                  <a href="sorted-issues.html" class="report-card">
+                      <h2>📝 Issues Report</h2>
+                      <p>Browse and filter open issues by priority, labels, and assignees</p>
+                  </a>
+
+                  <a href="pending-prs.html" class="report-card">
+                      <h2>🚀 Pull Requests Report</h2>
+                      <p>Track pending PRs with LLK team reviewers and sort by various criteria</p>
+                  </a>
+              </div>
+
+              <div class="last-updated">
+                  Last updated: $TIMESTAMP
+              </div>
+          </body>
+          </html>
+          EOF
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload to GitHub Pages
+        uses: actions/upload-pages-artifact@v3
         with:
-          issue: ${{ steps.pr.outputs.issue }}
-          message: >
-            ✨ A mirror branch has been created/updated for this PR:
-            [`${{ steps.create_branch.outputs.target_branch }}`](
-              https://github.com/${{ github.repository }}/tree/${{ steps.create_branch.outputs.target_branch }}
-            )
+          path: .
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/sort-issues.yml
+++ b/.github/workflows/sort-issues.yml
@@ -1,136 +1,136 @@
-name: 📋 List Open Issues and Pull Requests
+name: 🪞 Mirror Fork Branch to Origin
 
 on:
+  workflow_call:
+    inputs:
+      source:
+        description: 'Source in format <fork_owner>:<branch>'
+        required: true
+        type: string
+      target_branch:
+        description: >
+          Optional. Target branch name in origin. If not provided, the branch will be named
+          `mirror/<fork_owner>/<branch>`.
+        required: false
+        type: string
   workflow_dispatch:
-  schedule:
-    - cron: '0 * * * *'
+    inputs:
+      source:
+        description: 'Source in format <fork_owner>:<branch>'
+        required: true
+      target_branch:
+        description: >
+          Optional. Target branch name in origin. If not provided, the branch will be named
+          `mirror/<fork_owner>/<branch>`.
+        required: false
 
 permissions:
-  contents: read
-  pages: write
-  id-token: write
+  contents: write
+  pull-requests: write
 
 jobs:
-  generate_reports:
+  mirror-fork-branch:
     runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - name: Checkout repo
+      - name: Parse input
+        id: parse_input
+        shell: bash
+        run: |
+          # Expect input format: <fork_owner>:<branch>
+          source="${{ github.event.inputs.source }}"
+          FORK_OWNER="${source%%:*}"
+          SRC_BRANCH="${source#*:}"
+          if [ -z "$FORK_OWNER" ] || [ -z "$SRC_BRANCH" ]; then
+            echo "Error: Input must be in the format <fork_owner>:<branch>"
+            exit 1
+          fi
+          # Derive the fork repository name from the current repository.
+          ORIGIN_REPO_NAME=$(echo "${{ github.repository }}" | cut -d'/' -f2)
+          FORK_REPO="${FORK_OWNER}/${ORIGIN_REPO_NAME}"
+          echo "FORK_OWNER: $FORK_OWNER"
+          echo "Source branch: $SRC_BRANCH"
+          echo "Fork repository: $FORK_REPO"
+          echo "fork_owner=$FORK_OWNER" >> $GITHUB_OUTPUT
+          echo "src_branch=$SRC_BRANCH" >> $GITHUB_OUTPUT
+          echo "fork_repo=$FORK_REPO" >> $GITHUB_OUTPUT
+
+      - name: Checkout base repository
         uses: actions/checkout@v4
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          fetch-depth: 0
 
-      - name: Install dependencies
-        run: npm install
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Run information collection scripts
+      - name: Add fork remote and fetch branch
+        run: |
+          FORK_OWNER="${{ steps.parse_input.outputs.fork_owner }}"
+          REMOTE_NAME="fork-${FORK_OWNER}"
+          echo "Adding remote for fork: ${{ steps.parse_input.outputs.fork_repo }}"
+          git remote add "$REMOTE_NAME" https://github.com/${{ steps.parse_input.outputs.fork_repo }}.git \
+            || echo "Remote '$REMOTE_NAME' already exists"
+          echo "Fetching branch: ${{ steps.parse_input.outputs.src_branch }}"
+          git fetch "$REMOTE_NAME" ${{ steps.parse_input.outputs.src_branch }}
+
+      - name: Create or update local branch from fork branch
+        id: create_branch
+        shell: bash
+        run: |
+          FORK_OWNER="${{ steps.parse_input.outputs.fork_owner }}"
+          SRC_BRANCH="${{ steps.parse_input.outputs.src_branch }}"
+          REMOTE_NAME="fork-${FORK_OWNER}"
+          # Determine the target branch name.
+          if [ -n "${{ github.event.inputs.target_branch }}" ]; then
+            TARGET_BRANCH="${{ github.event.inputs.target_branch }}"
+          else
+            TARGET_BRANCH="mirror/${FORK_OWNER}/${SRC_BRANCH}"
+          fi
+          echo "Using target branch: $TARGET_BRANCH"
+          # If the branch exists locally, update it; if not, create it.
+          if git show-ref --verify --quiet "refs/heads/$TARGET_BRANCH"; then
+            echo "Branch '$TARGET_BRANCH' exists. Updating with latest commits from fork."
+            git checkout "$TARGET_BRANCH"
+            git reset --hard "$REMOTE_NAME/$SRC_BRANCH"
+          else
+            echo "Branch '$TARGET_BRANCH' does not exist. Creating it from fork branch."
+            git checkout -b "$TARGET_BRANCH" "$REMOTE_NAME/$SRC_BRANCH"
+          fi
+          echo "target_branch=$TARGET_BRANCH" >> $GITHUB_OUTPUT
+
+      - name: Push branch to origin
+        run: |
+          TARGET_BRANCH="${{ steps.create_branch.outputs.target_branch }}"
+          echo "Pushing branch '$TARGET_BRANCH' to origin"
+          git push origin "$TARGET_BRANCH" --force-with-lease
+
+      - name: Find PR
+        id: pr
+        shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
-          node .github/scripts/sort-issues.js
-          node .github/scripts/list-pending-prs.js
+          # Look for a PR with head "fork_owner:src_branch"
+          HEAD_QUERY="${{ steps.parse_input.outputs.fork_owner }}:${{ steps.parse_input.outputs.src_branch }}"
+          echo "Searching for PR with head: ${HEAD_QUERY}"
+          PR_NUMBER=$(gh pr list --repo "${{ github.repository }}" \
+            --head "${HEAD_QUERY}" --json number --jq '.[0].number // empty')
+          if [ -z "$PR_NUMBER" ]; then
+            echo "No PR found"
+            echo "issue=" >> $GITHUB_OUTPUT
+          else
+            echo "Found PR #$PR_NUMBER"
+            echo "issue=$PR_NUMBER" >> $GITHUB_OUTPUT
+          fi
 
-      - name: Organize files for deployment
-        run: |
-          # Create reports directory structure
-          mkdir -p reports
-
-          # Move generated reports to reports directory
-          mv sorted-issues.html reports/
-          mv pending-prs.html reports/
-
-          # Create dashboard in reports directory
-          TIMESTAMP=$(date '+%B %d, %Y at %H:%M UTC')
-          cat > reports/index.html << EOF
-          <!DOCTYPE html>
-          <html>
-          <head>
-              <meta charset="UTF-8">
-              <title>LLK GitHub Reports</title>
-              <style>
-                  body {
-                      font-family: "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-                      background-color: #f4f6f9;
-                      color: #333;
-                      padding: 40px;
-                      text-align: center;
-                  }
-                  h1 {
-                      color: #007bff;
-                      margin-bottom: 30px;
-                  }
-                  .report-links {
-                      display: flex;
-                      justify-content: center;
-                      gap: 30px;
-                      margin-top: 30px;
-                  }
-                  .report-card {
-                      background: white;
-                      border-radius: 8px;
-                      padding: 30px;
-                      box-shadow: 0 2px 10px rgba(0,0,0,0.1);
-                      text-decoration: none;
-                      color: #333;
-                      transition: transform 0.2s;
-                      min-width: 250px;
-                  }
-                  .report-card:hover {
-                      transform: translateY(-2px);
-                      box-shadow: 0 4px 15px rgba(0,0,0,0.15);
-                  }
-                  .report-card h2 {
-                      color: #007bff;
-                      margin-bottom: 15px;
-                  }
-                  .report-card p {
-                      margin: 0;
-                      color: #666;
-                  }
-                  .last-updated {
-                      margin-top: 40px;
-                      color: #666;
-                      font-size: 14px;
-                  }
-              </style>
-          </head>
-          <body>
-              <h1>LLK GitHub Reports Dashboard</h1>
-              <p>Automatically generated reports for repository insights</p>
-
-              <div class="report-links">
-                  <a href="sorted-issues.html" class="report-card">
-                      <h2>📝 Issues Report</h2>
-                      <p>Browse and filter open issues by priority, labels, and assignees</p>
-                  </a>
-
-                  <a href="pending-prs.html" class="report-card">
-                      <h2>🚀 Pull Requests Report</h2>
-                      <p>Track pending PRs with LLK team reviewers and sort by various criteria</p>
-                  </a>
-              </div>
-
-              <div class="last-updated">
-                  Last updated: $TIMESTAMP
-              </div>
-          </body>
-          </html>
-          EOF
-
-      - name: Setup Pages
-        uses: actions/configure-pages@v5
-
-      - name: Upload to GitHub Pages
-        uses: actions/upload-pages-artifact@v3
+      - name: Post comment on PR
+        if: steps.pr.outputs.issue != ''
+        uses: mshick/add-pr-comment@v2
         with:
-          path: .
-
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+          issue: ${{ steps.pr.outputs.issue }}
+          message: >
+            ✨ A mirror branch has been created/updated for this PR:
+            [`${{ steps.create_branch.outputs.target_branch }}`](
+              https://github.com/${{ github.repository }}/tree/${{ steps.create_branch.outputs.target_branch }}
+            )

--- a/.github/workflows/sort-issues.yml
+++ b/.github/workflows/sort-issues.yml
@@ -113,6 +113,7 @@ jobs:
         run: |
           # Look for a PR with head "fork_owner:src_branch"
           HEAD_QUERY="${{ steps.parse_input.outputs.fork_owner }}:${{ steps.parse_input.outputs.src_branch }}"
+          echo "HEAD_QUERY: $HEAD_QUERY"
           echo "Searching for PR with head: ${HEAD_QUERY}"
           PR_NUMBER=$(gh pr list --repo "${{ github.repository }}" \
             --head "${HEAD_QUERY}" --json number --jq '.[0].number // empty')

--- a/.github/workflows/sort-issues.yml
+++ b/.github/workflows/sort-issues.yml
@@ -115,8 +115,10 @@ jobs:
           HEAD_QUERY="${{ steps.parse_input.outputs.fork_owner }}:${{ steps.parse_input.outputs.src_branch }}"
           echo "HEAD_QUERY: $HEAD_QUERY"
           echo "Searching for PR with head: ${HEAD_QUERY}"
-          PR_NUMBER=$(gh pr list --repo "${{ github.repository }}" \
-            --head "${HEAD_QUERY}" --json number --jq '.[0].number // empty')
+          PR_JSON=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${{ github.repository }}/pulls?head=${HEAD_QUERY}")
+          PR_NUMBER=$(echo "$PR_JSON" | jq '.[0].number // empty')
           if [ -z "$PR_NUMBER" ]; then
             echo "No PR found"
             echo "issue=" >> $GITHUB_OUTPUT


### PR DESCRIPTION
### Ticket
None

### Problem description
This workflow creates a mirror image of a fork branch. That will be useful for running metal integration tests (post commit tests), and should help us spend less time juggling the branches.

### What's changed
Added a new workflow for creating mirror images of branches coming from forks.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update