### PR TITLE
Create max pool with indices LLK on SFPU

### DIFF
--- a/tt_llk_blackhole/common/inc/ckernel_sfpu.h
+++ b/tt_llk_blackhole/common/inc/ckernel_sfpu.h
@@ -32,6 +32,7 @@
 #include "sfpu/ckernel_sfpu_log.h"
 #include "sfpu/ckernel_sfpu_max.h"
 #include "sfpu/ckernel_sfpu_max_int32.h"
+#include "sfpu/ckernel_sfpu_max_pool_indices.h"
 #include "sfpu/ckernel_sfpu_mul_int.h"
 #include "sfpu/ckernel_sfpu_negative.h"
 #include "sfpu/ckernel_sfpu_power.h"

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_max_pool_indices.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_max_pool_indices.h
@@ -13,13 +13,27 @@ namespace ckernel
 namespace sfpu
 {
 
+/**
+ * @brief Calculates column-wise MaxPool of a tile, placing output values into the first row.
+ *        Also places the index of the max value into the first row of the indices tile.
+ *        Supports {FP32, FP16_B} for values, and {UINT16, INT32, UINT32} for indices, implied from the Dest mode used.
+ * @tparam APPROXIMATION_MODE Whether to use the approximation mode (unused).
+ * @tparam is_fp32_dest_acc_en Whether Dest is in 32bit mode (true) or 16bit mode (false).
+ * @tparam num_rows The number of rows in the tile, must be one of: {9}
+ * @tparam ITERATIONS The number of iterations to use for the MaxPool operation (unused).
+ * @param indices_tile_idx The index of the tile in the Dest register containing the indices of the data.
+ */
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int num_rows, int ITERATIONS>
-inline void _calculate_max_pool_with_indices_(const uint idx_addr)
+inline void _calculate_max_pool_with_indices_(const uint indices_tile_idx)
 {
-    static_assert(num_rows == 9, "num_rows must be one of: {9}");
-    const uint idx_tile_offset        = idx_addr * 64;
-    constexpr uint8_t instr_mod_index = is_fp32_dest_acc_en ? InstrModLoadStore::INT32 : InstrModLoadStore::LO16;
+    static_assert(num_rows == 9, "num_rows must be one of: {9}"); // add others as support is added
+
+    // size of each tile in Dest is 64 rows
+    constexpr uint dst_tile_size = 64;
+    // each face is 16 rows
     constexpr uint face_offset        = 16;
+    const uint idx_tile_offset        = indices_tile_idx * dst_tile_size;
+    constexpr uint8_t instr_mod_index = is_fp32_dest_acc_en ? InstrModLoadStore::INT32 : InstrModLoadStore::LO16;
 
     // F0
     // data
@@ -84,7 +98,9 @@ inline void _calculate_max_pool_with_indices_(const uint idx_addr)
 
 inline void _init_max_pool_with_indices_()
 {
-    // Set bit [2] of the SFPU_CONTROL_REG to enable index tracking mode
+    // Set bit [2] of the SFPU_CONTROL_REG to enable Destination Index Tracking Mode:
+    // LREGs 4-7 will be treated as indices corresponding to the values in LREGs 0-3,
+    // and LREGs 4-7 will mirror the movement of the values in LREGs 0-3;
     _sfpu_load_config32_(0xF, 0x0, 0x4);
 
     // Program replay buffer
@@ -93,15 +109,16 @@ inline void _init_max_pool_with_indices_()
         7,
         []
         {
-            // transpose to put Dest rows into separate LREGS
+            // Values have been loaded such that 4 rows of Dest occupy the 4 lanes of each LREG
+            // To sort those 4 rows, we transpose the SFPU LREGs to put the 4 rows into separate LREGs
             TTI_SFPTRANSP(0, 0, 0, 0);
 
-            // put max into LREG0 (index into LREG4)
+            // Sort the 4 rows of Dest, placing the max value into LREG0 (index into LREG4)
             TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG1, p_sfpswap::ALL_ROWS_MAX);
             TTI_SFPSWAP(0, p_sfpu::LREG2, p_sfpu::LREG3, p_sfpswap::ALL_ROWS_MAX);
             TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG2, p_sfpswap::ALL_ROWS_MAX);
 
-            // transpose back
+            // Transpose the LREGs back
             TTI_SFPTRANSP(0, 0, 0, 0);
 
             TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG1, p_sfpswap::ALL_ROWS_MAX);

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_max_pool_indices.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_max_pool_indices.h
@@ -1,0 +1,113 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ckernel_addrmod.h"
+#include "ckernel_instr_params.h"
+#include "sfpi.h"
+
+namespace ckernel
+{
+namespace sfpu
+{
+
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int num_rows, int ITERATIONS>
+inline void _calculate_max_pool_with_indices_(const uint idx_addr)
+{
+    static_assert(num_rows == 9, "num_rows must be one of: {9}");
+    const uint idx_tile_offset        = idx_addr * 64;
+    constexpr uint8_t instr_mod_index = is_fp32_dest_acc_en ? InstrModLoadStore::INT32 : InstrModLoadStore::LO16;
+    constexpr uint face_offset        = 16;
+
+    // F0
+    // data
+    TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0); // even cols
+    TTI_SFPLOAD(p_sfpu::LREG1, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 4);
+    TTI_SFPLOAD(p_sfpu::LREG2, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 2); // odd cols
+    TTI_SFPLOAD(p_sfpu::LREG3, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 6);
+    // index
+    TT_SFPLOAD(p_sfpu::LREG4, instr_mod_index, ADDR_MOD_7, idx_tile_offset); // even cols
+    TT_SFPLOAD(p_sfpu::LREG5, instr_mod_index, ADDR_MOD_7, idx_tile_offset + 4);
+    TT_SFPLOAD(p_sfpu::LREG6, instr_mod_index, ADDR_MOD_7, idx_tile_offset + 2); // odd cols
+    TT_SFPLOAD(p_sfpu::LREG7, instr_mod_index, ADDR_MOD_7, idx_tile_offset + 6);
+
+    // sort 4 rows
+    lltt::replay(0, 7);
+
+    // data
+    TTI_SFPLOAD(p_sfpu::LREG1, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 8);  // even cols
+    TTI_SFPLOAD(p_sfpu::LREG3, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 10); // odd cols
+    // index
+    TT_SFPLOAD(p_sfpu::LREG5, instr_mod_index, ADDR_MOD_7, idx_tile_offset + 8);  // even cols
+    TT_SFPLOAD(p_sfpu::LREG7, instr_mod_index, ADDR_MOD_7, idx_tile_offset + 10); // cols cols
+
+    TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG1, p_sfpswap::ALL_ROWS_MAX);
+    TTI_SFPSWAP(0, p_sfpu::LREG2, p_sfpu::LREG3, p_sfpswap::ALL_ROWS_MAX);
+
+    TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);
+    TTI_SFPSTORE(p_sfpu::LREG2, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 2);
+    TT_SFPSTORE(p_sfpu::LREG4, instr_mod_index, ADDR_MOD_7, idx_tile_offset);
+    TT_SFPSTORE(p_sfpu::LREG6, instr_mod_index, ADDR_MOD_7, idx_tile_offset + 2);
+
+    // F1
+    // data
+    TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, face_offset); // even cols
+    TTI_SFPLOAD(p_sfpu::LREG1, InstrModLoadStore::DEFAULT, ADDR_MOD_7, face_offset + 4);
+    TTI_SFPLOAD(p_sfpu::LREG2, InstrModLoadStore::DEFAULT, ADDR_MOD_7, face_offset + 2); // odd cols
+    TTI_SFPLOAD(p_sfpu::LREG3, InstrModLoadStore::DEFAULT, ADDR_MOD_7, face_offset + 6);
+    // index
+    TT_SFPLOAD(p_sfpu::LREG4, instr_mod_index, ADDR_MOD_7, idx_tile_offset + face_offset); // even cols
+    TT_SFPLOAD(p_sfpu::LREG5, instr_mod_index, ADDR_MOD_7, idx_tile_offset + face_offset + 4);
+    TT_SFPLOAD(p_sfpu::LREG6, instr_mod_index, ADDR_MOD_7, idx_tile_offset + face_offset + 2); // odd cols
+    TT_SFPLOAD(p_sfpu::LREG7, instr_mod_index, ADDR_MOD_7, idx_tile_offset + face_offset + 6);
+
+    // sort 4 rows
+    lltt::replay(0, 7);
+
+    // data
+    TTI_SFPLOAD(p_sfpu::LREG1, InstrModLoadStore::DEFAULT, ADDR_MOD_7, face_offset + 8);  // even cols
+    TTI_SFPLOAD(p_sfpu::LREG3, InstrModLoadStore::DEFAULT, ADDR_MOD_7, face_offset + 10); // odd cols
+    // index
+    TT_SFPLOAD(p_sfpu::LREG5, instr_mod_index, ADDR_MOD_7, idx_tile_offset + face_offset + 8);  // even cols
+    TT_SFPLOAD(p_sfpu::LREG7, instr_mod_index, ADDR_MOD_7, idx_tile_offset + face_offset + 10); // cols cols
+
+    TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG1, p_sfpswap::ALL_ROWS_MAX);
+    TTI_SFPSWAP(0, p_sfpu::LREG2, p_sfpu::LREG3, p_sfpswap::ALL_ROWS_MAX);
+
+    TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, face_offset);
+    TTI_SFPSTORE(p_sfpu::LREG2, InstrModLoadStore::DEFAULT, ADDR_MOD_7, face_offset + 2);
+    TT_SFPSTORE(p_sfpu::LREG4, instr_mod_index, ADDR_MOD_7, idx_tile_offset + face_offset);
+    TT_SFPSTORE(p_sfpu::LREG6, instr_mod_index, ADDR_MOD_7, idx_tile_offset + face_offset + 2);
+}
+
+inline void _init_max_pool_with_indices_()
+{
+    // Set bit [2] of the SFPU_CONTROL_REG to enable index tracking mode
+    _sfpu_load_config32_(0xF, 0x0, 0x4);
+
+    // Program replay buffer
+    load_replay_buf(
+        0,
+        7,
+        []
+        {
+            // transpose to put Dest rows into separate LREGS
+            TTI_SFPTRANSP(0, 0, 0, 0);
+
+            // put max into LREG0 (index into LREG4)
+            TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG1, p_sfpswap::ALL_ROWS_MAX);
+            TTI_SFPSWAP(0, p_sfpu::LREG2, p_sfpu::LREG3, p_sfpswap::ALL_ROWS_MAX);
+            TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG2, p_sfpswap::ALL_ROWS_MAX);
+
+            // transpose back
+            TTI_SFPTRANSP(0, 0, 0, 0);
+
+            TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG1, p_sfpswap::ALL_ROWS_MAX);
+            TTI_SFPSWAP(0, p_sfpu::LREG2, p_sfpu::LREG3, p_sfpswap::ALL_ROWS_MAX);
+        });
+}
+
+} // namespace sfpu
+} // namespace ckernel

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_max_pool_indices.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_max_pool_indices.h
@@ -41,7 +41,7 @@ inline void _calculate_max_pool_with_indices_(const uint idx_addr)
     TTI_SFPLOAD(p_sfpu::LREG3, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 10); // odd cols
     // index
     TT_SFPLOAD(p_sfpu::LREG5, instr_mod_index, ADDR_MOD_7, idx_tile_offset + 8);  // even cols
