### PR TITLE
Fix typecast fp16_b double rounding

### DIFF
--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_typecast.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_typecast.h
@@ -39,8 +39,8 @@ inline void _calculate_typecast_uint16_to_fp16b_()
     {
         TTI_SFPLOAD(0, 6, ADDR_MOD_7, 0);
         TTI_SFPCAST(0, 1, 0);
-        TTI_SFP_STOCH_RND(0, 0, 3, 1, 2, 1);
-        TTI_SFPSTORE(2, 2, ADDR_MOD_7, 0);
+        TTI_SFP_STOCH_RND(0, 0, 3, 1, 2, 9);
+        TTI_SFPSTORE(2, 0, ADDR_MOD_7, 0);
         sfpi::dst_reg++;
     }
 }
@@ -63,8 +63,8 @@ inline void _calculate_typecast_int32_to_fp16b_()
         // Required after cast due to a bug in Blackhole RTL.
         TTI_SFPSETSGN(0, 2, 0, 0);
         TTI_SFPCAST(0, 1, 0);
-        TTI_SFP_STOCH_RND(0, 0, 3, 1, 2, 1);
-        TTI_SFPSTORE(2, 2, ADDR_MOD_7, 0);
+        TTI_SFP_STOCH_RND(0, 0, 3, 1, 2, 9);
+        TTI_SFPSTORE(2, 0, ADDR_MOD_7, 0);
         sfpi::dst_reg++;
     }
 }
@@ -124,7 +124,7 @@ inline void _calculate_typecast_fp32_to_fp16b_()
     for (int d = 0; d < ITERATIONS; d++)
     {
         TTI_SFPLOAD(0, 0, ADDR_MOD_7, 0);
-        TTI_SFP_STOCH_RND(0, 0, 2, 0, 1, 1);
+        TTI_SFP_STOCH_RND(0, 0, 2, 0, 1, 9);
         TTI_SFPSTORE(1, 0, ADDR_MOD_7, 0);
         sfpi::dst_reg++;
     }
@@ -230,11 +230,11 @@ inline void _calculate_typecast_uint32_to_fp16b_()
         TTI_SFPLOAD(0, 12, ADDR_MOD_7, 0);
         TTI_SFPSETSGN(0, 0, 1, 1);
         TTI_SFPCAST(1, 2, 0);
-        TTI_SFP_STOCH_RND(0, 0, 4, 2, 3, 1);
+        TTI_SFP_STOCH_RND(0, 0, 4, 2, 3, 9);
         TTI_SFPSETCC(0, 0, 0, 0);
         TTI_SFPADDI(0x4f00, 3, 0); // 2^31
         TTI_SFPENCC(0, 0, 0, 0);
-        TTI_SFPSTORE(3, 2, ADDR_MOD_7, 0);
+        TTI_SFPSTORE(3, 0, ADDR_MOD_7, 0);
         sfpi::dst_reg++;
     }
 }

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_typecast.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_typecast.h
@@ -36,8 +36,8 @@ inline void _calculate_typecast_uint16_to_fp16b_()
     {
         TTI_SFPLOAD(0, 6, 3, 0);
         TTI_SFPCAST(0, 1, 0);
-        TTI_SFP_STOCH_RND(0, 0, 3, 1, 2, 1);
-        TTI_SFPSTORE(2, 2, 3, 0);
+        TTI_SFP_STOCH_RND(0, 0, 3, 1, 2, 9);
+        TTI_SFPSTORE(2, 0, 3, 0);
         sfpi::dst_reg++;
     }
 }
@@ -50,8 +50,8 @@ inline void _calculate_typecast_int32_to_fp16b_()
     {
         TTI_SFPLOAD(0, 12, 3, 0);
         TTI_SFPCAST(0, 1, 0);
-        TTI_SFP_STOCH_RND(0, 0, 3, 1, 2, 1);
-        TTI_SFPSTORE(2, 2, 3, 0);
+        TTI_SFP_STOCH_RND(0, 0, 3, 1, 2, 9);
+        TTI_SFPSTORE(2, 0, 3, 0);
         sfpi::dst_reg++;
     }
 }
@@ -109,7 +109,7 @@ inline void _calculate_typecast_fp32_to_fp16b_()
     for (int d = 0; d < ITERATIONS; d++)
     {
         TTI_SFPLOAD(0, 0, 3, 0);
-        TTI_SFP_STOCH_RND(0, 0, 2, 0, 1, 1);
+        TTI_SFP_STOCH_RND(0, 0, 2, 0, 1, 9);
         TTI_SFPSTORE(1, 0, 3, 0);
         sfpi::dst_reg++;
     }
@@ -205,11 +205,11 @@ inline void _calculate_typecast_uint32_to_fp16b_()
         TTI_SFPLOAD(0, 4, 3, 0);
         TTI_SFPSETSGN(0, 0, 1, 1);
         TTI_SFPCAST(1, 2, 0);
-        TTI_SFP_STOCH_RND(0, 0, 4, 2, 3, 1);
+        TTI_SFP_STOCH_RND(0, 0, 4, 2, 3, 9);
         TTI_SFPSETCC(0, 0, 0, 0);
         TTI_SFPADDI(0x4f00, 3, 0); // 2^31
         TTI_SFPENCC(0, 0, 0, 0);
-        TTI_SFPSTORE(3, 2, 3, 0);
+        TTI_SFPSTORE(3, 0, 3, 0);
         sfpi::dst_reg++;
     }
 }


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/25656

### Problem description
-1 is represented as -1.00781 after int->fp16b typecast
This is because we are storing the output back as fp16b (mode 2) which only overwrites the Hi16 bits of the fp32 dest reg. Then when the packer packs out the value, it will round it again (including Lo16 bits) resulting in double rounding.

### What's changed
- Change the STORE mode of typecast kernels to 0 (default) in order to overwrite all 32bits of Dest. This fixes the issue.
- Also update stoch_rnd instruction to use imm operand for descale - this has no effect anyways but may prevent LREG3 from being used down the line by accident.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
