### PR TITLE
ci: fetch cpu-only version of torch

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -25,5 +25,5 @@ pytest-timeout==2.4.0
 sympy==1.14.0
 termcolor==3.1.0
 tomli==2.2.1
-torch==2.7.1
+torch==2.8.0 --index-url https://download.pytorch.org/whl/cpu
 typing-extensions==4.14.1


### PR DESCRIPTION
### Ticket
None

### Problem description
This change updates requirements.txt to pin PyTorch and related packages to their CPU-only builds from the official PyTorch wheel index.
The goal is to reduce package size and avoid installing unnecessary CUDA dependencies. This should significantly reduce our Docker container size. 

### What's changed
Pinned torch to a newer version, without cuda support.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update