-    TT_SFPLOAD(p_sfpu::LREG7, instr_mod_index, ADDR_MOD_7, idx_tile_offset + 10); // cols cols
+    TT_SFPLOAD(p_sfpu::LREG7, instr_mod_index, ADDR_MOD_7, idx_tile_offset + 10); // odd cols
 
     TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG1, p_sfpswap::ALL_ROWS_MAX);
     TTI_SFPSWAP(0, p_sfpu::LREG2, p_sfpu::LREG3, p_sfpswap::ALL_ROWS_MAX);
@@ -71,7 +71,7 @@ inline void _calculate_max_pool_with_indices_(const uint idx_addr)
     TTI_SFPLOAD(p_sfpu::LREG3, InstrModLoadStore::DEFAULT, ADDR_MOD_7, face_offset + 10); // odd cols
     // index
     TT_SFPLOAD(p_sfpu::LREG5, instr_mod_index, ADDR_MOD_7, idx_tile_offset + face_offset + 8);  // even cols
-    TT_SFPLOAD(p_sfpu::LREG7, instr_mod_index, ADDR_MOD_7, idx_tile_offset + face_offset + 10); // cols cols
+    TT_SFPLOAD(p_sfpu::LREG7, instr_mod_index, ADDR_MOD_7, idx_tile_offset + face_offset + 10); // odd cols
 
     TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG1, p_sfpswap::ALL_ROWS_MAX);
     TTI_SFPSWAP(0, p_sfpu::LREG2, p_sfpu::LREG3, p_sfpswap::ALL_ROWS_MAX);

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_max_pool_indices.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_max_pool_indices.h
@@ -16,7 +16,7 @@ namespace sfpu
 /**
  * @brief Calculates column-wise MaxPool of a tile, placing output values into the first row.
  *        Also places the index of the max value into the first row of the indices tile.
- *        Supports {FP32, FP16_B} for values, and {UINT16, INT32, UINT32} for indices, implied from the Dest mode used.
+ *        Supports {FP32, FP16_B} for values, and {UINT16, INT32, UINT32} for indices, inferred from the Dest mode used.
  * @tparam APPROXIMATION_MODE Whether to use the approximation mode (unused).
  * @tparam is_fp32_dest_acc_en Whether Dest is in 32bit mode (true) or 16bit mode (false).
  * @tparam num_rows The number of rows in the tile, must be one of: {9}
@@ -113,7 +113,7 @@ inline void _init_max_pool_with_indices_()
         []
         {
             // Values have been loaded such that 4 rows of Dest occupy the 4 lanes of each LREG
-            // To sort those 4 rows, we transpose the SFPU LREGs to put the 4 rows into separate LREGs
+            // To sort those 4 rows, we transpose the SFPU LREGs  to put elements of 4 rows of each column into separate LREGs of each unit of SFPU
             TTI_SFPTRANSP(0, 0, 0, 0);
 
             // Sort the 4 rows of Dest, placing the max value into LREG0 (index into LREG4)

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_max_pool_indices.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_max_pool_indices.h
@@ -21,79 +21,82 @@ namespace sfpu
  * @tparam is_fp32_dest_acc_en Whether Dest is in 32bit mode (true) or 16bit mode (false).
  * @tparam num_rows The number of rows in the tile, must be one of: {9}
  * @tparam ITERATIONS The number of iterations to use for the MaxPool operation (unused).
+ * @param values_tile_idx The index of the tile in the Dest register containing the data to be reduced.
  * @param indices_tile_idx The index of the tile in the Dest register containing the indices of the data.
+ * @param tile_idx Unused param, needed to conform with format in _llk_math_eltwise_binary_sfpu_params_.
  */
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int num_rows, int ITERATIONS>
-inline void _calculate_max_pool_with_indices_(const uint indices_tile_idx)
+inline void _calculate_max_pool_with_indices_(const uint values_tile_idx, const uint indices_tile_idx, const uint tile_idx /* unused */)
 {
     static_assert(num_rows == 9, "num_rows must be one of: {9}"); // add others as support is added
 
     // size of each tile in Dest is 64 rows
-    constexpr uint dst_tile_size = 64;
+    constexpr uint dst_tile_size   = 64;
+    const uint values_tile_offset  = values_tile_idx * dst_tile_size;
+    const uint indices_tile_offset = indices_tile_idx * dst_tile_size;
     // each face is 16 rows
     constexpr uint face_offset        = 16;
-    const uint idx_tile_offset        = indices_tile_idx * dst_tile_size;
     constexpr uint8_t instr_mod_index = is_fp32_dest_acc_en ? InstrModLoadStore::INT32 : InstrModLoadStore::LO16;
 
     // F0
     // data
-    TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0); // even cols
-    TTI_SFPLOAD(p_sfpu::LREG1, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 4);
-    TTI_SFPLOAD(p_sfpu::LREG2, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 2); // odd cols
-    TTI_SFPLOAD(p_sfpu::LREG3, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 6);
+    TT_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, values_tile_offset + 0); // even cols
+    TT_SFPLOAD(p_sfpu::LREG1, InstrModLoadStore::DEFAULT, ADDR_MOD_7, values_tile_offset + 4);
+    TT_SFPLOAD(p_sfpu::LREG2, InstrModLoadStore::DEFAULT, ADDR_MOD_7, values_tile_offset + 2); // odd cols
+    TT_SFPLOAD(p_sfpu::LREG3, InstrModLoadStore::DEFAULT, ADDR_MOD_7, values_tile_offset + 6);
     // index
