### PR TITLE
Expunge instrn_buffer parm from template API

### DIFF
--- a/tt_llk_blackhole/common/inc/ckernel_template.h
+++ b/tt_llk_blackhole/common/inc/ckernel_template.h
@@ -61,9 +61,9 @@ public:
     void set_last_inner_loop_instr(uint op);
     void set_last_outer_loop_instr(uint op);
 
-    void program(volatile uint *instrn_buffer);         // just programs the registers
-    static void run(volatile uint *instrn_buffer);      // runs - assumes that registers were already programmed
-    void program_and_run(volatile uint *instrn_buffer); // calls program, then run
+    void program();         // just programs the registers
+    static void run();      // runs - assumes that registers were already programmed
+    void program_and_run(); // calls program, then run
 };
 
 class ckernel_unpack_template
@@ -246,10 +246,10 @@ public:
     static ckernel_unpack_template loopx1instr(uint instr0, uint skip0 = TT_OP_NOP);
     static ckernel_unpack_template loopx2instr(uint instr0, uint instr1, uint skip0 = TT_OP_NOP, uint skip1 = TT_OP_NOP);
 
-    void program(volatile uint *instrn_buffer) const;                                                  // just programs the registers
-    static void run(volatile uint *instrn_buffer, const uint8_t count, const uint32_t zmask);          // runs - assumes that registers were already programmed
-    static void run(volatile uint *instrn_buffer, const uint8_t count);                                // runs - assumes that registers were already programmed
-    void program_and_run(volatile uint *instrn_buffer, const uint8_t count, const uint32_t zmask = 0); // calls program, then run
+    void program() const;                                                  // just programs the registers
+    static void run(const uint8_t count, const uint32_t zmask);          // runs - assumes that registers were already programmed
+    static void run(const uint8_t count);                                // runs - assumes that registers were already programmed
+    void program_and_run(const uint8_t count, const uint32_t zmask = 0); // calls program, then run
 };
 
 inline ckernel_template::ckernel_template(uint outer_loop_len, uint inner_loop_len) :
@@ -332,18 +332,18 @@ inline void ckernel_template::set_last_outer_loop_instr(uint op)
     m_loop0_last_instr = op;
 }
 
-inline void ckernel_template::program_and_run(volatile uint *instrn_buffer)
+inline void ckernel_template::program_and_run()
 {
-    program(instrn_buffer);
-    run(instrn_buffer);
+    program();
+    run();
 }
 
-inline void ckernel_template::run(volatile uint *instrn_buffer)
+inline void ckernel_template::run()
 {
     TTI_MOP(1, 0, 0); // run the double-loop template
 }
 
-inline void ckernel_template::program(volatile uint *instrn_buffer)
+inline void ckernel_template::program()
 {
     volatile uint *mop_cfg = reinterpret_cast<volatile uint *>(TENSIX_MOP_CFG_BASE);
 
@@ -360,25 +360,25 @@ inline void ckernel_template::program(volatile uint *instrn_buffer)
     mop_cfg[8] = m_loop1_last_instr;
 }
 
-inline void ckernel_unpack_template::program_and_run(volatile uint *instrn_buffer, const uint8_t count, const uint32_t zmask)
+inline void ckernel_unpack_template::program_and_run(const uint8_t count, const uint32_t zmask)
 {
-    program(instrn_buffer);
-    run(instrn_buffer, count, zmask);
+    program();
+    run(count, zmask);
 }
 
-inline void ckernel_unpack_template::run(volatile uint *instrn_buffer, const uint8_t count, const uint32_t zmask)
+inline void ckernel_unpack_template::run(const uint8_t count, const uint32_t zmask)
 {
     TT_MOP_CFG(zmask >> 16);              // Set the top 16 bits of zmask - we could skip this for count <= 16
     TT_MOP(0, count - 1, zmask & 0xFFFF); // Run the template
 }
 
 // Version without zmask, should be slightly faster by eliminating one instruction.
-inline void ckernel_unpack_template::run(volatile uint *instrn_buffer, const uint8_t count)
+inline void ckernel_unpack_template::run(const uint8_t count)
 {
     TT_MOP(0, count - 1, 0); // Run the template
 }
 
-inline void ckernel_unpack_template::program(volatile uint *instrn_buffer) const
+inline void ckernel_unpack_template::program() const
 {
     volatile uint *mop_cfg = reinterpret_cast<volatile uint *>(TENSIX_MOP_CFG_BASE);
 

--- a/tt_llk_blackhole/llk_lib/llk_math_eltwise_binary.h
+++ b/tt_llk_blackhole/llk_lib/llk_math_eltwise_binary.h
@@ -54,7 +54,7 @@ inline void _llk_math_eltwise_binary_(const std::uint32_t num_faces, uint dst_in
             for (std::uint32_t face_num = 0; face_num < outerloop; face_num++)
             {
                 eltwise_binary_reuse_dest_as_src<binary_reuse_dest>();
-                ckernel_template::run(instrn_buffer);
+                ckernel_template::run();
             }
             TTI_SETRWC(p_setrwc::CLR_B, 0, 0, 0, 0, 0);
             if (num_faces == 4)
@@ -63,7 +63,7 @@ inline void _llk_math_eltwise_binary_(const std::uint32_t num_faces, uint dst_in
                 for (std::uint32_t face_num = 0; face_num < outerloop; face_num++)
                 {
                     eltwise_binary_reuse_dest_as_src<binary_reuse_dest>();
-                    ckernel_template::run(instrn_buffer);
+                    ckernel_template::run();
                 }
                 TTI_SETRWC(p_setrwc::CLR_B, 0, 0, 0, 0, 0);
             }
@@ -75,7 +75,7 @@ inline void _llk_math_eltwise_binary_(const std::uint32_t num_faces, uint dst_in
             for (std::uint32_t face_num = 0; face_num < outerloop; face_num++)
             {
                 eltwise_binary_reuse_dest_as_src<binary_reuse_dest>();
-                ckernel_template::run(instrn_buffer);
+                ckernel_template::run();
             }
             // Manually clear B once mop is done for scaler bcast
             if constexpr (src_b_bcast_type == BroadcastType::SCALAR)
@@ -104,7 +104,7 @@ inline void _llk_math_eltwise_binary_(const std::uint32_t num_faces, uint dst_in
                         TT_ZEROACC(
                             ZERO_ACC_MODE, clear_fp32, 0, ADDR_MOD_1, (buffer_base + get_dest_index_in_faces(dst_index, (0 + face_num)))); // Clear faces 0 & 1
                     }
-                    ckernel_template::run(instrn_buffer);
+                    ckernel_template::run();
                 }
             }
             else
@@ -121,7 +121,7 @@ inline void _llk_math_eltwise_binary_(const std::uint32_t num_faces, uint dst_in
                         TT_ZEROACC(
                             ZERO_ACC_MODE, clear_fp32, 0, ADDR_MOD_1, (buffer_base + get_dest_index_in_faces(dst_index, (0 + face_num)))); // Clear faces 0 & 1
                     }
-                    ckernel_template::run(instrn_buffer);
+                    ckernel_template::run();
                 }
             }
             TTI_SETRWC(p_setrwc::CLR_B, 0, 0, 0, 0, 0);
@@ -145,7 +145,7 @@ inline void _llk_math_eltwise_binary_(const std::uint32_t num_faces, uint dst_in
                                 ADDR_MOD_1,
                                 (buffer_base + get_dest_index_in_faces(dst_index, (2 + face_num)))); // Clear faces 2 & 3
                         }
-                        ckernel_template::run(instrn_buffer);
+                        ckernel_template::run();
                     }
                 }
                 else
@@ -166,7 +166,7 @@ inline void _llk_math_eltwise_binary_(const std::uint32_t num_faces, uint dst_in
                                 ADDR_MOD_1,
                                 (buffer_base + get_dest_index_in_faces(dst_index, (2 + face_num)))); // Clear faces 2 & 3
                         }
-                        ckernel_template::run(instrn_buffer);
+                        ckernel_template::run();
                     }
                 }
                 TTI_SETRWC(p_setrwc::CLR_B, 0, 0, 0, 0, 0);
@@ -189,7 +189,7 @@ inline void _llk_math_eltwise_binary_(const std::uint32_t num_faces, uint dst_in
                         auto buffer_base = is_fp32_dest_acc_en && clear_fp32_dst_acc ? get_dest_buffer_base_32b() : get_dest_buffer_base_16b();
                         TT_ZEROACC(ZERO_ACC_MODE, clear_fp32, 0, ADDR_MOD_1, (buffer_base + get_dest_index_in_faces(dst_index, face_num)));
                     }
-                    ckernel_template::run(instrn_buffer);
+                    ckernel_template::run();
                 }
             }
             else
@@ -205,7 +205,7 @@ inline void _llk_math_eltwise_binary_(const std::uint32_t num_faces, uint dst_in
                         auto buffer_base = is_fp32_dest_acc_en && clear_fp32_dst_acc ? get_dest_buffer_base_32b() : get_dest_buffer_base_16b();
                         TT_ZEROACC(ZERO_ACC_MODE, clear_fp32, 0, ADDR_MOD_1, (buffer_base + get_dest_index_in_faces(dst_index, face_num)));
                     }
-                    ckernel_template::run(instrn_buffer);
+                    ckernel_template::run();
                 }
             }
             if constexpr (src_b_bcast_type == BroadcastType::SCALAR)
@@ -300,13 +300,13 @@ inline void eltwise_binary_configure_mop(const std::uint32_t acc_to_dest = 0, co
         {
             ckernel_template tmp(outerloop, innerloop, TT_OP_ELWADD(0, acc_to_dest, broadcast_type, addr_mod, 0));
             tmp.set_end_op(TT_OP_SETRWC(p_setrwc::CLR_A, p_setrwc::CR_AB, 0, 0, 0, p_setrwc::SET_AB));
-            tmp.program(instrn_buffer);
+            tmp.program();
         }
         else if constexpr (eltwise_binary_type == ELWSUB)
         {
             ckernel_template tmp(outerloop, innerloop, TT_OP_ELWSUB(0, acc_to_dest, broadcast_type, addr_mod, 0));
             tmp.set_end_op(TT_OP_SETRWC(p_setrwc::CLR_A, p_setrwc::CR_AB, 0, 0, 0, p_setrwc::SET_AB));
-            tmp.program(instrn_buffer);
+            tmp.program();
         }
         else if constexpr (eltwise_binary_type == ELWMUL)
         {
@@ -320,7 +320,7 @@ inline void eltwise_binary_configure_mop(const std::uint32_t acc_to_dest = 0, co
             {
                 tmp.set_end_op(TT_OP_SETRWC(p_setrwc::CLR_A, p_setrwc::CR_AB, 0, 0, 0, p_setrwc::SET_AB));
             }
-            tmp.program(instrn_buffer);
+            tmp.program();
         }
     }
     else
@@ -329,13 +329,13 @@ inline void eltwise_binary_configure_mop(const std::uint32_t acc_to_dest = 0, co
         {
             ckernel_template tmp(outerloop, innerloop, TT_OP_ELWADD(0, acc_to_dest, broadcast_type, addr_mod, 0));
             tmp.set_end_op(TT_OP_SETRWC(p_setrwc::CLR_AB, p_setrwc::CR_AB, 0, 0, 0, p_setrwc::SET_AB));
-            tmp.program(instrn_buffer);
+            tmp.program();
         }
         else if constexpr (eltwise_binary_type == ELWSUB)
         {
             ckernel_template tmp(outerloop, innerloop, TT_OP_ELWSUB(0, acc_to_dest, broadcast_type, addr_mod, 0));
             tmp.set_end_op(TT_OP_SETRWC(p_setrwc::CLR_AB, p_setrwc::CR_AB, 0, 0, 0, p_setrwc::SET_AB));
-            tmp.program(instrn_buffer);
+            tmp.program();
         }
         else if constexpr (eltwise_binary_type == ELWMUL)
         {
@@ -349,7 +349,7 @@ inline void eltwise_binary_configure_mop(const std::uint32_t acc_to_dest = 0, co
             {
                 tmp.set_end_op(TT_OP_SETRWC(p_setrwc::CLR_AB, p_setrwc::CR_AB, 0, 0, 0, p_setrwc::SET_AB));
             }
-            tmp.program(instrn_buffer);
+            tmp.program();
         }
     }
 }

--- a/tt_llk_blackhole/llk_lib/llk_math_eltwise_unary_datacopy.h
+++ b/tt_llk_blackhole/llk_lib/llk_math_eltwise_unary_datacopy.h
@@ -57,21 +57,21 @@ inline void _llk_math_eltwise_unary_datacopy_(
 
         if constexpr (type == A2D)
         {
-            ckernel_template::run(instrn_buffer);
+            ckernel_template::run();
         }
         else if constexpr (type == B2D)
         {
             if constexpr (src_b_bcast_type == BroadcastType::COL)
             {
                 // Mop for col broadcast only does 2 outerloops.  Needs to clear B manually and call twice
-                ckernel_template::run(instrn_buffer);
+                ckernel_template::run();
                 TTI_SETRWC(p_setrwc::CLR_B, 0, 0, 0, 0, 0);
-                ckernel_template::run(instrn_buffer);
+                ckernel_template::run();
                 TTI_SETRWC(p_setrwc::CLR_AB, 0, 0, 0, 0, 0);
             }
             else
             {
-                ckernel_template::run(instrn_buffer);
+                ckernel_template::run();
             }
         }
 
@@ -162,13 +162,13 @@ inline void eltwise_unary_configure_mop(uint rows_per_inst, uint total_rows, con
             // use elwadd to handle unpacking data into src A as fp16, but dest is in fp32 mode OR to handle uint8 datums
             ckernel_template tmp(outerloop, innerloop, TT_OP_ELWADD(0, 0, p_elwise::SRCB_NO_BCAST, ADDR_MOD_2, 0));
             tmp.set_end_op(TT_OP_SETRWC(p_setrwc::CLR_AB, 0, 0, 0, 0, p_setrwc::SET_AB));
-            tmp.program(instrn_buffer);
+            tmp.program();
         }
         else
         {
             ckernel_template tmp(outerloop, innerloop, TT_OP_MOVA2D(0, 0, ADDR_MOD_2, p_mova2d::MOV_8_ROWS, 0));
             tmp.set_end_op(TT_OP_SETRWC(p_setrwc::CLR_AB, 0, 0, 0, 0, p_setrwc::SET_AB));
-            tmp.program(instrn_buffer);
+            tmp.program();
         }
     }
     else if constexpr (type == B2D)
@@ -206,25 +206,25 @@ inline void eltwise_unary_configure_mop(uint rows_per_inst, uint total_rows, con
         {
             ckernel_template tmp(outerloop, innerloop, TT_OP_ELWADD(0, 0, broadcast_type, addr_mod, 0));
             tmp.set_end_op(TT_OP_SETRWC(p_setrwc::CLR_AB, 0, 0, 0, 0, 0));
-            tmp.program(instrn_buffer);
+            tmp.program();
         }
         else if constexpr (bcast_type == BroadcastType::COL)
         {
             ckernel_template tmp(outerloop, innerloop, TT_OP_ELWADD(0, 0, broadcast_type, addr_mod, 0));
             tmp.set_end_op(TT_OP_SETRWC(0, p_setrwc::CR_B, 0, 0, 0, p_setrwc::SET_B));
-            tmp.program(instrn_buffer);
+            tmp.program();
         }
         else if constexpr (bcast_type == BroadcastType::ROW)
         {
             ckernel_template tmp(outerloop, innerloop, TT_OP_MOVB2D(0, 0, addr_mod, broadcast_type, 0));
             tmp.set_end_op(TT_OP_SETRWC(p_setrwc::CLR_B, p_setrwc::CR_B, 0, 0, 0, p_setrwc::SET_B));
-            tmp.program(instrn_buffer);
+            tmp.program();
         }
         else
         {
             ckernel_template tmp(outerloop, innerloop, TT_OP_MOVB2D(0, 0, addr_mod, rows_per_inst, 0));
             tmp.set_end_op(TT_OP_SETRWC(p_setrwc::CLR_B, p_setrwc::CR_B, 0, 0, 0, p_setrwc::SET_B));
-            tmp.program(instrn_buffer);
+            tmp.program();
         }
     }
 }

