### PR TITLE
Extend relu impl to int support

### DIFF
--- a/tests/python_tests/helpers/format_arg_mapping.py
+++ b/tests/python_tests/helpers/format_arg_mapping.py
@@ -78,8 +78,10 @@ class MathOperation(Enum):
     Sqrt = OpSpec("sqrt", MathOpType.SFPU_UNARY)
     Square = OpSpec("square", MathOpType.SFPU_UNARY)
     Threshold = OpSpec("threshold", MathOpType.SFPU_UNARY)
-    ReluMax = OpSpec("relu_max", MathOpType.SFPU_UNARY)
-    ReluMin = OpSpec("relu_min", MathOpType.SFPU_UNARY)
+    ReluMax = OpSpec(
+        "relu_max", MathOpType.SFPU_UNARY
+    )  # ReLU_max(x, U) = max(0, min(x, U))
+    ReluMin = OpSpec("relu_min", MathOpType.SFPU_UNARY)  # ReLU_min(x, L) = max(x, L)
     # =============================================================================
     # SFPU BINARY OPERATIONS
     # =============================================================================

--- a/tests/python_tests/helpers/format_arg_mapping.py
+++ b/tests/python_tests/helpers/format_arg_mapping.py
@@ -78,6 +78,8 @@ class MathOperation(Enum):
     Sqrt = OpSpec("sqrt", MathOpType.SFPU_UNARY)
     Square = OpSpec("square", MathOpType.SFPU_UNARY)
     Threshold = OpSpec("threshold", MathOpType.SFPU_UNARY)
+    ReluMax = OpSpec("relu_max", MathOpType.SFPU_UNARY)
+    ReluMin = OpSpec("relu_min", MathOpType.SFPU_UNARY)
     # =============================================================================
     # SFPU BINARY OPERATIONS
     # =============================================================================

--- a/tests/python_tests/helpers/golden_generators.py
+++ b/tests/python_tests/helpers/golden_generators.py
@@ -650,6 +650,8 @@ class UnarySFPUGolden:
             MathOperation.Exp2: self._exp2,
             MathOperation.Hardsigmoid: self._hardsigmoid,
             MathOperation.Threshold: self._threshold,
+            MathOperation.ReluMax: self._relu_max,
+            MathOperation.ReluMin: self._relu_min,
         }
         self.data_format = None
         self.dest_acc = DestAccumulation.No
@@ -843,6 +845,22 @@ class UnarySFPUGolden:
             else torch.tensor(x, dtype=format_dict[self.data_format])
         )
         return torch.nn.functional.threshold(input_tensor, t, v).item()
+
+    def _relu_max(self, x, threshold=5):
+        input_tensor = (
+            x
+            if isinstance(x, torch.Tensor)
+            else torch.tensor(x, dtype=format_dict[self.data_format])
+        )
+        return torch.relu(torch.min(input_tensor, torch.tensor(threshold))).item()
+
+    def _relu_min(self, x, threshold=5):
+        input_tensor = (
+            x
+            if isinstance(x, torch.Tensor)
+            else torch.tensor(x, dtype=format_dict[self.data_format])
+        )
+        return torch.max(input_tensor, torch.tensor(threshold)).item()
 
 
 @register_golden

--- a/tests/python_tests/test_eltwise_unary_sfpu.py
+++ b/tests/python_tests/test_eltwise_unary_sfpu.py
@@ -59,6 +59,8 @@ from helpers.utils import passed_test
         MathOperation.Exp2,
         MathOperation.Hardsigmoid,
         MathOperation.Threshold,
+        MathOperation.ReluMax,
+        MathOperation.ReluMin,
     ],
     dest_acc=[DestAccumulation.No, DestAccumulation.Yes],
 )

--- a/tests/sources/eltwise_unary_sfpu_test.cpp
+++ b/tests/sources/eltwise_unary_sfpu_test.cpp
@@ -142,10 +142,10 @@ void call_sfpu_operation(SfpuType operation, uint32_t math_format)
             ckernel::sfpu::_calculate_threshold_<APPROX_MODE, iterations>(5.0f, 10.0f);
             break;
         case SfpuType::relu_max:
-            ckernel::sfpu::_relu_max_<APPROX_MODE, iterations>(5.0f);
+            ckernel::sfpu::_relu_max_<sfpi::vFloat, APPROX_MODE, iterations>(5.0f);
             break;
         case SfpuType::relu_min:
