### PR TITLE
Change ALU_FORMAT of SrcA in reduce init to fix MOVB2D bug with Tf32

### DIFF
--- a/tests/sources/reduce_test.cpp
+++ b/tests/sources/reduce_test.cpp
@@ -42,14 +42,14 @@ void run_kernel()
 
 void run_kernel()
 {
-    const std::uint32_t math_fid = 4;
-    const bool is_int_fpu_en     = false;
-    const bool fp32_transpose    = false;
+    const std::uint32_t math_fid         = 4;
+    const bool is_int_fpu_en             = false;
+    const bool enforce_fp32_accumulation = false;
     _llk_math_pack_sync_init_<DstSync::SyncFull, is_fp32_dest_acc_en>();
     _llk_math_wait_for_dest_available_<DstSync::SyncFull>();
     _llk_math_hw_configure_<false, row_pool>(formats.math, formats.math);
-    _llk_math_reduce_init_<POOL_TYPE, REDUCE_DIM, math_fid>(within_face_16x16_transpose);
-    _llk_math_reduce_<POOL_TYPE, REDUCE_DIM, is_fp32_dest_acc_en, math_fid, is_int_fpu_en, fp32_transpose>(0);
+    _llk_math_reduce_init_<POOL_TYPE, REDUCE_DIM, is_fp32_dest_acc_en, math_fid, enforce_fp32_accumulation>(within_face_16x16_transpose);
+    _llk_math_reduce_<POOL_TYPE, REDUCE_DIM, is_fp32_dest_acc_en, math_fid, is_int_fpu_en, enforce_fp32_accumulation>(0);
     _llk_math_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
 }
 

--- a/tt_llk_wormhole_b0/llk_lib/llk_math_reduce.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_math_reduce.h
@@ -436,7 +436,7 @@ inline void reduce_configure_mop()
     }
 }
 