--- a/tt_llk_blackhole/llk_lib/llk_math_matmul.h
+++ b/tt_llk_blackhole/llk_lib/llk_math_matmul.h
@@ -417,7 +417,7 @@ inline void matmul_configure_mop(
             tmp.set_end_op(TT_OP_SETRWC(p_setrwc::CLR_B, 0, 0, 0, 0, p_setrwc::SET_ABD_F));
         }
     }
-    tmp.program(instrn_buffer);
+    tmp.program();
 }
 
 template <int Level>
@@ -595,7 +595,7 @@ inline void matmul_configure_mop_throttled(
         }
     }
 
-    tmp.program(instrn_buffer);
+    tmp.program();
 }
 
 template <int MATH_FIDELITY_DESC, DstTileFaceLayout FaceLayout = DstTileFaceLayout::ColMajor, int THROTTLE_LEVEL = 0>
@@ -647,7 +647,7 @@ inline void _llk_math_matmul_(
             {
                 for (uint phase = 0; phase < NUM_FIDELITY_PHASES; phase++)
                 {
-                    ckernel_template::run(instrn_buffer);
+                    ckernel_template::run();
                 }
                 if (reuse_a)
                 {
@@ -660,7 +660,7 @@ inline void _llk_math_matmul_(
             }
             else
             {
-                ckernel_template::run(instrn_buffer);
+                ckernel_template::run();
             }
 
             // Clear srcB or srcA at end of reuse (once per u block row)

--- a/tt_llk_blackhole/llk_lib/llk_math_reduce.h
+++ b/tt_llk_blackhole/llk_lib/llk_math_reduce.h
@@ -43,7 +43,7 @@ inline void _llk_math_reduce_(const uint dst_index, bool narrow_tile = false, co
         }
         else if constexpr (HIGH_FIDELITY)
         {
-            ckernel_template::run(instrn_buffer);
+            ckernel_template::run();
             TTI_CLEARDVALID(p_setrwc::CLR_AB, 0);
         }
         else
@@ -57,7 +57,7 @@ inline void _llk_math_reduce_(const uint dst_index, bool narrow_tile = false, co
         }
         else if constexpr (HIGH_FIDELITY)
         {
-            ckernel_template::run(instrn_buffer);
+            ckernel_template::run();
         }
         else
         {
@@ -172,7 +172,7 @@ inline void _llk_math_reduce_(const uint dst_index, bool narrow_tile = false, co
             }
             else if constexpr (HIGH_FIDELITY)
             {
-                ckernel_template::run(instrn_buffer);
+                ckernel_template::run();
                 TTI_CLEARDVALID(p_setrwc::CLR_AB, 0);
             }
             else
@@ -186,7 +186,7 @@ inline void _llk_math_reduce_(const uint dst_index, bool narrow_tile = false, co
             }
             else if constexpr (HIGH_FIDELITY)
             {
-                ckernel_template::run(instrn_buffer);
+                ckernel_template::run();
             }
             else
             {
@@ -292,7 +292,7 @@ inline void _llk_math_reduce_(const uint dst_index, bool narrow_tile = false, co
             {
                 if constexpr (HIGH_FIDELITY)
                 {
-                    ckernel_template::run(instrn_buffer);
+                    ckernel_template::run();
                 }
                 else
                 {
@@ -312,7 +312,7 @@ inline void _llk_math_reduce_(const uint dst_index, bool narrow_tile = false, co
                 {
                     if constexpr (HIGH_FIDELITY)
                     {
-                        ckernel_template::run(instrn_buffer);
+                        ckernel_template::run();
                     }
                     else
                     {
@@ -337,7 +337,7 @@ inline void _llk_math_reduce_(const uint dst_index, bool narrow_tile = false, co
             {
                 if constexpr (HIGH_FIDELITY)
                 {
-                    ckernel_template::run(instrn_buffer);
+                    ckernel_template::run();
                     TTI_CLEARDVALID(p_setrwc::CLR_AB, 0);
                 }
                 else
@@ -355,7 +355,7 @@ inline void _llk_math_reduce_(const uint dst_index, bool narrow_tile = false, co
         {
             if constexpr (HIGH_FIDELITY)
             {
-                ckernel_template::run(instrn_buffer);
+                ckernel_template::run();
             }
             else
             {
@@ -437,14 +437,14 @@ inline void reduce_configure_mop()
         ckernel_template tmp(1, num_fidelity_phases, TT_OP_GAPOOL(p_setrwc::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_3, p_gpool::INDEX_DIS, 4));
         tmp.set_last_inner_loop_instr(TT_OP_GAPOOL(p_setrwc::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, 4));
         tmp.set_last_outer_loop_instr(TT_OP_GAPOOL(p_setrwc::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, 4));
-        tmp.program(instrn_buffer);
+        tmp.program();
     }
     else
     {
         ckernel_template tmp(1, num_fidelity_phases, TT_OP_GAPOOL(p_setrwc::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_3, p_gpool::INDEX_DIS, 0));
         tmp.set_last_inner_loop_instr(TT_OP_GAPOOL(p_setrwc::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, 0));
         tmp.set_last_outer_loop_instr(TT_OP_GAPOOL(p_setrwc::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, 0));
-        tmp.program(instrn_buffer);
+        tmp.program();
     }
 }
 

--- a/tt_llk_blackhole/llk_lib/llk_math_transpose_dest.h
+++ b/tt_llk_blackhole/llk_lib/llk_math_transpose_dest.h
@@ -53,12 +53,12 @@ inline void _llk_math_transpose_dest_(const std::uint32_t dst_index)
         if constexpr (transpose_of_faces)
         {
             // 4x 32b face transpositions followed by 8x middle-face row swaps.
-            ckernel_unpack_template::run(instrn_buffer, 12, 0xff0);
+            ckernel_unpack_template::run(12, 0xff0);
         }
         else
         {
             // 4x 32b face transpositions.
-            ckernel_unpack_template::run(instrn_buffer, 4, 0);
+            ckernel_unpack_template::run(4, 0);
         }
         if constexpr (is_fp32_dest_acc_en)
         {
@@ -67,7 +67,7 @@ inline void _llk_math_transpose_dest_(const std::uint32_t dst_index)
     }
     else
     {
-        ckernel_unpack_template::run(instrn_buffer, 2, 2);
+        ckernel_unpack_template::run(2, 2);
     }
 
     TTI_SETRWC(p_setrwc::CLR_AB, 0, 0, 0, 0, p_setrwc::SET_ABD);
@@ -179,7 +179,7 @@ inline void transpose_dest_configure_mop()
         // - zmask 0-bits: 32b 16x16 face transpose.
         // - zmask 1-bits: 32b 32x1 middle face row swap via SFPU.
         ckernel_unpack_template tmp(true, true, movd2b_hi, transpose, movb2d_hi_d2b_lo, transpose, /* skip A */ macro0, /* B */ movb2d_lo, /* skip B */ macro1);
-        tmp.program(instrn_buffer);
+        tmp.program();
     }
     else
     {
@@ -228,7 +228,7 @@ inline void transpose_dest_configure_mop()
 
         // The following MOP config simply runs the above 7 instructions in order (when executed with zmask 0b10):
         ckernel_unpack_template tmp(true, true, EFGHIJKLM, EFGHI, ABCDEFG, P, /* skip A */ Q, /* B */ IJKL, /* skip B */ EFGHIJKLMNO);
-        tmp.program(instrn_buffer);
+        tmp.program();
     }
 }
 

--- a/tt_llk_blackhole/llk_lib/llk_pack.h
+++ b/tt_llk_blackhole/llk_lib/llk_pack.h
@@ -136,7 +136,7 @@ inline void _llk_pack_mop_config_(
             p_pacr::NO_CTXT_CTRL,
             0,
             1));
-        tmp.program(instrn_buffer);
+        tmp.program();
     }
     else if constexpr (tilize && !untilize)
     {
@@ -402,7 +402,7 @@ inline void _llk_pack_mop_config_(
             tmp.set_end_op(TT_OP_SETADCZW(p_setadc::PAC, 0, 2, 0, 0, 0b0100)); // ch0_z = 0, ch1_z = 2;
         }
 
-        tmp.program(instrn_buffer);
+        tmp.program();
     }
     else
     {
@@ -467,7 +467,7 @@ inline void _llk_pack_mop_config_(
             tmp.set_end_op(TT_OP_STOREIND(1, 0, p_ind::LD_16B, LO_16(0), p_ind::INC_NONE, p_gpr_pack::TILE_HEADER, p_gpr_pack::OUTPUT_ADDR));
         }
 
-        tmp.program(instrn_buffer);
+        tmp.program();
     }
 }
 

--- a/tt_llk_blackhole/llk_lib/llk_pack_untilize.h
+++ b/tt_llk_blackhole/llk_lib/llk_pack_untilize.h
@@ -124,7 +124,7 @@ inline void _llk_pack_untilize_mop_config_(
 
     tmp.set_last_outer_loop_instr(last_loop_op);
 
-    tmp.program(instrn_buffer);
+    tmp.program();
 }
 
 template <
@@ -199,7 +199,7 @@ inline void _llk_pack_untilize_(
     // Iterate over top, then over bottom faces in the block (if num_faces > 2)
     for (std::uint32_t face = 0; face < num_faces_per_rdim_tile; face++)
     {
-        ckernel::ckernel_template::run(instrn_buffer);
+        ckernel::ckernel_template::run();
 
         TTI_INCADCZW(p_setadc::PAC, 0, 0, 0, 1);         // z cnt increments by 2xface_r_dimxFACE_C_DIM
         TTI_SETADCXY(p_setadc::PAC, 0, 0, 0, 0, 0b0010); // reset ch0_y counters

--- a/tt_llk_blackhole/llk_lib/llk_unpack_A.h
+++ b/tt_llk_blackhole/llk_lib/llk_unpack_A.h
@@ -54,14 +54,14 @@ inline void _llk_unpack_A_mop_config_(
             const uint32_t innerloop = 2;
             ckernel_template tmp(outerloop, innerloop, unpack_srca_to_dest_transpose_of_faces);
             tmp.set_end_op(TT_OP_SETADCZW(p_setadc::UNP_A, 0, 2, 0, 1, 0b0101));
-            tmp.program(instrn_buffer);
+            tmp.program();
         }
         else
         {
             const uint32_t outerloop     = num_faces;
             constexpr uint32_t innerloop = 1;
             ckernel_template tmp(outerloop, innerloop, unpack_srca_to_dest);
-            tmp.program(instrn_buffer);
+            tmp.program();
         }
     }
     else if constexpr (BType == BroadcastType::COL)
@@ -73,7 +73,7 @@ inline void _llk_unpack_A_mop_config_(
             ckernel_template tmp(outerloop, innerloop, unpack_srca_set_dvalid, unpack_srca_set_dvalid);
             tmp.set_start_op(unpack_srcb);
             tmp.set_end_op(srcb_set_z_2);
-            tmp.program(instrn_buffer);
+            tmp.program();
         }
         else
         {
@@ -82,7 +82,7 @@ inline void _llk_unpack_A_mop_config_(
             ckernel_template tmp(outerloop, innerloop, unpack_srcb, srcb_set_z_2);
             tmp.set_start_op(unpack_srca_set_dvalid);
             tmp.set_end_op(unpack_srcb);
-            tmp.program(instrn_buffer);
+            tmp.program();
         }
     }
     else if constexpr (BType == BroadcastType::ROW)
@@ -93,13 +93,13 @@ inline void _llk_unpack_A_mop_config_(
         {
             ckernel_template tmp(outerloop, innerloop, unpack_srcb, unpack_srca_set_dvalid);
             tmp.set_end_op(srcb_clear_z);
-            tmp.program(instrn_buffer);
+            tmp.program();
         }
         else
         {
             ckernel_template tmp(outerloop, innerloop, unpack_srcb);
             tmp.set_end_op(srcb_clear_z);
-            tmp.program(instrn_buffer);
+            tmp.program();
         }
     }
     else if constexpr (BType == BroadcastType::SCALAR)
@@ -110,7 +110,7 @@ inline void _llk_unpack_A_mop_config_(
         ckernel_template tmp(outerloop, innerloop, unpack_srcb_inc_z_0);
         // ELWADD used in datacopy due to broadcast bug, use zerosrca regardless of acc_to_dest
         tmp.set_start_op(unpack_srca_set_dvalid);
-        tmp.program(instrn_buffer);
+        tmp.program();
     }
     else
     {
@@ -141,7 +141,7 @@ inline void _llk_unpack_A_mop_config_(
             {
                 tmp.set_end_op(srca_set_z_1);
             }
-            tmp.program(instrn_buffer);
+            tmp.program();
         }
         else
         {
@@ -156,7 +156,7 @@ inline void _llk_unpack_A_mop_config_(
                 const uint32_t outerloop     = num_faces;
                 constexpr uint32_t innerloop = 1;
                 ckernel_template tmp(outerloop, innerloop, unpack_srca_reuse, unpack_srcb_reuse);
-                tmp.program(instrn_buffer);
+                tmp.program();
             }
             else
             {
@@ -164,7 +164,7 @@ inline void _llk_unpack_A_mop_config_(
                 constexpr uint32_t innerloop = 1;
                 ckernel_template tmp(outerloop, innerloop, unpack_srcb_set_dvalid);
                 tmp.set_start_op(unpack_srca);
-                tmp.program(instrn_buffer);
+                tmp.program();
             }
         }
     }
@@ -269,7 +269,7 @@ inline void _llk_unpack_A_(
     TTI_STALLWAIT(p_stall::STALL_UNPACK, p_stall::TRISC_CFG);
 
     // Run MOP
-    ckernel::ckernel_template::run(instrn_buffer);
+    ckernel::ckernel_template::run();
 
     // T6::SEMGET for context release
     t6_semaphore_get(semaphore::UNPACK_SYNC);

--- a/tt_llk_blackhole/llk_lib/llk_unpack_AB.h
+++ b/tt_llk_blackhole/llk_lib/llk_unpack_AB.h
@@ -37,7 +37,7 @@ inline void _llk_unpack_AB_mop_config_(const bool transpose_of_faces = false, co
         {
             tmp.set_end_op(unpack_srcb_set_z);
         }
-        tmp.program(instrn_buffer);
+        tmp.program();
     }
     else if constexpr (BType == BroadcastType::ROW)
     {
@@ -47,7 +47,7 @@ inline void _llk_unpack_AB_mop_config_(const bool transpose_of_faces = false, co
         const uint32_t innerloop                   = num_faces < 2 ? 1 : 2;
         ckernel_template tmp(outerloop, innerloop, narrow_tile ? unpack_srcb_no_z_inc : unpack_srcb, unpack_srca);
         tmp.set_end_op(unpack_srcb_clear_z);
-        tmp.program(instrn_buffer);
+        tmp.program();
     }
     else if constexpr (BType == BroadcastType::SCALAR)
     {
@@ -55,7 +55,7 @@ inline void _llk_unpack_AB_mop_config_(const bool transpose_of_faces = false, co
         const uint32_t innerloop = num_faces;
         ckernel_template tmp(outerloop, innerloop, unpack_srca);
         tmp.set_start_op(unpack_srcb);
-        tmp.program(instrn_buffer);
+        tmp.program();
     }
     else
     {
@@ -67,14 +67,14 @@ inline void _llk_unpack_AB_mop_config_(const bool transpose_of_faces = false, co
             const uint32_t innerloop                 = num_faces < 2 ? 1 : 2;
             ckernel_template tmp(outerloop, innerloop, num_faces < 4 ? unpack_srca : unpack_srca_skip_z, unpack_srcb);
             tmp.set_end_op(srca_set_z);
-            tmp.program(instrn_buffer);
+            tmp.program();
         }
         else
         {
             constexpr uint32_t outerloop = 1;
             const uint32_t innerloop     = num_faces;
             ckernel_template tmp(outerloop, innerloop, unpack_srca, unpack_srcb);
-            tmp.program(instrn_buffer);
+            tmp.program();
         }
     }
 }
@@ -143,7 +143,7 @@ inline void _llk_unpack_AB_(const std::uint32_t address_a, const std::uint32_t a
     TTI_STALLWAIT(p_stall::STALL_UNPACK, p_stall::TRISC_CFG);
 
     // Run MOP
-    ckernel::ckernel_template::run(instrn_buffer);
+    ckernel::ckernel_template::run();
 
     // T6::SEMGET for context release
     t6_semaphore_get(semaphore::UNPACK_SYNC);

--- a/tt_llk_blackhole/llk_lib/llk_unpack_AB_matmul.h
+++ b/tt_llk_blackhole/llk_lib/llk_unpack_AB_matmul.h
@@ -185,7 +185,7 @@ inline void _llk_unpack_AB_matmul_mop_config_(
         0,
         0);
 
-    tmp.program(instrn_buffer);
+    tmp.program();
 }
 
 template <bool is_fp32_dest_acc_en, StochRndType stoch_rnd_mode = StochRndType::None>

--- a/tt_llk_blackhole/llk_lib/llk_unpack_reduce.h
+++ b/tt_llk_blackhole/llk_lib/llk_unpack_reduce.h
@@ -33,7 +33,7 @@ inline void _llk_unpack_reduce_mop_config_()
         0,
         unpack_srcb,
         0);
-    tmp.program(instrn_buffer);
+    tmp.program();
 }
 
 template <bool is_fp32_dest_acc_en, StochRndType stoch_rnd_mode = StochRndType::None>

--- a/tt_llk_blackhole/llk_lib/llk_unpack_tilize.h
+++ b/tt_llk_blackhole/llk_lib/llk_unpack_tilize.h
@@ -34,7 +34,7 @@ inline void _llk_unpack_tilize_mop_config_(const bool narrow_tile = false, const
         tmp.set_start_op(unpack_srca);
     }
 
-    tmp.program(instrn_buffer);
+    tmp.program();
 }
 
 template <bool is_fp32_dest_acc_en, StochRndType stoch_rnd_mode = StochRndType::None>
@@ -161,7 +161,7 @@ inline void _llk_unpack_tilize_(
     TTI_STALLWAIT(p_stall::STALL_UNPACK, p_stall::TRISC_CFG);
 
     // Run MOP
-    ckernel::ckernel_template::run(instrn_buffer);
+    ckernel::ckernel_template::run();
 
     // T6::SEMGET for context release
     t6_semaphore_get(semaphore::UNPACK_SYNC);
@@ -242,7 +242,7 @@ inline void _llk_unpack_tilizeA_B_mop_config_(const bool narrow_tile = false, co
         0,
         0);
 
-    tmp.program(instrn_buffer);
+    tmp.program();
 }
 
 template <bool neginf_srcA = false, std::uint32_t reload_srcB = false, bool zero_srcA = false, bool zero_srcA_reduce = false>
@@ -351,7 +351,7 @@ inline void _llk_unpack_tilizeA_B_(
         // Unpacks face_r_dim-1 rows of 1x16 datums to SrcA
         if (run_r_dim_loop)
         {
-            ckernel_unpack_template::run(instrn_buffer, face_r_dim - 1, unp_cfg_context == 0 ? 0 : 0xffff);
+            ckernel_unpack_template::run(face_r_dim - 1, unp_cfg_context == 0 ? 0 : 0xffff);
         }
 
         // Unpack last SrcA row of a 16x16 face and SetDvalid

--- a/tt_llk_blackhole/llk_lib/llk_unpack_untilize.h
+++ b/tt_llk_blackhole/llk_lib/llk_unpack_untilize.h
@@ -48,7 +48,7 @@ inline void _llk_unpack_untilize_mop_config_()
         lltt::replay_insn(0, replay_buf_len),
         load_offset_addr_cntx0,
         load_offset_addr_cntx1);
-    tmp.program(instrn_buffer);
+    tmp.program();
 }
 
 template <bool is_fp32_dest_acc_en, StochRndType stoch_rnd_mode = StochRndType::None>

--- a/tt_llk_quasar/common/inc/ckernel_template.h
+++ b/tt_llk_quasar/common/inc/ckernel_template.h
@@ -48,15 +48,15 @@ public:
     void set_inner_loop_len(uint len);
     void set_loop_instr(uint loop_op0, uint loop_op1);
 
-    void program(volatile uint *instrn_buffer);                    // just programs the registers
-    void program_bank0_sw_cntl(volatile uint *instrn_buffer);      // programs BANK0 in software control mode
-    void program_bank1_sw_cntl(volatile uint *instrn_buffer);      // programs BANK1 in software control mode
-    static void run(volatile uint *instrn_buffer);                 // runs - assumes that registers were already programmed
-    static void run_and_finish(volatile uint *instrn_buffer);      // runs and switches mop_config bank - assumes that registers were already programmed
-    static void run_bank0_sw_cntl(volatile uint *instrn_buffer);   // run bank 0 in SW control mode
-    static void run_bank1_sw_cntl(volatile uint *instrn_buffer);   // run bank 1 in SW control mode
-    void program_and_run(volatile uint *instrn_buffer);            // calls program, then run
-    void program_and_run_and_finish(volatile uint *instrn_buffer); // calls program, then runs and switches the mop_config bank
+    void program();                    // just programs the registers
+    void program_bank0_sw_cntl();      // programs BANK0 in software control mode
+    void program_bank1_sw_cntl();      // programs BANK1 in software control mode
+    static void run();                 // runs - assumes that registers were already programmed
+    static void run_and_finish();      // runs and switches mop_config bank - assumes that registers were already programmed
+    static void run_bank0_sw_cntl();   // run bank 0 in SW control mode
+    static void run_bank1_sw_cntl();   // run bank 1 in SW control mode
+    void program_and_run();            // calls program, then run
+    void program_and_run_and_finish(); // calls program, then runs and switches the mop_config bank
 };
 
 #if 0
@@ -256,9 +256,9 @@ public:
 
     static ckernel_unpack_template lBAD();
 
-    void program(volatile uint *instrn_buffer) const;         // just programs the registers
-    static void run(volatile uint *instrn_buffer, const uint8_t count, const uint32_t zmask = 0);      // runs - assumes that registers were already programmed
-    void program_and_run(volatile uint *instrn_buffer, const uint8_t count, const uint32_t zmask = 0); // calls program, then run
+    void program() const;         // just programs the registers
+    static void run(const uint8_t count, const uint32_t zmask = 0);      // runs - assumes that registers were already programmed
+    void program_and_run(const uint8_t count, const uint32_t zmask = 0); // calls program, then run
 
 };
 #endif
@@ -335,39 +335,39 @@ void ckernel_template::set_last_outer_loop_instr(uint op)
     m_loop0_last_instr = op;
 }
 
-void ckernel_template::program_and_run(volatile uint *instrn_buffer)
+void ckernel_template::program_and_run()
 {
-    program(instrn_buffer);
-    run(instrn_buffer);
+    program();
+    run();
 }
 
-void ckernel_template::program_and_run_and_finish(volatile uint *instrn_buffer)
+void ckernel_template::program_and_run_and_finish()
 {
-    program(instrn_buffer);
-    run_and_finish(instrn_buffer);
+    program();
+    run_and_finish();
 }
 
-void ckernel_template::run(volatile uint *instrn_buffer)
-{
-    TTI_MOP(1, 0, 0, 0); // run the double-loop template
-}
-
-void ckernel_template::run_bank0_sw_cntl(volatile uint *instrn_buffer)
+void ckernel_template::run()
 {
     TTI_MOP(1, 0, 0, 0); // run the double-loop template
 }
 
-void ckernel_template::run_and_finish(volatile uint *instrn_buffer)
+void ckernel_template::run_bank0_sw_cntl()
+{
+    TTI_MOP(1, 0, 0, 0); // run the double-loop template
+}
+
+void ckernel_template::run_and_finish()
 {
     TTI_MOP(1, 1, 0, 0); // run the double-loop template
 }
 
-void ckernel_template::run_bank1_sw_cntl(volatile uint *instrn_buffer)
+void ckernel_template::run_bank1_sw_cntl()
 {
     TTI_MOP(1, 1, 0, 0); // run the double-loop template
 }
 
-void ckernel_template::program(volatile uint *instrn_buffer)
+void ckernel_template::program()
 {
     volatile mop_config_regs_t *mop_cfg = reinterpret_cast<volatile mop_config_regs_t *>(MOP_CFG_BASE);
 
@@ -387,7 +387,7 @@ void ckernel_template::program(volatile uint *instrn_buffer)
     mop_cfg->MOP_CONFIG              = 1;
 }
 
-void ckernel_template::program_bank0_sw_cntl(volatile uint *instrn_buffer)
+void ckernel_template::program_bank0_sw_cntl()
 {
     volatile mop_config_regs_t *mop_cfg = reinterpret_cast<volatile mop_config_regs_t *>(MOP_CFG_BASE);
 
@@ -406,7 +406,7 @@ void ckernel_template::program_bank0_sw_cntl(volatile uint *instrn_buffer)
     //    mop_cfg->MOP_CONFIG               = 1;
 }
 
-void ckernel_template::program_bank1_sw_cntl(volatile uint *instrn_buffer)
+void ckernel_template::program_bank1_sw_cntl()
 {
     volatile mop_config_regs_t *mop_cfg = reinterpret_cast<volatile mop_config_regs_t *>(MOP_CFG_BASE);
 
@@ -426,20 +426,20 @@ void ckernel_template::program_bank1_sw_cntl(volatile uint *instrn_buffer)
 }
 
 #if 0
-void ckernel_unpack_template::program_and_run(volatile uint *instrn_buffer, const uint8_t count, const uint32_t zmask)
+void ckernel_unpack_template::program_and_run(const uint8_t count, const uint32_t zmask)
 {
-  program(instrn_buffer);
-  run(instrn_buffer, count, zmask);
+  program();
+  run(count, zmask);
 }
 
-void ckernel_unpack_template::run(volatile uint *instrn_buffer, const uint8_t count, const uint32_t zmask)
+void ckernel_unpack_template::run(const uint8_t count, const uint32_t zmask)
 {
   FWASSERT("Unpack template only supports loops up to 128", count <= 128);
   TT_MOP_CFG(zmask >> 16);                // Set the top 16 bits of zmask - we could skip this for count <= 16
   TT_MOP(0, count-1, zmask & 0xFFFF);     // Run the template
 }
 
-void ckernel_unpack_template::program(volatile uint *instrn_buffer) const
+void ckernel_unpack_template::program() const
 {
   volatile uint *mop_cfg = reinterpret_cast<volatile uint *>(TENSIX_MOP_CFG_BASE);
 

--- a/tt_llk_quasar/llk_lib/llk_math_eltwise_binary.h
+++ b/tt_llk_quasar/llk_lib/llk_math_eltwise_binary.h
@@ -80,7 +80,7 @@ inline void _llk_math_eltwise_binary_mop_config_(const TileShape& tile_shape)
         temp.set_last_inner_loop_instr(eltwise_binary_op_clr_fidelity); // clear math fidelity
     }
 
-    temp.program_bank0_sw_cntl(instrn_buffer);
+    temp.program_bank0_sw_cntl();
 }
 
 //----------------------
@@ -147,7 +147,7 @@ inline void _llk_math_eltwise_di_binary_mop_config_(const TileShape& tile_shape)
         temp.set_end_op(TT_OP_SETRWC(p_setrwc::CLR_AB, 0, 0, p_setrwc::SET_ABD_F));
     }
 
-    temp.program_bank0_sw_cntl(instrn_buffer);
+    temp.program_bank0_sw_cntl();
 }
 
 //----------------------
@@ -234,7 +234,7 @@ inline void _llk_math_eltwise_binary_(const uint32_t tile_idx)
     _set_dst_write_addr_<DstTileShape::Tile32x32>(tile_idx);
 
     // Run MOP
-    ckernel::ckernel_template::run_bank0_sw_cntl(instrn_buffer);
+    ckernel::ckernel_template::run_bank0_sw_cntl();
 
     // Reset all counters
     _reset_counters_<p_setrwc::SET_ABD_F>();

--- a/tt_llk_quasar/llk_lib/llk_math_eltwise_binary_broadcast.h
+++ b/tt_llk_quasar/llk_lib/llk_math_eltwise_binary_broadcast.h
@@ -72,7 +72,7 @@ inline void _llk_math_eltwise_binary_broadcast_mop_config_(const TileShape& tile
     }
 
     temp.set_last_outer_loop_instr(eltwise_binary_op_clr_srcAB_valid);
-    temp.program_bank0_sw_cntl(instrn_buffer);
+    temp.program_bank0_sw_cntl();
 }
 
 /**
@@ -167,7 +167,7 @@ inline void _llk_math_eltwise_binary_broadcast_(const uint32_t tile_idx)
     _set_dst_write_addr_<DstTileShape::Tile32x32>(tile_idx);
 
     // Run MOP
-    ckernel::ckernel_template::run_bank0_sw_cntl(instrn_buffer);
+    ckernel::ckernel_template::run_bank0_sw_cntl();
 
     // Reset all counters
     _reset_counters_<p_setrwc::SET_ABD_F>();

--- a/tt_llk_quasar/llk_lib/llk_math_eltwise_unary_datacopy.h
+++ b/tt_llk_quasar/llk_lib/llk_math_eltwise_unary_datacopy.h
@@ -61,7 +61,7 @@ inline void _llk_math_eltwise_unary_datacopy_mop_config_(
 
     temp.set_last_inner_loop_instr(datacopy_func(ADDR_MOD_1));
 
-    temp.program_bank0_sw_cntl(instrn_buffer);
+    temp.program_bank0_sw_cntl();
 }
 
 /**
@@ -150,7 +150,7 @@ inline void _llk_math_eltwise_unary_datacopy_(const uint32_t tile_idx)
     _set_dst_write_addr_by_rows_<num_rows_per_tile>(tile_idx);
 
     // Run MOP
-    ckernel::ckernel_template::run_bank0_sw_cntl(instrn_buffer);
+    ckernel::ckernel_template::run_bank0_sw_cntl();
 
     // Reset all counters
     _reset_counters_<p_setrwc::SET_ABD_F>();

--- a/tt_llk_quasar/llk_lib/llk_math_matmul.h
+++ b/tt_llk_quasar/llk_lib/llk_math_matmul.h
@@ -145,7 +145,7 @@ inline void _llk_math_matmul_mop_config_()
     ckernel_template temp(1 /* outer loop */, FIDELITY_PHASES, TT_OP_REPLAY(0, replay_buf_len, 0, 0, 0, 0), matmul_op);
     temp.set_last_outer_loop_instr(matmul_op_last);
 
-    temp.program_bank0_sw_cntl(instrn_buffer);
+    temp.program_bank0_sw_cntl();
 }
 
 /**
@@ -268,7 +268,7 @@ inline void _llk_math_matmul_di_mop_config_()
             temp.set_end_op(TT_OP_SETRWC(p_setrwc::CLR_B, 0, 0, p_setrwc::SET_ABD_F));
         }
     }
-    temp.program_bank0_sw_cntl(instrn_buffer);
+    temp.program_bank0_sw_cntl();
 }
 
 /**
@@ -313,7 +313,7 @@ inline void _llk_math_matmul_init_()
 inline void _llk_math_matmul_tile_(const uint dst_index)
 {
     _set_dst_write_addr_<DstTileShape::Tile32x32>(dst_index);
-    ckernel_template::run_bank0_sw_cntl(instrn_buffer);
+    ckernel_template::run_bank0_sw_cntl();
     TTI_SETRWC(p_setrwc::CLR_B, 0, 0, p_setrwc::SET_ABD_F);
 }
 
@@ -342,7 +342,7 @@ inline void _llk_math_matmul_block_()
     {
         for (uint rut = 0; rut < rut_dim; rut++)
         {
-            ckernel_template::run_bank0_sw_cntl(instrn_buffer);
+            ckernel_template::run_bank0_sw_cntl();
 
             // Clear srcB or srcA at end of reuse (once per u block row)
             if (rut == (rut_dim - 1))

--- a/tt_llk_quasar/llk_lib/llk_math_reduce.h
+++ b/tt_llk_quasar/llk_lib/llk_math_reduce.h
@@ -78,7 +78,7 @@ inline void _llk_math_reduce_col_mop_config_(const TileShape& tile_shape)
 
     ckernel_template temp(MOP_OUTER_LOOP, MOP_INNER_LOOP, TT_OP_REPLAY(0, replay_buf_len, 0, 0, 0, 0));
 
-    temp.program_bank0_sw_cntl(instrn_buffer);
+    temp.program_bank0_sw_cntl();
 }
 
 /**
@@ -194,7 +194,7 @@ inline void _llk_math_reduce_row_mop_config_(const TileShape& tile_shape)
 
     ckernel_template temp(MOP_OUTER_LOOP, MOP_INNER_LOOP, TT_OP_REPLAY(0, replay_buf_len, 0, 0, 0, 0));
 
-    temp.program_bank0_sw_cntl(instrn_buffer);
+    temp.program_bank0_sw_cntl();
 }
 
 /**
@@ -281,7 +281,7 @@ inline void _llk_math_reduce_scalar_mop_config_(const TileShape& tile_shape)
 
     ckernel_template temp(MOP_OUTER_LOOP, MOP_INNER_LOOP, TT_OP_REPLAY(0, replay_buf_len, 0, 0, 0, 0));
 
-    temp.program_bank0_sw_cntl(instrn_buffer);
+    temp.program_bank0_sw_cntl();
 }
 
 /**
@@ -356,7 +356,7 @@ inline void _llk_math_reduce_(const uint32_t tile_idx)
 {
     _set_dst_write_addr_<DstTileShape::Tile32x32>(tile_idx);
     // Run MOP
-    ckernel::ckernel_template::run_bank0_sw_cntl(instrn_buffer);
+    ckernel::ckernel_template::run_bank0_sw_cntl();
 
     // Since only 1 face of srcB is used for constant values,
     // can clear data valid after all operations are done

--- a/tt_llk_quasar/llk_lib/llk_pack.h
+++ b/tt_llk_quasar/llk_lib/llk_pack.h
@@ -42,7 +42,7 @@ inline void _llk_pack_mop_config_(const uint32_t num_tiles)
     }();
     ckernel_template temp(MOP_OUTER_LOOP, MOP_INNER_LOOP, pack_instrn);
 
-    temp.program_bank0_sw_cntl(instrn_buffer);
+    temp.program_bank0_sw_cntl();
 }
 
 /**
@@ -85,5 +85,5 @@ inline void _llk_pack_(
     TT_SET_DST_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, PACK_SEL, start_l1_tile_idx);
 
     // Runs MOP
-    ckernel::ckernel_template::run_bank0_sw_cntl(instrn_buffer);
+    ckernel::ckernel_template::run_bank0_sw_cntl();
 }

--- a/tt_llk_quasar/llk_lib/llk_pack_matmul.h
+++ b/tt_llk_quasar/llk_lib/llk_pack_matmul.h
@@ -35,7 +35,7 @@ inline void _llk_pack_matmul_mop_config_()
     ckernel_template temp(MOP_OUTER_LOOP, MOP_INNER_LOOP, pack_instrn);
     temp.set_end_op(incr_l1_ptr);
 
-    temp.program_bank0_sw_cntl(instrn_buffer);
+    temp.program_bank0_sw_cntl();
 }
 
 /**
@@ -78,5 +78,5 @@ inline void _llk_pack_matmul_(
     TT_SET_DST_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, PACK_SEL, start_l1_tile_idx);
 
     // Runs MOP
-    ckernel::ckernel_template::run_bank0_sw_cntl(instrn_buffer);
+    ckernel::ckernel_template::run_bank0_sw_cntl();
 }

--- a/tt_llk_quasar/llk_lib/llk_pack_untilize.h
+++ b/tt_llk_quasar/llk_lib/llk_pack_untilize.h
@@ -33,7 +33,7 @@ inline void _llk_pack_untilize_mop_config_()
     ckernel_template temp(MOP_OUTER_LOOP, MOP_INNER_LOOP, pack_instrn);
     temp.set_last_outer_loop_instr(reset_src_reg_instrn);
 
-    temp.program_bank0_sw_cntl(instrn_buffer);
+    temp.program_bank0_sw_cntl();
 }
 
 /**
@@ -60,7 +60,7 @@ inline void _llk_pack_untilize_init_(const TileShape& tile_shape)
 inline void _llk_pack_untilize_()
 {
     // Runs MOP
-    ckernel::ckernel_template::run_bank0_sw_cntl(instrn_buffer);
+    ckernel::ckernel_template::run_bank0_sw_cntl();
 }
 
 /**
@@ -84,7 +84,7 @@ inline void _llk_pack_untilize_strided_mop_config_()
     ckernel_template temp(MOP_OUTER_LOOP, MOP_INNER_LOOP, pack_instrn, incr_L1_ptr);
     // temp.set_end_op(pack_instrn);
 
-    temp.program_bank0_sw_cntl(instrn_buffer);
+    temp.program_bank0_sw_cntl();
 }
 
 /**
@@ -109,7 +109,7 @@ inline void _llk_pack_untilize_strided_4x32_mop_config_()
     ckernel_template temp(MOP_OUTER_LOOP, MOP_INNER_LOOP, pack_instrn, pack_instrn);
     temp.set_start_op(reset_dest_reg_ptr);
     temp.set_last_outer_loop_instr(pack_instrn_rest_reg_ctr);
-    temp.program_bank0_sw_cntl(instrn_buffer);
+    temp.program_bank0_sw_cntl();
 }
 
 template <uint8_t BUF_DESC_ID, uint32_t FULL_CT_DIM, uint32_t NUM_TILES_PER_BLOCK, uint32_t C_DIM_FACES>
@@ -135,7 +135,7 @@ inline void _llk_pack_untilize_strided_2x32_mop_config_()
     ckernel_template temp(MOP_OUTER_LOOP, MOP_INNER_LOOP, TT_OP_REPLAY(0, replay_buf_len, 0, 0, 0, 0));
     temp.set_start_op(reset_dest_reg_ptr);
     temp.set_last_outer_loop_instr(pack_instrn_rest_reg_ctr);
-    temp.program_bank0_sw_cntl(instrn_buffer);
+    temp.program_bank0_sw_cntl();
 }
 
 template <uint8_t BUF_DESC_ID, uint32_t FULL_CT_DIM, uint32_t NUM_TILES_PER_BLOCK, uint32_t C_DIM_FACES>
@@ -153,7 +153,7 @@ inline void _llk_pack_untilize_strided_1x32_mop_config_()
     ckernel_template temp(MOP_OUTER_LOOP, MOP_INNER_LOOP, pack_instrn, pack_instrn);
     temp.set_start_op(reset_dest_reg_ptr);
     temp.set_last_outer_loop_instr(pack_instrn_rest_reg_ctr);
-    temp.program_bank0_sw_cntl(instrn_buffer);
+    temp.program_bank0_sw_cntl();
 }
 
 /**
@@ -208,24 +208,24 @@ inline void _llk_pack_untilize_strided_(const TileShape& tile_shape, const uint 
     TT_SET_DST_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, p_pacr::PACK0, l1_tile_idx * C_DIM_FACES);
 
     // Face 0
-    ckernel::ckernel_template::run_bank0_sw_cntl(instrn_buffer);
+    ckernel::ckernel_template::run_bank0_sw_cntl();
     TTI_PACR_STRIDE(1, 1, 0, 0, 0, BUF_DESC_ID, 0 /*pck0 sel*/, 0 /*dvalid*/);
 
     // Face 1
     TT_SET_DST_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, p_pacr::PACK0, f1_row_idx);