-    TT_SFPLOAD(p_sfpu::LREG4, instr_mod_index, ADDR_MOD_7, idx_tile_offset); // even cols
-    TT_SFPLOAD(p_sfpu::LREG5, instr_mod_index, ADDR_MOD_7, idx_tile_offset + 4);
-    TT_SFPLOAD(p_sfpu::LREG6, instr_mod_index, ADDR_MOD_7, idx_tile_offset + 2); // odd cols
-    TT_SFPLOAD(p_sfpu::LREG7, instr_mod_index, ADDR_MOD_7, idx_tile_offset + 6);
+    TT_SFPLOAD(p_sfpu::LREG4, instr_mod_index, ADDR_MOD_7, indices_tile_offset + 0); // even cols
+    TT_SFPLOAD(p_sfpu::LREG5, instr_mod_index, ADDR_MOD_7, indices_tile_offset + 4);
+    TT_SFPLOAD(p_sfpu::LREG6, instr_mod_index, ADDR_MOD_7, indices_tile_offset + 2); // odd cols
+    TT_SFPLOAD(p_sfpu::LREG7, instr_mod_index, ADDR_MOD_7, indices_tile_offset + 6);
 
     // sort 4 rows
     lltt::replay(0, 7);
 
     // data
-    TTI_SFPLOAD(p_sfpu::LREG1, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 8);  // even cols
-    TTI_SFPLOAD(p_sfpu::LREG3, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 10); // odd cols
+    TT_SFPLOAD(p_sfpu::LREG1, InstrModLoadStore::DEFAULT, ADDR_MOD_7, values_tile_offset + 8);  // even cols
+    TT_SFPLOAD(p_sfpu::LREG3, InstrModLoadStore::DEFAULT, ADDR_MOD_7, values_tile_offset + 10); // odd cols
     // index
