### PR TITLE
[Test Infra] Sweep dst_index for multiple tiles across math_matmul API

### DIFF
--- a/tests/python_tests/helpers/test_config.py
+++ b/tests/python_tests/helpers/test_config.py
@@ -147,6 +147,10 @@ def generate_build_header(
     else:
         header_content.append(f"constexpr std::uint32_t TILE_SIZE = 128;")
 
+    # Dest Register Index
+    dst_index = test_config.get("dst_index", 0)
+    header_content.append(f"constexpr std::uint32_t DST_INDEX = {dst_index};")
+
     # Fused Test L1 to L1 : Input of first run is used as input for the second run ...
     # Not fusing: single L1-to-L1 iteration, so we retrieve one format configuration
     # L1_to_L1_iterations is the number of times we perform llk operations from L1 input tensor to L1 output tensor

--- a/tests/python_tests/helpers/test_config.py
+++ b/tests/python_tests/helpers/test_config.py
@@ -20,7 +20,7 @@ from .format_arg_mapping import (
     Transpose,
     format_tile_sizes,
 )
-from .format_config import FormatConfig, InputOutputFormat
+from .format_config import DataFormat, FormatConfig, InputOutputFormat
 from .utils import run_shell_command
 
 
@@ -137,6 +137,15 @@ def generate_build_header(
     header_content.append(
         f"constexpr auto STOCHASTIC_RND = ckernel::{stochastic_rnd.value};"
     )
+
+    # tile_size i.e num rows in a tile
+    formats = test_config["formats"]
+    if formats.output_format == DataFormat.Bfp8_b:
+        header_content.append(f"constexpr std::uint32_t TILE_SIZE = 68;")
+    elif formats.output_format == DataFormat.Float32:
+        header_content.append(f"constexpr std::uint32_t TILE_SIZE = 256;")
+    else:
+        header_content.append(f"constexpr std::uint32_t TILE_SIZE = 128;")
 
     # Fused Test L1 to L1 : Input of first run is used as input for the second run ...
     # Not fusing: single L1-to-L1 iteration, so we retrieve one format configuration

--- a/tests/python_tests/test_math_matmul.py
+++ b/tests/python_tests/test_math_matmul.py
@@ -7,8 +7,10 @@ from helpers.device import (
     collect_results,
     write_stimuli_to_l1,
 )
+from helpers.dimensions import (
+    calculate_matmul_dimensions,
+)
 from helpers.format_arg_mapping import (
-    DestAccumulation,
     MathFidelity,
     Transpose,
     format_dict,
@@ -20,6 +22,7 @@ from helpers.golden_generators import (
     get_golden_generator,
 )
 from helpers.param_config import (
+    generate_format_aware_matmul_combinations,
     input_output_formats,
     parametrize,
 )
@@ -28,17 +31,18 @@ from helpers.test_config import run_test
 from helpers.tilize_untilize import tilize_block
 from helpers.utils import passed_test
 
+MATMUL_FORMATS = input_output_formats(
+    [
+        DataFormat.Float16_b,
+        DataFormat.Float16,
+        DataFormat.Float32,
+    ]
+)
+ALL_MATMUL_COMBINATIONS = generate_format_aware_matmul_combinations(MATMUL_FORMATS)
+
 
 @parametrize(
     test_name="math_matmul_test",
-    formats=input_output_formats(
-        [
-            DataFormat.Float16_b,
-            DataFormat.Float16,
-            DataFormat.Float32,
-        ]
-    ),
-    dest_acc=[DestAccumulation.No, DestAccumulation.Yes],
     math_fidelity=[
         MathFidelity.LoFi,
         MathFidelity.HiFi2,
@@ -46,60 +50,73 @@ from helpers.utils import passed_test
         MathFidelity.HiFi4,
     ],
     transpose=[Transpose.Yes, Transpose.No],
+    format_dest_acc_and_dims=ALL_MATMUL_COMBINATIONS,
     throttle=list(
         range(0, 6)
     ),  # Throttle levels include 1-->5, level 0 doesn't throttle
 )
-def test_matmul(test_name, formats, dest_acc, math_fidelity, transpose, throttle):
+def test_matmul(
+    test_name, math_fidelity, transpose, format_dest_acc_and_dims, throttle
+):
+
+    formats = format_dest_acc_and_dims[0]
+    dest_acc = format_dest_acc_and_dims[1]
+    input_A_dimensions = format_dest_acc_and_dims[2][0]
+    input_B_dimensions = format_dest_acc_and_dims[2][1]
 
     torch_format = format_dict[formats.output_format]
 
-    input_dimensions = [32, 32]  # Will be sweeping over dimensions
+    # Calculate all matmul dimensions using helper function
+    matmul_dims = calculate_matmul_dimensions(input_A_dimensions, input_B_dimensions)
 
-    src_A, src_B, tile_cnt = generate_stimuli(
-        formats.input_format, formats.input_format, input_dimensions=input_dimensions
+    src_A, _, tile_cnt_A = generate_stimuli(
+        formats.input_format,
+        formats.input_format,
+        input_dimensions=input_A_dimensions,
+        sfpu=False,
     )
-    src_B_golden = src_B
+
+    src_B, _, tile_cnt_B = generate_stimuli(
+        formats.input_format,
+        formats.input_format,
+        input_dimensions=input_B_dimensions,
+        sfpu=False,
+    )
+
     if transpose == Transpose.Yes:
-        # In hw we tilize inputs for matmul and then transpose on src_B
-        # We must first tilize src_B before transpose + haloize
-        # However, torch works with row major data so we untilize this for now in order to properly compute golden
         t_matrix = get_golden_generator(TransposeGolden)
-        src_B_golden = t_matrix.transpose_faces(
-            src_B, formats.input_format, tilize=True, input_dimensions=input_dimensions
+
+        src_B_golden = t_matrix.transpose_faces_multi_tile(
+            src_B,
+            formats.input_format,
+            num_tiles=tile_cnt_B,
+            tilize=True,
+            input_dimensions=input_B_dimensions,
         )
-        src_B_golden = t_matrix.transpose_within_faces(
+        src_B_golden = t_matrix.transpose_within_faces_multi_tile(
             src_B_golden,
             formats.input_format,
+            num_tiles=tile_cnt_B,
             untilize=True,
-            input_dimensions=input_dimensions,
+            input_dimensions=input_B_dimensions,
         )
 
     generate_golden = get_golden_generator(MatmulGolden)
     golden_tensor = generate_golden(
-        src_A,  # not tilized
-        src_B_golden,  # needs to be transposed and tilized
+        src_A,
+        src_B_golden,
         formats.output_format,
         math_fidelity,
-        input_A_dimensions=input_dimensions,
-        input_B_dimensions=input_dimensions,
-    )
-    # Golden cannot model FPU strided for tilized data computation, so we tilize output after computation
-    golden_tensor = (
-        tilize_block(
-            golden_tensor,
-            dimensions=input_dimensions,
-            stimuli_format=formats.output_format,
-        )
-        .to(torch_format)
-        .flatten()
+        input_A_dimensions=input_A_dimensions,
+        input_B_dimensions=input_B_dimensions,
+        tilize=True,  # Golden cannot model FPU strided for tilized data computation, so we tilize output after computation
     )
 
     tilized_A = tilize_block(
-        src_A, dimensions=input_dimensions, stimuli_format=formats.input_format
+        src_A, dimensions=input_A_dimensions, stimuli_format=formats.input_format
     )
     tilized_B = tilize_block(
-        src_B, dimensions=input_dimensions, stimuli_format=formats.input_format
+        src_B, dimensions=input_B_dimensions, stimuli_format=formats.input_format
     )
 
     test_config = {
@@ -107,9 +124,13 @@ def test_matmul(test_name, formats, dest_acc, math_fidelity, transpose, throttle
         "testname": test_name,
         "dest_acc": dest_acc,
         "math_fidelity": math_fidelity,
-        "tile_cnt": tile_cnt,
-        "input_A_dimensions": input_dimensions,
-        "input_B_dimensions": input_dimensions,
+        "tile_cnt": matmul_dims["output_tile_cnt"],
+        "input_A_dimensions": input_A_dimensions,
+        "input_B_dimensions": input_B_dimensions,
+        "output_dimensions": matmul_dims["output_dimensions"],
+        "rt_dim": matmul_dims["rt_dim"],
+        "ct_dim": matmul_dims["ct_dim"],
+        "kt_dim": matmul_dims["kt_dim"],
         "unpack_transpose_faces": transpose.value,
         "unpack_transpose_within_face": transpose.value,  # matmul transposes both faces and within faces, there is no option for one or the other
         "throttle": throttle,
@@ -121,13 +142,15 @@ def test_matmul(test_name, formats, dest_acc, math_fidelity, transpose, throttle
         tilized_B.flatten(),
         formats.input_format,
         formats.input_format,
-        tile_count_A=tile_cnt,
-        tile_count_B=tile_cnt,
+        tile_count_A=tile_cnt_A,
+        tile_count_B=tile_cnt_B,
     )
 
     run_test(test_config)
 
-    res_from_L1 = collect_results(formats, tile_count=tile_cnt, address=res_address)
+    res_from_L1 = collect_results(
+        formats, tile_count=matmul_dims["output_tile_cnt"], address=res_address
+    )
     assert len(res_from_L1) == len(golden_tensor)
 
     res_tensor = torch.tensor(res_from_L1, dtype=torch_format)

--- a/tests/python_tests/test_math_matmul.py
+++ b/tests/python_tests/test_math_matmul.py
@@ -63,7 +63,7 @@ def test_matmul(
     dest_acc = format_dest_acc_and_dims[1]
     input_A_dimensions = format_dest_acc_and_dims[2][0]
     input_B_dimensions = format_dest_acc_and_dims[2][1]
-
+    dst_index = format_dest_acc_and_dims[3]
     torch_format = format_dict[formats.output_format]
 
     # Calculate all matmul dimensions using helper function
@@ -123,6 +123,7 @@ def test_matmul(
         "formats": formats,
         "testname": test_name,
         "dest_acc": dest_acc,
+        "dst_index": dst_index,
         "math_fidelity": math_fidelity,
         "tile_cnt": matmul_dims["output_tile_cnt"],
         "input_A_dimensions": input_A_dimensions,

--- a/tests/python_tests/test_matmul.py
+++ b/tests/python_tests/test_matmul.py
@@ -77,13 +77,8 @@ def test_matmul(test_name, math_fidelity, format_dest_acc_and_dims):
         math_fidelity,
         input_A_dimensions=input_A_dimensions,
         input_B_dimensions=input_B_dimensions,
+        tilize=True,  # Golden cannot model FPU strided for tilized data computation, so we tilize output after computation
     )
-    golden_tensor = tilize_block(
-        golden_tensor,
-        dimensions=matmul_dims["output_dimensions"],
-        stimuli_format=formats.output_format,
-    ).to(torch_format)
-    golden_tensor = golden_tensor.flatten()
 
     if formats.input_format != DataFormat.Bfp8_b:
         tilized_A = tilize_block(

--- a/tests/python_tests/test_matmul.py
+++ b/tests/python_tests/test_matmul.py
@@ -52,6 +52,7 @@ def test_matmul(test_name, math_fidelity, format_dest_acc_and_dims):
     dest_acc = format_dest_acc_and_dims[1]
     input_A_dimensions = format_dest_acc_and_dims[2][0]
     input_B_dimensions = format_dest_acc_and_dims[2][1]
+    dst_index = format_dest_acc_and_dims[3]
 
     src_A, _, tile_cnt_A = generate_stimuli(
         formats.input_format,
@@ -104,6 +105,7 @@ def test_matmul(test_name, math_fidelity, format_dest_acc_and_dims):
         "rt_dim": matmul_dims["rt_dim"],
         "ct_dim": matmul_dims["ct_dim"],
         "kt_dim": matmul_dims["kt_dim"],
+        "dst_index": dst_index,
     }
 
     # Use the new helper function for writing stimuli

--- a/tests/python_tests/test_unpack_matmul.py
+++ b/tests/python_tests/test_unpack_matmul.py
@@ -58,7 +58,7 @@ ALL_MATMUL_COMBINATIONS = generate_format_aware_matmul_combinations(MATMUL_FORMA
         StochasticRounding.All,
         StochasticRounding.No,
     ],
-    transpose=[Transpose.Yes],
+    transpose=[Transpose.Yes, Transpose.No],
     format_dest_acc_and_dims=ALL_MATMUL_COMBINATIONS,
 )
 def test_matmul(

--- a/tests/python_tests/test_unpack_matmul.py
+++ b/tests/python_tests/test_unpack_matmul.py
@@ -7,8 +7,10 @@ from helpers.device import (
     collect_results,
     write_stimuli_to_l1,
 )
+from helpers.dimensions import (
+    calculate_matmul_dimensions,
+)
 from helpers.format_arg_mapping import (
-    DestAccumulation,
     MathFidelity,
     StochasticRounding,
     Transpose,
@@ -21,6 +23,7 @@ from helpers.golden_generators import (
     get_golden_generator,
 )
 from helpers.param_config import (
+    generate_format_aware_matmul_combinations,
     input_output_formats,
     parametrize,
 )
@@ -29,17 +32,20 @@ from helpers.test_config import run_test
 from helpers.tilize_untilize import tilize_block
 from helpers.utils import passed_test
 
+# Generate format-aware combinations
+MATMUL_FORMATS = input_output_formats(
+    [
+        DataFormat.Float16_b,
+        DataFormat.Float16,
+        DataFormat.Float32,
+    ]
+)
+
+ALL_MATMUL_COMBINATIONS = generate_format_aware_matmul_combinations(MATMUL_FORMATS)
+
 
 @parametrize(
     test_name="unpack_matmul_test",
-    formats=input_output_formats(
-        [
-            DataFormat.Float16_b,
-            DataFormat.Float16,
-            DataFormat.Float32,
-        ]
-    ),
-    dest_acc=[DestAccumulation.No, DestAccumulation.Yes],
     math_fidelity=[
         MathFidelity.LoFi,
         MathFidelity.HiFi2,
@@ -52,31 +58,52 @@ from helpers.utils import passed_test
         StochasticRounding.All,
         StochasticRounding.No,
     ],
-    transpose=[Transpose.Yes, Transpose.No],
+    transpose=[Transpose.Yes],
+    format_dest_acc_and_dims=ALL_MATMUL_COMBINATIONS,
 )
-def test_matmul(test_name, formats, dest_acc, math_fidelity, stochastic_rnd, transpose):
+def test_matmul(
+    test_name, math_fidelity, stochastic_rnd, transpose, format_dest_acc_and_dims
+):
+
+    formats = format_dest_acc_and_dims[0]
+    dest_acc = format_dest_acc_and_dims[1]
+    input_A_dimensions = format_dest_acc_and_dims[2][0]
+    input_B_dimensions = format_dest_acc_and_dims[2][1]
 
     torch_format = format_dict[formats.output_format]
 
-    input_dimensions = [32, 32]  # Will be sweeping over dimensions
+    # Calculate all matmul dimensions using helper function
+    matmul_dims = calculate_matmul_dimensions(input_A_dimensions, input_B_dimensions)
 
-    src_A, src_B, tile_cnt = generate_stimuli(
-        formats.input_format, formats.input_format, input_dimensions=input_dimensions
+    src_A, _, tile_cnt_A = generate_stimuli(
+        formats.input_format,
+        formats.input_format,
+        input_dimensions=input_A_dimensions,
+        sfpu=False,
     )
-    src_B_golden = src_B
+    src_B, _, tile_cnt_B = generate_stimuli(
+        formats.input_format,
+        formats.input_format,
+        input_dimensions=input_B_dimensions,
+        sfpu=False,
+    )
+
     if transpose == Transpose.Yes:
-        # In hw we tilize inputs for matmul and then transpose on src_B
-        # We must first tilize src_B before transpose + haloize
-        # However, torch works with row major data so we untilize this for now in order to properly compute golden
         t_matrix = get_golden_generator(TransposeGolden)
-        src_B_golden = t_matrix.transpose_faces(
-            src_B, formats.input_format, tilize=True, input_dimensions=input_dimensions
+
+        src_B_golden = t_matrix.transpose_faces_multi_tile(
+            src_B,
+            formats.input_format,
+            num_tiles=tile_cnt_B,
+            tilize=True,
+            input_dimensions=input_B_dimensions,
         )
-        src_B_golden = t_matrix.transpose_within_faces(
+        src_B_golden = t_matrix.transpose_within_faces_multi_tile(
             src_B_golden,
             formats.input_format,
+            num_tiles=tile_cnt_B,
             untilize=True,
-            input_dimensions=input_dimensions,
+            input_dimensions=input_B_dimensions,
         )
 
     generate_golden = get_golden_generator(MatmulGolden)
@@ -85,25 +112,16 @@ def test_matmul(test_name, formats, dest_acc, math_fidelity, stochastic_rnd, tra
         src_B_golden,  # needs to be transposed and tilized
         formats.output_format,
         math_fidelity,
-        input_A_dimensions=input_dimensions,
-        input_B_dimensions=input_dimensions,
-    )
-    # Golden cannot model FPU strided for tilized data computation, so we tilize output after computation
-    golden_tensor = (
-        tilize_block(
-            golden_tensor,
-            dimensions=input_dimensions,
-            stimuli_format=formats.output_format,
-        )
-        .to(torch_format)
-        .flatten()
+        input_A_dimensions=input_A_dimensions,
+        input_B_dimensions=input_B_dimensions,
+        tilize=True,  # Golden cannot model FPU strided for tilized data computation, so we tilize output after computation
     )
 
     tilized_A = tilize_block(
-        src_A, dimensions=input_dimensions, stimuli_format=formats.input_format
+        src_A, dimensions=input_A_dimensions, stimuli_format=formats.input_format
     )
     tilized_B = tilize_block(
-        src_B, dimensions=input_dimensions, stimuli_format=formats.input_format
+        src_B, dimensions=input_B_dimensions, stimuli_format=formats.input_format
     )
 
     test_config = {
@@ -111,9 +129,13 @@ def test_matmul(test_name, formats, dest_acc, math_fidelity, stochastic_rnd, tra
         "testname": test_name,
         "dest_acc": dest_acc,
         "math_fidelity": math_fidelity,
-        "tile_cnt": tile_cnt,
-        "input_A_dimensions": input_dimensions,
-        "input_B_dimensions": input_dimensions,
+        "tile_cnt": matmul_dims["output_tile_cnt"],
+        "input_A_dimensions": input_A_dimensions,
+        "input_B_dimensions": input_B_dimensions,
+        "output_dimensions": matmul_dims["output_dimensions"],
+        "rt_dim": matmul_dims["rt_dim"],
+        "ct_dim": matmul_dims["ct_dim"],
+        "kt_dim": matmul_dims["kt_dim"],
         "stochastic_rnd": stochastic_rnd,
         "unpack_transpose_faces": transpose.value,
         "unpack_transpose_within_face": transpose.value,  # matmul transposes both faces and within faces, there is no option for one or the other
@@ -125,13 +147,15 @@ def test_matmul(test_name, formats, dest_acc, math_fidelity, stochastic_rnd, tra
         tilized_B.flatten(),
         formats.input_format,
         formats.input_format,
-        tile_count_A=tile_cnt,
-        tile_count_B=tile_cnt,
+        tile_count_A=tile_cnt_A,
+        tile_count_B=tile_cnt_B,
     )
 
     run_test(test_config)
 
-    res_from_L1 = collect_results(formats, tile_count=tile_cnt, address=res_address)
+    res_from_L1 = collect_results(
+        formats, tile_count=matmul_dims["output_tile_cnt"], address=res_address
+    )
     assert len(res_from_L1) == len(golden_tensor)
 
     res_tensor = torch.tensor(res_from_L1, dtype=torch_format)

--- a/tests/sources/math_matmul_test.cpp
+++ b/tests/sources/math_matmul_test.cpp
@@ -21,19 +21,9 @@ uint32_t math_sync_tile_dst_index = 0;
 
 void run_kernel()
 {
-    std::uint32_t ct_dim    = CT_DIM;
-    std::uint32_t rt_dim    = RT_DIM;
-    std::uint32_t kt_dim    = KT_DIM; // for square matrices, kt_dim == ct_dim
-    std::uint32_t tile_size = 128;
-
-    if constexpr (static_cast<DataFormat>(formats.unpack_src) == DataFormat::Bfp8_b)
-    {
-        tile_size = 68;
-    }
-    else if constexpr (static_cast<DataFormat>(formats.unpack_src) == DataFormat::Float32)
-    {
-        tile_size = 256;
-    }
+    std::uint32_t ct_dim = CT_DIM;
+    std::uint32_t rt_dim = RT_DIM;
+    std::uint32_t kt_dim = KT_DIM; // for square matrices, kt_dim == ct_dim
 
     _llk_unpack_AB_matmul_hw_configure_<is_fp32_dest_acc_en, StochRndType::None>(
         formats.unpack_src,
@@ -45,8 +35,8 @@ void run_kernel()
         UNPACK_TRANSPOSE_WITHIN_FACE,
         4,
         4,
-        tile_size,
-        tile_size);
+        TILE_SIZE,
+        TILE_SIZE);
     _llk_unpack_AB_matmul_init_<>(UNPACK_TRANSPOSE_FACES, ct_dim, rt_dim, kt_dim, FACE_R_DIM, FACE_R_DIM);
     for (uint32_t j = 0; j < kt_dim; j++)
     {
@@ -55,8 +45,8 @@ void run_kernel()
             L1_ADDRESS(buffer_B[0]),
             j,
             j * ct_dim,
-            tile_size,
-            tile_size,
+            TILE_SIZE,
+            TILE_SIZE,
             FACE_R_DIM,
             FACE_R_DIM,
             false,

--- a/tests/sources/math_matmul_test.cpp
+++ b/tests/sources/math_matmul_test.cpp
@@ -78,7 +78,7 @@ void run_kernel()
     _llk_math_wait_for_dest_available_<DstSync::SyncHalf>();
     for (uint32_t j = 0; j < kt_dim; j++)
     {
-        _llk_math_matmul_<MATH_FIDELITY, DstTileFaceLayout::RowMajor, THROTTLE_LEVEL>(0, UNPACK_TRANSPOSE_FACES, ct_dim, rt_dim, kt_dim);
+        _llk_math_matmul_<MATH_FIDELITY, DstTileFaceLayout::RowMajor, THROTTLE_LEVEL>(DST_INDEX, UNPACK_TRANSPOSE_FACES, ct_dim, rt_dim, kt_dim);
     }
 
     _llk_math_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
@@ -107,7 +107,7 @@ void run_kernel()
     for (int i = 0; i < TILE_CNT; i++)
     {
         _llk_packer_wait_for_math_done_();
-        _llk_pack_<DstSync::SyncHalf, is_fp32_dest_acc_en, false>(i, L1_ADDRESS(buffer_Res[i]));
+        _llk_pack_<DstSync::SyncHalf, is_fp32_dest_acc_en, false>(DST_INDEX + i, L1_ADDRESS(buffer_Res[i]));
     }
     _llk_pack_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
 }

--- a/tests/sources/math_matmul_test.cpp
+++ b/tests/sources/math_matmul_test.cpp
@@ -21,9 +21,9 @@ uint32_t math_sync_tile_dst_index = 0;
 
 void run_kernel()
 {
-    std::uint32_t ct_dim    = BLOCK_CT_DIM;
-    std::uint32_t rt_dim    = BLOCK_RT_DIM;
-    std::uint32_t kt_dim    = BLOCK_CT_DIM; // for square matrices, kt_dim == ct_dim
+    std::uint32_t ct_dim    = CT_DIM;
+    std::uint32_t rt_dim    = RT_DIM;
+    std::uint32_t kt_dim    = KT_DIM; // for square matrices, kt_dim == ct_dim
     std::uint32_t tile_size = 128;
 
     if constexpr (static_cast<DataFormat>(formats.unpack_src) == DataFormat::Bfp8_b)
@@ -77,9 +77,9 @@ void run_kernel()
 
 void run_kernel()
 {
-    std::uint32_t ct_dim = BLOCK_CT_DIM;
-    std::uint32_t rt_dim = BLOCK_RT_DIM;
-    std::uint32_t kt_dim = BLOCK_CT_DIM; // for square matrices, kt_dim == ct_dim
+    std::uint32_t ct_dim = CT_DIM;
+    std::uint32_t rt_dim = RT_DIM;
+    std::uint32_t kt_dim = KT_DIM; // for square matrices, kt_dim == ct_dim
 
     _llk_math_matmul_init_<MATH_FIDELITY, DstTileFaceLayout::RowMajor, THROTTLE_LEVEL>(
         TILE_R_DIM, TILE_C_DIM, TILE_R_DIM, TILE_C_DIM, false, UNPACK_TRANSPOSE_FACES, ct_dim, rt_dim, kt_dim);

--- a/tests/sources/matmul_test.cpp
+++ b/tests/sources/matmul_test.cpp
@@ -25,19 +25,8 @@ void run_kernel()
     std::uint32_t rt_dim = RT_DIM;
     std::uint32_t kt_dim = KT_DIM;
 
-    std::uint32_t tile_size = 128;
-
-    if constexpr (static_cast<DataFormat>(formats.unpack_src) == DataFormat::Bfp8_b)
-    {
-        tile_size = 68;
-    }
-    else if constexpr (static_cast<DataFormat>(formats.unpack_src) == DataFormat::Float32)
-    {
-        tile_size = 256;
-    }
-
     _llk_unpack_AB_matmul_hw_configure_<is_fp32_dest_acc_en, StochRndType::None>(
-        formats.unpack_src, formats.unpack_src, formats.unpack_dst, formats.unpack_dst, FACE_R_DIM, FACE_R_DIM, 0, 4, 4, tile_size, tile_size);
+        formats.unpack_src, formats.unpack_src, formats.unpack_dst, formats.unpack_dst, FACE_R_DIM, FACE_R_DIM, 0, 4, 4, TILE_SIZE, TILE_SIZE);
     _llk_unpack_AB_matmul_init_<>(0, ct_dim, rt_dim, kt_dim, FACE_R_DIM, FACE_R_DIM);
     for (uint32_t j = 0; j < kt_dim; j++)
     {
@@ -46,8 +35,8 @@ void run_kernel()
             L1_ADDRESS(buffer_B[0]),
             j,
             j * ct_dim,
-            tile_size,
-            tile_size,
+            TILE_SIZE,
+            TILE_SIZE,
             FACE_R_DIM,
             FACE_R_DIM,
             false,
@@ -93,23 +82,12 @@ void run_kernel()
 
 void run_kernel()
 {
-    std::uint32_t tile_size = 128;
-
-    if constexpr (static_cast<DataFormat>(formats.pack_dst) == DataFormat::Bfp8_b)
-    {
-        tile_size = 68;
-    }
-    else if constexpr (static_cast<DataFormat>(formats.pack_dst) == DataFormat::Float32)
-    {
-        tile_size = 256;
-    }
-
 #ifdef ARCH_BLACKHOLE
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, false, false>(formats.pack_src, formats.pack_dst, tile_size);
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, false, false>(formats.pack_src, formats.pack_dst, TILE_SIZE);
     _llk_pack_init_<false, false, DstTileFaceLayout::RowMajor, false, false>(formats.pack_dst);
     _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en, DstTileFaceLayout::RowMajor>();
 #else
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, false>(formats.pack_src, formats.pack_dst, tile_size);
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, false>(formats.pack_src, formats.pack_dst, TILE_SIZE);
     _llk_pack_init_<false, false, DstTileFaceLayout::RowMajor, false>(formats.pack_dst);
     _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en, DstTileFaceLayout::RowMajor, false>();
 #endif

--- a/tests/sources/unpack_matmul_test.cpp
+++ b/tests/sources/unpack_matmul_test.cpp
@@ -25,17 +25,6 @@ void run_kernel()
     std::uint32_t rt_dim = RT_DIM;
     std::uint32_t kt_dim = KT_DIM; // for square matrices, kt_dim == ct_dim
 
-    std::uint32_t tile_size = 128;
-
-    if constexpr (static_cast<DataFormat>(formats.unpack_src) == DataFormat::Bfp8_b)
-    {
-        tile_size = 68;
-    }
-    else if constexpr (static_cast<DataFormat>(formats.unpack_src) == DataFormat::Float32)
-    {
-        tile_size = 256;
-    }
-
     _llk_unpack_AB_matmul_hw_configure_<is_fp32_dest_acc_en, STOCHASTIC_RND>(
         formats.unpack_src,
         formats.unpack_src,
@@ -46,8 +35,8 @@ void run_kernel()
         UNPACK_TRANSPOSE_WITHIN_FACE,
         4,
         4,
-        tile_size,
-        tile_size);
+        TILE_SIZE,
+        TILE_SIZE);
     _llk_unpack_AB_matmul_init_<>(UNPACK_TRANSPOSE_FACES, ct_dim, rt_dim, kt_dim, FACE_R_DIM, FACE_R_DIM);
     for (uint32_t j = 0; j < kt_dim; j++)
     {
@@ -56,8 +45,8 @@ void run_kernel()
             L1_ADDRESS(buffer_B[0]),
             j,
             j * ct_dim,
-            tile_size,
-            tile_size,
+            TILE_SIZE,
+            TILE_SIZE,
             FACE_R_DIM,
             FACE_R_DIM,
             false,

--- a/tests/sources/unpack_matmul_test.cpp
+++ b/tests/sources/unpack_matmul_test.cpp
@@ -21,9 +21,9 @@ uint32_t math_sync_tile_dst_index = 0;
 
 void run_kernel()
 {
-    std::uint32_t ct_dim = BLOCK_CT_DIM;
-    std::uint32_t rt_dim = BLOCK_RT_DIM;
-    std::uint32_t kt_dim = BLOCK_CT_DIM; // for square matrices, kt_dim == ct_dim
+    std::uint32_t ct_dim = CT_DIM;
+    std::uint32_t rt_dim = RT_DIM;
+    std::uint32_t kt_dim = KT_DIM; // for square matrices, kt_dim == ct_dim
 
     std::uint32_t tile_size = 128;
 
@@ -78,9 +78,9 @@ void run_kernel()
 
 void run_kernel()
 {
-    std::uint32_t ct_dim = BLOCK_CT_DIM;
-    std::uint32_t rt_dim = BLOCK_RT_DIM;
-    std::uint32_t kt_dim = BLOCK_CT_DIM; // for square matrices, kt_dim == ct_dim
+    std::uint32_t ct_dim = CT_DIM;
+    std::uint32_t rt_dim = RT_DIM;
+    std::uint32_t kt_dim = KT_DIM; // for square matrices, kt_dim == ct_dim
 
     _llk_math_matmul_init_<MATH_FIDELITY, DstTileFaceLayout::RowMajor>(
         TILE_R_DIM, TILE_C_DIM, TILE_R_DIM, TILE_C_DIM, false, UNPACK_TRANSPOSE_FACES, ct_dim, rt_dim, kt_dim);


### PR DESCRIPTION
### Ticket
<!-- Link to Github Issue -->
https://github.com/orgs/tenstorrent/projects/123/views/1?pane=issue&itemId=118348523&issue=tenstorrent%7Ctt-llk%7C453
### Problem description
<!-- Provide context for the problem. -->
The dst register can accommodate up to 8 tiles when configured with DstSync::SyncHalf. During a multi-tile sweep, we may store up to four 32-bit tiles or up to eight 16-bit tiles. Given x tiles to write, there are `8-x` available positions in the destination register. This addition performs a cross product of all dst indexing options and iterates through them to exhaustively test all valid configurations.
### What's changed
<!-- Describe the approach used to solve the problem.
Summarize the changes made and its impact. -->
Number of tests increased to 128,640 ‼️
### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update