-    ckernel::ckernel_template::run_bank0_sw_cntl(instrn_buffer);
+    ckernel::ckernel_template::run_bank0_sw_cntl();
 
     if (tile_shape.num_faces == ckernel::trisc::NUM_FACES)
     {
         TTI_PACR_STRIDE(1, 1, 0, 0, 0, BUF_DESC_ID, 0 /*pck0 sel*/, 0 /*dvalid*/);
         // Face 2
         TT_SET_DST_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, p_pacr::PACK0, l1_tile_idx * C_DIM_FACES + C_DIM_FACES * tile_shape.face_r_dim * FULL_CT_DIM);
-        ckernel::ckernel_template::run_bank0_sw_cntl(instrn_buffer);
+        ckernel::ckernel_template::run_bank0_sw_cntl();
         TTI_PACR_STRIDE(1, 1, 0, 0, 0, BUF_DESC_ID, 0 /*pck0 sel*/, 0 /*dvalid*/);
 
         // Face 3
         TT_SET_DST_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, p_pacr::PACK0, l1_tile_idx * C_DIM_FACES + C_DIM_FACES * tile_shape.face_r_dim * FULL_CT_DIM + 1);
-        ckernel::ckernel_template::run_bank0_sw_cntl(instrn_buffer);
+        ckernel::ckernel_template::run_bank0_sw_cntl();
         TTI_PACR_STRIDE(0, 1, 0, 0, 0, BUF_DESC_ID, 0 /*pck0 sel*/, 0 /*dvalid*/);
     }
     else