-    TT_SFPLOAD(p_sfpu::LREG5, instr_mod_index, ADDR_MOD_7, idx_tile_offset + 8);  // even cols
-    TT_SFPLOAD(p_sfpu::LREG7, instr_mod_index, ADDR_MOD_7, idx_tile_offset + 10); // odd cols
+    TT_SFPLOAD(p_sfpu::LREG5, instr_mod_index, ADDR_MOD_7, indices_tile_offset + 8);  // even cols
+    TT_SFPLOAD(p_sfpu::LREG7, instr_mod_index, ADDR_MOD_7, indices_tile_offset + 10); // odd cols
 
     TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG1, p_sfpswap::ALL_ROWS_MAX);
     TTI_SFPSWAP(0, p_sfpu::LREG2, p_sfpu::LREG3, p_sfpswap::ALL_ROWS_MAX);
 
-    TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);
-    TTI_SFPSTORE(p_sfpu::LREG2, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 2);
-    TT_SFPSTORE(p_sfpu::LREG4, instr_mod_index, ADDR_MOD_7, idx_tile_offset);
-    TT_SFPSTORE(p_sfpu::LREG6, instr_mod_index, ADDR_MOD_7, idx_tile_offset + 2);
+    TT_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, values_tile_offset + 0);
+    TT_SFPSTORE(p_sfpu::LREG2, InstrModLoadStore::DEFAULT, ADDR_MOD_7, values_tile_offset + 2);
+    TT_SFPSTORE(p_sfpu::LREG4, instr_mod_index, ADDR_MOD_7, indices_tile_offset + 0);
+    TT_SFPSTORE(p_sfpu::LREG6, instr_mod_index, ADDR_MOD_7, indices_tile_offset + 2);
 
     // F1
     // data
-    TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, face_offset); // even cols
-    TTI_SFPLOAD(p_sfpu::LREG1, InstrModLoadStore::DEFAULT, ADDR_MOD_7, face_offset + 4);
-    TTI_SFPLOAD(p_sfpu::LREG2, InstrModLoadStore::DEFAULT, ADDR_MOD_7, face_offset + 2); // odd cols
-    TTI_SFPLOAD(p_sfpu::LREG3, InstrModLoadStore::DEFAULT, ADDR_MOD_7, face_offset + 6);
+    TT_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, values_tile_offset + face_offset); // even cols
+    TT_SFPLOAD(p_sfpu::LREG1, InstrModLoadStore::DEFAULT, ADDR_MOD_7, values_tile_offset + face_offset + 4);
+    TT_SFPLOAD(p_sfpu::LREG2, InstrModLoadStore::DEFAULT, ADDR_MOD_7, values_tile_offset + face_offset + 2); // odd cols
+    TT_SFPLOAD(p_sfpu::LREG3, InstrModLoadStore::DEFAULT, ADDR_MOD_7, values_tile_offset + face_offset + 6);
     // index
-    TT_SFPLOAD(p_sfpu::LREG4, instr_mod_index, ADDR_MOD_7, idx_tile_offset + face_offset); // even cols
-    TT_SFPLOAD(p_sfpu::LREG5, instr_mod_index, ADDR_MOD_7, idx_tile_offset + face_offset + 4);
-    TT_SFPLOAD(p_sfpu::LREG6, instr_mod_index, ADDR_MOD_7, idx_tile_offset + face_offset + 2); // odd cols
-    TT_SFPLOAD(p_sfpu::LREG7, instr_mod_index, ADDR_MOD_7, idx_tile_offset + face_offset + 6);
+    TT_SFPLOAD(p_sfpu::LREG4, instr_mod_index, ADDR_MOD_7, indices_tile_offset + face_offset); // even cols
+    TT_SFPLOAD(p_sfpu::LREG5, instr_mod_index, ADDR_MOD_7, indices_tile_offset + face_offset + 4);
+    TT_SFPLOAD(p_sfpu::LREG6, instr_mod_index, ADDR_MOD_7, indices_tile_offset + face_offset + 2); // odd cols
+    TT_SFPLOAD(p_sfpu::LREG7, instr_mod_index, ADDR_MOD_7, indices_tile_offset + face_offset + 6);
 
     // sort 4 rows
     lltt::replay(0, 7);
 
     // data