-template <PoolType type, ReduceDim dim, int MATH_FIDELITY_DESC = 0>
+template <PoolType type, ReduceDim dim, int MATH_FIDELITY_DESC = 0, bool fp32_transpose = false>
 inline void _llk_math_reduce_init_(const std::uint32_t within_face_16x16_transpose = 0)
 { // within_face_16x16_transpose used for unpack, ignored by math
 
@@ -449,6 +449,11 @@ inline void _llk_math_reduce_init_(const std::uint32_t within_face_16x16_transpo
         reduce_configure_mop<dim, MATH_FIDELITY_PHASES>();
     }
 
+    if constexpr (fp32_transpose)
+    {
+        // MOVB2D depends on SrcA ALU Format - Hi/Lo16 does not work with Tf32
+        cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG0_SrcA_RMW>((uint)DataFormat::Float16_b);
+    }
     TTI_SETC16(CLR_DVALID_SrcA_Disable_ADDR32, 0);
 
     math::reset_counters(p_setrwc::SET_ABD_F);

--- a/tt_llk_wormhole_b0/llk_lib/llk_math_reduce.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_math_reduce.h
@@ -460,7 +460,7 @@ inline void _llk_math_reduce_init_(const std::uint32_t within_face_16x16_transpo
         static_assert(is_fp32_dest_acc_en, "FP32 Dest must be enabled for FP32 accumulation");
         // MOVB2D/D2B depends on SrcA ALU Format - Hi/Lo16 does not work with Tf32 (only on WH)
         // This is needed because FP32 data from L1 that is unpacked to Src registers is reduced to Tf32
-        cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG0_SrcA_RMW>((uint)DataFormat::Float16_b);
+        cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG0_SrcA_RMW>((uint)DataFormat::Float32);
     }
     TTI_SETC16(CLR_DVALID_SrcA_Disable_ADDR32, 0);
 

--- a/tt_llk_wormhole_b0/llk_lib/llk_math_reduce.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_math_reduce.h
@@ -451,7 +451,7 @@ inline void _llk_math_reduce_init_(const std::uint32_t within_face_16x16_transpo
 
     if constexpr (fp32_transpose)
     {
-        // MOVB2D depends on SrcA ALU Format - Hi/Lo16 does not work with Tf32
+        // MOVB2D depends on SrcA ALU Format - Hi/Lo16 does not work with Tf32 (only on WH)
         cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG0_SrcA_RMW>((uint)DataFormat::Float16_b);
     }
     TTI_SETC16(CLR_DVALID_SrcA_Disable_ADDR32, 0);

--- a/tt_llk_wormhole_b0/llk_lib/llk_math_reduce.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_math_reduce.h
@@ -21,7 +21,13 @@ inline void reduce_configure_addrmod();
 template <ReduceDim dim, int num_fidelity_phases>
 inline void reduce_configure_mop();
 
-template <PoolType type, ReduceDim dim, bool is_fp32_dest_acc_en, int MATH_FIDELITY_DESC = 0, bool is_int_fpu_en = false, bool fp32_transpose = false>
+template <
+    PoolType type,
+    ReduceDim dim,
+    bool is_fp32_dest_acc_en,
+    int MATH_FIDELITY_DESC         = 0,
+    bool is_int_fpu_en             = false,
+    bool enforce_fp32_accumulation = false>
 inline void _llk_math_reduce_(const uint dst_index, bool narrow_tile = false, const uint num_faces = 4)
 {
     constexpr int MATH_FIDELITY_PHASES = get_math_num_fidelity_phases(MATH_FIDELITY_DESC);
@@ -58,7 +64,7 @@ inline void _llk_math_reduce_(const uint dst_index, bool narrow_tile = false, co
             TTI_GAPOOL(p_setrwc::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, 0);
         }
 
-        if constexpr (fp32_transpose)
+        if constexpr (enforce_fp32_accumulation)
         {
             // Move back to B and transpose in 2 parts, first hi16 bits then lo16 bits
             constexpr int dest_32b_hi = 0;
@@ -184,7 +190,7 @@ inline void _llk_math_reduce_(const uint dst_index, bool narrow_tile = false, co
                 TTI_GAPOOL(p_setrwc::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, 0);
             }
 
-            if constexpr (fp32_transpose)
+            if constexpr (enforce_fp32_accumulation)
             {
                 // Move back to B and transpose in 2 parts, first hi16 bits then lo16 bits
                 constexpr int dest_32b_hi = 0;
@@ -436,7 +442,7 @@ inline void reduce_configure_mop()
     }
 }
 
-template <PoolType type, ReduceDim dim, int MATH_FIDELITY_DESC = 0, bool fp32_transpose = false>
+template <PoolType type, ReduceDim dim, bool is_fp32_dest_acc_en, int MATH_FIDELITY_DESC = 0, bool enforce_fp32_accumulation = false>
 inline void _llk_math_reduce_init_(const std::uint32_t within_face_16x16_transpose = 0)
 { // within_face_16x16_transpose used for unpack, ignored by math
 
@@ -449,8 +455,9 @@ inline void _llk_math_reduce_init_(const std::uint32_t within_face_16x16_transpo
         reduce_configure_mop<dim, MATH_FIDELITY_PHASES>();
     }
 
-    if constexpr (fp32_transpose)
+    if constexpr (enforce_fp32_accumulation)
     {
+        static_assert(is_fp32_dest_acc_en, "FP32 Dest must be enabled for FP32 accumulation");
         // MOVB2D depends on SrcA ALU Format - Hi/Lo16 does not work with Tf32 (only on WH)
         cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG0_SrcA_RMW>((uint)DataFormat::Float16_b);
     }

--- a/tt_llk_wormhole_b0/llk_lib/llk_math_reduce.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_math_reduce.h
@@ -458,7 +458,8 @@ inline void _llk_math_reduce_init_(const std::uint32_t within_face_16x16_transpo
     if constexpr (enforce_fp32_accumulation)
     {
         static_assert(is_fp32_dest_acc_en, "FP32 Dest must be enabled for FP32 accumulation");
-        // MOVB2D depends on SrcA ALU Format - Hi/Lo16 does not work with Tf32 (only on WH)
+        // MOVB2D/D2B depends on SrcA ALU Format - Hi/Lo16 does not work with Tf32 (only on WH)
+        // This is needed because FP32 data from L1 that is unpacked to Src registers is reduced to Tf32
         cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG0_SrcA_RMW>((uint)DataFormat::Float16_b);
     }
     TTI_SETC16(CLR_DVALID_SrcA_Disable_ADDR32, 0);


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/25266

### Problem description
Setting Tf32 as ALU FORMAT for SrcA changes behaviour of MOVB2D/D2B. This arises in situations where the values in SrcA (being reduced) are Tf32.

This only affects WH, BH works correctly for Tf32 as well.

### What's changed
Set to valid format in the reduce init, since expecting OP writers to know this HW quirk seems unreasonable.
This must be accompanied by tt-metal change as well. (https://github.com/tenstorrent/tt-metal/pull/26528)

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16833535686) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16833537470) CI with demo tests passes (if applicable)