@@ -237,5 +237,5 @@ inline void _llk_pack_untilize_strided_(const TileShape& tile_shape, const uint 
 template <uint8_t BUF_DESC_ID>
 inline void _llk_pack_untilize_strided_4x32_()
 {
-    ckernel::ckernel_template::run_bank0_sw_cntl(instrn_buffer);
+    ckernel::ckernel_template::run_bank0_sw_cntl();
 }

--- a/tt_llk_quasar/llk_lib/llk_unpack_binary_broadcast_operands.h
+++ b/tt_llk_quasar/llk_lib/llk_unpack_binary_broadcast_operands.h
@@ -59,7 +59,7 @@ inline void _llk_unpack_binary_broadcast_operands_mop_config_(const uint32_t num
 
     temp.set_start_op(unpack_srca_tile_inc);
 
-    temp.program_bank0_sw_cntl(instrn_buffer);
+    temp.program_bank0_sw_cntl();
 }
 
 /**
@@ -98,5 +98,5 @@ inline void _llk_unpack_binary_broadcast_operands_(const uint start_l1_tile_idx_
     TTI_SET_DST_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, p_unpacr::UNP_A | p_unpacr::UNP_B, 0);
 
     // Runs MOP
-    ckernel::ckernel_template::run_bank0_sw_cntl(instrn_buffer);
+    ckernel::ckernel_template::run_bank0_sw_cntl();
 }

--- a/tt_llk_quasar/llk_lib/llk_unpack_binary_operands.h
+++ b/tt_llk_quasar/llk_lib/llk_unpack_binary_operands.h
@@ -30,7 +30,7 @@ inline void _llk_unpack_binary_operands_mop_config_(const uint32_t num_tiles)
 
     ckernel_template temp(MOP_OUTER_LOOP, MOP_INNER_LOOP, unpack_instrn0, unpack_instrn1);
 
-    temp.program_bank0_sw_cntl(instrn_buffer);
+    temp.program_bank0_sw_cntl();
 }
 
 /**
@@ -67,5 +67,5 @@ inline void _llk_unpack_binary_operands_(const uint start_l1_tile_idx_0, const u
     TTI_SET_DST_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, p_unpacr::UNP_A | p_unpacr::UNP_B, 0);
 
     // Runs MOP
-    ckernel::ckernel_template::run_bank0_sw_cntl(instrn_buffer);
+    ckernel::ckernel_template::run_bank0_sw_cntl();
 }

--- a/tt_llk_quasar/llk_lib/llk_unpack_matmul.h
+++ b/tt_llk_quasar/llk_lib/llk_unpack_matmul.h
@@ -51,7 +51,7 @@ inline void _llk_unpack_matmul_mop_config_()
     }
     ckernel_template temp(MOP_OUTER_LOOP, MOP_INNER_LOOP, unpack_instrn /*, inc_l1_instrn*/);
     temp.set_start_op(unpack_reuse_instrn);
