### PR TITLE
[skip ci] chore: add missing permissions to nightly runs

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -15,6 +15,7 @@ on:
 permissions:
   checks: write
   contents: read
+  packages: write
 
 jobs:
   build-images:


### PR DESCRIPTION
### Ticket
None

### Problem description
Nightly run did not start due to missing permissions for packages. This caused failure on fetching docker images, which is a prerequisite for further workflow steps.

### What's changed
Added missing permissions.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
