### PR TITLE
ci: install tt-smi from prebuilt wheel instead of installing it from git repository

### DIFF
--- a/.github/scripts/install-exalens.sh
+++ b/.github/scripts/install-exalens.sh
@@ -10,6 +10,6 @@ EXALENS_TAG="${EXALENS_VERSION%%+*}"
 EXALENS_WHEEL="ttexalens-${EXALENS_VERSION}.whl"
 
 wget -O ${EXALENS_WHEEL} \
-    https://github.com/tenstorrent/tt-exalens/releases/download/${EXALENS_TAG}/${EXALENS_WHEEL}
+    https://github.com/tenstorrent/tt-exalens/releases/download/${EXALENS_TAG}/${EXALENS_WHEEL} || exit 1
 pip install --no-cache-dir ${EXALENS_WHEEL}
 rm ${EXALENS_WHEEL}

--- a/.github/scripts/install-exalens.sh
+++ b/.github/scripts/install-exalens.sh
@@ -6,9 +6,10 @@
 set -e
 
 EXALENS_VERSION="0.1.250626+dev.7538f60-cp310-cp310-linux_x86_64"
+EXALENS_TAG="${EXALENS_VERSION%%+*}"
 EXALENS_WHEEL="ttexalens-${EXALENS_VERSION}.whl"
 
 wget -O ${EXALENS_WHEEL} \
-    https://github.com/tenstorrent/tt-exalens/releases/download/0.1.250626/${EXALENS_WHEEL}
+    https://github.com/tenstorrent/tt-exalens/releases/download/${EXALENS_TAG}/${EXALENS_WHEEL}
 pip install --no-cache-dir ${EXALENS_WHEEL}
 rm ${EXALENS_WHEEL}

--- a/.github/scripts/install-smi.sh
+++ b/.github/scripts/install-smi.sh
@@ -5,10 +5,10 @@
 
 set -e
 
-SM_VERSION="3.0.27"
-SM_WHEEL="tt_smi-${SM_VERSION}-py3-none-any.whl"
+TT_SMI_VERSION="3.0.27"
+TT_SMI_WHEEL="tt_smi-${TT_SMI_VERSION}-py3-none-any.whl"
 
-wget -O ${SM_WHEEL} \
-    https://github.com/tenstorrent/tt-smi/releases/download/v${SM_VERSION}/${SM_WHEEL}
-pip install --no-cache-dir ${SM_WHEEL}
-rm ${SM_WHEEL}
+wget -O ${TT_SMI_WHEEL} \
+    https://github.com/tenstorrent/tt-smi/releases/download/v${TT_SMI_VERSION}/${TT_SMI_WHEEL}
+pip install --no-cache-dir ${TT_SMI_WHEEL}
+rm ${TT_SMI_WHEEL}

--- a/.github/scripts/install-smi.sh
+++ b/.github/scripts/install-smi.sh
@@ -5,5 +5,10 @@
 
 set -e
 
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-pip install --no-cache-dir git+https://github.com/tenstorrent/tt-smi.git
+SM_VERSION="3.0.27"
+SM_WHEEL="tt_smi-${SM_VERSION}-py3-none-any.whl"
+
+wget -O ${SM_WHEEL} \
+    https://github.com/tenstorrent/tt-smi/releases/download/v${SM_VERSION}/${SM_WHEEL}
+pip install --no-cache-dir ${SM_WHEEL}
+rm ${SM_WHEEL}

--- a/.github/scripts/install-smi.sh
+++ b/.github/scripts/install-smi.sh
@@ -9,6 +9,6 @@ TT_SMI_VERSION="3.0.27"
 TT_SMI_WHEEL="tt_smi-${TT_SMI_VERSION}-py3-none-any.whl"
 
 wget -O ${TT_SMI_WHEEL} \
-    https://github.com/tenstorrent/tt-smi/releases/download/v${TT_SMI_VERSION}/${TT_SMI_WHEEL}
+    https://github.com/tenstorrent/tt-smi/releases/download/v${TT_SMI_VERSION}/${TT_SMI_WHEEL} || exit 1
 pip install --no-cache-dir ${TT_SMI_WHEEL}
 rm ${TT_SMI_WHEEL}

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          fetch-depth: 200
 
       - name: Log in to Docker registry
         uses: docker/login-action@v3

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 1
 
       - name: Log in to Docker registry
         uses: docker/login-action@v3

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0  # Fetch all history so 'origin/main' is available
+          fetch-depth: 1
 
       - name: Detect which directories changed
         uses: dorny/paths-filter@v3

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          fetch-depth: 200
 
       - name: Detect which directories changed
         uses: dorny/paths-filter@v3

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0  # Fetch all history so 'origin/main' is available
+          fetch-depth: 1
 
       - name: Set up Python
         uses: actions/setup-python@v4

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          fetch-depth: 200
 
       - name: Set up Python
         uses: actions/setup-python@v4

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          fetch-depth: 200
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v4


### PR DESCRIPTION
### Ticket
None

### Problem description
This PR aims at replacing `pip install git+<repo>` of `tt-smi` with wheel-based installation for improved reliability and performance. This was made possible with completion of https://github.com/tenstorrent/tt-smi/issues/99
Key benefits:
- Pre-compiled wheels eliminate compilation time
- Consistent binaries across environments
- No build tools required in runtime containers
- Explicit wheel versions for reproducible builds

### What's changed
- Updated install scripts to use configurable wheel URLs
- Added version-based tag extraction for dynamic URL construction

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update