-    temp.program_bank0_sw_cntl(instrn_buffer);
+    temp.program_bank0_sw_cntl();
 }
 
 /**
@@ -119,6 +119,6 @@ inline void _llk_unpack_matmul_(const std::uint32_t start_l1_tile_idx_0, const s
         TT_SET_SRC_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, p_unpacr::UNP_A, tile_idx_1);
 
         // Runs MOP
-        ckernel::ckernel_template::run_bank0_sw_cntl(instrn_buffer);
+        ckernel::ckernel_template::run_bank0_sw_cntl();
     }
 }

--- a/tt_llk_quasar/llk_lib/llk_unpack_reduce.h
+++ b/tt_llk_quasar/llk_lib/llk_unpack_reduce.h
@@ -43,7 +43,7 @@ inline void _llk_unpack_reduce_mop_config_(const uint32_t num_tiles, const TileS
     }
 
     temp.set_start_op(unpack_srcB_face);
-    temp.program_bank0_sw_cntl(instrn_buffer);
+    temp.program_bank0_sw_cntl();
 }
 
 /**
@@ -85,5 +85,5 @@ inline void _llk_unpack_reduce_(const uint start_l1_tile_idx_0, const uint start
     TTI_SET_DST_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, p_unpacr::UNP_A | p_unpacr::UNP_B, 0);
 
     // Runs MOP
-    ckernel::ckernel_template::run_bank0_sw_cntl(instrn_buffer);
+    ckernel::ckernel_template::run_bank0_sw_cntl();
 }

--- a/tt_llk_quasar/llk_lib/llk_unpack_tilize.h
+++ b/tt_llk_quasar/llk_lib/llk_unpack_tilize.h
@@ -40,7 +40,7 @@ inline void _llk_unpack_tilize_mop_config_()
         temp.set_end_op(TT_OP_UNPACR_NOP(p_unpacr::UNP_B, 1 /*Dvalid*/, 0, 0, 0 /*clear to 0*/, 0 /*clear to 0*/));
     }
 
-    temp.program_bank0_sw_cntl(instrn_buffer);
+    temp.program_bank0_sw_cntl();
 }
 
 /**
@@ -94,7 +94,7 @@ inline void _llk_unpack_tilize_(const uint l1_tile_idx)
     TTI_SET_DST_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, UNP_SEL, 0);
 
     // Runs MOP
-    ckernel::ckernel_template::run_bank0_sw_cntl(instrn_buffer);
+    ckernel::ckernel_template::run_bank0_sw_cntl();
 }
 
 /**
@@ -129,7 +129,7 @@ inline void _llk_unpack_tilize_strided_mop_config_()
     ckernel_template temp(MOP_OUTER_LOOP, MOP_INNER_LOOP, unpack_half_face_instrn, increment_half_face_instrn);
     temp.set_end_op(unpack_half_face_instrn);
 
-    temp.program_bank0_sw_cntl(instrn_buffer);
+    temp.program_bank0_sw_cntl();
 }
 
 /**
@@ -180,17 +180,17 @@ inline void _llk_unpack_tilize_strided_(const TileShape& tile_shape, const uint 
     TTI_SET_DST_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, UNP_SEL, 0);
 
     // Face 0
-    ckernel::ckernel_template::run_bank0_sw_cntl(instrn_buffer);
+    ckernel::ckernel_template::run_bank0_sw_cntl();
     TT_SET_SRC_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, UNP_SEL, f1_row_idx); // Set L1 ptr
 
     if (tile_shape.num_faces == ckernel::trisc::NUM_FACES)
     {
         // Face 1
-        ckernel::ckernel_template::run_bank0_sw_cntl(instrn_buffer); // Unpack half face and increment L1 ptr
+        ckernel::ckernel_template::run_bank0_sw_cntl(); // Unpack half face and increment L1 ptr
 
         // Face 2
         TT_SET_SRC_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, UNP_SEL, l1_tile_idx * C_DIM_FACES + C_DIM_FACES * tile_shape.face_r_dim * FULL_CT_DIM);
-        ckernel::ckernel_template::run_bank0_sw_cntl(instrn_buffer);
+        ckernel::ckernel_template::run_bank0_sw_cntl();
 
         // Face 3
         TT_SET_SRC_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, UNP_SEL, l1_tile_idx * C_DIM_FACES + C_DIM_FACES * tile_shape.face_r_dim * FULL_CT_DIM + 1);
@@ -248,7 +248,7 @@ inline void _llk_unpack_tilize_strided_mop_config_small_faces_()
         temp.set_end_op(TT_OP_UNPACR_NOP(p_unpacr::UNP_B, 1 /*Dvalid*/, 0, 0, 0 /*clear to 0*/, 0 /*clear to 0*/));
     }
 
-    temp.program_bank0_sw_cntl(instrn_buffer);
+    temp.program_bank0_sw_cntl();
 }
 
 /**
@@ -286,5 +286,5 @@ inline void _llk_unpack_tilize_strided_small_faces_(const TileShape& tile_shape)
     // Set Source counter to L1 base + offset
 
     // Face 0 & 1
-    ckernel::ckernel_template::run_bank0_sw_cntl(instrn_buffer);
+    ckernel::ckernel_template::run_bank0_sw_cntl();
 }

--- a/tt_llk_quasar/llk_lib/llk_unpack_unary_operand.h
+++ b/tt_llk_quasar/llk_lib/llk_unpack_unary_operand.h
@@ -65,7 +65,7 @@ inline void _llk_unpack_unary_operand_mop_config_(const uint32_t num_tiles)
         temp.set_end_op(TT_OP_UNPACR_NOP(p_unpacr::UNP_A, 1 /*Dvalid*/, 0, 0, 0 /*clear to 0*/, 0 /*clear to 0*/));
     }
 
