### PR TITLE
perf :zap:: introduce loop_factor as profiler feature

### DIFF
--- a/tests/python_tests/helpers/perf.py
+++ b/tests/python_tests/helpers/perf.py
@@ -95,12 +95,13 @@ def timing_l1_congestion(perf_data: PerfData) -> int:
 
 
 def process_runs(runs, test_config):
+    loop_factor = test_config.get("loop_factor", 1)
     tile_cnt = test_config.get("tile_cnt", 1)
 
     return tuple(
         {
-            "mean": mean(column) / tile_cnt,
-            "stddev": stdev(column) / tile_cnt,
+            "mean": mean(column) / loop_factor / tile_cnt,
+            "stddev": stdev(column) / loop_factor / tile_cnt,
         }
         for column in zip(*runs)
     )
@@ -205,6 +206,7 @@ def update_report(report: PerfReport, test_config, results):
     exclude = {
         "testname",
         "perf_run_type",
+        "loop_factor",  # used to minimize the effect of profiler overhead for short loops
     }
 
     params = {

--- a/tests/python_tests/helpers/test_config.py
+++ b/tests/python_tests/helpers/test_config.py
@@ -103,6 +103,15 @@ def generate_build_header(
     if profiler_build == ProfilerBuild.Yes:
         header_content.append("#define LLK_PROFILER")
 
+    loop_factor = test_config.get("loop_factor", 1)
+
+    if profiler_build == ProfilerBuild.No and loop_factor != 1:
+        raise ValueError(
+            "test_config['loop_factor'] should only be used when profiler is enabled"
+        )
+
+    header_content.append(f"constexpr int LOOP_FACTOR = {loop_factor};")
+
     if boot_mode == BootMode.BRISC:
         header_content.append("#define LLK_BOOT_MODE_BRISC")
     elif boot_mode == BootMode.TRISC:

--- a/tests/python_tests/perf_fast_tilize.py
+++ b/tests/python_tests/perf_fast_tilize.py
@@ -88,6 +88,7 @@ def test_fast_tilize_perf(
     test_config = {
         "formats": formats,
         "testname": TEST_NAME,
+        "loop_factor": 1024,
         "tile_cnt": input_height * input_width,
         "input_A_dimensions": input_dimensions,
         "input_B_dimensions": input_dimensions,

--- a/tests/sources/fast_tilize_test.cpp
+++ b/tests/sources/fast_tilize_test.cpp
@@ -16,12 +16,6 @@ uint32_t unp_cfg_context          = 0;
 uint32_t pack_sync_tile_dst_ptr   = 0;
 uint32_t math_sync_tile_dst_index = 0;
 
-#if defined(LLK_PROFILER)
-uint32_t loop_factor = 1024;
-#else
-uint32_t loop_factor = 1;
-#endif
-
 #ifdef LLK_TRISC_UNPACK
 
 #include "llk_unpack_common.h"
@@ -72,7 +66,7 @@ void run_kernel()
     }
     {
         ZONE_SCOPED("TILE_LOOP")
-        for (uint32_t loop = 0; loop < loop_factor; loop++)
+        for (uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
         {
             for (uint32_t i = 0; i < BLOCK_RT_DIM; i++)
             {
@@ -148,7 +142,7 @@ void run_kernel()
     }
     {
         ZONE_SCOPED("TILE_LOOP")
-        for (uint32_t loop = 0; loop < loop_factor; loop++)
+        for (uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
         {
             for (uint32_t i = 0; i < BLOCK_RT_DIM; i++)
             {
@@ -226,7 +220,7 @@ void run_kernel()
     }
     {
         ZONE_SCOPED("TILE_LOOP")
-        for (uint32_t loop = 0; loop < loop_factor; loop++)
+        for (uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
         {
             for (uint32_t i = 0; i < BLOCK_RT_DIM; i++)
             {


### PR DESCRIPTION
### Ticket
<!-- Link to Github Issue -->

### Problem description
<!-- Provide context for the problem. -->
Introduces `loop_factor` as test configuration setting. This is supposed to be used as a setting with `ProfilerBuild.Yes` and can be used to minimize the overhead of a profiler zone for short zones by running it multiple times.

### What's changed
<!-- Describe the approach used to solve the problem.
Summarize the changes made and its impact. -->

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
