### PR TITLE
perf :zap:: use stddev instead of variance

### DIFF
--- a/tests/python_tests/helpers/perf.py
+++ b/tests/python_tests/helpers/perf.py
@@ -7,7 +7,7 @@ import shutil
 from dataclasses import dataclass, fields, is_dataclass
 from enum import Enum
 from pathlib import Path
-from statistics import mean, variance
+from statistics import mean, stdev
 from typing import List
 
 import plotly.graph_objects as go
@@ -100,7 +100,7 @@ def process_runs(runs, test_config):
     return tuple(
         {
             "mean": mean(column) / tile_cnt,
-            "variance": variance(column) / (tile_cnt * tile_cnt),
+            "stddev": stdev(column) / tile_cnt,
         }
         for column in zip(*runs)
     )
@@ -194,7 +194,7 @@ def _get_stat_names(result):
         for idx in range(stats_count):
             idx_str = f"[{idx}]" if len(stats) > 1 else ""
             names[column] = f"mean({run_type.name}{idx_str})"
-            names[column + 1] = f"variance({run_type.name}{idx_str})"
+            names[column + 1] = f"stddev({run_type.name}{idx_str})"
             column += 2
 
     return names
@@ -229,7 +229,7 @@ def update_report(report: PerfReport, test_config, results):
     for stats in results.values():
         for stat in stats:
             stat_values.append(stat["mean"])
-            stat_values.append(stat["variance"])
+            stat_values.append(stat["stddev"])
     report.stat_values.append(stat_values)
 
 


### PR DESCRIPTION
### Ticket
<!-- Link to Github Issue -->

### Problem description
<!-- Provide context for the problem. -->
Variance is hard to intuitively reason about, stddev seems more appropriate here

### What's changed
<!-- Describe the approach used to solve the problem.
Summarize the changes made and its impact. -->

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