-    temp.program_bank0_sw_cntl(instrn_buffer);
+    temp.program_bank0_sw_cntl();
 }
 
 /**
@@ -125,7 +125,7 @@ inline void _llk_unpack_unary_operand_transpose_mop_config_(const uint32_t num_t
         }
     }
 
-    temp.program_bank0_sw_cntl(instrn_buffer);
+    temp.program_bank0_sw_cntl();
 }
 
 /**
@@ -178,5 +178,5 @@ inline void _llk_unpack_unary_operand_(const uint l1_tile_idx)
     TTI_SET_DST_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, UNP_SEL, 0);
 
     // Runs MOP
-    ckernel::ckernel_template::run_bank0_sw_cntl(instrn_buffer);
+    ckernel::ckernel_template::run_bank0_sw_cntl();
 }

--- a/tt_llk_wormhole_b0/common/inc/ckernel_template.h
+++ b/tt_llk_wormhole_b0/common/inc/ckernel_template.h
@@ -53,9 +53,9 @@ public:
     void set_last_inner_loop_instr(uint op);
     void set_last_outer_loop_instr(uint op);
 
-    void program(volatile uint *instrn_buffer);         // just programs the registers
-    static void run(volatile uint *instrn_buffer);      // runs - assumes that registers were already programmed
-    void program_and_run(volatile uint *instrn_buffer); // calls program, then run
+    void program();         // just programs the registers
+    static void run();      // runs - assumes that registers were already programmed
+    void program_and_run(); // calls program, then run
 };
 
 class ckernel_unpack_template
@@ -235,10 +235,10 @@ public:
     static ckernel_unpack_template loopx1instr(uint instr0, uint skip0 = TT_OP_NOP);
     static ckernel_unpack_template loopx2instr(uint instr0, uint instr1, uint skip0 = TT_OP_NOP, uint skip1 = TT_OP_NOP);
 
-    void program(volatile uint *instrn_buffer) const;                                                  // just programs the registers
-    static void run(volatile uint *instrn_buffer, const uint8_t count, const uint32_t zmask);          // runs - assumes that registers were already programmed
-    static void run(volatile uint *instrn_buffer, const uint8_t count);                                // runs - assumes that registers were already programmed
-    void program_and_run(volatile uint *instrn_buffer, const uint8_t count, const uint32_t zmask = 0); // calls program, then run
+    void program() const;                                                  // just programs the registers
+    static void run(const uint8_t count, const uint32_t zmask);          // runs - assumes that registers were already programmed
+    static void run(const uint8_t count);                                // runs - assumes that registers were already programmed
+    void program_and_run(const uint8_t count, const uint32_t zmask = 0); // calls program, then run
 };
 
 inline ckernel_template::ckernel_template(uint outer_loop_len, uint inner_loop_len, uint loop_op) :
@@ -303,18 +303,18 @@ inline void ckernel_template::set_last_outer_loop_instr(uint op)
     m_loop0_last_instr = op;
 }
 
-inline void ckernel_template::program_and_run(volatile uint *instrn_buffer)
+inline void ckernel_template::program_and_run()
 {
-    program(instrn_buffer);
-    run(instrn_buffer);
+    program();
+    run();
 }
 
-inline void ckernel_template::run(volatile uint *instrn_buffer)
+inline void ckernel_template::run()
 {
     TTI_MOP(1, 0, 0); // run the double-loop template
 }
 
-inline void ckernel_template::program(volatile uint *instrn_buffer)
+inline void ckernel_template::program()
 {
     volatile uint *mop_cfg = reinterpret_cast<volatile uint *>(TENSIX_MOP_CFG_BASE);
 
@@ -331,25 +331,25 @@ inline void ckernel_template::program(volatile uint *instrn_buffer)
     mop_cfg[8] = m_loop1_last_instr;
 }
 
-inline void ckernel_unpack_template::program_and_run(volatile uint *instrn_buffer, const uint8_t count, const uint32_t zmask)
+inline void ckernel_unpack_template::program_and_run(const uint8_t count, const uint32_t zmask)
 {
-    program(instrn_buffer);
-    run(instrn_buffer, count, zmask);
+    program();
+    run(count, zmask);
 }
 
-inline void ckernel_unpack_template::run(volatile uint *instrn_buffer, const uint8_t count, const uint32_t zmask)
+inline void ckernel_unpack_template::run(const uint8_t count, const uint32_t zmask)
 {
     TT_MOP_CFG(zmask >> 16);              // Set the top 16 bits of zmask - we could skip this for count <= 16
     TT_MOP(0, count - 1, zmask & 0xFFFF); // Run the template
 }
 
 // Version without zmask, should be slightly faster by eliminating one instruction.
-inline void ckernel_unpack_template::run(volatile uint *instrn_buffer, const uint8_t count)
+inline void ckernel_unpack_template::run(const uint8_t count)
 {
     TT_MOP(0, count - 1, 0); // Run the template
 }
 
-inline void ckernel_unpack_template::program(volatile uint *instrn_buffer) const
+inline void ckernel_unpack_template::program() const
 {
     volatile uint *mop_cfg = reinterpret_cast<volatile uint *>(TENSIX_MOP_CFG_BASE);
 

--- a/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_binary.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_binary.h
@@ -54,7 +54,7 @@ inline void _llk_math_eltwise_binary_(const std::uint32_t num_faces, uint dst_in
             for (std::uint32_t n = 0; n < outerloop; n++)
             {
                 eltwise_binary_reuse_dest_as_src<binary_reuse_dest>();
-                ckernel_template::run(instrn_buffer);
+                ckernel_template::run();
             }
             TTI_SETRWC(p_setrwc::CLR_B, 0, 0, 0, 0, 0);
             if (num_faces == 4)
@@ -63,7 +63,7 @@ inline void _llk_math_eltwise_binary_(const std::uint32_t num_faces, uint dst_in
                 for (std::uint32_t n = 0; n < outerloop; n++)
                 {
                     eltwise_binary_reuse_dest_as_src<binary_reuse_dest>();
-                    ckernel_template::run(instrn_buffer);
+                    ckernel_template::run();
                 }
                 TTI_SETRWC(p_setrwc::CLR_B, 0, 0, 0, 0, 0);
             }
@@ -75,7 +75,7 @@ inline void _llk_math_eltwise_binary_(const std::uint32_t num_faces, uint dst_in
             for (std::uint32_t n = 0; n < outerloop; n++)
             {
                 eltwise_binary_reuse_dest_as_src<binary_reuse_dest>();
-                ckernel_template::run(instrn_buffer);
+                ckernel_template::run();
             }
             // Manually clear B once mop is done for scaler bcast
             if constexpr (src_b_bcast_type == BroadcastType::SCALAR)
@@ -110,7 +110,7 @@ inline void _llk_math_eltwise_binary_(const std::uint32_t num_faces, uint dst_in
                             TT_ZEROACC(ZERO_ACC_MODE, ADDR_MOD_1, base_address + (0 + n)); // Clear faces 0 & 1
                         }
                     }
-                    ckernel_template::run(instrn_buffer);
+                    ckernel_template::run();
                 }
             }
             else
@@ -133,7 +133,7 @@ inline void _llk_math_eltwise_binary_(const std::uint32_t num_faces, uint dst_in
                             TT_ZEROACC(ZERO_ACC_MODE, ADDR_MOD_1, base_address + (0 + n)); // Clear faces 0 & 1
                         }
                     }
-                    ckernel_template::run(instrn_buffer);
+                    ckernel_template::run();
                 }
             }
             TTI_SETRWC(p_setrwc::CLR_B, 0, 0, 0, 0, 0);
@@ -159,7 +159,7 @@ inline void _llk_math_eltwise_binary_(const std::uint32_t num_faces, uint dst_in
                                 TT_ZEROACC(ZERO_ACC_MODE, ADDR_MOD_1, base_address + (2 + n)); // Clear faces 2 & 3
                             }
                         }
-                        ckernel_template::run(instrn_buffer);
+                        ckernel_template::run();
                     }
                 }
                 else
@@ -182,7 +182,7 @@ inline void _llk_math_eltwise_binary_(const std::uint32_t num_faces, uint dst_in
                                 TT_ZEROACC(ZERO_ACC_MODE, ADDR_MOD_1, base_address + (2 + n)); // Clear faces 2 & 3
                             }
                         }
-                        ckernel_template::run(instrn_buffer);
+                        ckernel_template::run();
                     }
                 }
                 TTI_SETRWC(p_setrwc::CLR_B, 0, 0, 0, 0, 0);
@@ -212,7 +212,7 @@ inline void _llk_math_eltwise_binary_(const std::uint32_t num_faces, uint dst_in
                             TT_ZEROACC(ZERO_ACC_MODE, ADDR_MOD_1, base_address + n);
                         }
                     }
-                    ckernel_template::run(instrn_buffer);
+                    ckernel_template::run();
                 }
             }
             else
@@ -235,7 +235,7 @@ inline void _llk_math_eltwise_binary_(const std::uint32_t num_faces, uint dst_in
                             TT_ZEROACC(ZERO_ACC_MODE, ADDR_MOD_1, base_address + n);
                         }
                     }
-                    ckernel_template::run(instrn_buffer);
+                    ckernel_template::run();
                 }
             }
             if constexpr (src_b_bcast_type == BroadcastType::SCALAR)
@@ -330,13 +330,13 @@ inline void eltwise_binary_configure_mop(const std::uint32_t acc_to_dest = 0, co
         {
             ckernel_template tmp(outerloop, innerloop, TT_OP_ELWADD(0, acc_to_dest, broadcast_type, addr_mod, 0));
             tmp.set_end_op(TT_OP_SETRWC(p_setrwc::CLR_A, p_setrwc::CR_AB, 0, 0, 0, p_setrwc::SET_AB));
-            tmp.program(instrn_buffer);
+            tmp.program();
         }
         else if constexpr (eltwise_binary_type == ELWSUB)
         {
             ckernel_template tmp(outerloop, innerloop, TT_OP_ELWSUB(0, acc_to_dest, broadcast_type, addr_mod, 0));
             tmp.set_end_op(TT_OP_SETRWC(p_setrwc::CLR_A, p_setrwc::CR_AB, 0, 0, 0, p_setrwc::SET_AB));
-            tmp.program(instrn_buffer);
+            tmp.program();
         }
         else if constexpr (eltwise_binary_type == ELWMUL)
         {
@@ -350,7 +350,7 @@ inline void eltwise_binary_configure_mop(const std::uint32_t acc_to_dest = 0, co
             {
                 tmp.set_end_op(TT_OP_SETRWC(p_setrwc::CLR_A, p_setrwc::CR_AB, 0, 0, 0, p_setrwc::SET_AB));
             }
-            tmp.program(instrn_buffer);
+            tmp.program();
         }
     }
     else
@@ -359,13 +359,13 @@ inline void eltwise_binary_configure_mop(const std::uint32_t acc_to_dest = 0, co
         {
             ckernel_template tmp(outerloop, innerloop, TT_OP_ELWADD(0, acc_to_dest, broadcast_type, addr_mod, 0));
             tmp.set_end_op(TT_OP_SETRWC(p_setrwc::CLR_AB, p_setrwc::CR_AB, 0, 0, 0, p_setrwc::SET_AB));
-            tmp.program(instrn_buffer);
+            tmp.program();
         }
         else if constexpr (eltwise_binary_type == ELWSUB)
         {
             ckernel_template tmp(outerloop, innerloop, TT_OP_ELWSUB(0, acc_to_dest, broadcast_type, addr_mod, 0));
             tmp.set_end_op(TT_OP_SETRWC(p_setrwc::CLR_AB, p_setrwc::CR_AB, 0, 0, 0, p_setrwc::SET_AB));
-            tmp.program(instrn_buffer);
+            tmp.program();
         }
         else if constexpr (eltwise_binary_type == ELWMUL)
         {
@@ -379,7 +379,7 @@ inline void eltwise_binary_configure_mop(const std::uint32_t acc_to_dest = 0, co
             {
                 tmp.set_end_op(TT_OP_SETRWC(p_setrwc::CLR_AB, p_setrwc::CR_AB, 0, 0, 0, p_setrwc::SET_AB));
             }
-            tmp.program(instrn_buffer);
+            tmp.program();
         }
     }
 }

--- a/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_unary_datacopy.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_unary_datacopy.h
@@ -33,21 +33,21 @@ inline void _llk_math_eltwise_unary_datacopy_(const std::uint32_t dst_index, con
 
         if constexpr (type == A2D)
         {
-            ckernel_template::run(instrn_buffer);
+            ckernel_template::run();
         }
         else if constexpr (type == B2D)
         {
             if constexpr (src_b_bcast_type == BroadcastType::COL)
             {
                 // Mop for col broadcast only does 2 outerloops.  Needs to clear B manually and call twice
-                ckernel_template::run(instrn_buffer);
+                ckernel_template::run();
                 TTI_SETRWC(p_setrwc::CLR_B, 0, 0, 0, 0, 0);
-                ckernel_template::run(instrn_buffer);
+                ckernel_template::run();
                 TTI_SETRWC(p_setrwc::CLR_AB, 0, 0, 0, 0, 0);
             }
             else
             {
-                ckernel_template::run(instrn_buffer);
+                ckernel_template::run();
             }
         }
 
@@ -131,13 +131,13 @@ inline void eltwise_unary_configure_mop(uint rows_per_inst, uint total_rows, con
             // use elwadd to handle unpacking data into src A as fp16, but dest is in fp32 mode OR to handle uint8 datums
             ckernel_template tmp(outerloop, innerloop, TT_OP_ELWADD(0, 0, p_elwise::SRCB_NO_BCAST, ADDR_MOD_2, 0));
             tmp.set_end_op(TT_OP_SETRWC(p_setrwc::CLR_AB, 0, 0, 0, 0, p_setrwc::SET_AB));
-            tmp.program(instrn_buffer);
+            tmp.program();
         }
         else
         {
             ckernel_template tmp(outerloop, innerloop, TT_OP_MOVA2D(0, 0, ADDR_MOD_2, p_mova2d::MOV_8_ROWS, 0));
             tmp.set_end_op(TT_OP_SETRWC(p_setrwc::CLR_AB, 0, 0, 0, 0, p_setrwc::SET_AB));
-            tmp.program(instrn_buffer);
+            tmp.program();
         }
     }
     else if constexpr (type == B2D)
@@ -175,25 +175,25 @@ inline void eltwise_unary_configure_mop(uint rows_per_inst, uint total_rows, con
         {
             ckernel_template tmp(outerloop, innerloop, TT_OP_ELWADD(0, 0, broadcast_type, addr_mod, 0));
             tmp.set_end_op(TT_OP_SETRWC(p_setrwc::CLR_AB, 0, 0, 0, 0, 0));
-            tmp.program(instrn_buffer);
+            tmp.program();
         }
         else if constexpr (bcast_type == BroadcastType::COL)
         {
             ckernel_template tmp(outerloop, innerloop, TT_OP_ELWADD(0, 0, broadcast_type, addr_mod, 0));
             tmp.set_end_op(TT_OP_SETRWC(0, p_setrwc::CR_B, 0, 0, 0, p_setrwc::SET_B));
-            tmp.program(instrn_buffer);
+            tmp.program();
         }
         else if constexpr (bcast_type == BroadcastType::ROW)
         {
             ckernel_template tmp(outerloop, innerloop, TT_OP_MOVB2D(0, 0, addr_mod, broadcast_type, 0));
             tmp.set_end_op(TT_OP_SETRWC(p_setrwc::CLR_B, p_setrwc::CR_B, 0, 0, 0, p_setrwc::SET_B));
-            tmp.program(instrn_buffer);
+            tmp.program();
         }
         else
         {
             ckernel_template tmp(outerloop, innerloop, TT_OP_MOVB2D(0, 0, addr_mod, rows_per_inst, 0));
             tmp.set_end_op(TT_OP_SETRWC(p_setrwc::CLR_B, p_setrwc::CR_B, 0, 0, 0, p_setrwc::SET_B));
-            tmp.program(instrn_buffer);
+            tmp.program();
         }
     }
 }
@@ -291,7 +291,7 @@ inline void _llk_math_fast_tilize_mop_config_()
         TT_OP_NOP,
         TT_OP_NOP);
 
-    tmp.program(instrn_buffer);
+    tmp.program();
 }
 
 inline void _llk_math_fast_tilize_init_(const std::uint32_t unpack_dst_format, const std::uint32_t unit_dim)

--- a/tt_llk_wormhole_b0/llk_lib/llk_math_matmul.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_math_matmul.h
@@ -462,7 +462,7 @@ inline void matmul_configure_mop(
             }
         }
     }
-    tmp.program(instrn_buffer);
+    tmp.program();
 }
 
 template <int THROTTLE_LEVEL, bool HIGH_FIDELITY>
@@ -684,7 +684,7 @@ inline void matmul_configure_mop_throttled(
         }
     }
 
-    tmp.program(instrn_buffer);
+    tmp.program();
 }
 
 template <int MATH_FIDELITY_DESC, DstTileFaceLayout FaceLayout = DstTileFaceLayout::ColMajor, int THROTTLE_LEVEL = 0>
@@ -755,7 +755,7 @@ inline void _llk_math_matmul_(
                 {
                     for (uint phase = 0; phase < NUM_FIDELITY_PHASES; phase++)
                     {
-                        ckernel_template::run(instrn_buffer);
+                        ckernel_template::run();
                     }
                     if (reuse_a)
                     {
@@ -768,7 +768,7 @@ inline void _llk_math_matmul_(
                 }
                 else
                 {
-                    ckernel_template::run(instrn_buffer);
+                    ckernel_template::run();
                 }
 
                 // Done with reuse. Clear srcA or srcB valid
@@ -790,13 +790,13 @@ inline void _llk_math_matmul_(
                 {
                     for (uint phase = 0; phase < NUM_FIDELITY_PHASES; phase++)
                     {
-                        ckernel_template::run(instrn_buffer);
+                        ckernel_template::run();
                     }
                     TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_ABD_F);
                 }
                 else
                 {
-                    ckernel_template::run(instrn_buffer);
+                    ckernel_template::run();
                 }
 
                 if ((t + 1) < t_dim)
@@ -835,13 +835,13 @@ inline void _llk_math_matmul_(
                     {
                         for (uint phase = 0; phase < NUM_FIDELITY_PHASES; phase++)
                         {
-                            ckernel_template::run(instrn_buffer);
+                            ckernel_template::run();
                         }
                         TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_ABD_F);
                     }
                     else
                     {
-                        ckernel_template::run(instrn_buffer);
+                        ckernel_template::run();
                     }
                 }
 

--- a/tt_llk_wormhole_b0/llk_lib/llk_math_reduce.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_math_reduce.h
@@ -43,7 +43,7 @@ inline void _llk_math_reduce_(const uint dst_index, bool narrow_tile = false, co
         }
         else if constexpr (HIGH_FIDELITY)
         {
-            ckernel_template::run(instrn_buffer);
+            ckernel_template::run();
             TTI_CLEARDVALID(p_setrwc::CLR_AB, 0);
         }
         else
@@ -57,7 +57,7 @@ inline void _llk_math_reduce_(const uint dst_index, bool narrow_tile = false, co
         }
         else if constexpr (HIGH_FIDELITY)
         {
-            ckernel_template::run(instrn_buffer);
+            ckernel_template::run();
         }
         else
         {
@@ -169,7 +169,7 @@ inline void _llk_math_reduce_(const uint dst_index, bool narrow_tile = false, co
             }
             else if constexpr (HIGH_FIDELITY)
             {
-                ckernel_template::run(instrn_buffer);
+                ckernel_template::run();
                 TTI_CLEARDVALID(p_setrwc::CLR_AB, 0);
             }
             else
@@ -183,7 +183,7 @@ inline void _llk_math_reduce_(const uint dst_index, bool narrow_tile = false, co
             }
             else if constexpr (HIGH_FIDELITY)
             {
-                ckernel_template::run(instrn_buffer);
+                ckernel_template::run();
             }
             else
             {
@@ -286,7 +286,7 @@ inline void _llk_math_reduce_(const uint dst_index, bool narrow_tile = false, co
             {
                 if constexpr (HIGH_FIDELITY)
                 {
-                    ckernel_template::run(instrn_buffer);
+                    ckernel_template::run();
                 }
                 else
                 {
@@ -306,7 +306,7 @@ inline void _llk_math_reduce_(const uint dst_index, bool narrow_tile = false, co
                 {
                     if constexpr (HIGH_FIDELITY)
                     {
-                        ckernel_template::run(instrn_buffer);
+                        ckernel_template::run();
                     }
                     else
                     {
@@ -331,7 +331,7 @@ inline void _llk_math_reduce_(const uint dst_index, bool narrow_tile = false, co
             {
                 if constexpr (HIGH_FIDELITY)
                 {
-                    ckernel_template::run(instrn_buffer);
+                    ckernel_template::run();
                     TTI_CLEARDVALID(p_setrwc::CLR_AB, 0);
                 }
                 else
@@ -349,7 +349,7 @@ inline void _llk_math_reduce_(const uint dst_index, bool narrow_tile = false, co
         {
             if constexpr (HIGH_FIDELITY)
             {
-                ckernel_template::run(instrn_buffer);
+                ckernel_template::run();
             }
             else
             {
@@ -431,14 +431,14 @@ inline void reduce_configure_mop()
         ckernel_template tmp(1, num_fidelity_phases, TT_OP_GAPOOL(p_setrwc::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_3, p_gpool::INDEX_DIS, 4));
         tmp.set_last_inner_loop_instr(TT_OP_GAPOOL(p_setrwc::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, 4));
         tmp.set_last_outer_loop_instr(TT_OP_GAPOOL(p_setrwc::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, 4));
-        tmp.program(instrn_buffer);
+        tmp.program();
     }
     else
     {
         ckernel_template tmp(1, num_fidelity_phases, TT_OP_GAPOOL(p_setrwc::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_3, p_gpool::INDEX_DIS, 0));
         tmp.set_last_inner_loop_instr(TT_OP_GAPOOL(p_setrwc::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, 0));
         tmp.set_last_outer_loop_instr(TT_OP_GAPOOL(p_setrwc::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, 0));
-        tmp.program(instrn_buffer);
+        tmp.program();
     }
 }
 

--- a/tt_llk_wormhole_b0/llk_lib/llk_math_transpose_dest.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_math_transpose_dest.h
@@ -49,17 +49,17 @@ inline void _llk_math_transpose_dest_(const std::uint32_t dst_index)
         if constexpr (transpose_of_faces)
         {
             // 4x 32b face transpositions followed by 8x middle-face row swaps.
-            ckernel_unpack_template::run(instrn_buffer, 12, 0xff0);
+            ckernel_unpack_template::run(12, 0xff0);
         }
         else
         {
             // 4x 32b face transpositions.
-            ckernel_unpack_template::run(instrn_buffer, 4, 0);
+            ckernel_unpack_template::run(4, 0);
         }
     }
     else
     {
-        ckernel_unpack_template::run(instrn_buffer, 2, 2);
+        ckernel_unpack_template::run(2, 2);
     }
 
     TTI_SETRWC(p_setrwc::CLR_AB, 0, 0, 0, 0, p_setrwc::SET_ABD);
@@ -169,7 +169,7 @@ inline void transpose_dest_configure_mop()
         // - zmask 0-bits: 32b 16x16 face transpose.
         // - zmask 1-bits: 32b 32x1 middle face row swap via SFPU.
         ckernel_unpack_template tmp(true, true, movd2b_hi, transpose, movb2d_hi_d2b_lo, transpose, /* skip A */ macro0, /* B */ movb2d_lo, /* skip B */ macro1);
