### PR TITLE
Fix SFP_STOCH_RND instruction modifiers

### DIFF
--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_typecast.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_typecast.h
@@ -25,7 +25,7 @@ inline void _calculate_typecast_fp16b_to_uint16_()
         TTI_SFPSETCC(0, 0, 0, 0);
         TTI_SFPLOADI(0, 0, 0);
         TTI_SFPENCC(0, 0, 0, 0);
-        TTI_SFP_STOCH_RND(0, 0, 2, 0, 1, 14);
+        TTI_SFP_STOCH_RND(0, 0, 2, 0, 1, 6);
         TTI_SFPSTORE(1, 6, ADDR_MOD_7, 0);
         sfpi::dst_reg++;
     }
@@ -39,7 +39,7 @@ inline void _calculate_typecast_uint16_to_fp16b_()
     {
         TTI_SFPLOAD(0, 6, ADDR_MOD_7, 0);
         TTI_SFPCAST(0, 1, 0);
-        TTI_SFP_STOCH_RND(0, 0, 3, 1, 2, 9);
+        TTI_SFP_STOCH_RND(0, 0, 3, 1, 2, 1);
         TTI_SFPSTORE(2, 0, ADDR_MOD_7, 0);
         sfpi::dst_reg++;
     }
@@ -63,7 +63,7 @@ inline void _calculate_typecast_int32_to_fp16b_()
         // Required after cast due to a bug in Blackhole RTL.
         TTI_SFPSETSGN(0, 2, 0, 0);
         TTI_SFPCAST(0, 1, 0);
-        TTI_SFP_STOCH_RND(0, 0, 3, 1, 2, 9);
+        TTI_SFP_STOCH_RND(0, 0, 3, 1, 2, 1);
         TTI_SFPSTORE(2, 0, ADDR_MOD_7, 0);
         sfpi::dst_reg++;
     }
@@ -124,7 +124,7 @@ inline void _calculate_typecast_fp32_to_fp16b_()
     for (int d = 0; d < ITERATIONS; d++)
     {
         TTI_SFPLOAD(0, 0, ADDR_MOD_7, 0);
-        TTI_SFP_STOCH_RND(0, 0, 2, 0, 1, 9);
+        TTI_SFP_STOCH_RND(0, 0, 2, 0, 1, 1);
         TTI_SFPSTORE(1, 0, ADDR_MOD_7, 0);
         sfpi::dst_reg++;
     }
@@ -230,7 +230,7 @@ inline void _calculate_typecast_uint32_to_fp16b_()
         TTI_SFPLOAD(0, 12, ADDR_MOD_7, 0);
         TTI_SFPSETSGN(0, 0, 1, 1);
         TTI_SFPCAST(1, 2, 0);
-        TTI_SFP_STOCH_RND(0, 0, 4, 2, 3, 9);
+        TTI_SFP_STOCH_RND(0, 0, 4, 2, 3, 1);
         TTI_SFPSETCC(0, 0, 0, 0);
         TTI_SFPADDI(0x4f00, 3, 0); // 2^31
         TTI_SFPENCC(0, 0, 0, 0);

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_typecast.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_typecast.h
@@ -22,7 +22,7 @@ inline void _calculate_typecast_fp16b_to_uint16_()
         TTI_SFPSETCC(0, 0, 0, 0);
         TTI_SFPLOADI(0, 0, 0);
         TTI_SFPENCC(0, 0, 0, 0);
-        TTI_SFP_STOCH_RND(0, 0, 2, 0, 1, 14);
+        TTI_SFP_STOCH_RND(0, 0, 2, 0, 1, 6);
         TTI_SFPSTORE(1, 6, 3, 0);
         sfpi::dst_reg++;
     }
@@ -36,7 +36,7 @@ inline void _calculate_typecast_uint16_to_fp16b_()
     {
         TTI_SFPLOAD(0, 6, 3, 0);
         TTI_SFPCAST(0, 1, 0);
-        TTI_SFP_STOCH_RND(0, 0, 3, 1, 2, 9);
+        TTI_SFP_STOCH_RND(0, 0, 3, 1, 2, 1);
         TTI_SFPSTORE(2, 0, 3, 0);
         sfpi::dst_reg++;
     }
@@ -50,7 +50,7 @@ inline void _calculate_typecast_int32_to_fp16b_()
     {
         TTI_SFPLOAD(0, 12, 3, 0);
         TTI_SFPCAST(0, 1, 0);
-        TTI_SFP_STOCH_RND(0, 0, 3, 1, 2, 9);
+        TTI_SFP_STOCH_RND(0, 0, 3, 1, 2, 1);
         TTI_SFPSTORE(2, 0, 3, 0);
         sfpi::dst_reg++;
     }
@@ -109,7 +109,7 @@ inline void _calculate_typecast_fp32_to_fp16b_()
     for (int d = 0; d < ITERATIONS; d++)
     {
         TTI_SFPLOAD(0, 0, 3, 0);
-        TTI_SFP_STOCH_RND(0, 0, 2, 0, 1, 9);
+        TTI_SFP_STOCH_RND(0, 0, 2, 0, 1, 1);
         TTI_SFPSTORE(1, 0, 3, 0);
         sfpi::dst_reg++;
     }
@@ -205,7 +205,7 @@ inline void _calculate_typecast_uint32_to_fp16b_()
         TTI_SFPLOAD(0, 4, 3, 0);
         TTI_SFPSETSGN(0, 0, 1, 1);
         TTI_SFPCAST(1, 2, 0);
-        TTI_SFP_STOCH_RND(0, 0, 4, 2, 3, 9);
+        TTI_SFP_STOCH_RND(0, 0, 4, 2, 3, 1);
         TTI_SFPSETCC(0, 0, 0, 0);
         TTI_SFPADDI(0x4f00, 3, 0); // 2^31
         TTI_SFPENCC(0, 0, 0, 0);


### PR DESCRIPTION
### Ticket
none

### Problem description
SFP_STOCH_RND modes were being used that relied on one of the opcode bits being ignored in current HW

### What's changed
Bit 3 is ignored in these opcodes, so remap 14 -> 6 and 9 -> 1 to be consistent with usage elsewhere in the SW, with the enums that are defined for this modifier, and with the tt-isa-documentation specs.

### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
