### PR TITLE
Support dynamic multiple tiles  + matmul sweep over all matrix dimension combinations 

### DIFF
--- a/tests/helpers/include/params.h
+++ b/tests/helpers/include/params.h
@@ -50,3 +50,16 @@ constexpr auto& formats = formats_array[0];
 constexpr bool is_fp32_dest_acc_en = dest_acc_en_input; // dest_acc doesn't require adjustment; configuration is hard-coded
 constexpr FormatConfig formats     = FormatConfig(UNPACK_A_IN, UNPACK_A_OUT, MATH, PACK_IN, PACK_OUT);
 #endif
+
+// Tile count validation - applies to all kernel variants (UNPACK, MATH, PACK)
+constexpr uint32_t tile_count          = RT_DIM * CT_DIM;
+constexpr uint32_t max_tiles_fp32_dest = 4; // 32-bit dest accumulation limit
+constexpr uint32_t max_tiles_fp16_dest = 8; // 16-bit dest accumulation limit
+
+static_assert(tile_count > 0, "Matrix dimensions invalid: RT_DIM and CT_DIM must be positive");
+
+static_assert(tile_count <= max_tiles_fp16_dest, "Tile count exceeds hardware limit: RT_DIM * CT_DIM must be <= 8");
+
+static_assert(
+    !is_fp32_dest_acc_en || (tile_count <= max_tiles_fp32_dest),
+    "FP32 dest accumulation requires RT_DIM * CT_DIM <= 4 (current configuration exceeds this limit)");

