### PR TITLE
ci: terminate obsolete merge group runs

### DIFF
--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -29,6 +29,7 @@ concurrency:
 
 jobs:
   pre-commit:
+    if: ${{ github.event.action != 'destroyed' }}
     name: "🔍 Static checks"
     uses: ./.github/workflows/pre-commit.yml
 

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -156,7 +156,7 @@ jobs:
     name: "🕳️ Perform checks (Blackhole)"
     uses: ./.github/workflows/setup-and-test.yml
     needs: [build-images, detect-changes]
-    if: ${{ (needs.detect-changes.outputs.wormhole == 'true' ||
+    if: ${{ (needs.detect-changes.outputs.blackhole == 'true' ||
             needs.detect-changes.outputs.tests == 'true' ||
             needs.detect-changes.outputs.github == 'true') &&
             github.event.action != 'destroyed' }}

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -35,6 +35,7 @@ jobs:
 
   detect-changes:
     name: "🔍 Detect changes"
+    if: ${{ github.event.action != 'destroyed' }}
     runs-on: ubuntu-latest
     needs: pre-commit
     outputs:
@@ -133,6 +134,7 @@ jobs:
 
   build-images:
     name: "🐳️ Docker setup"
+    if: ${{ github.event.action != 'destroyed' }}
     uses: ./.github/workflows/build-images.yml
     needs: pre-commit
     secrets: inherit
@@ -141,9 +143,10 @@ jobs:
     name: "🌀 Perform checks (Wormhole)"
     uses: ./.github/workflows/setup-and-test.yml
     needs: [build-images, detect-changes]
-    if: ${{ needs.detect-changes.outputs.wormhole == 'true' ||
+    if: ${{ (needs.detect-changes.outputs.wormhole == 'true' ||
             needs.detect-changes.outputs.tests == 'true' ||
-            needs.detect-changes.outputs.github == 'true' }}
+            needs.detect-changes.outputs.github == 'true') &&
+            github.event.action != 'destroyed' }}
     with:
       docker_image: ${{ needs.build-images.outputs.docker-image }}
       runs_on: tt-beta-ubuntu-2204-n150-large-stable
@@ -153,9 +156,10 @@ jobs:
     name: "🕳️ Perform checks (Blackhole)"
     uses: ./.github/workflows/setup-and-test.yml
     needs: [build-images, detect-changes]
-    if: ${{ needs.detect-changes.outputs.blackhole == 'true' ||
+    if: ${{ (needs.detect-changes.outputs.wormhole == 'true' ||
             needs.detect-changes.outputs.tests == 'true' ||
-            needs.detect-changes.outputs.github == 'true' }}
+            needs.detect-changes.outputs.github == 'true') &&
+            github.event.action != 'destroyed' }}
     with:
       docker_image: ${{ needs.build-images.outputs.docker-image }}
       runs_on: tt-beta-ubuntu-2204-p150b-large-stable

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -7,6 +7,9 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
     branches: ["main"]
   merge_group:
+    types:
+      - checks_requested
+      - destroyed
 
 permissions:
   checks: write


### PR DESCRIPTION
### Ticket
None

### Problem description

Assume there are 3 PRs --- PR1, PR2 and PR3, and there is a workflow to run to get the required checks. When all PRs queued in the merge queue, 3 workflows started.
workflow 1 running on main + PR1
workflow 2 running on main + PR1 + PR2
workflow 3 running on main + PR1 + PR2 + PR3

Now, if we want to move PR3 to be at the head of the queue, 3 new workflows will start:
workflow 4 running on main + PR3
workflow 5 running on main + PR3 + PR1
workflow 6 running on main + PR3 + PR1 + PR2

When this happens, workflow 1, 2 and 3 should be cancelled automatically because the results are irrelevant at this point.
However, currently this is not done automatically.

### What's changed
Added checks to prevent running orphaned builds.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
