### PR TITLE
fix: use exalens to fetch architecture instead of tt-smi

### DIFF
--- a/tests/python_tests/helpers/chip_architecture.py
+++ b/tests/python_tests/helpers/chip_architecture.py
@@ -26,7 +26,7 @@ class ChipArchitecture(Enum):
 
 def get_chip_architecture():
     context = check_context()
-    if len(context.devices) == 0:
+    if not context.devices:
         raise RuntimeError(
             "No devices found. Please ensure a device is connected and tt-smi is working correctly."
         )


### PR DESCRIPTION
### Ticket
None

### Problem description
This PR updates the chip architecture detection mechanism to use the `tt-exalens` instead of the `tt-smi` command-line tool. The change simplifies the architecture detection process by leveraging a direct Python API rather than executing external commands.

### What's changed
- Replaced tt-smi subprocess calls with `ttexalens.tt_exalens_lib.check_context()` function
- Removed complex subprocess handling and error management code

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update