--- a/tests/helpers/include/params.h
+++ b/tests/helpers/include/params.h
@@ -52,6 +52,7 @@ constexpr FormatConfig formats     = FormatConfig(UNPACK_A_IN, UNPACK_A_OUT, MAT
 #endif
 
 // Tile count validation - applies to all kernel variants (UNPACK, MATH, PACK)
+#if defined(RT_DIM) && defined(CT_DIM)
 constexpr uint32_t tile_count          = RT_DIM * CT_DIM;
 constexpr uint32_t max_tiles_fp32_dest = 4; // 32-bit dest accumulation limit
 constexpr uint32_t max_tiles_fp16_dest = 8; // 16-bit dest accumulation limit
@@ -63,3 +64,4 @@ static_assert(tile_count <= max_tiles_fp16_dest, "Tile count exceeds hardware li
 static_assert(
     !is_fp32_dest_acc_en || (tile_count <= max_tiles_fp32_dest),
     "FP32 dest accumulation requires RT_DIM * CT_DIM <= 4 (current configuration exceeds this limit)");
+#endif

--- a/tests/python_tests/helpers/device.py
+++ b/tests/python_tests/helpers/device.py
@@ -133,6 +133,7 @@ def write_stimuli_to_l1(
     Write matmul stimuli to L1 with different matrix sizes.
 
     Args:
+        test_config: Used to store addresses of A B and Result
         buffer_A: Flattened tensor data for matrix A
         buffer_B: Flattened tensor data for matrix B
         stimuli_A_format: DataFormat for matrix A

--- a/tests/python_tests/helpers/device.py
+++ b/tests/python_tests/helpers/device.py
@@ -164,17 +164,17 @@ def write_stimuli_to_l1(
     # Helper function to get packer
     def get_packer(data_format):
         packers = {
-            "Float16": pack_fp16,
-            "Float16_b": pack_bfp16,
-            "Float32": pack_fp32,
-            "Bfp8_b": pack_bfp8_b,
-            "Int32": pack_int32,
-            "UInt32": pack_uint32,
-            "UInt16": pack_uint16,
-            "Int8": pack_int8,
-            "UInt8": pack_uint8,
+            DataFormat.Float16: pack_fp16,
+            DataFormat.Float16_b: pack_bfp16,
+            DataFormat.Float32: pack_fp32,
+            DataFormat.Bfp8_b: pack_bfp8_b,
+            DataFormat.Int32: pack_int32,
+            DataFormat.UInt32: pack_uint32,
+            DataFormat.UInt16: pack_uint16,
+            DataFormat.Int8: pack_int8,
+            DataFormat.UInt8: pack_uint8,
         }
-        return packers.get(data_format.name)
+        return packers.get(data_format)
 
     pack_function_A = get_packer(stimuli_A_format)
     pack_function_B = get_packer(stimuli_B_format)

--- a/tests/python_tests/helpers/device.py
+++ b/tests/python_tests/helpers/device.py
@@ -123,6 +123,7 @@ def run_elf_files(testname, core_loc="0,0"):
 
 
 def write_stimuli_to_l1(
+    test_config,
     buffer_A,
     buffer_B,
     stimuli_A_format,
@@ -146,7 +147,7 @@ def write_stimuli_to_l1(
     Returns:
         int: Address where result will be stored
     """
-    from .format_arg_mapping import L1BufferLocations, format_tile_sizes
+    from .format_arg_mapping import format_tile_sizes
 
     tile_cnt_A = tile_count
     if tile_cnt_B is None:
@@ -206,18 +207,10 @@ def write_stimuli_to_l1(
         buffer_B, tile_cnt_B, pack_function_B, buffer_B_address, tile_size_B_bytes
     )
 
-    # Set buffer addresses in device
-    write_to_device(
-        core_loc, L1BufferLocations.srcA.value, buffer_A_address.to_bytes(4, "little")
-    )
-    write_to_device(
-        core_loc, L1BufferLocations.srcB.value, buffer_B_address.to_bytes(4, "little")
-    )
-    write_to_device(
-        core_loc,
-        L1BufferLocations.Result.value,
-        result_buffer_address.to_bytes(4, "little"),
-    )
+    # Set buffer addresses in device to be defined in build header
+    test_config["buffer_A_address"] = buffer_A_address
+    test_config["buffer_B_address"] = buffer_B_address
+    test_config["result_buffer_address"] = result_buffer_address
 
     return result_buffer_address
 

--- a/tests/python_tests/helpers/dimensions.py
+++ b/tests/python_tests/helpers/dimensions.py
@@ -62,11 +62,6 @@ def calculate_matmul_dimensions(
         "kt_dim": kt_dim,
         "output_dimensions": output_dimensions,
         "output_tile_cnt": output_tile_cnt,
-        "tile_cnt_A": tile_cnt_A,
-        "tile_cnt_B": tile_cnt_B,
-        "M": M,
-        "K": K1,
-        "N": N,
     }
 
 

--- a/tests/python_tests/helpers/dimensions.py
+++ b/tests/python_tests/helpers/dimensions.py
@@ -5,7 +5,7 @@
 Helper functions for dimension-related calculations in matrix operations.
 """
 
-from typing import List
+from typing import List, Tuple
 
 
 def validate_tile_dimensions(dimension: int, row_col_dim: int):
@@ -15,7 +15,7 @@ def validate_tile_dimensions(dimension: int, row_col_dim: int):
 
 
 def calculate_matmul_dimensions(
-    input_A_dimensions: List[int], input_B_dimensions: List[int]
+    input_A_dimensions: Tuple[int, int], input_B_dimensions: Tuple[int, int]
 ) -> dict:
     """
     Calculate matrix multiplication tile dimensions.
@@ -46,7 +46,7 @@ def calculate_matmul_dimensions(
     ), f"Matrix dimensions incompatible for multiplication: A[{M},{K1}] × B[{K2},{N}]"
 
     # Calculate output dimensions: A[M,K] × B[K,N] = C[M,N]
-    output_dimensions = [M, N]
+    output_dimensions = (M, N)
 
     # Calculate tile dimensions (each tile is 32×32)
     num_rows = 32  # matrix A

--- a/tests/python_tests/helpers/dimensions.py
+++ b/tests/python_tests/helpers/dimensions.py
@@ -1,0 +1,159 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Helper functions for dimension-related calculations in matrix operations.
+"""
+
+from typing import List
+
+
+def calculate_dimension_properties(
+    input_dimensions: List[int], format_size: int
+) -> dict:
+    """
+    Calculate all dimension-related properties for a given input.
+
+    Args:
+        input_dimensions: List containing [rows, cols] dimensions
+        format_size: Size of the data format in bytes
+
+    Returns:
+        Dictionary containing all calculated properties:
+        - num_rows: Hardware-specific row count for LLK functions
+        - faces: Number of unpack faces (each face is 16x16)
+        - face_r_dim: Row dimension for face calculations
+        - partial_face: Whether this represents a partial face (row dimension < 16)
+    """
+    return {
+        "num_rows": calculate_num_rows(input_dimensions, format_size),
+        "faces": calculate_unpack_faces(input_dimensions),
+        "face_r_dim": get_face_r_dimension(input_dimensions),
+        "partial_face": is_partial_face(input_dimensions),
+    }
+
+
+def calculate_matmul_dimensions(
+    input_A_dimensions: List[int], input_B_dimensions: List[int]
+) -> dict:
+    """
+    Calculate matrix multiplication tile dimensions.
+
+    For matrix multiplication A[M,K] × B[K,N] = C[M,N], calculate:
+    - rt_dim: Row tiles (M dimension)
+    - ct_dim: Column tiles (N dimension)
+    - kt_dim: Inner dimension tiles (K dimension)
+    - output_dimensions: Result matrix dimensions
+    - output_tile_cnt: Number of tiles in result
+
+    Args:
+        input_A_dimensions: List containing [rows, cols] for matrix A
+        input_B_dimensions: List containing [rows, cols] for matrix B
+
+    Returns:
+        dict: Dictionary containing all calculated dimensions
+
+    Raises:
+        AssertionError: If matrix dimensions are incompatible for multiplication
+    """
+    M, K1 = input_A_dimensions[0], input_A_dimensions[1]
+    K2, N = input_B_dimensions[0], input_B_dimensions[1]
+
+    # Verify K dimensions match for valid matmul
+    assert (
+        K1 == K2
+    ), f"Matrix dimensions incompatible for multiplication: A[{M},{K1}] × B[{K2},{N}]"
+
+    # Calculate output dimensions: A[M,K] × B[K,N] = C[M,N]
+    output_dimensions = [M, N]
+
+    # Calculate tile dimensions (each tile is 32×32)
+    rt_dim = M // 32  # Row tiles in result
+    ct_dim = N // 32  # Column tiles in result
+    kt_dim = K1 // 32  # Inner dimension tiles
+
+    # Calculate tile counts
+    tile_cnt_A = (M // 32) * (K1 // 32)
+    tile_cnt_B = (K2 // 32) * (N // 32)
+    output_tile_cnt = rt_dim * ct_dim
+
+    return {
+        "rt_dim": rt_dim,
+        "ct_dim": ct_dim,
+        "kt_dim": kt_dim,
+        "output_dimensions": output_dimensions,
+        "output_tile_cnt": output_tile_cnt,
+        "tile_cnt_A": tile_cnt_A,
+        "tile_cnt_B": tile_cnt_B,
+        "M": M,
+        "K": K1,
+        "N": N,
+    }
+
+
+def generate_matmul_dimension_combinations(max_tiles: int) -> List[tuple]:
+    """
+    Generate all valid matrix multiplication dimension combinations.
+
+    Creates all possible combinations of (inputA_dimensions, inputB_dimensions) where:
+    - Each input matrix has at most max_tiles tiles (each tile is 32×32)
+    - The result matrix also has at most max_tiles tiles
+    - Matrix multiplication is valid: inputA[1] == inputB[0] (K dimensions match)
+    - Returns combinations that can be used for comprehensive matmul testing
+
+    Args:
+        max_tiles: Maximum number of tiles allowed per matrix (inputs AND result)
+
+    Returns:
+        List of tuples: Each tuple contains (inputA_dimensions, inputB_dimensions)
+        where inputA_dimensions and inputB_dimensions are [rows, cols] lists
+
+    Example:
+        For max_tiles=4:
+        Returns combinations like:
+        ([32, 32], [32, 32])    # 1×1 tiles each, result: 1×1 = 1 tile
+        ([32, 64], [64, 32])    # 1×2 and 2×1 tiles, result: 1×1 = 1 tile
+        ([64, 64], [64, 64])    # 2×2 tiles each, result: 2×2 = 4 tiles
+        ([32, 128], [128, 32])  # 1×4 and 4×1 tiles, result: 1×1 = 1 tile
+
+        But NOT ([256, 32], [32, 256]) because result would be 8×8 = 64 tiles > 4
+    """
+
+    def generate_all_matrix_dimensions(max_tiles: int) -> List[List[int]]:
+        """Generate all possible matrix dimensions up to max_tiles."""
+        dimensions = []
+
+        # Generate all combinations of (row_tiles, col_tiles) where product <= max_tiles
+        for row_tiles in range(1, max_tiles + 1):
+            for col_tiles in range(1, max_tiles + 1):
+                if row_tiles * col_tiles <= max_tiles:
+                    rows = row_tiles * 32
+                    cols = col_tiles * 32
+                    dimensions.append([rows, cols])
+
+        return dimensions
+
+    # Generate all possible matrix dimensions
+    all_dimensions = generate_all_matrix_dimensions(max_tiles)
+
+    # Find all valid matmul combinations
+    valid_combinations = []
+
+    for inputA_dims in all_dimensions:
+        for inputB_dims in all_dimensions:
+            # Check if matrices are compatible for multiplication: A[M,K] × B[K,N]
+            if inputA_dims[1] == inputB_dims[0]:  # K dimensions must match
+
+                # Calculate result matrix dimensions and tile count
+                M = inputA_dims[0]  # Rows in A
+                K = inputA_dims[1]  # Cols in A (= Rows in B)
+                N = inputB_dims[1]  # Cols in B
+
+                # Result matrix C will be [M, N]
+                result_tiles = (M // 32) * (N // 32)
+
+                # Only include if result matrix also fits within max_tiles
+                if result_tiles <= max_tiles:
+                    valid_combinations.append((inputA_dims, inputB_dims))
+
+    return valid_combinations

--- a/tests/python_tests/helpers/dimensions.py
+++ b/tests/python_tests/helpers/dimensions.py
@@ -28,8 +28,8 @@ def calculate_matmul_dimensions(
     - output_tile_cnt: Number of tiles in result
 
     Args:
-        input_A_dimensions: List containing [rows, cols] for matrix A
-        input_B_dimensions: List containing [rows, cols] for matrix B
+        input_A_dimensions: (rows, cols) for matrix A
+        input_B_dimensions: (rows, cols) for matrix B
 
     Returns:
         dict: Dictionary containing all calculated dimensions
@@ -63,8 +63,6 @@ def calculate_matmul_dimensions(
     )  # Inner dimension tiles rt_dim (matrix A) = kt_dim = ct_dim (matrix B) = 1
 
     # Calculate tile counts
-    tile_cnt_A = rt_dim * kt_dim
-    tile_cnt_B = kt_dim * ct_dim
     output_tile_cnt = rt_dim * ct_dim
 
     return {
@@ -81,13 +79,12 @@ def generate_matmul_dimension_combinations(max_tiles: int) -> List[tuple]:
     Generate all valid matrix multiplication dimension combinations.
 
     Creates all possible combinations of (inputA_dimensions, inputB_dimensions) where:
-    - Each input matrix has at most max_tiles tiles (each tile is 32×32)
     - The result matrix also has at most max_tiles tiles
     - Matrix multiplication is valid: inputA[1] == inputB[0] (K dimensions match)
     - Returns combinations that can be used for comprehensive matmul testing
 
     Args:
-        max_tiles: Maximum number of tiles allowed per matrix (inputs AND result)
+        max_tiles: Maximum number of tiles allowed per result matrix
 
     Returns:
         List of tuples: Each tuple contains (inputA_dimensions, inputB_dimensions)

--- a/tests/python_tests/helpers/dimensions.py
+++ b/tests/python_tests/helpers/dimensions.py
@@ -8,6 +8,12 @@ Helper functions for dimension-related calculations in matrix operations.
 from typing import List
 
 
+def validate_tile_dimensions(dimension: int, row_col_dim: int):
+    """Validate that dimension is divisible by row/col."""
+    if dimension % row_col_dim != 0:
+        raise AssertionError(f"{dimension} must be divisible by {row_col_dim}")
+
+
 def calculate_matmul_dimensions(
     input_A_dimensions: List[int], input_B_dimensions: List[int]
 ) -> dict:
@@ -45,6 +51,11 @@ def calculate_matmul_dimensions(
     # Calculate tile dimensions (each tile is 32×32)
     num_rows = 32  # matrix A
     num_cols = 32  # matrix B
+
+    validate_tile_dimensions(M, num_cols)
+    validate_tile_dimensions(N, num_rows)
+    validate_tile_dimensions(K1, num_cols)
+
     rt_dim = M // num_cols  # Row tiles in result
     ct_dim = N // num_rows  # Column tiles in result
     kt_dim = (

--- a/tests/python_tests/helpers/format_config.py
+++ b/tests/python_tests/helpers/format_config.py
@@ -69,6 +69,13 @@ class DataFormat(Enum):
             DataFormat.Float32,
         }
 
+    def num_bytes_per_tile(self, num_datums: int = 1024) -> int:
+        """Returns the number of bytes per tile for the data format."""
+        num_exponents = 0
+        if self == DataFormat.Bfp8_b:
+            num_exponents = num_datums // 16
+        return (self.size * num_datums) + num_exponents
+
 
 @dataclass
 class FormatConfig:

--- a/tests/python_tests/helpers/golden_generators.py
+++ b/tests/python_tests/helpers/golden_generators.py
@@ -328,7 +328,6 @@ class MatmulGolden(FidelityMasking):
         operand2,
         data_format,
         math_fidelity,
-        input_dimensions=[32, 32],
         input_A_dimensions=None,
         input_B_dimensions=None,
     ):
@@ -350,11 +349,6 @@ class MatmulGolden(FidelityMasking):
                 )
 
             output_dimensions = [M, N]
-        else:
-            # Legacy single-tile case
-            M, K1 = input_dimensions[0], input_dimensions[1]
-            K2, N = input_dimensions[0], input_dimensions[1]  # assume square
-            output_dimensions = input_dimensions
 
         num_fidelity_phases = math_fidelity.value
 

--- a/tests/python_tests/helpers/golden_generators.py
+++ b/tests/python_tests/helpers/golden_generators.py
@@ -344,9 +344,10 @@ class MatmulGolden(FidelityMasking):
             K2, N = input_B_dimensions[0], input_B_dimensions[1]
 
             # Verify K dimensions match for valid matmul
-            assert (
-                K1 == K2
-            ), f"Matrix dimensions incompatible: A[{M},{K1}] × B[{K2},{N}]"
+            if K1 != K2:
+                raise AssertionError(
+                    f"Matrix dimensions incompatible: A[{M},{K1}] × B[{K2},{N}]"
+                )
 
             output_dimensions = [M, N]
         else:

--- a/tests/python_tests/helpers/golden_generators.py
+++ b/tests/python_tests/helpers/golden_generators.py
@@ -323,12 +323,37 @@ class TransposeGolden:
 class MatmulGolden(FidelityMasking):
 
     def __call__(
-        self, operand1, operand2, data_format, math_fidelity, input_dimensions=[32, 32]
+        self,
+        operand1,
+        operand2,
+        data_format,
+        math_fidelity,
+        input_dimensions=[32, 32],
+        input_A_dimensions=None,
+        input_B_dimensions=None,
     ):
         torch_format = format_dict[data_format]
 
         t1 = to_tensor(operand1, data_format)
         t2 = to_tensor(operand2, data_format)
+
+        # Handle multi-tile matmul with different operand dimensions
+        if input_A_dimensions is not None and input_B_dimensions is not None:
+            # Multi-tile matmul: A[M,K] × B[K,N] = C[M,N]
+            M, K1 = input_A_dimensions[0], input_A_dimensions[1]
+            K2, N = input_B_dimensions[0], input_B_dimensions[1]
+
+            # Verify K dimensions match for valid matmul
+            assert (
+                K1 == K2
+            ), f"Matrix dimensions incompatible: A[{M},{K1}] × B[{K2},{N}]"
+
+            output_dimensions = [M, N]
+        else:
+            # Legacy single-tile case
+            M, K1 = input_dimensions[0], input_dimensions[1]
+            K2, N = input_dimensions[0], input_dimensions[1]  # assume square
+            output_dimensions = input_dimensions
 
         num_fidelity_phases = math_fidelity.value
 
@@ -337,12 +362,10 @@ class MatmulGolden(FidelityMasking):
         if num_fidelity_phases == 0:
 
             t1, t2 = self._apply_fidelity_masking(t1, t2, 0, data_format)
-            t1, t2 = t1.view(input_dimensions[0], input_dimensions[1]), t2.view(
-                input_dimensions[0], input_dimensions[1]
-            )
+            t1, t2 = t1.view(M, K1), t2.view(K2, N)
             res = (
                 torch.matmul(t1, t2)
-                .view(input_dimensions[0] * input_dimensions[1])
+                .view(output_dimensions[0] * output_dimensions[1])
                 .to(torch_format)
             )
 
@@ -351,24 +374,20 @@ class MatmulGolden(FidelityMasking):
         elif num_fidelity_phases == 1:
 
             t1, t2 = self._apply_fidelity_masking(t1, t2, 0, data_format)
-            t1, t2 = t1.view(input_dimensions[0], input_dimensions[1]), t2.view(
-                input_dimensions[0], input_dimensions[1]
-            )
+            t1, t2 = t1.view(M, K1), t2.view(K2, N)
             res = (
                 torch.matmul(t1, t2)
-                .view(input_dimensions[0] * input_dimensions[1])
+                .view(output_dimensions[0] * output_dimensions[1])
                 .to(torch_format)
             )
 
             t1 = to_tensor(operand1, data_format)
             t2 = to_tensor(operand2, data_format)
             t1, t2 = self._apply_fidelity_masking(t1, t2, 1, data_format)
-            t1, t2 = t1.view(input_dimensions[0], input_dimensions[1]), t2.view(
-                input_dimensions[0], input_dimensions[1]
-            )
+            t1, t2 = t1.view(M, K1), t2.view(K2, N)
             res += (
                 torch.matmul(t1, t2)
-                .view(input_dimensions[0] * input_dimensions[1])
+                .view(output_dimensions[0] * output_dimensions[1])
                 .to(torch_format)
             )
 
@@ -377,24 +396,20 @@ class MatmulGolden(FidelityMasking):
         elif num_fidelity_phases == 2:
 
             t1, t2 = self._apply_fidelity_masking(t1, t2, 0, data_format)
-            t1, t2 = t1.view(input_dimensions[0], input_dimensions[1]), t2.view(
-                input_dimensions[0], input_dimensions[1]
-            )
+            t1, t2 = t1.view(M, K1), t2.view(K2, N)
             res = (
                 torch.matmul(t1, t2)
-                .view(input_dimensions[0] * input_dimensions[1])
+                .view(output_dimensions[0] * output_dimensions[1])
                 .to(torch_format)
             )
 
             t1 = to_tensor(operand1, data_format)
             t2 = to_tensor(operand2, data_format)
             t1, t2 = self._apply_fidelity_masking(t1, t2, 1, data_format)
-            t1, t2 = t1.view(input_dimensions[0], input_dimensions[1]), t2.view(
-                input_dimensions[0], input_dimensions[1]
-            )
+            t1, t2 = t1.view(M, K1), t2.view(K2, N)
             res += (
                 torch.matmul(t1, t2)
-                .view(input_dimensions[0] * input_dimensions[1])
+                .view(output_dimensions[0] * output_dimensions[1])
                 .to(torch_format)
             )
 
@@ -403,18 +418,16 @@ class MatmulGolden(FidelityMasking):
             # t1 = to_tensor(operand1, data_format)
             # t2 = to_tensor(operand2, data_format)
             # t1, t2 = self._apply_fidelity_masking(t1, t2, 2, data_format)
-            # t1,t2 = t1.view(input_dimensions[0],input_dimensions[1]), t2.view(input_dimensions[0],input_dimensions[1])
-            # res +=  torch.matmul(t1, t2).view(input_dimensions[0] * input_dimensions[1]).to(torch_format)
+            # t1,t2 = t1.view(M, K1), t2.view(K2, N)
+            # res +=  torch.matmul(t1, t2).view(output_dimensions[0] * output_dimensions[1]).to(torch_format)
 
             return res
         elif num_fidelity_phases == 3:
 
-            t1, t2 = t1.view(input_dimensions[0], input_dimensions[1]), t2.view(
-                input_dimensions[0], input_dimensions[1]
-            )
+            t1, t2 = t1.view(M, K1), t2.view(K2, N)
             res = (
                 torch.matmul(t1, t2)
-                .view(input_dimensions[0] * input_dimensions[1])
+                .view(output_dimensions[0] * output_dimensions[1])
                 .to(torch_format)
             )
 

--- a/tests/python_tests/helpers/stimuli_generator.py
+++ b/tests/python_tests/helpers/stimuli_generator.py
@@ -27,7 +27,7 @@ def generate_random_face(
                     torch.ones(size, dtype=format_dict[stimuli_format]) * const_value
                 )
             else:  # random for both faces
-                srcA_face = torch.rand(size, dtype=format_dict[stimuli_format]) + 0.1
+                srcA_face = torch.rand(size, dtype=format_dict[stimuli_format]) * 0.5
 
     else:
 

--- a/tests/python_tests/helpers/stimuli_generator.py
+++ b/tests/python_tests/helpers/stimuli_generator.py
@@ -12,7 +12,7 @@ def flatten_list(sublists):
 
 
 def generate_random_face(
-    stimuli_format=DataFormat.Float16_b, const_value=1, const_face=False
+    stimuli_format=DataFormat.Float16_b, const_value=1, const_face=False, sfpu=True
 ):
     size = 256
     if stimuli_format != DataFormat.Bfp8_b:
@@ -26,9 +26,11 @@ def generate_random_face(
                 srcA_face = (
                     torch.ones(size, dtype=format_dict[stimuli_format]) * const_value
                 )
-            else:  # random for both faces
-                srcA_face = torch.rand(size, dtype=format_dict[stimuli_format]) * 0.5
-
+            else:
+                # random for both faces
+                srcA_face = torch.rand(size, dtype=format_dict[stimuli_format])
+                if sfpu:
+                    srcA_face += 0.1
     else:
 
         integer_part = torch.randint(0, 3, (size,))
@@ -47,10 +49,11 @@ def generate_random_face_ab(
     const_face=False,
     const_value_A=1,
     const_value_B=2,
+    sfpu=True,
 ):
     return generate_random_face(
-        stimuli_format_A, const_value_A, const_face
-    ), generate_random_face(stimuli_format_B, const_value_B, const_face)
+        stimuli_format_A, const_value_A, const_face, sfpu
+    ), generate_random_face(stimuli_format_B, const_value_B, const_face, sfpu)
 
 
 def generate_stimuli(
@@ -60,6 +63,7 @@ def generate_stimuli(
     const_face=False,
     const_value_A=1,
     const_value_B=1,
+    sfpu=True,
 ):
 
     srcA = []
@@ -69,7 +73,12 @@ def generate_stimuli(
 
     for _ in range(4 * tile_cnt):
         face_a, face_b = generate_random_face_ab(
-            stimuli_format_A, stimuli_format_B, const_face, const_value_A, const_value_B
+            stimuli_format_A,
+            stimuli_format_B,
+            const_face,
+            const_value_A,
+            const_value_B,
+            sfpu,
         )
         srcA.extend(face_a.tolist())
         srcB.extend(face_b.tolist())

--- a/tests/python_tests/helpers/test_config.py
+++ b/tests/python_tests/helpers/test_config.py
@@ -246,13 +246,9 @@ def generate_build_header(
         "volatile uint32_t* buffer_Res[TILE_CNT] = {" + buffer_res_str + "}; \n"
         "#endif\n"
     )
-    input_dimensions = test_config.get("input_dimensions", False)
-    if input_dimensions:
-        input_A_dimensions = input_dimensions
-        input_B_dimensions = input_dimensions
-    else:
-        input_A_dimensions = test_config.get("input_A_dimensions", [32, 32])
-        input_B_dimensions = test_config.get("input_B_dimensions", [32, 32])
+
+    input_A_dimensions = test_config.get("input_A_dimensions", [32, 32])
+    input_B_dimensions = test_config.get("input_B_dimensions", [32, 32])
 
     num_rows = 32
     num_cols = 32

--- a/tests/python_tests/helpers/test_config.py
+++ b/tests/python_tests/helpers/test_config.py
@@ -250,10 +250,16 @@ def generate_build_header(
         "volatile uint32_t* buffer_Res[TILE_CNT] = {" + buffer_res_str + "}; \n"
         "#endif\n"
     )
+    input_dimensions = test_config.get("input_dimensions", False)
+    if input_dimensions:
+        input_A_dimensions = input_dimensions
+        input_B_dimensions = input_dimensions
+    else:
+        input_A_dimensions = test_config.get("input_A_dimensions", [32, 32])
+        input_B_dimensions = test_config.get("input_B_dimensions", [32, 32])
 
-    input_dimensions = test_config.get("input_dimensions", [32, 32])
-    block_ct_dim = input_dimensions[1] // 32
-    block_rt_dim = input_dimensions[0] // 32
+    block_rt_dim = input_A_dimensions[0] // 32
+    block_ct_dim = input_B_dimensions[1] // 32
 
     header_content.extend(
         [
@@ -263,6 +269,16 @@ def generate_build_header(
             "#endif",
         ]
     )
+
+    # Add matrix multiplication tile dimensions if they exist
+    if "rt_dim" in test_config:
+        header_content.append(f"constexpr uint32_t RT_DIM = {test_config['rt_dim']};")
+    if "ct_dim" in test_config:
+        header_content.append(f"constexpr uint32_t CT_DIM = {test_config['ct_dim']};")
+    if "kt_dim" in test_config:
+        header_content.append(f"constexpr uint32_t KT_DIM = {test_config['kt_dim']};")
+
+    header_content.append("")
 
     if perf_run_type := test_config.get("perf_run_type"):
         header_content.append("")

--- a/tests/python_tests/helpers/test_config.py
+++ b/tests/python_tests/helpers/test_config.py
@@ -5,10 +5,6 @@ import os
 from enum import Enum
 from pathlib import Path
 
-from ttexalens.tt_exalens_lib import (
-    read_word_from_device,
-)
-
 from .device import run_elf_files, wait_for_tensix_operations_finished
 from .format_arg_mapping import (
     FPU_BINARY_OPERATIONS,
@@ -17,7 +13,6 @@ from .format_arg_mapping import (
     SFPU_UNARY_OPERATIONS,
     ApproximationMode,
     DestAccumulation,
-    L1BufferLocations,
     MathFidelity,
     MathOperation,
     StochasticRounding,
@@ -210,10 +205,10 @@ def generate_build_header(
     header_content.append("// Multi-tile test configuration")
     header_content.append(f"constexpr int TILE_CNT = {tile_cnt};")
 
-    # Unpack an result buffer addresses arrays generations
-    buffer_A_address = read_word_from_device("0,0", L1BufferLocations.srcA.value)
-    buffer_B_address = read_word_from_device("0,0", L1BufferLocations.srcB.value)
-    result_buffer_address = read_word_from_device("0,0", L1BufferLocations.Result.value)
+    # Unpack + result buffer addresses arrays generations
+    buffer_A_address = test_config.get("buffer_A_address", 0x1A000)
+    buffer_B_address = test_config.get("buffer_B_address", 0x1B000)
+    result_buffer_address = test_config.get("result_buffer_address", 0x1C000)
 
     buffer_A_array = []
     buffer_B_array = []

--- a/tests/python_tests/helpers/test_config.py
+++ b/tests/python_tests/helpers/test_config.py
@@ -6,6 +6,7 @@ from enum import Enum
 from pathlib import Path
 
 from .device import run_elf_files, wait_for_tensix_operations_finished
+from .dimensions import validate_tile_dimensions
 from .format_arg_mapping import (
     FPU_BINARY_OPERATIONS,
     REDUCE_OPERATIONS,
@@ -253,8 +254,12 @@ def generate_build_header(
         input_A_dimensions = test_config.get("input_A_dimensions", [32, 32])
         input_B_dimensions = test_config.get("input_B_dimensions", [32, 32])
 
-    block_rt_dim = input_A_dimensions[0] // 32
-    block_ct_dim = input_B_dimensions[1] // 32
+    num_rows = 32
+    num_cols = 32
+    validate_tile_dimensions(input_A_dimensions[0], num_cols)
+    validate_tile_dimensions(input_B_dimensions[1], num_rows)
+    block_rt_dim = input_A_dimensions[0] // num_cols
+    block_ct_dim = input_B_dimensions[1] // num_rows
 
     header_content.extend(
         [

--- a/tests/python_tests/perf_fast_tilize.py
+++ b/tests/python_tests/perf_fast_tilize.py
@@ -94,7 +94,13 @@ def test_fast_tilize_perf(
     }
 
     res_address = write_stimuli_to_l1(
-        test_config, src_A, src_B, input_format, input_format, tile_count=tile_cnt
+        test_config,
+        src_A,
+        src_B,
+        input_format,
+        input_format,
+        tile_count_A=tile_cnt,
+        tile_count_B=tile_cnt,
     )
 
     results = perf_benchmark(test_config, [PerfRunType.L1_TO_L1], 2)

--- a/tests/python_tests/perf_fast_tilize.py
+++ b/tests/python_tests/perf_fast_tilize.py
@@ -89,7 +89,8 @@ def test_fast_tilize_perf(
         "formats": formats,
         "testname": TEST_NAME,
         "tile_cnt": input_height * input_width,
-        "input_dimensions": input_dimensions,
+        "input_A_dimensions": input_dimensions,
+        "input_B_dimensions": input_dimensions,
         "dest_acc": fp32_dest,
     }
 

--- a/tests/python_tests/perf_fast_tilize.py
+++ b/tests/python_tests/perf_fast_tilize.py
@@ -83,10 +83,6 @@ def test_fast_tilize_perf(
         input_format, input_format, input_dimensions=input_dimensions
     )
 
-    res_address = write_stimuli_to_l1(
-        src_A, src_B, input_format, input_format, tile_count=tile_cnt
-    )
-
     formats = InputOutputFormat(input_format, output_format)
 
     test_config = {
@@ -96,6 +92,10 @@ def test_fast_tilize_perf(
         "input_dimensions": input_dimensions,
         "dest_acc": fp32_dest,
     }
+
+    res_address = write_stimuli_to_l1(
+        test_config, src_A, src_B, input_format, input_format, tile_count=tile_cnt
+    )
 
     results = perf_benchmark(test_config, [PerfRunType.L1_TO_L1], 2)
     update_report(report, test_config, results)

--- a/tests/python_tests/test_eltwise_unary_datacopy.py
+++ b/tests/python_tests/test_eltwise_unary_datacopy.py
@@ -43,9 +43,6 @@ def test_unary_datacopy(test_name, formats, dest_acc):
 
     generate_golden = get_golden_generator(DataCopyGolden)
     golden_tensor = generate_golden(src_A, formats.output_format)
-    res_address = write_stimuli_to_l1(
-        src_A, src_B, formats.input_format, formats.input_format, tile_count=tile_cnt
-    )
 
     unpack_to_dest = formats.input_format.is_32_bit()
 
@@ -56,6 +53,15 @@ def test_unary_datacopy(test_name, formats, dest_acc):
         "unpack_to_dest": unpack_to_dest,
         "tile_cnt": tile_cnt,
     }
+
+    res_address = write_stimuli_to_l1(
+        test_config,
+        src_A,
+        src_B,
+        formats.input_format,
+        formats.input_format,
+        tile_count=tile_cnt,
+    )
 
     run_test(test_config)
 

--- a/tests/python_tests/test_eltwise_unary_datacopy.py
+++ b/tests/python_tests/test_eltwise_unary_datacopy.py
@@ -50,6 +50,8 @@ def test_unary_datacopy(test_name, formats, dest_acc):
         "formats": formats,
         "testname": test_name,
         "dest_acc": dest_acc,
+        "input_A_dimensions": input_dimensions,
+        "input_B_dimensions": input_dimensions,
         "unpack_to_dest": unpack_to_dest,
         "tile_cnt": tile_cnt,
     }

--- a/tests/python_tests/test_eltwise_unary_datacopy.py
+++ b/tests/python_tests/test_eltwise_unary_datacopy.py
@@ -60,7 +60,8 @@ def test_unary_datacopy(test_name, formats, dest_acc):
         src_B,
         formats.input_format,
         formats.input_format,
-        tile_count=tile_cnt,
+        tile_count_A=tile_cnt,
+        tile_count_B=tile_cnt,
     )
 
     run_test(test_config)

--- a/tests/python_tests/test_eltwise_unary_datacopy.py
+++ b/tests/python_tests/test_eltwise_unary_datacopy.py
@@ -44,7 +44,7 @@ def test_unary_datacopy(test_name, formats, dest_acc):
     generate_golden = get_golden_generator(DataCopyGolden)
     golden_tensor = generate_golden(src_A, formats.output_format)
     res_address = write_stimuli_to_l1(
-        src_A, src_B, formats.input_format, formats.input_format, tile_cnt
+        src_A, src_B, formats.input_format, formats.input_format, tile_count=tile_cnt
     )
 
     unpack_to_dest = formats.input_format.is_32_bit()

--- a/tests/python_tests/test_eltwise_unary_datacopy.py
+++ b/tests/python_tests/test_eltwise_unary_datacopy.py
@@ -44,7 +44,7 @@ def test_unary_datacopy(test_name, formats, dest_acc):
     generate_golden = get_golden_generator(DataCopyGolden)
     golden_tensor = generate_golden(src_A, formats.output_format)
     res_address = write_stimuli_to_l1(
-        src_A, src_B, formats.input_format, formats.input_format, tile_count=tile_cnt
+        src_A, src_B, formats.input_format, formats.input_format, tile_cnt
     )
 
     unpack_to_dest = formats.input_format.is_32_bit()

--- a/tests/python_tests/test_eltwise_unary_sfpu.py
+++ b/tests/python_tests/test_eltwise_unary_sfpu.py
@@ -125,6 +125,8 @@ def eltwise_unary_sfpu(test_name, formats, dest_acc, approx_mode, mathop):
         "formats": formats,
         "testname": test_name,
         "dest_acc": dest_acc,
+        "input_A_dimensions": input_dimensions,
+        "input_B_dimensions": input_dimensions,
         "mathop": mathop,
         "approx_mode": approx_mode,
         "unpack_to_dest": unpack_to_dest,

--- a/tests/python_tests/test_eltwise_unary_sfpu.py
+++ b/tests/python_tests/test_eltwise_unary_sfpu.py
@@ -116,10 +116,6 @@ def eltwise_unary_sfpu(test_name, formats, dest_acc, approx_mode, mathop):
         mathop, src_A, formats.output_format, dest_acc, formats.input_format
     )
 
-    res_address = write_stimuli_to_l1(
-        src_A, src_B, formats.input_format, formats.input_format, tile_count=tile_cnt
-    )
-
     unpack_to_dest = (
         formats.input_format.is_32_bit()
         and dest_acc
@@ -134,6 +130,15 @@ def eltwise_unary_sfpu(test_name, formats, dest_acc, approx_mode, mathop):
         "unpack_to_dest": unpack_to_dest,
         "tile_cnt": tile_cnt,
     }
+
+    res_address = write_stimuli_to_l1(
+        test_config,
+        src_A,
+        src_B,
+        formats.input_format,
+        formats.input_format,
+        tile_count=tile_cnt,
+    )
 
     run_test(test_config)
 

--- a/tests/python_tests/test_eltwise_unary_sfpu.py
+++ b/tests/python_tests/test_eltwise_unary_sfpu.py
@@ -137,7 +137,8 @@ def eltwise_unary_sfpu(test_name, formats, dest_acc, approx_mode, mathop):
         src_B,
         formats.input_format,
         formats.input_format,
-        tile_count=tile_cnt,
+        tile_count_A=tile_cnt,
+        tile_count_B=tile_cnt,
     )
 
     run_test(test_config)

--- a/tests/python_tests/test_fast_tilize.py
+++ b/tests/python_tests/test_fast_tilize.py
@@ -80,7 +80,8 @@ def test_fast_tilize(test_name, formats, dest_acc, dimensions):
         "formats": formats,
         "testname": test_name,
         "tile_cnt": tile_cnt,
-        "input_dimensions": input_dimensions,
+        "input_A_dimensions": input_dimensions,
+        "input_B_dimensions": input_dimensions,
         "dest_acc": dest_acc,
     }
 

--- a/tests/python_tests/test_fast_tilize.py
+++ b/tests/python_tests/test_fast_tilize.py
@@ -85,7 +85,13 @@ def test_fast_tilize(test_name, formats, dest_acc, dimensions):
     }
 
     res_address = write_stimuli_to_l1(
-        test_config, src_A, src_B, formats.input, formats.input, tile_count=tile_cnt
+        test_config,
+        src_A,
+        src_B,
+        formats.input,
+        formats.input,
+        tile_count_A=tile_cnt,
+        tile_count_B=tile_cnt,
     )
 
     run_test(test_config)

--- a/tests/python_tests/test_fast_tilize.py
+++ b/tests/python_tests/test_fast_tilize.py
@@ -76,10 +76,6 @@ def test_fast_tilize(test_name, formats, dest_acc, dimensions):
     generate_golden = get_golden_generator(TilizeGolden)
     golden_tensor = generate_golden(src_A, input_dimensions, formats.output)
 
-    res_address = write_stimuli_to_l1(
-        src_A, src_B, formats.input, formats.input, tile_count=tile_cnt
-    )
-
     test_config = {
         "formats": formats,
         "testname": test_name,
@@ -87,6 +83,10 @@ def test_fast_tilize(test_name, formats, dest_acc, dimensions):
         "input_dimensions": input_dimensions,
         "dest_acc": dest_acc,
     }
+
+    res_address = write_stimuli_to_l1(
+        test_config, src_A, src_B, formats.input, formats.input, tile_count=tile_cnt
+    )
 
     run_test(test_config)
 

--- a/tests/python_tests/test_math_matmul.py
+++ b/tests/python_tests/test_math_matmul.py
@@ -100,13 +100,6 @@ def test_matmul(test_name, formats, dest_acc, math_fidelity, transpose, throttle
     tilized_B = tilize_block(
         src_B, dimensions=input_dimensions, stimuli_format=formats.input_format
     )
-    res_address = write_stimuli_to_l1(
-        tilized_A.flatten(),
-        tilized_B.flatten(),
-        formats.input_format,
-        formats.input_format,
-        tile_count=tile_cnt,
-    )
 
     test_config = {
         "formats": formats,
@@ -119,6 +112,15 @@ def test_matmul(test_name, formats, dest_acc, math_fidelity, transpose, throttle
         "unpack_transpose_within_face": transpose.value,  # matmul transposes both faces and within faces, there is no option for one or the other
         "throttle": throttle,
     }
+
+    res_address = write_stimuli_to_l1(
+        test_config,
+        tilized_A.flatten(),
+        tilized_B.flatten(),
+        formats.input_format,
+        formats.input_format,
+        tile_count=tile_cnt,
+    )
 
     run_test(test_config)
 

--- a/tests/python_tests/test_math_matmul.py
+++ b/tests/python_tests/test_math_matmul.py
@@ -81,7 +81,8 @@ def test_matmul(test_name, formats, dest_acc, math_fidelity, transpose, throttle
         src_B_golden,  # needs to be transposed and tilized
         formats.output_format,
         math_fidelity,
-        input_dimensions=input_dimensions,
+        input_A_dimensions=input_dimensions,
+        input_B_dimensions=input_dimensions,
     )
     # Golden cannot model FPU strided for tilized data computation, so we tilize output after computation
     golden_tensor = (

--- a/tests/python_tests/test_math_matmul.py
+++ b/tests/python_tests/test_math_matmul.py
@@ -119,7 +119,8 @@ def test_matmul(test_name, formats, dest_acc, math_fidelity, transpose, throttle
         tilized_B.flatten(),
         formats.input_format,
         formats.input_format,
-        tile_count=tile_cnt,
+        tile_count_A=tile_cnt,
+        tile_count_B=tile_cnt,
     )
 
     run_test(test_config)

--- a/tests/python_tests/test_math_matmul.py
+++ b/tests/python_tests/test_math_matmul.py
@@ -108,7 +108,8 @@ def test_matmul(test_name, formats, dest_acc, math_fidelity, transpose, throttle
         "dest_acc": dest_acc,
         "math_fidelity": math_fidelity,
         "tile_cnt": tile_cnt,
-        "input_dimensions": input_dimensions,
+        "input_A_dimensions": input_dimensions,
+        "input_B_dimensions": input_dimensions,
         "unpack_transpose_faces": transpose.value,
         "unpack_transpose_within_face": transpose.value,  # matmul transposes both faces and within faces, there is no option for one or the other
         "throttle": throttle,

--- a/tests/python_tests/test_matmul.py
+++ b/tests/python_tests/test_matmul.py
@@ -7,6 +7,10 @@ from helpers.device import (
     collect_results,
     write_stimuli_to_l1,
 )
+from helpers.dimensions import (
+    calculate_matmul_dimensions,
+    generate_matmul_dimension_combinations,
+)
 from helpers.format_arg_mapping import DestAccumulation, MathFidelity, format_dict
 from helpers.format_config import DataFormat
 from helpers.golden_generators import MatmulGolden, get_golden_generator
@@ -19,6 +23,14 @@ from helpers.test_config import run_test
 from helpers.tilize_untilize import tilize_block
 from helpers.utils import passed_test
 
+# Generate all valid dimension combinations for both dest_acc modes
+ALL_MATMUL_COMBINATIONS = [
+    (DestAccumulation.No, dims) for dims in generate_matmul_dimension_combinations(8)
+]  # When 16-bit datums in dest can fit 8 tiles
++[
+    (DestAccumulation.Yes, dims) for dims in generate_matmul_dimension_combinations(4)
+]  # When 32 bit datums in dest can fit 4 tiles
+
 
 @parametrize(
     test_name="matmul_test",
@@ -26,26 +38,33 @@ from helpers.utils import passed_test
         [
             DataFormat.Float16_b,
             DataFormat.Float16,
-            # DataFormat.Bfp8_b,
             DataFormat.Float32,
         ]
     ),
-    dest_acc=[DestAccumulation.No, DestAccumulation.Yes],
     math_fidelity=[
         MathFidelity.LoFi,
         MathFidelity.HiFi2,
         MathFidelity.HiFi3,
         MathFidelity.HiFi4,
     ],
+    dest_acc_and_dims=ALL_MATMUL_COMBINATIONS,
 )
-def test_matmul(test_name, formats, dest_acc, math_fidelity):
+def test_matmul(test_name, formats, math_fidelity, dest_acc_and_dims):
     torch_format = format_dict[formats.output_format]
 
-    input_dimensions = [64, 64]
+    dest_acc = dest_acc_and_dims[0]
+    input_A_dimensions = dest_acc_and_dims[1][0]
+    input_B_dimensions = dest_acc_and_dims[1][1]
 
-    src_A, src_B, tile_cnt = generate_stimuli(
-        formats.input_format, formats.input_format, input_dimensions=input_dimensions
+    src_A, _, tile_cnt_A = generate_stimuli(
+        formats.input_format, formats.input_format, input_dimensions=input_A_dimensions
     )
+    src_B, _, tile_cnt_B = generate_stimuli(
+        formats.input_format, formats.input_format, input_dimensions=input_B_dimensions
+    )
+
+    # Calculate all matmul dimensions using helper function
+    matmul_dims = calculate_matmul_dimensions(input_A_dimensions, input_B_dimensions)
 
     generate_golden = get_golden_generator(MatmulGolden)
     golden_tensor = generate_golden(
@@ -53,31 +72,36 @@ def test_matmul(test_name, formats, dest_acc, math_fidelity):
         src_B,
         formats.output_format,
         math_fidelity,
-        input_dimensions=input_dimensions,
+        input_A_dimensions=input_A_dimensions,
+        input_B_dimensions=input_B_dimensions,
     )
     golden_tensor = tilize_block(
-        golden_tensor, dimensions=input_dimensions, stimuli_format=formats.output_format
+        golden_tensor,
+        dimensions=matmul_dims["output_dimensions"],
+        stimuli_format=formats.output_format,
     ).to(torch_format)
     golden_tensor = golden_tensor.flatten()
 
     if formats.input_format != DataFormat.Bfp8_b:
         tilized_A = tilize_block(
-            src_A, dimensions=input_dimensions, stimuli_format=formats.input_format
+            src_A, dimensions=input_A_dimensions, stimuli_format=formats.input_format
         )
         tilized_B = tilize_block(
-            src_B, dimensions=input_dimensions, stimuli_format=formats.input_format
+            src_B, dimensions=input_B_dimensions, stimuli_format=formats.input_format
         )
     else:
         # BFP8 format requires special handling for tilization
         tilized_A = src_A
         tilized_B = src_B
 
+    # Use the new helper function for writing stimuli
     res_address = write_stimuli_to_l1(
         tilized_A.flatten(),
         tilized_B.flatten(),
         formats.input_format,
         formats.input_format,
-        tile_count=tile_cnt,
+        tile_cnt_A,
+        tile_cnt_B,
     )
 
     test_config = {
@@ -85,13 +109,20 @@ def test_matmul(test_name, formats, dest_acc, math_fidelity):
         "testname": test_name,
         "dest_acc": dest_acc,
         "math_fidelity": math_fidelity,
-        "tile_cnt": tile_cnt,
-        "input_dimensions": input_dimensions,
+        "tile_cnt": matmul_dims["output_tile_cnt"],
+        "input_A_dimensions": input_A_dimensions,
+        "input_B_dimensions": input_B_dimensions,
+        "output_dimensions": matmul_dims["output_dimensions"],
+        "rt_dim": matmul_dims["rt_dim"],
+        "ct_dim": matmul_dims["ct_dim"],
+        "kt_dim": matmul_dims["kt_dim"],
     }
 
     run_test(test_config)
 
-    res_from_L1 = collect_results(formats, tile_count=tile_cnt, address=res_address)
+    res_from_L1 = collect_results(
+        formats, tile_count=matmul_dims["output_tile_cnt"], address=res_address
+    )
     assert len(res_from_L1) == len(golden_tensor)
 
     res_tensor = torch.tensor(res_from_L1, dtype=torch_format)

--- a/tests/python_tests/test_matmul.py
+++ b/tests/python_tests/test_matmul.py
@@ -92,16 +92,6 @@ def test_matmul(test_name, formats, math_fidelity, dest_acc_and_dims):
         tilized_A = src_A
         tilized_B = src_B
 
-    # Use the new helper function for writing stimuli
-    res_address = write_stimuli_to_l1(
-        tilized_A.flatten(),
-        tilized_B.flatten(),
-        formats.input_format,
-        formats.input_format,
-        tile_cnt_A,
-        tile_cnt_B,
-    )
-
     test_config = {
         "formats": formats,
         "testname": test_name,
@@ -115,6 +105,17 @@ def test_matmul(test_name, formats, math_fidelity, dest_acc_and_dims):
         "ct_dim": matmul_dims["ct_dim"],
         "kt_dim": matmul_dims["kt_dim"],
     }
+
+    # Use the new helper function for writing stimuli
+    res_address = write_stimuli_to_l1(
+        test_config,
+        tilized_A.flatten(),
+        tilized_B.flatten(),
+        formats.input_format,
+        formats.input_format,
+        tile_cnt_A,
+        tile_cnt_B,
+    )
 
     run_test(test_config)
 

--- a/tests/python_tests/test_matmul.py
+++ b/tests/python_tests/test_matmul.py
@@ -24,7 +24,7 @@ from helpers.tilize_untilize import tilize_block
 from helpers.utils import passed_test
 
 # Generate all valid dimension combinations for both dest_acc modes
-# When 16-bit datums in dest can fit 8 tiles and 4 tiles for 32-bit datums
+# When 16-bit datums in dest can fit max 8 tiles and 4 tiles for 32-bit datums
 ALL_MATMUL_COMBINATIONS = [
     (DestAccumulation.No, dims) for dims in generate_matmul_dimension_combinations(8)
 ] + [(DestAccumulation.Yes, dims) for dims in generate_matmul_dimension_combinations(4)]

--- a/tests/python_tests/test_matmul.py
+++ b/tests/python_tests/test_matmul.py
@@ -54,10 +54,16 @@ def test_matmul(test_name, math_fidelity, format_dest_acc_and_dims):
     input_B_dimensions = format_dest_acc_and_dims[2][1]
 
     src_A, _, tile_cnt_A = generate_stimuli(
-        formats.input_format, formats.input_format, input_dimensions=input_A_dimensions
+        formats.input_format,
+        formats.input_format,
+        input_dimensions=input_A_dimensions,
+        sfpu=False,
     )
     src_B, _, tile_cnt_B = generate_stimuli(
-        formats.input_format, formats.input_format, input_dimensions=input_B_dimensions
+        formats.input_format,
+        formats.input_format,
+        input_dimensions=input_B_dimensions,
+        sfpu=False,
     )
 
     # Calculate all matmul dimensions using helper function

--- a/tests/python_tests/test_matmul.py
+++ b/tests/python_tests/test_matmul.py
@@ -24,12 +24,10 @@ from helpers.tilize_untilize import tilize_block
 from helpers.utils import passed_test
 
 # Generate all valid dimension combinations for both dest_acc modes
+# When 16-bit datums in dest can fit 8 tiles and 4 tiles for 32-bit datums
 ALL_MATMUL_COMBINATIONS = [
     (DestAccumulation.No, dims) for dims in generate_matmul_dimension_combinations(8)
-]  # When 16-bit datums in dest can fit 8 tiles
-+[
-    (DestAccumulation.Yes, dims) for dims in generate_matmul_dimension_combinations(4)
-]  # When 32 bit datums in dest can fit 4 tiles
+] + [(DestAccumulation.Yes, dims) for dims in generate_matmul_dimension_combinations(4)]
 
 
 @parametrize(

--- a/tests/python_tests/test_matmul_and_unary_sfpu.py
+++ b/tests/python_tests/test_matmul_and_unary_sfpu.py
@@ -96,7 +96,12 @@ def test_matmul_and_unary_sfpu(
 
     generate_matmul_golden = get_golden_generator(MatmulGolden)
     golden_tensor = generate_matmul_golden(
-        src_A, src_B, formats.output_format, math_fidelity
+        src_A,
+        src_B,
+        formats.output_format,
+        math_fidelity,
+        input_A_dimensions=input_dimensions,
+        input_B_dimensions=input_dimensions,
     )
     golden_tensor = tilize(golden_tensor, formats.output_format)
 

--- a/tests/python_tests/test_matmul_and_unary_sfpu.py
+++ b/tests/python_tests/test_matmul_and_unary_sfpu.py
@@ -115,6 +115,8 @@ def test_matmul_and_unary_sfpu(
         "formats": formats,
         "testname": test_name,
         "dest_acc": dest_acc,
+        "input_A_dimensions": input_dimensions,
+        "input_B_dimensions": input_dimensions,
         "math_fidelity": math_fidelity,
         "approx_mode": approx_mode,
         "mathop": mathop,

--- a/tests/python_tests/test_matmul_and_unary_sfpu.py
+++ b/tests/python_tests/test_matmul_and_unary_sfpu.py
@@ -106,13 +106,6 @@ def test_matmul_and_unary_sfpu(
     )
     golden_tensor = golden_tensor.to(torch_format)
 
-    res_address = write_stimuli_to_l1(
-        tilize(src_A, formats.input_format),
-        tilize(src_B, formats.input_format),
-        formats.input_format,
-        formats.input_format,
-    )
-
     test_config = {
         "formats": formats,
         "testname": test_name,
@@ -122,6 +115,14 @@ def test_matmul_and_unary_sfpu(
         "mathop": mathop,
         "L1_to_L1_iterations": 2,  # This is a fused test does two runs of L1-L1, result tensor from first run (matmul) is used as input for second run (sfpu operation)
     }
+
+    res_address = write_stimuli_to_l1(
+        test_config,
+        tilize(src_A, formats.input_format),
+        tilize(src_B, formats.input_format),
+        formats.input_format,
+        formats.input_format,
+    )
 
     run_test(test_config)
 

--- a/tests/python_tests/test_matmul_and_unary_sfpu.py
+++ b/tests/python_tests/test_matmul_and_unary_sfpu.py
@@ -122,6 +122,8 @@ def test_matmul_and_unary_sfpu(
         tilize(src_B, formats.input_format),
         formats.input_format,
         formats.input_format,
+        tile_count_A=tile_cnt,
+        tile_count_B=tile_cnt,
     )
 
     run_test(test_config)

--- a/tests/python_tests/test_matmul_pack_untilize.py
+++ b/tests/python_tests/test_matmul_pack_untilize.py
@@ -64,6 +64,8 @@ def test_matmul_pack_untilize(test_name, formats, dest_acc, math_fidelity):
         "testname": test_name,
         "formats": formats,
         "dest_acc": dest_acc,
+        "input_A_dimensions": input_dimensions,
+        "input_B_dimensions": input_dimensions,
         "math_fidelity": math_fidelity,
     }
 

--- a/tests/python_tests/test_matmul_pack_untilize.py
+++ b/tests/python_tests/test_matmul_pack_untilize.py
@@ -52,20 +52,21 @@ def test_matmul_pack_untilize(test_name, formats, dest_acc, math_fidelity):
     generate_golden = get_golden_generator(MatmulGolden)
     golden_tensor = generate_golden(src_A, src_B, formats.output_format, math_fidelity)
 
-    res_address = write_stimuli_to_l1(
-        tilize(src_A, formats.input_format),
-        tilize(src_B, formats.input_format),
-        formats.input_format,
-        formats.input_format,
-        tile_count=tile_cnt,
-    )
-
     test_config = {
         "testname": test_name,
         "formats": formats,
         "dest_acc": dest_acc,
         "math_fidelity": math_fidelity,
     }
+
+    res_address = write_stimuli_to_l1(
+        test_config,
+        tilize(src_A, formats.input_format),
+        tilize(src_B, formats.input_format),
+        formats.input_format,
+        formats.input_format,
+        tile_count=tile_cnt,
+    )
 
     run_test(test_config)
 

--- a/tests/python_tests/test_matmul_pack_untilize.py
+++ b/tests/python_tests/test_matmul_pack_untilize.py
@@ -44,13 +44,21 @@ def test_matmul_pack_untilize(test_name, formats, dest_acc, math_fidelity):
         pytest.skip("Pack untilize does not support Bfp8_b")
 
     torch_format = format_dict[formats.output_format]
+    input_dimensions = [32, 32]
 
     src_A, src_B, tile_cnt = generate_stimuli(
         formats.input_format, formats.input_format
     )
 
     generate_golden = get_golden_generator(MatmulGolden)
-    golden_tensor = generate_golden(src_A, src_B, formats.output_format, math_fidelity)
+    golden_tensor = generate_golden(
+        src_A,
+        src_B,
+        formats.output_format,
+        math_fidelity,
+        input_A_dimensions=input_dimensions,
+        input_B_dimensions=input_dimensions,
+    )
 
     test_config = {
         "testname": test_name,

--- a/tests/python_tests/test_matmul_pack_untilize.py
+++ b/tests/python_tests/test_matmul_pack_untilize.py
@@ -65,7 +65,8 @@ def test_matmul_pack_untilize(test_name, formats, dest_acc, math_fidelity):
         tilize(src_B, formats.input_format),
         formats.input_format,
         formats.input_format,
-        tile_count=tile_cnt,
+        tile_count_A=tile_cnt,
+        tile_count_B=tile_cnt,
     )
 
     run_test(test_config)

--- a/tests/python_tests/test_matmul_unpack_tilize.py
+++ b/tests/python_tests/test_matmul_unpack_tilize.py
@@ -64,6 +64,8 @@ def test_matmul_unpack_tilize(test_name, formats, dest_acc, math_fidelity):
         "formats": formats,
         "testname": test_name,
         "dest_acc": dest_acc,
+        "input_A_dimensions": input_dimensions,
+        "input_B_dimensions": input_dimensions,
         "math_fidelity": math_fidelity,
         "L1_to_L1_iterations": 2,
     }

--- a/tests/python_tests/test_matmul_unpack_tilize.py
+++ b/tests/python_tests/test_matmul_unpack_tilize.py
@@ -66,6 +66,8 @@ def test_matmul_unpack_tilize(test_name, formats, dest_acc, math_fidelity):
         src_B,
         formats.input_format,
         formats.input_format,
+        tile_count_A=tile_cnt,
+        tile_count_B=tile_cnt,
     )
 
     run_test(test_config)

--- a/tests/python_tests/test_matmul_unpack_tilize.py
+++ b/tests/python_tests/test_matmul_unpack_tilize.py
@@ -52,13 +52,6 @@ def test_matmul_unpack_tilize(test_name, formats, dest_acc, math_fidelity):
     )
     golden_tensor = golden_tensor.to(torch_format)
 
-    res_address = write_stimuli_to_l1(
-        src_A,
-        src_B,
-        formats.input_format,
-        formats.input_format,
-    )
-    buffer_dest_address = 0x1E000
     test_config = {
         "formats": formats,
         "testname": test_name,
@@ -66,6 +59,14 @@ def test_matmul_unpack_tilize(test_name, formats, dest_acc, math_fidelity):
         "math_fidelity": math_fidelity,
         "L1_to_L1_iterations": 2,
     }
+
+    res_address = write_stimuli_to_l1(
+        test_config,
+        src_A,
+        src_B,
+        formats.input_format,
+        formats.input_format,
+    )
 
     run_test(test_config)
 

--- a/tests/python_tests/test_matmul_unpack_tilize.py
+++ b/tests/python_tests/test_matmul_unpack_tilize.py
@@ -41,6 +41,7 @@ from helpers.utils import passed_test
 def test_matmul_unpack_tilize(test_name, formats, dest_acc, math_fidelity):
 
     torch_format = format_dict[formats.output_format]
+    input_dimensions = [32, 32]
 
     src_A, src_B, tile_cnt = generate_stimuli(
         formats.input_format, formats.input_format
@@ -48,7 +49,14 @@ def test_matmul_unpack_tilize(test_name, formats, dest_acc, math_fidelity):
 
     generate_golden = get_golden_generator(MatmulGolden)
     golden_tensor = tilize(
-        generate_golden(src_A, src_B, formats.output_format, math_fidelity)
+        generate_golden(
+            src_A,
+            src_B,
+            formats.output_format,
+            math_fidelity,
+            input_A_dimensions=input_dimensions,
+            input_B_dimensions=input_dimensions,
+        )
     )
     golden_tensor = golden_tensor.to(torch_format)
 

--- a/tests/python_tests/test_multiple_tiles_eltwise.py
+++ b/tests/python_tests/test_multiple_tiles_eltwise.py
@@ -65,7 +65,6 @@ def test_multiple_tiles(
         src_B,
         formats.input_format,
         formats.input_format,
-        "0,0",
         tile_count=tile_cnt,
     )
 

--- a/tests/python_tests/test_multiple_tiles_eltwise.py
+++ b/tests/python_tests/test_multiple_tiles_eltwise.py
@@ -60,13 +60,6 @@ def test_multiple_tiles(
     golden_tensor = generate_golden(
         mathop, src_A, src_B, formats.output_format, math_fidelity
     )
-    res_address = write_stimuli_to_l1(
-        src_A,
-        src_B,
-        formats.input_format,
-        formats.input_format,
-        tile_count=tile_cnt,
-    )
 
     test_config = {
         "formats": formats,
@@ -76,6 +69,15 @@ def test_multiple_tiles(
         "math_fidelity": math_fidelity,
         "tile_cnt": tile_cnt,
     }
+
+    res_address = write_stimuli_to_l1(
+        test_config,
+        src_A,
+        src_B,
+        formats.input_format,
+        formats.input_format,
+        tile_count=tile_cnt,
+    )
 
     run_test(test_config)
 

--- a/tests/python_tests/test_multiple_tiles_eltwise.py
+++ b/tests/python_tests/test_multiple_tiles_eltwise.py
@@ -76,7 +76,8 @@ def test_multiple_tiles(
         src_B,
         formats.input_format,
         formats.input_format,
-        tile_count=tile_cnt,
+        tile_count_A=tile_cnt,
+        tile_count_B=tile_cnt,
     )
 
     run_test(test_config)

--- a/tests/python_tests/test_multiple_tiles_eltwise.py
+++ b/tests/python_tests/test_multiple_tiles_eltwise.py
@@ -65,6 +65,8 @@ def test_multiple_tiles(
         "formats": formats,
         "testname": test_name,
         "dest_acc": dest_acc,
+        "input_A_dimensions": input_dimensions,
+        "input_B_dimensions": input_dimensions,
         "mathop": mathop,
         "math_fidelity": math_fidelity,
         "tile_cnt": tile_cnt,

--- a/tests/python_tests/test_pack_untilize.py
+++ b/tests/python_tests/test_pack_untilize.py
@@ -53,7 +53,8 @@ def test_pack_untilize(test_name, formats):
         "formats": formats,
         "testname": test_name,
         "tile_cnt": tile_cnt,
-        "input_dimensions": input_dimensions,
+        "input_A_dimensions": input_dimensions,
+        "input_B_dimensions": input_dimensions,
         "unpack_to_dest": formats.input_format.is_32_bit(),
     }
 

--- a/tests/python_tests/test_pack_untilize.py
+++ b/tests/python_tests/test_pack_untilize.py
@@ -49,10 +49,6 @@ def test_pack_untilize(test_name, formats):
     generate_golden = get_golden_generator(UntilizeGolden)
     golden_tensor = generate_golden(src_A, formats.output_format, input_dimensions)
 
-    res_address = write_stimuli_to_l1(
-        src_A, src_B, formats.input_format, formats.input_format, tile_count=tile_cnt
-    )
-
     test_config = {
         "formats": formats,
         "testname": test_name,
@@ -60,6 +56,15 @@ def test_pack_untilize(test_name, formats):
         "input_dimensions": input_dimensions,
         "unpack_to_dest": formats.input_format.is_32_bit(),
     }
+
+    res_address = write_stimuli_to_l1(
+        test_config,
+        src_A,
+        src_B,
+        formats.input_format,
+        formats.input_format,
+        tile_count=tile_cnt,
+    )
 
     run_test(test_config)
 

--- a/tests/python_tests/test_pack_untilize.py
+++ b/tests/python_tests/test_pack_untilize.py
@@ -63,7 +63,8 @@ def test_pack_untilize(test_name, formats):
         src_B,
         formats.input_format,
         formats.input_format,
-        tile_count=tile_cnt,
+        tile_count_A=tile_cnt,
+        tile_count_B=tile_cnt,
     )
 
     run_test(test_config)

--- a/tests/python_tests/test_reduce.py
+++ b/tests/python_tests/test_reduce.py
@@ -87,7 +87,8 @@ def test_reduce(test_name, formats, dest_acc, reduce_dim, pool_type):
         src_B,
         formats.input_format,
         formats.input_format,
-        tile_count=tile_cnt,
+        tile_count_A=tile_cnt,
+        tile_count_B=tile_cnt,
     )
 
     run_test(test_config)

--- a/tests/python_tests/test_reduce.py
+++ b/tests/python_tests/test_reduce.py
@@ -69,9 +69,6 @@ def test_reduce(test_name, formats, dest_acc, reduce_dim, pool_type):
 
     generate_golden = get_golden_generator(ReduceGolden)
     golden_tensor = generate_golden(src_A, reduce_dim, pool_type, formats.output_format)
-    res_address = write_stimuli_to_l1(
-        src_A, src_B, formats.input_format, formats.input_format, tile_count=tile_cnt
-    )
 
     mathop = mathop_mapping[reduce_dim]
 
@@ -83,6 +80,15 @@ def test_reduce(test_name, formats, dest_acc, reduce_dim, pool_type):
         "pool_type": pool_type,
         "mathop": mathop,
     }
+
+    res_address = write_stimuli_to_l1(
+        test_config,
+        src_A,
+        src_B,
+        formats.input_format,
+        formats.input_format,
+        tile_count=tile_cnt,
+    )
 
     run_test(test_config)
 

--- a/tests/python_tests/test_sfpu_binary.py
+++ b/tests/python_tests/test_sfpu_binary.py
@@ -94,6 +94,8 @@ def sfpu_binary(test_name, formats, dest_acc, mathop):
         "formats": formats,
         "testname": test_name,
         "dest_acc": dest_acc,
+        "input_A_dimensions": input_dimensions,
+        "input_B_dimensions": input_dimensions,
         "mathop": mathop,
         "unpack_to_dest": unpack_to_dest,
         "tile_cnt": tile_cnt,

--- a/tests/python_tests/test_sfpu_binary.py
+++ b/tests/python_tests/test_sfpu_binary.py
@@ -83,9 +83,6 @@ def sfpu_binary(test_name, formats, dest_acc, mathop):
 
     generate_golden = get_golden_generator(BinarySFPUGolden)
     golden_tensor = generate_golden(mathop, src_A, src_B, formats.output_format)
-    res_address = write_stimuli_to_l1(
-        src_A, src_B, formats.input_format, formats.input_format, tile_count=tile_cnt
-    )
 
     unpack_to_dest = formats.input_format.is_32_bit()
 
@@ -101,6 +98,15 @@ def sfpu_binary(test_name, formats, dest_acc, mathop):
         "unpack_to_dest": unpack_to_dest,
         "tile_cnt": tile_cnt,
     }
+
+    res_address = write_stimuli_to_l1(
+        test_config,
+        src_A,
+        src_B,
+        formats.input_format,
+        formats.input_format,
+        tile_count=tile_cnt,
+    )
 
     run_test(test_config)
 

--- a/tests/python_tests/test_sfpu_binary.py
+++ b/tests/python_tests/test_sfpu_binary.py
@@ -105,7 +105,8 @@ def sfpu_binary(test_name, formats, dest_acc, mathop):
         src_B,
         formats.input_format,
         formats.input_format,
-        tile_count=tile_cnt,
+        tile_count_A=tile_cnt,
+        tile_count_B=tile_cnt,
     )
 
     run_test(test_config)

--- a/tests/python_tests/test_tilize_calculate_untilize_L1.py
+++ b/tests/python_tests/test_tilize_calculate_untilize_L1.py
@@ -59,14 +59,6 @@ def test_tilize_calculate_untilize_L1(
         mathop, tilize(src_A), tilize(src_B), formats.output_format, math_fidelity
     )
 
-    res_address = write_stimuli_to_l1(
-        src_A,
-        src_B,
-        formats.input_format,
-        formats.input_format,
-        tile_count=tile_cnt,
-    )
-
     test_config = {
         "formats": formats,
         "testname": test_name,
@@ -76,6 +68,15 @@ def test_tilize_calculate_untilize_L1(
         "tile_cnt": tile_cnt,
         "L1_to_L1_iterations": 2,  # Fused L1 to L1 test has multiple L1-L1 runs: output of first run is used as input for the second run ... This flag marks the number of L1-L1 runs in the test
     }
+
+    res_address = write_stimuli_to_l1(
+        test_config,
+        src_A,
+        src_B,
+        formats.input_format,
+        formats.input_format,
+        tile_count=tile_cnt,
+    )
 
     run_test(test_config)
 

--- a/tests/python_tests/test_tilize_calculate_untilize_L1.py
+++ b/tests/python_tests/test_tilize_calculate_untilize_L1.py
@@ -63,6 +63,8 @@ def test_tilize_calculate_untilize_L1(
         "formats": formats,
         "testname": test_name,
         "dest_acc": dest_acc,
+        "input_A_dimensions": input_dimensions,
+        "input_B_dimensions": input_dimensions,
         "math_fidelity": math_fidelity,
         "mathop": mathop,
         "tile_cnt": tile_cnt,

--- a/tests/python_tests/test_tilize_calculate_untilize_L1.py
+++ b/tests/python_tests/test_tilize_calculate_untilize_L1.py
@@ -64,7 +64,6 @@ def test_tilize_calculate_untilize_L1(
         src_B,
         formats.input_format,
         formats.input_format,
-        "0,0",
         tile_count=tile_cnt,
     )
 

--- a/tests/python_tests/test_tilize_calculate_untilize_L1.py
+++ b/tests/python_tests/test_tilize_calculate_untilize_L1.py
@@ -75,7 +75,8 @@ def test_tilize_calculate_untilize_L1(
         src_B,
         formats.input_format,
         formats.input_format,
-        tile_count=tile_cnt,
+        tile_count_A=tile_cnt,
+        tile_count_B=tile_cnt,
     )
 
     run_test(test_config)

--- a/tests/python_tests/test_unpack_matmul.py
+++ b/tests/python_tests/test_unpack_matmul.py
@@ -85,7 +85,8 @@ def test_matmul(test_name, formats, dest_acc, math_fidelity, stochastic_rnd, tra
         src_B_golden,  # needs to be transposed and tilized
         formats.output_format,
         math_fidelity,
-        input_dimensions=input_dimensions,
+        input_A_dimensions=input_dimensions,
+        input_B_dimensions=input_dimensions,
     )
     # Golden cannot model FPU strided for tilized data computation, so we tilize output after computation
     golden_tensor = (
@@ -104,13 +105,6 @@ def test_matmul(test_name, formats, dest_acc, math_fidelity, stochastic_rnd, tra
     tilized_B = tilize_block(
         src_B, dimensions=input_dimensions, stimuli_format=formats.input_format
     )
-    res_address = write_stimuli_to_l1(
-        tilized_A.flatten(),
-        tilized_B.flatten(),
-        formats.input_format,
-        formats.input_format,
-        tile_count=tile_cnt,
-    )
 
     test_config = {
         "formats": formats,
@@ -118,11 +112,22 @@ def test_matmul(test_name, formats, dest_acc, math_fidelity, stochastic_rnd, tra
         "dest_acc": dest_acc,
         "math_fidelity": math_fidelity,
         "tile_cnt": tile_cnt,
-        "input_dimensions": input_dimensions,
+        "input_A_dimensions": input_dimensions,
+        "input_B_dimensions": input_dimensions,
         "stochastic_rnd": stochastic_rnd,
         "unpack_transpose_faces": transpose.value,
         "unpack_transpose_within_face": transpose.value,  # matmul transposes both faces and within faces, there is no option for one or the other
     }
+
+    res_address = write_stimuli_to_l1(
+        test_config,
+        tilized_A.flatten(),
+        tilized_B.flatten(),
+        formats.input_format,
+        formats.input_format,
+        tile_count_A=tile_cnt,
+        tile_count_B=tile_cnt,
+    )
 
     run_test(test_config)
 

--- a/tests/python_tests/test_unpack_tilize.py
+++ b/tests/python_tests/test_unpack_tilize.py
@@ -59,7 +59,8 @@ def unpack_tilize(test_name, formats):
         "formats": formats,
         "testname": test_name,
         "tile_cnt": tile_cnt,
-        "input_dimensions": input_dimensions,
+        "input_A_dimensions": input_dimensions,
+        "input_B_dimensions": input_dimensions,
         "unpack_to_dest": formats.input_format == DataFormat.Int32,
     }
 

--- a/tests/python_tests/test_unpack_tilize.py
+++ b/tests/python_tests/test_unpack_tilize.py
@@ -55,10 +55,6 @@ def unpack_tilize(test_name, formats):
     generate_golden = get_golden_generator(TilizeGolden)
     golden_tensor = generate_golden(src_A, input_dimensions, formats.output_format)
 
-    res_address = write_stimuli_to_l1(
-        src_A, src_B, formats.input_format, formats.input_format, tile_count=tile_cnt
-    )
-
     test_config = {
         "formats": formats,
         "testname": test_name,
@@ -66,6 +62,15 @@ def unpack_tilize(test_name, formats):
         "input_dimensions": input_dimensions,
         "unpack_to_dest": formats.input_format == DataFormat.Int32,
     }
+
+    res_address = write_stimuli_to_l1(
+        test_config,
+        src_A,
+        src_B,
+        formats.input_format,
+        formats.input_format,
+        tile_count=tile_cnt,
+    )
 
     run_test(test_config)
 

--- a/tests/python_tests/test_unpack_tilize.py
+++ b/tests/python_tests/test_unpack_tilize.py
@@ -69,7 +69,8 @@ def unpack_tilize(test_name, formats):
         src_B,
         formats.input_format,
         formats.input_format,
-        tile_count=tile_cnt,
+        tile_count_A=tile_cnt,
+        tile_count_B=tile_cnt,
     )
 
     run_test(test_config)

--- a/tests/python_tests/test_unpack_untilize.py
+++ b/tests/python_tests/test_unpack_untilize.py
@@ -54,9 +54,6 @@ def test_unpack_untilize(test_name, formats):
     golden_tensor = generate_golden(
         src_A, formats.output_format, dimensions=input_dimensions
     )
-    res_address = write_stimuli_to_l1(
-        src_A, src_B, formats.input_format, formats.input_format, tile_count=tile_cnt
-    )
 
     test_config = {
         "formats": formats,
@@ -64,6 +61,15 @@ def test_unpack_untilize(test_name, formats):
         "tile_cnt": tile_cnt,
         "input_dimensions": input_dimensions,
     }
+
+    res_address = write_stimuli_to_l1(
+        test_config,
+        src_A,
+        src_B,
+        formats.input_format,
+        formats.input_format,
+        tile_count=tile_cnt,
+    )
 
     run_test(test_config)
 

--- a/tests/python_tests/test_unpack_untilize.py
+++ b/tests/python_tests/test_unpack_untilize.py
@@ -68,7 +68,8 @@ def test_unpack_untilize(test_name, formats):
         src_B,
         formats.input_format,
         formats.input_format,
-        tile_count=tile_cnt,
+        tile_count_A=tile_cnt,
+        tile_count_B=tile_cnt,
     )
 
     run_test(test_config)

--- a/tests/python_tests/test_unpack_untilize.py
+++ b/tests/python_tests/test_unpack_untilize.py
@@ -59,7 +59,8 @@ def test_unpack_untilize(test_name, formats):
         "formats": formats,
         "testname": test_name,
         "tile_cnt": tile_cnt,
-        "input_dimensions": input_dimensions,
+        "input_A_dimensions": input_dimensions,
+        "input_B_dimensions": input_dimensions,
     }
 
     res_address = write_stimuli_to_l1(

--- a/tests/sources/matmul_test.cpp
+++ b/tests/sources/matmul_test.cpp
@@ -21,9 +21,9 @@ uint32_t math_sync_tile_dst_index = 0;
 
 void run_kernel()
 {
-    std::uint32_t ct_dim = BLOCK_CT_DIM;
-    std::uint32_t rt_dim = BLOCK_RT_DIM;
-    std::uint32_t kt_dim = BLOCK_CT_DIM; // for square matrices, kt_dim == ct_dim
+    std::uint32_t ct_dim = CT_DIM;
+    std::uint32_t rt_dim = RT_DIM;
+    std::uint32_t kt_dim = KT_DIM;
 
     std::uint32_t tile_size = 128;
 
@@ -68,9 +68,9 @@ void run_kernel()
 
 void run_kernel()
 {
-    std::uint32_t ct_dim = BLOCK_CT_DIM;
-    std::uint32_t rt_dim = BLOCK_RT_DIM;
-    std::uint32_t kt_dim = BLOCK_CT_DIM; // for square matrices, kt_dim == ct_dim
+    std::uint32_t ct_dim = CT_DIM;
+    std::uint32_t rt_dim = RT_DIM;
+    std::uint32_t kt_dim = KT_DIM;
 
     _llk_math_matmul_init_<MATH_FIDELITY, DstTileFaceLayout::RowMajor>(TILE_R_DIM, TILE_C_DIM, TILE_R_DIM, TILE_C_DIM, false, 0, ct_dim, rt_dim, kt_dim);
     _llk_math_pack_sync_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();

--- a/tests/sources/matmul_test.cpp
+++ b/tests/sources/matmul_test.cpp
@@ -80,7 +80,6 @@ void run_kernel()
     {
         _llk_math_matmul_<MATH_FIDELITY, DstTileFaceLayout::RowMajor>(0, 0, ct_dim, rt_dim, kt_dim);
     }
-
     _llk_math_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
 }
 
@@ -103,10 +102,9 @@ void run_kernel()
     _llk_pack_init_<false, false, DstTileFaceLayout::RowMajor, false>(formats.pack_dst);
     _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en, DstTileFaceLayout::RowMajor, false>();
 #endif
-
+    _llk_packer_wait_for_math_done_();
     for (int i = 0; i < TILE_CNT; i++)
     {
-        _llk_packer_wait_for_math_done_();
         _llk_pack_<DstSync::SyncHalf, is_fp32_dest_acc_en, false>(i, L1_ADDRESS(buffer_Res[i]));
     }
     _llk_pack_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();

--- a/tests/sources/matmul_test.cpp
+++ b/tests/sources/matmul_test.cpp
@@ -93,12 +93,23 @@ void run_kernel()
 
 void run_kernel()
 {
+    std::uint32_t tile_size = 128;
+
+    if constexpr (static_cast<DataFormat>(formats.pack_dst) == DataFormat::Bfp8_b)
+    {
+        tile_size = 68;
+    }
+    else if constexpr (static_cast<DataFormat>(formats.pack_dst) == DataFormat::Float32)
+    {
+        tile_size = 256;
+    }
+
 #ifdef ARCH_BLACKHOLE
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, false, false>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, false, false>(formats.pack_src, formats.pack_dst, tile_size);
     _llk_pack_init_<false, false, DstTileFaceLayout::RowMajor, false, false>(formats.pack_dst);
     _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en, DstTileFaceLayout::RowMajor>();
 #else
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, false>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, false>(formats.pack_src, formats.pack_dst, tile_size);
     _llk_pack_init_<false, false, DstTileFaceLayout::RowMajor, false>(formats.pack_dst);
     _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en, DstTileFaceLayout::RowMajor, false>();
 #endif


### PR DESCRIPTION
### Ticket
<!-- Link to Github Issue -->
https://github.com/tenstorrent/tt-llk/issues/562
### Problem description
<!-- Provide context for the problem. -->
This closes the gap in the previous implementation, which only handled a hardcoded case (2×2 tiles), and now enables full coverage of all 58 valid combinations under the following constraints:
* When using 32-bit dest registers: output matrix must have ≤ 4 tiles.
* When using 16-bit dest registers: output matrix may use up to 8 tiles.

Test coverage jumped from 72 to 2088 test cases
### What's changed
<!-- Describe the approach used to solve the problem.
Summarize the changes made and its impact. -->
This PR extends the matmul testing infrastructure to fully support writes to memory with multiple tiles across various matrix dimensions. Key changes include:
 ✅ Differentiated writes to memory when inputA and inputB have different numbers of tiles and matrix dimensions.
 ✅ Generalized test infrastructure to accept dynamic tile dimensions and input configurations.
 ✅ Generated all valid multiple-tile combinations to enable a complete sweep of matmul tile/dimension scenarios.
 ✅ Updated golden/reference logic to match outputs for multiple tiles and varying shapes.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

