### PR TITLE
Fix race between MMIO and Unpacker

### DIFF
--- a/tt_llk_wormhole_b0/llk_lib/llk_unpack_tilize.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_unpack_tilize.h
@@ -177,14 +177,13 @@ inline void unpack_tilize_to_dest_impl(
         // Increment address to point to bottom faces in L1
         address += bot_face_offset_address;
 
-        // Stall write to cfg until unpacker finishes
-        TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::UNPACK);
-
         // Get tile address
-        cfg[THCON_SEC0_REG3_Base_address_ADDR32] = address;
+        TT_SETDMAREG(0, LOWER_HALFWORD(address), 0, LO_16(p_gpr_unpack::TMP0));
+        TT_SETDMAREG(0, UPPER_HALFWORD(address), 0, HI_16(p_gpr_unpack::TMP0));
+        TTI_REG2FLOP(1, 0, 0, 0, THCON_SEC0_REG3_Base_address_ADDR32 - THCON_CFGREG_BASE_ADDR32, p_gpr_unpack::TMP0);
 
         // Stall unpacker until pending CFG writes from Trisc have completed
-        TTI_STALLWAIT(p_stall::STALL_UNPACK, p_stall::TRISC_CFG);
+        TTI_STALLWAIT(p_stall::STALL_UNPACK, p_stall::THCON);
 
         // Unpack bottom faces
         ckernel::ckernel_template::run(instrn_buffer);


### PR DESCRIPTION
### Ticket
(https://github.com/tenstorrent/tt-metal/issues/22298)

### Problem description
Unpack Tilize to Dest, in wormhole uses only one context and the register THCON_SEC0_REG3_Base_address_ADDR32 is used for addressing. We potentially run the mop twice while changing the register inbetween using MMIO. We cannot make an MMIO wait for the unpacker to finish using stallwaits, leading to race conditions. More in the issue. 

### What's changed
Used REG2FLOP since we can make UNPACKER wait till REG2FLOP is finished, and if there is a STALLWAIT waiting on unpacker before it with a corresponding instruction, that instruction will be blocked till unpacker is not finished thus blocking the REG2FLOP too, which is the case here. 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