-        tmp.program(instrn_buffer);
+        tmp.program();
     }
     else
     {
@@ -214,7 +214,7 @@ inline void transpose_dest_configure_mop()
 
         // The following MOP config simply runs the above 7 instructions in order (when executed with zmask 0b10):
         ckernel_unpack_template tmp(true, true, EFGHIJKLM, EFGHI, ABCDEFG, P, /* skip A */ Q, /* B */ IJKL, /* skip B */ EFGHIJKLMNO);
-        tmp.program(instrn_buffer);
+        tmp.program();
     }
 }
 

--- a/tt_llk_wormhole_b0/llk_lib/llk_pack.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_pack.h
@@ -84,7 +84,7 @@ inline void _llk_pack_mop_config_(
             tmp.set_end_op(TT_OP_STOREIND(1, 0, p_ind::LD_16B, LO_16(0), p_ind::INC_NONE, p_gpr_pack::TILE_HEADER, p_gpr_pack::OUTPUT_ADDR));
         }
 
-        tmp.program(instrn_buffer);
+        tmp.program();
     }
     else
     {
@@ -93,7 +93,7 @@ inline void _llk_pack_mop_config_(
         if ((face_r_dim == 1) || narrow_tile)
         {
             ckernel::ckernel_template tmp(MOP_OUTER_LOOP, MOP_INNER_LOOP, TT_OP_PACR(ADDR_MOD_0, ZERO_OUTPUT_FLAG, PACK_SEL(PACKCNT), 0, MEGAROW, 0, 1));
-            tmp.program(instrn_buffer);
+            tmp.program();
         }
         else
         {
@@ -101,7 +101,7 @@ inline void _llk_pack_mop_config_(
             ckernel::ckernel_template tmp(MOP_OUTER_LOOP, MOP_INNER_LOOP, TT_OP_INCADCXY(p_setadc::PAC, 0, 0, 1, 0));
             tmp.set_start_op(TT_OP_PACR(ADDR_MOD_0, ZERO_OUTPUT_FLAG, PACK_SEL(PACKCNT), 0, MEGAROW, 0, 0));
             tmp.set_end_op(TT_OP_PACR(ADDR_MOD_1, ZERO_OUTPUT_FLAG, PACK_SEL(PACKCNT), 0, MEGAROW, 0, 0));
-            tmp.program(instrn_buffer);
+            tmp.program();
         }
     }
 }
@@ -309,7 +309,7 @@ inline void _llk_pack_fast_tilize_mop_config_(const std::uint32_t unit_dim)
         TT_OP_NOP,
         TT_OP_NOP);
 
-    tmp.program(instrn_buffer);
+    tmp.program();
 }
 
 template <DstSync Dst>