-    TTI_SFPLOAD(p_sfpu::LREG1, InstrModLoadStore::DEFAULT, ADDR_MOD_7, face_offset + 8);  // even cols
-    TTI_SFPLOAD(p_sfpu::LREG3, InstrModLoadStore::DEFAULT, ADDR_MOD_7, face_offset + 10); // odd cols
+    TT_SFPLOAD(p_sfpu::LREG1, InstrModLoadStore::DEFAULT, ADDR_MOD_7, values_tile_offset + face_offset + 8);  // even cols
+    TT_SFPLOAD(p_sfpu::LREG3, InstrModLoadStore::DEFAULT, ADDR_MOD_7, values_tile_offset + face_offset + 10); // odd cols
     // index
-    TT_SFPLOAD(p_sfpu::LREG5, instr_mod_index, ADDR_MOD_7, idx_tile_offset + face_offset + 8);  // even cols
-    TT_SFPLOAD(p_sfpu::LREG7, instr_mod_index, ADDR_MOD_7, idx_tile_offset + face_offset + 10); // odd cols
+    TT_SFPLOAD(p_sfpu::LREG5, instr_mod_index, ADDR_MOD_7, indices_tile_offset + face_offset + 8);  // even cols
+    TT_SFPLOAD(p_sfpu::LREG7, instr_mod_index, ADDR_MOD_7, indices_tile_offset + face_offset + 10); // odd cols
 
     TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG1, p_sfpswap::ALL_ROWS_MAX);
     TTI_SFPSWAP(0, p_sfpu::LREG2, p_sfpu::LREG3, p_sfpswap::ALL_ROWS_MAX);
 
-    TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, face_offset);
-    TTI_SFPSTORE(p_sfpu::LREG2, InstrModLoadStore::DEFAULT, ADDR_MOD_7, face_offset + 2);
-    TT_SFPSTORE(p_sfpu::LREG4, instr_mod_index, ADDR_MOD_7, idx_tile_offset + face_offset);
-    TT_SFPSTORE(p_sfpu::LREG6, instr_mod_index, ADDR_MOD_7, idx_tile_offset + face_offset + 2);
+    TT_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, values_tile_offset + face_offset);
+    TT_SFPSTORE(p_sfpu::LREG2, InstrModLoadStore::DEFAULT, ADDR_MOD_7, values_tile_offset + face_offset + 2);
+    TT_SFPSTORE(p_sfpu::LREG4, instr_mod_index, ADDR_MOD_7, indices_tile_offset + face_offset);
+    TT_SFPSTORE(p_sfpu::LREG6, instr_mod_index, ADDR_MOD_7, indices_tile_offset + face_offset + 2);
 }
 
 inline void _init_max_pool_with_indices_()

--- a/tt_llk_wormhole_b0/common/inc/ckernel_sfpu.h
+++ b/tt_llk_wormhole_b0/common/inc/ckernel_sfpu.h
@@ -32,6 +32,7 @@
 #include "sfpu/ckernel_sfpu_log.h"
 #include "sfpu/ckernel_sfpu_max.h"
 #include "sfpu/ckernel_sfpu_max_int32.h"
