### PR TITLE
ci: cancel all metal-post-commit workflows except last

### DIFF
--- a/.github/workflows/trigger-tt-metal-post-commit.yml
+++ b/.github/workflows/trigger-tt-metal-post-commit.yml
@@ -11,7 +11,7 @@ on:
         type: number
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.inputs.pr_number }}
+  group: post-commit-tests-${{ github.event.pull_request.number || github.event.inputs.pr_number }}
   cancel-in-progress: true
 
 permissions:


### PR DESCRIPTION
### Ticket
None

### Problem description
Cancelling of workflows in progress wasn't working due to having special UTF characters (🚀) in workflow name.

### What's changed
Renamed concurrency group.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update