-            ckernel::sfpu::_relu_min_<APPROX_MODE, iterations>(5.0f);
+            ckernel::sfpu::_relu_min_<sfpi::vFloat, APPROX_MODE, iterations>(5.0f);
             break;
         default:
             return;

--- a/tests/sources/eltwise_unary_sfpu_test.cpp
+++ b/tests/sources/eltwise_unary_sfpu_test.cpp
@@ -141,6 +141,12 @@ void call_sfpu_operation(SfpuType operation, uint32_t math_format)
         case SfpuType::threshold:
             ckernel::sfpu::_calculate_threshold_<APPROX_MODE, iterations>(5.0f, 10.0f);
             break;
+        case SfpuType::relu_max:
+            ckernel::sfpu::_relu_max_<APPROX_MODE, iterations>(5.0f);
+            break;
+        case SfpuType::relu_min:
+            ckernel::sfpu::_relu_min_<APPROX_MODE, iterations>(5.0f);
+            break;
         default:
             return;
     }

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_relu.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_relu.h
@@ -135,7 +135,7 @@ inline void _relu_min_(T threshold)
     {
         if constexpr (std::is_same_v<VectorType, sfpi::vInt>)
         {
-            v_threshold = static_cast<int>(Converter::as_float(threshold));
+            v_threshold = static_cast<int>(threshold);
         }
         else
         {

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_relu.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_relu.h
@@ -76,25 +76,12 @@ inline void _relu_max_impl_(const int iterations, VecType threshold)
 }
 
 // Wrappers
-template <bool APPROXIMATION_MODE, int ITERATIONS, typename T>
+template <typename VectorType, bool APPROXIMATION_MODE, int ITERATIONS, typename T>
 inline void _relu_max_(T threshold)
 {
-    sfpi::vFloat v_threshold;
-    if constexpr (std::is_same_v<T, float>)
-    {
-        v_threshold = threshold;
-    }
-    else if constexpr (std::is_same_v<T, uint32_t>)
-    {
-        v_threshold = Converter::as_float(threshold);
-    }
-    _relu_max_impl_<APPROXIMATION_MODE, ITERATIONS, sfpi::vFloat>(ITERATIONS, v_threshold);
-}
+    static_assert(std::is_same_v<VectorType, sfpi::vFloat> || std::is_same_v<VectorType, sfpi::vInt>, "VectorType must be sfpi::vFloat or sfpi::vInt");
 
-template <bool APPROXIMATION_MODE, int ITERATIONS, typename T>
-inline void _relu_max_int_(T threshold)
-{
-    sfpi::vInt v_threshold;
+    VectorType v_threshold;
     if constexpr (std::is_same_v<T, float>)
     {
         v_threshold = threshold;
@@ -103,7 +90,12 @@ inline void _relu_max_int_(T threshold)
     {
         v_threshold = Converter::as_float(threshold);
     }
-    _relu_max_impl_<APPROXIMATION_MODE, ITERATIONS, sfpi::vInt>(ITERATIONS, v_threshold);
+    else
+    {
+        static_assert(std::is_same_v<T, float> || std::is_same_v<T, uint32_t>, "Threshold type must be float or uint32_t");
+    }
+
+    _relu_max_impl_<APPROXIMATION_MODE, ITERATIONS, VectorType>(ITERATIONS, v_threshold);
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS, typename VecType>
@@ -123,25 +115,12 @@ inline void _relu_min_impl_(const int iterations, VecType threshold)
 }
 
 // Wrappers
-template <bool APPROXIMATION_MODE, int ITERATIONS, typename T>
+template <typename VectorType, bool APPROXIMATION_MODE, int ITERATIONS, typename T>
 inline void _relu_min_(T threshold)
 {
-    sfpi::vFloat v_threshold;
-    if constexpr (std::is_same_v<T, float>)
-    {
-        v_threshold = threshold;
-    }
-    else if constexpr (std::is_same_v<T, uint32_t>)
-    {
-        v_threshold = Converter::as_float(threshold);
-    }
-    _relu_min_impl_<APPROXIMATION_MODE, ITERATIONS, sfpi::vFloat>(ITERATIONS, v_threshold);
-}
+    static_assert(std::is_same_v<VectorType, sfpi::vFloat> || std::is_same_v<VectorType, sfpi::vInt>, "VectorType must be sfpi::vFloat or sfpi::vInt");
 
-template <bool APPROXIMATION_MODE, int ITERATIONS, typename T>
-inline void _relu_min_int_(T threshold)
-{
-    sfpi::vInt v_threshold;
+    VectorType v_threshold;
     if constexpr (std::is_same_v<T, float>)
     {
         v_threshold = threshold;
@@ -150,7 +129,12 @@ inline void _relu_min_int_(T threshold)
     {
         v_threshold = Converter::as_float(threshold);
     }
-    _relu_min_impl_<APPROXIMATION_MODE, ITERATIONS, sfpi::vInt>(ITERATIONS, v_threshold);
+    else
+    {
+        static_assert(std::is_same_v<T, float> || std::is_same_v<T, uint32_t>, "Threshold type must be float or uint32_t");
+    }
+
+    _relu_min_impl_<APPROXIMATION_MODE, ITERATIONS, VectorType>(ITERATIONS, v_threshold);
 }
 
 } // namespace sfpu

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_relu.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_relu.h
@@ -54,7 +54,7 @@ sfpi_inline sfpi::vFloat _relu_max_body_(sfpi::vFloat val, sfpi::vFloat threshol
     return result;
 }
 
-template <bool APPROXIMATION_MODE, int ITERATIONS, typename VecType>
+template <typename VecType, bool APPROXIMATION_MODE, int ITERATIONS>
 inline void _relu_max_impl_(const int iterations, VecType threshold)
 {
     for (int d = 0; d < iterations; d++)
@@ -95,10 +95,10 @@ inline void _relu_max_(T threshold)
         static_assert(std::is_same_v<T, float> || std::is_same_v<T, uint32_t>, "Threshold type must be float or uint32_t");
     }
 
-    _relu_max_impl_<APPROXIMATION_MODE, ITERATIONS, VectorType>(ITERATIONS, v_threshold);
+    _relu_max_impl_<VectorType, APPROXIMATION_MODE, ITERATIONS>(ITERATIONS, v_threshold);
 }
 
-template <bool APPROXIMATION_MODE, int ITERATIONS, typename VecType>
+template <typename VecType, bool APPROXIMATION_MODE, int ITERATIONS>
 inline void _relu_min_impl_(const int iterations, VecType threshold)
 {
     for (int d = 0; d < iterations; d++)
@@ -106,10 +106,9 @@ inline void _relu_min_impl_(const int iterations, VecType threshold)
         VecType a = sfpi::dst_reg[0];
         v_if (a < threshold)
         {
-            a = threshold;
+            sfpi::dst_reg[0] = threshold;
         }
         v_endif;
-        sfpi::dst_reg[0] = a;
         sfpi::dst_reg++;
     }
 }