+#include "sfpu/ckernel_sfpu_max_pool_indices.h"
 #include "sfpu/ckernel_sfpu_mul_int.h"
 #include "sfpu/ckernel_sfpu_negative.h"
 #include "sfpu/ckernel_sfpu_power.h"

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_max_pool_indices.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_max_pool_indices.h
@@ -16,7 +16,7 @@ namespace sfpu
 /**
  * @brief Calculates column-wise MaxPool of a tile, placing output values into the first row.
  *        Also places the index of the max value into the first row of the indices tile.
- *        Supports {FP32, FP16_B} for values, and {UINT16, INT32, UINT32} for indices, implied from the Dest mode used.
+ *        Supports {FP32, FP16_B} for values, and {UINT16, INT32, UINT32} for indices, inferred from the Dest mode used.
  * @tparam APPROXIMATION_MODE Whether to use the approximation mode (unused).
  * @tparam is_fp32_dest_acc_en Whether Dest is in 32bit mode (true) or 16bit mode (false).
  * @tparam num_rows The number of rows in the tile, must be one of: {9}
@@ -110,7 +110,7 @@ inline void _init_max_pool_with_indices_()
     lltt::record(0, 7);
 
     // Values have been loaded such that 4 rows of Dest occupy the 4 lanes of each LREG
-    // To sort those 4 rows, we transpose the SFPU LREGs to put the 4 rows into separate LREGs
+    // To sort those 4 rows, we transpose the SFPU LREGs to put elements of 4 rows of each column into separate LREGs of each unit of SFPU
     TTI_SFPTRANSP(0, 0, 0, 0);
 
     // Sort the 4 rows of Dest, placing the max value into LREG0 (index into LREG4)

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_max_pool_indices.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_max_pool_indices.h
@@ -41,7 +41,7 @@ inline void _calculate_max_pool_with_indices_(const uint idx_addr)
     TTI_SFPLOAD(p_sfpu::LREG3, InstrModLoadStore::DEFAULT, ADDR_MOD_3, 10); // odd cols
     // index
     TT_SFPLOAD(p_sfpu::LREG5, instr_mod_index, ADDR_MOD_3, idx_tile_offset + 8);  // even cols
-    TT_SFPLOAD(p_sfpu::LREG7, instr_mod_index, ADDR_MOD_3, idx_tile_offset + 10); // cols cols
+    TT_SFPLOAD(p_sfpu::LREG7, instr_mod_index, ADDR_MOD_3, idx_tile_offset + 10); // odd cols
 
     TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG1, p_sfpswap::ALL_ROWS_MAX);
     TTI_SFPSWAP(0, p_sfpu::LREG2, p_sfpu::LREG3, p_sfpswap::ALL_ROWS_MAX);
@@ -71,7 +71,7 @@ inline void _calculate_max_pool_with_indices_(const uint idx_addr)
     TTI_SFPLOAD(p_sfpu::LREG3, InstrModLoadStore::DEFAULT, ADDR_MOD_3, face_offset + 10); // odd cols
     // index
     TT_SFPLOAD(p_sfpu::LREG5, instr_mod_index, ADDR_MOD_3, idx_tile_offset + face_offset + 8);  // even cols
-    TT_SFPLOAD(p_sfpu::LREG7, instr_mod_index, ADDR_MOD_3, idx_tile_offset + face_offset + 10); // cols cols
+    TT_SFPLOAD(p_sfpu::LREG7, instr_mod_index, ADDR_MOD_3, idx_tile_offset + face_offset + 10); // odd cols
 
     TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG1, p_sfpswap::ALL_ROWS_MAX);
     TTI_SFPSWAP(0, p_sfpu::LREG2, p_sfpu::LREG3, p_sfpswap::ALL_ROWS_MAX);

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_max_pool_indices.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_max_pool_indices.h
@@ -33,19 +33,8 @@ inline void _calculate_max_pool_with_indices_(const uint idx_addr)
     TT_SFPLOAD(p_sfpu::LREG6, instr_mod_index, ADDR_MOD_3, idx_tile_offset + 2); // odd cols
     TT_SFPLOAD(p_sfpu::LREG7, instr_mod_index, ADDR_MOD_3, idx_tile_offset + 6);
 
-    // transpose to put Dest rows into separate LREGS
-    TTI_SFPTRANSP(0, 0, 0, 0);
-
-    // put max into LREG0 (index into LREG4)
-    TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG1, p_sfpswap::ALL_ROWS_MAX);
-    TTI_SFPSWAP(0, p_sfpu::LREG2, p_sfpu::LREG3, p_sfpswap::ALL_ROWS_MAX);
-    TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG2, p_sfpswap::ALL_ROWS_MAX);
-
-    // transpose back
-    TTI_SFPTRANSP(0, 0, 0, 0);
-
-    TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG1, p_sfpswap::ALL_ROWS_MAX);
-    TTI_SFPSWAP(0, p_sfpu::LREG2, p_sfpu::LREG3, p_sfpswap::ALL_ROWS_MAX);
+    // sort 4 rows
+    lltt::replay(0, 7);
 
     // data
     TTI_SFPLOAD(p_sfpu::LREG1, InstrModLoadStore::DEFAULT, ADDR_MOD_3, 8);  // even cols
@@ -74,19 +63,8 @@ inline void _calculate_max_pool_with_indices_(const uint idx_addr)
     TT_SFPLOAD(p_sfpu::LREG6, instr_mod_index, ADDR_MOD_3, idx_tile_offset + face_offset + 2); // odd cols
     TT_SFPLOAD(p_sfpu::LREG7, instr_mod_index, ADDR_MOD_3, idx_tile_offset + face_offset + 6);
 
-    // transpose to put Dest rows into separate LREGS
-    TTI_SFPTRANSP(0, 0, 0, 0);
-
-    // put max into LREG0 (index into LREG4)
-    TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG1, p_sfpswap::ALL_ROWS_MAX);
-    TTI_SFPSWAP(0, p_sfpu::LREG2, p_sfpu::LREG3, p_sfpswap::ALL_ROWS_MAX);
-    TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG2, p_sfpswap::ALL_ROWS_MAX);
-
-    // transpose back
-    TTI_SFPTRANSP(0, 0, 0, 0);
-
-    TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG1, p_sfpswap::ALL_ROWS_MAX);
-    TTI_SFPSWAP(0, p_sfpu::LREG2, p_sfpu::LREG3, p_sfpswap::ALL_ROWS_MAX);
+    // sort 4 rows
+    lltt::replay(0, 7);
 
     // data
     TTI_SFPLOAD(p_sfpu::LREG1, InstrModLoadStore::DEFAULT, ADDR_MOD_3, face_offset + 8);  // even cols
@@ -106,7 +84,25 @@ inline void _calculate_max_pool_with_indices_(const uint idx_addr)
 
 inline void _init_max_pool_with_indices_()
 {
-    _sfpu_load_config32_(0xF, 0x0, 0x4); // Set bit [2] of the SFPU_CONTROL_REG to enable index tracking mode
+    // Set bit [2] of the SFPU_CONTROL_REG to enable index tracking mode
+    _sfpu_load_config32_(0xF, 0x0, 0x4);
+
+    // Program replay buffer
+    lltt::record(0, 7);
+
+    // transpose to put Dest rows into separate LREGS
+    TTI_SFPTRANSP(0, 0, 0, 0);
+
+    // put max into LREG0 (index into LREG4)
+    TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG1, p_sfpswap::ALL_ROWS_MAX);
+    TTI_SFPSWAP(0, p_sfpu::LREG2, p_sfpu::LREG3, p_sfpswap::ALL_ROWS_MAX);
+    TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG2, p_sfpswap::ALL_ROWS_MAX);
+
+    // transpose back
+    TTI_SFPTRANSP(0, 0, 0, 0);
+
+    TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG1, p_sfpswap::ALL_ROWS_MAX);
+    TTI_SFPSWAP(0, p_sfpu::LREG2, p_sfpu::LREG3, p_sfpswap::ALL_ROWS_MAX);
 }
 
 } // namespace sfpu

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_max_pool_indices.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_max_pool_indices.h
@@ -13,13 +13,27 @@ namespace ckernel
 namespace sfpu
 {
 
+/**
+ * @brief Calculates column-wise MaxPool of a tile, placing output values into the first row.
+ *        Also places the index of the max value into the first row of the indices tile.
+ *        Supports {FP32, FP16_B} for values, and {UINT16, INT32, UINT32} for indices, implied from the Dest mode used.
+ * @tparam APPROXIMATION_MODE Whether to use the approximation mode (unused).
+ * @tparam is_fp32_dest_acc_en Whether Dest is in 32bit mode (true) or 16bit mode (false).
+ * @tparam num_rows The number of rows in the tile, must be one of: {9}
+ * @tparam ITERATIONS The number of iterations to use for the MaxPool operation (unused).
+ * @param indices_tile_idx The index of the tile in the Dest register containing the indices of the data.
+ */
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int num_rows, int ITERATIONS>
-inline void _calculate_max_pool_with_indices_(const uint idx_addr)
+inline void _calculate_max_pool_with_indices_(const uint indices_tile_idx)
 {
-    static_assert(num_rows == 9, "num_rows must be one of: {9}");
-    const uint idx_tile_offset        = idx_addr * 64;
-    constexpr uint8_t instr_mod_index = is_fp32_dest_acc_en ? InstrModLoadStore::INT32 : InstrModLoadStore::LO16;
+    static_assert(num_rows == 9, "num_rows must be one of: {9}"); // add others as support is added
+
+    // size of each tile in Dest is 64 rows
+    constexpr uint dst_tile_size = 64;
+    // each face is 16 rows
     constexpr uint face_offset        = 16;
+    const uint idx_tile_offset        = indices_tile_idx * dst_tile_size;
+    constexpr uint8_t instr_mod_index = is_fp32_dest_acc_en ? InstrModLoadStore::INT32 : InstrModLoadStore::LO16;
 
     // F0
     // data
@@ -84,21 +98,24 @@ inline void _calculate_max_pool_with_indices_(const uint idx_addr)
 
 inline void _init_max_pool_with_indices_()
 {
-    // Set bit [2] of the SFPU_CONTROL_REG to enable index tracking mode
+    // Set bit [2] of the SFPU_CONTROL_REG to enable Destination Index Tracking Mode:
+    // LREGs 4-7 will be treated as indices corresponding to the values in LREGs 0-3,
+    // and LREGs 4-7 will mirror the movement of the values in LREGs 0-3;
     _sfpu_load_config32_(0xF, 0x0, 0x4);
 
     // Program replay buffer
     lltt::record(0, 7);
 
-    // transpose to put Dest rows into separate LREGS
+    // Values have been loaded such that 4 rows of Dest occupy the 4 lanes of each LREG
+    // To sort those 4 rows, we transpose the SFPU LREGs to put the 4 rows into separate LREGs
     TTI_SFPTRANSP(0, 0, 0, 0);
 
-    // put max into LREG0 (index into LREG4)
+    // Sort the 4 rows of Dest, placing the max value into LREG0 (index into LREG4)
     TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG1, p_sfpswap::ALL_ROWS_MAX);
     TTI_SFPSWAP(0, p_sfpu::LREG2, p_sfpu::LREG3, p_sfpswap::ALL_ROWS_MAX);
     TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG2, p_sfpswap::ALL_ROWS_MAX);
 
