### PR TITLE
qsr: cleanup ckernel_risc_atomics.h

### DIFF
--- a/tt_llk_quasar/common/inc/ckernel_risc_atomics.h
+++ b/tt_llk_quasar/common/inc/ckernel_risc_atomics.h
@@ -4,107 +4,62 @@
 
 #pragma once
 
-#include <atomic>
 #include <cstdint>
+#include <cstring>
+#include <type_traits>
 
-inline std::int32_t amomin(std::int32_t volatile *ptr, std::int32_t const against)
+inline std::int32_t amomin(std::int32_t *ptr, std::int32_t const against)
 {
-    std::int32_t old_val;
-    asm volatile("amomin.w %[ret], %[against_val], (%[addr_val])\n" : [ret] "=r"(old_val) : [against_val] "r"(against), [addr_val] "r"(ptr));
+    std::int32_t old;
+    asm volatile("amomin.w %[old], %[against], (%[ptr])\n" : [old] "=r"(old), "+m"(*ptr) : [against] "r"(against), [ptr] "r"(ptr));
 
-    return old_val;
+    return old;
 }
 
-inline std::uint32_t amominu(std::uint32_t volatile *ptr, std::uint32_t const against)
+inline std::uint32_t amominu(std::uint32_t *ptr, std::uint32_t const against)
 {
-    std::uint32_t old_val;
-    asm volatile("amominu.w %[ret], %[against_val], (%[addr_val])\n" : [ret] "=r"(old_val) : [against_val] "r"(against), [addr_val] "r"(ptr));
+    std::uint32_t old;
+    asm volatile("amominu.w %[old], %[against], (%[ptr])\n" : [old] "=r"(old), "+m"(*ptr) : [against] "r"(against), [ptr] "r"(ptr));
 
-    return old_val;
+    return old;
 }
 
-inline std::int32_t amomax(std::int32_t volatile *ptr, std::int32_t const against)
+inline std::int32_t amomax(std::int32_t *ptr, std::int32_t const against)
 {
-    std::int32_t old_val;
-    asm volatile("amomax.w %[ret], %[against_val], (%[addr_val])\n" : [ret] "=r"(old_val) : [against_val] "r"(against), [addr_val] "r"(ptr));
+    std::int32_t old;
+    asm volatile("amomax.w %[old], %[against], (%[ptr])\n" : [old] "=r"(old), "+m"(*ptr) : [against] "r"(against), [ptr] "r"(ptr));
 
-    return old_val;
+    return old;
 }
 
-inline std::uint32_t amomaxu(std::uint32_t volatile *ptr, std::uint32_t const against)
+inline std::uint32_t amomaxu(std::uint32_t *ptr, std::uint32_t const against)
 {
-    std::uint32_t old_val;
-    asm volatile("amomaxu.w %[ret], %[against_val], (%[addr_val])\n" : [ret] "=r"(old_val) : [against_val] "r"(against), [addr_val] "r"(ptr));
+    std::uint32_t old;
+    asm volatile("amomaxu.w %[old], %[against], (%[ptr])\n" : [old] "=r"(old), "+m"(*ptr) : [against] "r"(against), [ptr] "r"(ptr));
 
-    return old_val;
+    return old;
 }
 
-template <typename T>
-inline std::atomic<T> *mk_atomic_ptr(T *ptr)
+template <typename T, std::enable_if_t<std::is_trivially_copyable_v<T>, int> = 0>
+inline T load_acquire(T *ptr)
 {
-    // C++ is very persnickety... only way to get around a compile error
-    // was to invite satan into our living room and use reinterpret_cast
-    std::atomic<T> *p_ato = reinterpret_cast<std::atomic<std::uint32_t> *>(ptr);
-    return p_ato;
+    static_assert(sizeof(T) == sizeof(std::uint32_t), "load_acquire: operand must be 32bit");
+
+    std::uint32_t ret;
+    asm volatile("amoadd.w.aq %[ret], zero, (%[ptr])" : [ret] "=r"(ret), "+m"(*ptr) : [ptr] "r"(ptr));
+
+    T result;
+    std::memcpy(&result, &ret, sizeof(result));
+    return result;
 }
 
-// Only meant to be used with 32-bit types
-template <typename T>
-inline T load_acquire(std::atomic<T> *p_ato)
+template <typename T, std::enable_if_t<std::is_trivially_copyable_v<T>, int> = 0>
+inline void store_release(T *ptr, T val)
 {
-    T ret;
-    T volatile *addr = reinterpret_cast<T volatile *>(p_ato);
-    asm volatile("amoadd.w.aq %[ret], zero, (%[addr])\n" : [ret] "=r"(ret) : [addr] "r"(addr));
+    static_assert(sizeof(T) == sizeof(std::uint32_t), "store_release: operand must be 32bit");
 
-    return ret;
+    std::uint32_t val_raw;
+    std::memcpy(&val_raw, &val, sizeof(val_raw));
+
+    asm volatile("amoswap.w.rl x0, %[val], (%[ptr])" : "+m"(*ptr) : [val] "r"(val_raw), [ptr] "r"(ptr));
 }
-
-// Only meant to be used with 32-bit types
-// Returns original value from before store
-template <typename T>
-inline T store_release(std::atomic<T> *p_ato, T val)
-{
-    T ret;
-    T volatile *addr = reinterpret_cast<T volatile *>(p_ato);
-    asm volatile("amoswap.w.rl %[ret], %[val], (%[addr])\n" : [ret] "=r"(ret) : [val] "r"(val), [addr] "r"(addr));
-
-    return ret;
-}
-
-#if 0
-//I started working on this to amuse myself while my tests were running.
-//None of this is tested
-typedef std::atomic<std::int32_t>* semaphore;
-
-semaphore create_semaphore_at(std::int32_t *l1_addr) {
-    semaphore ret = reinterpret_cast<std::atomic<std::int32_t> *>(l1_addr);
-    store_release(ret, std::int32_t(0));
-    return ret;
-}
-
-inline void semaphore_inc(semaphore s) {
-    std::atomic_fetch_add(s, std::int32_t(1));
-}
-
-inline void semaphore_dec(semaphore s) {
-    std::atomic_fetch_add(s, std::int32_t(-1));
-}
-
-void spinlock_on_nonzero_semaphore(semaphore s) {
-    while (load_acquire(s) != 0);
-}
-
-struct mutex {
-    enum {
-        AVAIL = 0,
-        LOCKED
-    };
-
-    std::uint32_t val = AVAIL;
-
-    std::atomic<std::uint32_t>* operator&() {
-        return reinterpret_cast<std::atomic<std::int32_t> *>(&val);
-    }
-};
-
-#endif


### PR DESCRIPTION
### Ticket
<!-- Link to Github Issue -->

### Problem description
<!-- Provide context for the problem. -->

### What's changed
<!-- Describe the approach used to solve the problem.
Summarize the changes made and its impact. -->
Made a few improvements to `load_acquire` and `store_release`:
- They no longer take a pointer to an atomic, but a raw pointer (if it's atomic you can already use std::atomic<T>::load())
- From what I know the volatile cast for `addr` is redundant here
- Switched  `T ret -> uint32_t ret` so that structs can be used as `T`
- Added static assert to check if the underlying type can be atomically loaded

Example:
```cpp
typedef struct fifo {
    uint16_t rd_ptr;
    uint16_t wr_ptr;
} fifo_t;


int main () {
    fifo_t fifo = load_acquire((fifo_t*)0x1000);        // -> works fine
    uint8_t val = load_acquire((uint8_t*)0x2000);  // -> errors on the static assert
    return 0;
}
```


### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