@@ -134,7 +133,7 @@ inline void _relu_min_(T threshold)
         static_assert(std::is_same_v<T, float> || std::is_same_v<T, uint32_t>, "Threshold type must be float or uint32_t");
     }
 
-    _relu_min_impl_<APPROXIMATION_MODE, ITERATIONS, VectorType>(ITERATIONS, v_threshold);
+    _relu_min_impl_<VectorType, APPROXIMATION_MODE, ITERATIONS>(ITERATIONS, v_threshold);
 }
 
 } // namespace sfpu

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_relu.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_relu.h
@@ -88,7 +88,14 @@ inline void _relu_max_(T threshold)
     }
     else if constexpr (std::is_same_v<T, uint32_t>)
     {
-        v_threshold = Converter::as_float(threshold);
+        if constexpr (std::is_same_v<VectorType, sfpi::vInt>)
+        {
+            v_threshold = (int)Converter::as_float(threshold);
+        }
+        else
+        {
+            v_threshold = Converter::as_float(threshold);
+        }
     }
     else
     {
@@ -126,7 +133,14 @@ inline void _relu_min_(T threshold)
     }
     else if constexpr (std::is_same_v<T, uint32_t>)
     {
-        v_threshold = Converter::as_float(threshold);
+        if constexpr (std::is_same_v<VectorType, sfpi::vInt>)
+        {
+            v_threshold = (int)Converter::as_float(threshold);
+        }
+        else
+        {
+            v_threshold = Converter::as_float(threshold);
+        }
     }
     else
     {

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_relu.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_relu.h
@@ -90,7 +90,7 @@ inline void _relu_max_(T threshold)
     {
         if constexpr (std::is_same_v<VectorType, sfpi::vInt>)
         {
-            v_threshold = (int)Converter::as_float(threshold);
+            v_threshold = static_cast<int>(Converter::as_float(threshold));
         }
         else
         {
@@ -135,7 +135,7 @@ inline void _relu_min_(T threshold)
     {
         if constexpr (std::is_same_v<VectorType, sfpi::vInt>)
         {
-            v_threshold = (int)Converter::as_float(threshold);
+            v_threshold = static_cast<int>(Converter::as_float(threshold));
         }
         else
         {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_relu.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_relu.h
@@ -76,25 +76,12 @@ inline void _relu_max_impl_(const int iterations, VecType threshold)
 }
 
 // Wrappers
-template <bool APPROXIMATION_MODE, int ITERATIONS, typename T>
+template <typename VectorType, bool APPROXIMATION_MODE, int ITERATIONS, typename T>
 inline void _relu_max_(T threshold)
 {
-    sfpi::vFloat v_threshold;
-    if constexpr (std::is_same_v<T, float>)
-    {
-        v_threshold = threshold;
-    }
-    else if constexpr (std::is_same_v<T, uint32_t>)
-    {
-        v_threshold = Converter::as_float(threshold);
-    }
-    _relu_max_impl_<APPROXIMATION_MODE, ITERATIONS, sfpi::vFloat>(ITERATIONS, v_threshold);
-}
+    static_assert(std::is_same_v<VectorType, sfpi::vFloat> || std::is_same_v<VectorType, sfpi::vInt>, "VectorType must be sfpi::vFloat or sfpi::vInt");
 
-template <bool APPROXIMATION_MODE, int ITERATIONS, typename T>
-inline void _relu_max_int_(T threshold)
-{
-    sfpi::vInt v_threshold;
+    VectorType v_threshold;
     if constexpr (std::is_same_v<T, float>)
     {
         v_threshold = threshold;
@@ -103,7 +90,12 @@ inline void _relu_max_int_(T threshold)
     {
         v_threshold = Converter::as_float(threshold);
     }
-    _relu_max_impl_<APPROXIMATION_MODE, ITERATIONS, sfpi::vInt>(ITERATIONS, v_threshold);
+    else
+    {
+        static_assert(std::is_same_v<T, float> || std::is_same_v<T, uint32_t>, "Threshold type must be float or uint32_t");
+    }
+
+    _relu_max_impl_<APPROXIMATION_MODE, ITERATIONS, VectorType>(ITERATIONS, v_threshold);
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS, typename VecType>
@@ -123,25 +115,12 @@ inline void _relu_min_impl_(const int iterations, VecType threshold)
 }
 
 // Wrappers
-template <bool APPROXIMATION_MODE, int ITERATIONS, typename T>
+template <typename VectorType, bool APPROXIMATION_MODE, int ITERATIONS, typename T>
 inline void _relu_min_(T threshold)
 {
-    sfpi::vFloat v_threshold;
-    if constexpr (std::is_same_v<T, float>)
-    {
-        v_threshold = threshold;
-    }
-    else if constexpr (std::is_same_v<T, uint32_t>)
-    {
-        v_threshold = Converter::as_float(threshold);
-    }
-    _relu_min_impl_<APPROXIMATION_MODE, ITERATIONS, sfpi::vFloat>(ITERATIONS, v_threshold);
-}
+    static_assert(std::is_same_v<VectorType, sfpi::vFloat> || std::is_same_v<VectorType, sfpi::vInt>, "VectorType must be sfpi::vFloat or sfpi::vInt");
 
-template <bool APPROXIMATION_MODE, int ITERATIONS, typename T>
-inline void _relu_min_int_(T threshold)
-{
-    sfpi::vInt v_threshold;
+    VectorType v_threshold;
     if constexpr (std::is_same_v<T, float>)
     {
         v_threshold = threshold;
@@ -150,7 +129,12 @@ inline void _relu_min_int_(T threshold)
     {
         v_threshold = Converter::as_float(threshold);
     }
-    _relu_min_impl_<APPROXIMATION_MODE, ITERATIONS, sfpi::vInt>(ITERATIONS, v_threshold);
+    else
+    {
+        static_assert(std::is_same_v<T, float> || std::is_same_v<T, uint32_t>, "Threshold type must be float or uint32_t");
+    }
+
+    _relu_min_impl_<APPROXIMATION_MODE, ITERATIONS, VectorType>(ITERATIONS, v_threshold);
 }
 
 } // namespace sfpu

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_relu.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_relu.h
@@ -54,7 +54,7 @@ sfpi_inline sfpi::vFloat _relu_max_body_(sfpi::vFloat val, sfpi::vFloat threshol
     return result;
 }
 
-template <bool APPROXIMATION_MODE, int ITERATIONS, typename VecType>
+template <typename VecType, bool APPROXIMATION_MODE, int ITERATIONS>
 inline void _relu_max_impl_(const int iterations, VecType threshold)
 {
     for (int d = 0; d < iterations; d++)
@@ -95,10 +95,10 @@ inline void _relu_max_(T threshold)
         static_assert(std::is_same_v<T, float> || std::is_same_v<T, uint32_t>, "Threshold type must be float or uint32_t");
     }
 
-    _relu_max_impl_<APPROXIMATION_MODE, ITERATIONS, VectorType>(ITERATIONS, v_threshold);
+    _relu_max_impl_<VectorType, APPROXIMATION_MODE, ITERATIONS>(ITERATIONS, v_threshold);
 }
 
-template <bool APPROXIMATION_MODE, int ITERATIONS, typename VecType>
+template <typename VecType, bool APPROXIMATION_MODE, int ITERATIONS>
 inline void _relu_min_impl_(const int iterations, VecType threshold)
 {
     for (int d = 0; d < iterations; d++)
@@ -106,10 +106,9 @@ inline void _relu_min_impl_(const int iterations, VecType threshold)
         VecType a = sfpi::dst_reg[0];
         v_if (a < threshold)
         {
-            a = threshold;
+            sfpi::dst_reg[0] = threshold;
         }
         v_endif;
-        sfpi::dst_reg[0] = a;
         sfpi::dst_reg++;
     }
 }
@@ -134,7 +133,7 @@ inline void _relu_min_(T threshold)
         static_assert(std::is_same_v<T, float> || std::is_same_v<T, uint32_t>, "Threshold type must be float or uint32_t");
     }
 
-    _relu_min_impl_<APPROXIMATION_MODE, ITERATIONS, VectorType>(ITERATIONS, v_threshold);
+    _relu_min_impl_<VectorType, APPROXIMATION_MODE, ITERATIONS>(ITERATIONS, v_threshold);
 }
 
 } // namespace sfpu

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_relu.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_relu.h
@@ -88,7 +88,14 @@ inline void _relu_max_(T threshold)
     }
     else if constexpr (std::is_same_v<T, uint32_t>)
     {
-        v_threshold = Converter::as_float(threshold);
+        if constexpr (std::is_same_v<VectorType, sfpi::vInt>)
+        {
+            v_threshold = (int)Converter::as_float(threshold);
+        }
+        else
+        {
+            v_threshold = Converter::as_float(threshold);
+        }
     }
     else
     {
@@ -126,7 +133,14 @@ inline void _relu_min_(T threshold)
     }
     else if constexpr (std::is_same_v<T, uint32_t>)
     {
-        v_threshold = Converter::as_float(threshold);
+        if constexpr (std::is_same_v<VectorType, sfpi::vInt>)
+        {
+            v_threshold = (int)Converter::as_float(threshold);
+        }
+        else
+        {
+            v_threshold = Converter::as_float(threshold);
+        }
     }
     else
     {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_relu.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_relu.h
@@ -90,7 +90,7 @@ inline void _relu_max_(T threshold)
     {
         if constexpr (std::is_same_v<VectorType, sfpi::vInt>)
         {
-            v_threshold = (int)Converter::as_float(threshold);
+            v_threshold = static_cast<int>(Converter::as_float(threshold));
         }
         else
         {
@@ -135,7 +135,7 @@ inline void _relu_min_(T threshold)
     {
         if constexpr (std::is_same_v<VectorType, sfpi::vInt>)
         {
-            v_threshold = (int)Converter::as_float(threshold);
+            v_threshold = static_cast<int>(Converter::as_float(threshold));
         }
         else
         {


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/26719

### Problem description
int32 support not provided for relu variants

### What's changed
Provide int32 support

```math
\text{ReLU}_{\text{min}}(x, L) = \max(x, L)
```

```math
\text{ReLU}_{\text{max}}(x, U) = \max\big(0, \min(x, U)\big)
```

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