-    // transpose back
+    // Transpose the LREGs back
     TTI_SFPTRANSP(0, 0, 0, 0);
 
     TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG1, p_sfpswap::ALL_ROWS_MAX);

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_max_pool_indices.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_max_pool_indices.h
@@ -1,0 +1,113 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ckernel_addrmod.h"
+#include "ckernel_instr_params.h"
+#include "sfpi.h"
+
+namespace ckernel
+{
+namespace sfpu
+{
+
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int num_rows, int ITERATIONS>
+inline void _calculate_max_pool_with_indices_(const uint idx_addr)
+{
+    static_assert(num_rows == 9, "num_rows must be one of: {9}");
+    const uint idx_tile_offset        = idx_addr * 64;
+    constexpr uint8_t instr_mod_index = is_fp32_dest_acc_en ? InstrModLoadStore::INT32 : InstrModLoadStore::LO16;
+    constexpr uint face_offset        = 16;
+
+    // F0
+    // data
+    TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_3, 0); // even cols
+    TTI_SFPLOAD(p_sfpu::LREG1, InstrModLoadStore::DEFAULT, ADDR_MOD_3, 4);
+    TTI_SFPLOAD(p_sfpu::LREG2, InstrModLoadStore::DEFAULT, ADDR_MOD_3, 2); // odd cols
+    TTI_SFPLOAD(p_sfpu::LREG3, InstrModLoadStore::DEFAULT, ADDR_MOD_3, 6);
+    // index
+    TT_SFPLOAD(p_sfpu::LREG4, instr_mod_index, ADDR_MOD_3, idx_tile_offset); // even cols
+    TT_SFPLOAD(p_sfpu::LREG5, instr_mod_index, ADDR_MOD_3, idx_tile_offset + 4);
+    TT_SFPLOAD(p_sfpu::LREG6, instr_mod_index, ADDR_MOD_3, idx_tile_offset + 2); // odd cols
+    TT_SFPLOAD(p_sfpu::LREG7, instr_mod_index, ADDR_MOD_3, idx_tile_offset + 6);
+
+    // transpose to put Dest rows into separate LREGS
+    TTI_SFPTRANSP(0, 0, 0, 0);
+
+    // put max into LREG0 (index into LREG4)
+    TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG1, p_sfpswap::ALL_ROWS_MAX);
+    TTI_SFPSWAP(0, p_sfpu::LREG2, p_sfpu::LREG3, p_sfpswap::ALL_ROWS_MAX);
+    TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG2, p_sfpswap::ALL_ROWS_MAX);
+
+    // transpose back
+    TTI_SFPTRANSP(0, 0, 0, 0);
+
+    TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG1, p_sfpswap::ALL_ROWS_MAX);
+    TTI_SFPSWAP(0, p_sfpu::LREG2, p_sfpu::LREG3, p_sfpswap::ALL_ROWS_MAX);
+
+    // data
+    TTI_SFPLOAD(p_sfpu::LREG1, InstrModLoadStore::DEFAULT, ADDR_MOD_3, 8);  // even cols
+    TTI_SFPLOAD(p_sfpu::LREG3, InstrModLoadStore::DEFAULT, ADDR_MOD_3, 10); // odd cols
+    // index
+    TT_SFPLOAD(p_sfpu::LREG5, instr_mod_index, ADDR_MOD_3, idx_tile_offset + 8);  // even cols
+    TT_SFPLOAD(p_sfpu::LREG7, instr_mod_index, ADDR_MOD_3, idx_tile_offset + 10); // cols cols
+
+    TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG1, p_sfpswap::ALL_ROWS_MAX);
+    TTI_SFPSWAP(0, p_sfpu::LREG2, p_sfpu::LREG3, p_sfpswap::ALL_ROWS_MAX);
+
+    TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_3, 0);
+    TTI_SFPSTORE(p_sfpu::LREG2, InstrModLoadStore::DEFAULT, ADDR_MOD_3, 2);
+    TT_SFPSTORE(p_sfpu::LREG4, instr_mod_index, ADDR_MOD_3, idx_tile_offset);
+    TT_SFPSTORE(p_sfpu::LREG6, instr_mod_index, ADDR_MOD_3, idx_tile_offset + 2);
+
+    // F1
+    // data
+    TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_3, face_offset); // even cols
+    TTI_SFPLOAD(p_sfpu::LREG1, InstrModLoadStore::DEFAULT, ADDR_MOD_3, face_offset + 4);
+    TTI_SFPLOAD(p_sfpu::LREG2, InstrModLoadStore::DEFAULT, ADDR_MOD_3, face_offset + 2); // odd cols
+    TTI_SFPLOAD(p_sfpu::LREG3, InstrModLoadStore::DEFAULT, ADDR_MOD_3, face_offset + 6);
+    // index
+    TT_SFPLOAD(p_sfpu::LREG4, instr_mod_index, ADDR_MOD_3, idx_tile_offset + face_offset); // even cols
+    TT_SFPLOAD(p_sfpu::LREG5, instr_mod_index, ADDR_MOD_3, idx_tile_offset + face_offset + 4);
+    TT_SFPLOAD(p_sfpu::LREG6, instr_mod_index, ADDR_MOD_3, idx_tile_offset + face_offset + 2); // odd cols
+    TT_SFPLOAD(p_sfpu::LREG7, instr_mod_index, ADDR_MOD_3, idx_tile_offset + face_offset + 6);
+
+    // transpose to put Dest rows into separate LREGS
+    TTI_SFPTRANSP(0, 0, 0, 0);
+
+    // put max into LREG0 (index into LREG4)
+    TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG1, p_sfpswap::ALL_ROWS_MAX);
+    TTI_SFPSWAP(0, p_sfpu::LREG2, p_sfpu::LREG3, p_sfpswap::ALL_ROWS_MAX);
+    TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG2, p_sfpswap::ALL_ROWS_MAX);
+
+    // transpose back
+    TTI_SFPTRANSP(0, 0, 0, 0);
+
+    TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG1, p_sfpswap::ALL_ROWS_MAX);
+    TTI_SFPSWAP(0, p_sfpu::LREG2, p_sfpu::LREG3, p_sfpswap::ALL_ROWS_MAX);
+
+    // data
+    TTI_SFPLOAD(p_sfpu::LREG1, InstrModLoadStore::DEFAULT, ADDR_MOD_3, face_offset + 8);  // even cols
+    TTI_SFPLOAD(p_sfpu::LREG3, InstrModLoadStore::DEFAULT, ADDR_MOD_3, face_offset + 10); // odd cols
+    // index
+    TT_SFPLOAD(p_sfpu::LREG5, instr_mod_index, ADDR_MOD_3, idx_tile_offset + face_offset + 8);  // even cols
+    TT_SFPLOAD(p_sfpu::LREG7, instr_mod_index, ADDR_MOD_3, idx_tile_offset + face_offset + 10); // cols cols
+
+    TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG1, p_sfpswap::ALL_ROWS_MAX);
+    TTI_SFPSWAP(0, p_sfpu::LREG2, p_sfpu::LREG3, p_sfpswap::ALL_ROWS_MAX);
+
+    TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_3, face_offset);
+    TTI_SFPSTORE(p_sfpu::LREG2, InstrModLoadStore::DEFAULT, ADDR_MOD_3, face_offset + 2);
+    TT_SFPSTORE(p_sfpu::LREG4, instr_mod_index, ADDR_MOD_3, idx_tile_offset + face_offset);
+    TT_SFPSTORE(p_sfpu::LREG6, instr_mod_index, ADDR_MOD_3, idx_tile_offset + face_offset + 2);
+}
+
+inline void _init_max_pool_with_indices_()
+{
+    _sfpu_load_config32_(0xF, 0x0, 0x4); // Set bit [2] of the SFPU_CONTROL_REG to enable index tracking mode
+}
+
+} // namespace sfpu
+} // namespace ckernel


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/17202

### Problem description
Maxpool op that also return the index of the max value is needed. Topk local sort can accomplish this, but also performs a lot of extra work (sorting whole tile column) while here we only need to extract single max value.

### What's changed
Wrote implementation for max reduce with indices for 9 row tiles. This is the specific case that is needed to meet perf requirement for a customer.
Other cases/more general implementation can be added as needed, and based on this one (just needs to be expanded).

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
- no tests in tt-llk yet, tested on tt-metal branch which will be merged with a test