### PR TITLE
ci: temp enable metal workflow from a branch

### DIFF
--- a/.github/workflows/trigger-tt-metal-post-commit.yml
+++ b/.github/workflows/trigger-tt-metal-post-commit.yml
@@ -221,7 +221,7 @@ jobs:
       github.event_name == 'workflow_dispatch') &&
       needs.detect-changes.result == 'success' &&
       needs.detect-changes.outputs.should-skip != 'true'
-    uses: tenstorrent/tt-metal/.github/workflows/test-llk-metal-integration.yaml@main
+    uses: tenstorrent/tt-metal/.github/workflows/test-llk-metal-integration.yaml@fvranic/fix-workflow
     secrets: inherit
     with:
       mirrored_branch: ${{ needs.setup-branch.outputs.branch-to-run }}


### PR DESCRIPTION
### Ticket
None

### Problem description
I was hoping to merge https://github.com/tenstorrent/tt-metal/pull/26180 by the time this merges, but that hasn't happened due to different reasons, leaving this (llk) workflow in a broken state.
This is just a band-aid solution, until the other PR is merged.

### What's changed
Changed metal post-commit workflow to trigger metal workflow from a branch, not main.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update