### PR TITLE
fix :bug: typo in EXALENS_WHEEL

### DIFF
--- a/tests/setup_external_testing_env.sh
+++ b/tests/setup_external_testing_env.sh
@@ -5,7 +5,7 @@
 
 # --- Configuration ---
 TT_SMI_REPO="https://github.com/tenstorrent/tt-smi"
-EXALENS_WHEEL="ttexalens-0.1.250813+dev.80e0cb9-cp310-cp310-linux_x86_6.whl"
+EXALENS_WHEEL="ttexalens-0.1.250813+dev.80e0cb9-cp310-cp310-linux_x86_64.whl"
 VENV_DIR=".venv"
 
 # --- Functions ---


### PR DESCRIPTION
### Ticket
<!-- Link to Github Issue -->

### Problem description
`setup_external_testing_env.sh` wasn't working properly because the EXALENS_WHEEL was missing a 4 in x86_64


### What's changed
<!-- Describe the approach used to solve the problem.
Summarize the changes made and its impact. -->

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
