### PR TITLE
ci: switch workflow to main branch

### DIFF
--- a/.github/workflows/trigger-tt-metal-post-commit.yml
+++ b/.github/workflows/trigger-tt-metal-post-commit.yml
@@ -221,7 +221,7 @@ jobs:
       github.event_name == 'workflow_dispatch') &&
       needs.detect-changes.result == 'success' &&
       needs.detect-changes.outputs.should-skip != 'true'
-    uses: tenstorrent/tt-metal/.github/workflows/test-llk-metal-integration.yaml@fvranic/fix-workflow
+    uses: tenstorrent/tt-metal/.github/workflows/test-llk-metal-integration.yaml@main
     secrets: inherit
     with:
       mirrored_branch: ${{ needs.setup-branch.outputs.branch-to-run }}


### PR DESCRIPTION
### Ticket
None

### Problem description
With all the fixes now merged into tt-metal, it's time to switch to using the tt-metal workflow from the main branch.

### What's changed
Implemented workflow cancellation. When a newer workflow is started, the old one will be cancelled. This time, workflows spanned by the cancelled workflow will be cancelled as well, so we won't be leaving orphaned runs that consume CPU.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update