--- a/tt_llk_wormhole_b0/llk_lib/llk_pack_untilize.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_pack_untilize.h
@@ -76,14 +76,14 @@ inline void _llk_pack_untilize_mop_config_(const std::uint32_t face_r_dim = FACE
         tmp.set_start_op(TT_OP_PACR(ADDR_MOD_0, ZERO_OUTPUT_FLAG, PACK_SEL(PACKCNT), 0, MEGAROW, 0, 0));
         tmp.set_last_inner_loop_instr(TT_OP_PACR(ADDR_MOD_1, ZERO_OUTPUT_FLAG, PACK_SEL(PACKCNT), 0, MEGAROW, 0, 0));
         tmp.set_end_ops(TT_OP_SETADCXX(p_setadc::PAC, 1 - 1, 0x0), TT_OP_INCADCZW(p_setadc::PAC, 0, 0, 1, 0)); // w cnt points to the next tile
-        tmp.program(instrn_buffer);
+        tmp.program();
     }
     else
     {
         if constexpr (narrow_row)
         { // always
             ckernel::ckernel_template tmp(MOP_OUTER_LOOP, MOP_INNER_LOOP, TT_OP_PACR(ADDR_MOD_0, ZERO_OUTPUT_FLAG, PACK_SEL(PACKCNT), 0, 0, 0, 0));
-            tmp.program(instrn_buffer);
+            tmp.program();
         }
         else
         {
@@ -95,13 +95,13 @@ inline void _llk_pack_untilize_mop_config_(const std::uint32_t face_r_dim = FACE
                 tmp.set_end_ops(
                     TT_OP_PACR(ADDR_MOD_1, ZERO_OUTPUT_FLAG, PACK_SEL(PACKCNT), 0, MEGAROW, 0, 0),
                     TT_OP_INCADCZW(p_setadc::PAC, 0, 0, 1, 0)); // w cnt points to the next tile
-                tmp.program(instrn_buffer);
+                tmp.program();
             }
             else
             {
                 ckernel::ckernel_template tmp(MOP_OUTER_LOOP, MOP_INNER_LOOP, TT_OP_PACR(ADDR_MOD_1, ZERO_OUTPUT_FLAG, PACK_SEL(PACKCNT), 0, MEGAROW, 0, 0));
                 tmp.set_end_op(TT_OP_INCADCZW(p_setadc::PAC, 0, 0, 1, 0)); // w cnt points to the next tile
-                tmp.program(instrn_buffer);
+                tmp.program();
             }
         }
 
@@ -160,7 +160,7 @@ inline void _llk_pack_untilize_(
 
     if constexpr (narrow_row)
     {
-        ckernel::ckernel_template::run(instrn_buffer);
+        ckernel::ckernel_template::run();
     }
     else
     {
@@ -169,7 +169,7 @@ inline void _llk_pack_untilize_(
         for (std::uint32_t row = 0; row < num_rows; row++)
         {
             TT_SETADC(p_setadc::PAC, p_setadc::CH_0, p_setadc::SET_W, tile_dst_offset); // Clear tile counter
-            ckernel::ckernel_template::run(instrn_buffer);
+            ckernel::ckernel_template::run();
             TTI_ADDRCRXY(p_setadc::PAC, 0, 0, 1, 0, 0b0010); // Read new row in the tile
             if constexpr (block_ct_dim != full_ct_dim)
             {

--- a/tt_llk_wormhole_b0/llk_lib/llk_unpack_A.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_unpack_A.h
@@ -65,14 +65,14 @@ inline void _llk_unpack_A_mop_config_(
             const uint32_t innerloop = 2;
             ckernel_template tmp(outerloop, innerloop, unpack_srca_to_dest_transpose_of_faces);
             tmp.set_end_op(TT_OP_SETADCZW(p_setadc::UNP_A, 0, 2, 0, 1, 0b0101));
-            tmp.program(instrn_buffer);
+            tmp.program();
         }
         else
         {
             const uint32_t outerloop     = num_faces;
             constexpr uint32_t innerloop = 1;
             ckernel_template tmp(outerloop, innerloop, unpack_srca_to_dest);
-            tmp.program(instrn_buffer);
+            tmp.program();
         }
     }
     else if constexpr (BType == BroadcastType::COL)
@@ -83,7 +83,7 @@ inline void _llk_unpack_A_mop_config_(
         // ELWADD used in datacopy due to WH broadcast bug, use zerosrca regardless of acc_to_dest
         tmp.set_start_op(unpack_srca_zerosrc_set_dvalid);
         tmp.set_end_op(unpack_srcb);
-        tmp.program(instrn_buffer);
+        tmp.program();
     }
     else if constexpr (BType == BroadcastType::ROW)
     {
@@ -95,7 +95,7 @@ inline void _llk_unpack_A_mop_config_(
             tmp.set_start_op(unpack_srca_zerosrc_set_dvalid);
         }
         tmp.set_end_op(unpack_srcb_unpack_srcb);
-        tmp.program(instrn_buffer);
+        tmp.program();
     }
     else if constexpr (BType == BroadcastType::SCALAR)
     {
@@ -105,7 +105,7 @@ inline void _llk_unpack_A_mop_config_(
         ckernel_template tmp(outerloop, innerloop, unpack_srcb_inc_z_0);
         // ELWADD used in datacopy due to WH broadcast bug, use zerosrca regardless of acc_to_dest
         tmp.set_start_op(unpack_srca_zerosrc_set_dvalid);
-        tmp.program(instrn_buffer);
+        tmp.program();
     }
     else
     {
@@ -132,7 +132,7 @@ inline void _llk_unpack_A_mop_config_(
             {
                 tmp.set_end_op(srca_set_z_1);
             }
-            tmp.program(instrn_buffer);
+            tmp.program();
         }
         else
         {
@@ -153,7 +153,7 @@ inline void _llk_unpack_A_mop_config_(
                 {
                     tmp.set_end_op(unpack_srca_set_dvalid);
                 }
-                tmp.program(instrn_buffer);
+                tmp.program();
             }
             else
             {
@@ -161,7 +161,7 @@ inline void _llk_unpack_A_mop_config_(
                 constexpr uint32_t innerloop = 1;
                 ckernel_template tmp(outerloop, innerloop, unpack_srcb_zerosrc, unpack_srcb_set_dvalid);
                 tmp.set_start_op(unpack_srca);
-                tmp.program(instrn_buffer);
+                tmp.program();
             }
         }
     }
@@ -266,7 +266,7 @@ inline void _llk_unpack_A_(
     TTI_STALLWAIT(p_stall::STALL_UNPACK, p_stall::TRISC_CFG);
 
     // Run MOP
-    ckernel::ckernel_template::run(instrn_buffer);
+    ckernel::ckernel_template::run();
 
     // T6::SEMGET for context release
     t6_semaphore_get(semaphore::UNPACK_SYNC);

--- a/tt_llk_wormhole_b0/llk_lib/llk_unpack_AB.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_unpack_AB.h
@@ -38,7 +38,7 @@ inline void _llk_unpack_AB_mop_config_(const bool transpose_of_faces = false, co
         {
             tmp.set_end_op(unpack_srcb_set_z);
         }
-        tmp.program(instrn_buffer);
+        tmp.program();
     }
     else if constexpr (BType == BroadcastType::ROW)
     {
@@ -48,7 +48,7 @@ inline void _llk_unpack_AB_mop_config_(const bool transpose_of_faces = false, co
         const uint32_t innerloop                   = num_faces < 2 ? 1 : 2;
         ckernel_template tmp(outerloop, innerloop, narrow_tile ? unpack_srcb_no_z_inc : unpack_srcb, unpack_srca);
         tmp.set_end_op(unpack_srcb_clear_z);
-        tmp.program(instrn_buffer);
+        tmp.program();
     }
     else if constexpr (BType == BroadcastType::SCALAR)
     {
@@ -56,7 +56,7 @@ inline void _llk_unpack_AB_mop_config_(const bool transpose_of_faces = false, co
         const uint32_t innerloop = num_faces;
         ckernel_template tmp(outerloop, innerloop, unpack_srca);
         tmp.set_start_op(unpack_srcb);
-        tmp.program(instrn_buffer);
+        tmp.program();
     }
     else
     {
@@ -68,14 +68,14 @@ inline void _llk_unpack_AB_mop_config_(const bool transpose_of_faces = false, co
             const uint32_t innerloop                 = num_faces < 2 ? 1 : 2;
             ckernel_template tmp(outerloop, innerloop, num_faces < 4 ? unpack_srca : unpack_srca_skip_z, unpack_srcb);
             tmp.set_end_op(srca_set_z);
-            tmp.program(instrn_buffer);
+            tmp.program();
         }
         else
         {
             constexpr uint32_t outerloop = 1;
             const uint32_t innerloop     = num_faces;
             ckernel_template tmp(outerloop, innerloop, unpack_srca, unpack_srcb);
-            tmp.program(instrn_buffer);
+            tmp.program();
         }
     }
 }
@@ -144,7 +144,7 @@ inline void _llk_unpack_AB_(const std::uint32_t address_a, const std::uint32_t a
     TTI_STALLWAIT(p_stall::STALL_UNPACK, p_stall::TRISC_CFG);
 
     // Run MOP
-    ckernel::ckernel_template::run(instrn_buffer);
+    ckernel::ckernel_template::run();
 
     // T6::SEMGET for context release
     t6_semaphore_get(semaphore::UNPACK_SYNC);

--- a/tt_llk_wormhole_b0/llk_lib/llk_unpack_AB_matmul.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_unpack_AB_matmul.h
@@ -153,7 +153,7 @@ inline void _llk_unpack_AB_matmul_mop_config_(
         0,
         0);
 
-    tmp.program(instrn_buffer);
+    tmp.program();
 }
 
 template <bool is_fp32_dest_acc_en, StochRndType stoch_rnd_mode = StochRndType::None>

--- a/tt_llk_wormhole_b0/llk_lib/llk_unpack_reduce.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_unpack_reduce.h
@@ -27,7 +27,7 @@ inline void _llk_unpack_reduce_mop_config_(const std::uint32_t num_faces)
     constexpr uint32_t innerloop = 1;
     ckernel_template tmp(outerloop, innerloop, unpack_zerosrca, unpack_srca);
     tmp.set_start_op(unpack_srcb);
-    tmp.program(instrn_buffer);
+    tmp.program();
 }
 
 template <bool is_fp32_dest_acc_en, StochRndType stoch_rnd_mode = StochRndType::None>
@@ -101,7 +101,7 @@ inline void _llk_unpack_reduce_(const std::uint32_t address)
     TTI_STALLWAIT(p_stall::STALL_UNPACK, p_stall::TRISC_CFG);
 
     // Run MOP
-    ckernel::ckernel_template::run(instrn_buffer);
+    ckernel::ckernel_template::run();
 
     // T6::SEMGET for context release
     t6_semaphore_get(semaphore::UNPACK_SYNC);

--- a/tt_llk_wormhole_b0/llk_lib/llk_unpack_tilize.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_unpack_tilize.h
@@ -31,13 +31,13 @@ inline void _llk_unpack_tilize_mop_config_(const bool narrow_tile = false, const
     if (unpack_to_dest)
     {
         ckernel_template tmp(outerloop, innerloop, unpack_srca_to_dest);
-        tmp.program(instrn_buffer);
+        tmp.program();
     }
     else
     {
         ckernel_template tmp(outerloop, innerloop, unpack_srcb_zerosrc, unpack_srcb_set_dvalid);
         tmp.set_start_op(unpack_srca);
-        tmp.program(instrn_buffer);
+        tmp.program();
     }
 }
 
@@ -125,7 +125,7 @@ inline void unpack_tilize_impl(
         TTI_STALLWAIT(p_stall::STALL_UNPACK, p_stall::TRISC_CFG);
 
         // Run MOP
-        ckernel::ckernel_template::run(instrn_buffer);
+        ckernel::ckernel_template::run();
 
         // T6::SEMGET for context release
         t6_semaphore_get(semaphore::UNPACK_SYNC);
@@ -163,7 +163,7 @@ inline void unpack_tilize_to_dest_impl(
     TTI_STALLWAIT(p_stall::STALL_UNPACK, p_stall::TRISC_CFG);
 
     // Unpack top faces
-    ckernel::ckernel_template::run(instrn_buffer);
+    ckernel::ckernel_template::run();
 
     // Unpack bottom faces if needed
     if (num_loops > 1)
@@ -186,7 +186,7 @@ inline void unpack_tilize_to_dest_impl(
         TTI_STALLWAIT(p_stall::STALL_UNPACK, p_stall::THCON);
 
         // Unpack bottom faces
-        ckernel::ckernel_template::run(instrn_buffer);
+        ckernel::ckernel_template::run();
     }
 
     // T6::SEMGET for context release
@@ -281,7 +281,7 @@ inline void _llk_unpack_tilizeA_B_mop_config_(const bool narrow_tile = false, co
             tmp.set_end_ops(unpack_srca_dat_valid, unpack_srcb_dat_valid);
         }
     }
-    tmp.program(instrn_buffer);
+    tmp.program();
 }
 
 template <bool neginf_srcA = false, std::uint32_t reload_srcB = false, bool zero_srcA = false, bool zero_srcA_reduce = false>
@@ -405,7 +405,7 @@ inline void _llk_unpack_tilizeA_B_(
                 TTI_UNPACR_NOP(SrcA, p_unpacr_nop::UNP_ZEROSRC);
             }
 
-            ckernel::ckernel_template::run(instrn_buffer);
+            ckernel::ckernel_template::run();
 
             if (num_faces == 4 && n != 0)
             {
@@ -415,7 +415,7 @@ inline void _llk_unpack_tilizeA_B_(
         }
         else
         {
-            ckernel::ckernel_template::run(instrn_buffer);
+            ckernel::ckernel_template::run();
         }
 
         // T6::SEMGET for context release
@@ -487,7 +487,7 @@ inline void _llk_unpack_fast_tilize_mop_config_()
         TT_OP_UNPACR_COMMON(SrcB, ADDRMOD_CH1Y_0_CH1Z_2_CH0Y_0_CH0Z_1, 0),
         TT_OP_UNPACR_COMMON(SrcB, ADDRMOD_CH1Y_0_CH1Z_3_CH0Y_0_CH0Z_1, 0));
 
-    tmp.program(instrn_buffer);
+    tmp.program();
 }
 
 inline void _llk_unpack_fast_tilize_init_(const std::uint32_t unpack_dst_format, std::uint32_t full_dim)

--- a/tt_llk_wormhole_b0/llk_lib/llk_unpack_untilize.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_unpack_untilize.h
@@ -44,7 +44,7 @@ inline void _llk_unpack_untilize_mop_config_()
         lltt::replay_insn(0, replay_buf_len),
         load_offset_addr_cntx0,
         load_offset_addr_cntx1);
-    tmp.program(instrn_buffer);
+    tmp.program();
 }
 
 template <bool is_fp32_dest_acc_en, StochRndType stoch_rnd_mode = StochRndType::None>


### PR DESCRIPTION
### Ticket
NA

### Problem description
We pass an `instrn_buffer` parameter into a bunch of functions, which the various TT macros use, in place of the global `instrn_buffer` variable.  The outermost call passes in that global variable.  However `instrn_buffer` is somewhat deeply embedded into SFPI itself, and this passing of a local variable only works for the TT macros via the preprocessor not having any scope.  This is somewhat brittle.

It is also blocking a reimplementation of the TT macros, which will remove the distinction between `TT_foo` and `TTI_foo` -- the compiler can just DTRT.

### What's changed
Remove the `instrn_buffer` parameter.

(this is independent of PR#603)

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [YES] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [YES] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [YES] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
