### PR TITLE
perf :zap:: unpack_tilize where matrices can't fit in dest

### DIFF
--- a/tests/python_tests/perf_unpack_tilize.py
+++ b/tests/python_tests/perf_unpack_tilize.py
@@ -42,8 +42,8 @@ def report_fixture():
             DataFormat.Bfp8_b,
         ]
     ),
-    rt_dim=[1, 2],
-    ct_dim=[1, 2],
+    rt_dim=[1, 2, 3, 4, 5, 6, 7, 8],
+    ct_dim=[1, 2, 3, 4, 5, 6, 7, 8],
 )
 def test_perf_unpack_tilize_float(report_fixture, test_name, formats, rt_dim, ct_dim):
     if formats.input_format == DataFormat.Bfp8_b:

--- a/tests/sources/unpack_tilize_perf.cpp
+++ b/tests/sources/unpack_tilize_perf.cpp
@@ -24,6 +24,8 @@ static_assert(BLOCK_RT_DIM * BLOCK_CT_DIM == TILE_CNT, "BLOCK_RT_DIM * BLOCK_CT_
 
 static_assert(PERF_RUN_TYPE != PerfRunType::MATH_ISOLATE, "Math isolation not supported for unpack_tilize");
 
+static constexpr uint32_t MAX_TILES_DEST = is_fp32_dest_acc_en ? 4 : 8;
+
 #ifdef LLK_TRISC_UNPACK
 
 #include "llk_unpack_common.h"
@@ -31,6 +33,7 @@ static_assert(PERF_RUN_TYPE != PerfRunType::MATH_ISOLATE, "Math isolation not su
 
 void run_kernel()
 {
+    volatile uint32_t* const src = reinterpret_cast<volatile uint32_t*>(0x1A000);
     {
         ZONE_SCOPED("INIT")
         _llk_unpack_tilize_hw_configure_<is_fp32_dest_acc_en, StochRndType::None>(formats.unpack_src, formats.unpack_dst, FACE_R_DIM, 0, 4);
@@ -47,14 +50,12 @@ void run_kernel()
 
         for (uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
         {
-            uint32_t read_offset = 0;
             for (uint32_t i = 0; i < BLOCK_RT_DIM; i++)
             {
                 for (uint32_t j = 0; j < BLOCK_CT_DIM; j++)
                 {
-                    _llk_unpack_tilize_(L1_ADDRESS(buffer_A[read_offset]), j, formats.unpack_src, BLOCK_CT_DIM, FACE_R_DIM, 4, false);
+                    _llk_unpack_tilize_(L1_ADDRESS(src + (i % 8) * 0x1000), j, formats.unpack_src, BLOCK_CT_DIM, FACE_R_DIM, 4, false);
                 }
-                read_offset += BLOCK_RT_DIM;
             }
         }
         PROFILER_SYNC();
@@ -126,13 +127,19 @@ void run_kernel()
 
         for (uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
         {
-            for (uint32_t i = 0; i < TILE_CNT; i++)
+            uint32_t remaining_tiles = TILE_CNT;
+            while (remaining_tiles > 0)
             {
                 _llk_math_wait_for_dest_available_<DstSync::SyncHalf>();
-                _llk_math_eltwise_unary_datacopy_<DataCopyType::A2D, DstSync::SyncHalf, is_fp32_dest_acc_en, BroadcastType::NONE, unpack_to_dest>(
-                    i, formats.math, formats.math);
+                uint32_t num_tiles = std::min(remaining_tiles, MAX_TILES_DEST);
+                for (uint32_t i = 0; i < num_tiles; ++i)
+                {
+                    _llk_math_eltwise_unary_datacopy_<DataCopyType::A2D, DstSync::SyncHalf, is_fp32_dest_acc_en, BroadcastType::NONE, unpack_to_dest>(
+                        i, formats.math, formats.math);
+                }
+                _llk_math_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+                remaining_tiles -= num_tiles;
             }
-            _llk_math_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
         }
         PROFILER_SYNC();
     }
@@ -147,7 +154,8 @@ void run_kernel()
 
 void run_kernel()
 {
-    const bool UNTILIZE = false;
+    volatile uint32_t* const dst = reinterpret_cast<volatile uint32_t*>(0x1E000);
+    const bool UNTILIZE          = false;
 
     {
         ZONE_SCOPED("INIT")
@@ -175,9 +183,9 @@ void run_kernel()
         {
             for (uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
             {
-                for (int i = 0; i < TILE_CNT; ++i)
+                for (uint32_t i = 0; i < TILE_CNT; ++i)
                 {
-                    _llk_pack_<DstSync::SyncHalf, is_fp32_dest_acc_en, UNTILIZE>(i, L1_ADDRESS(buffer_Res[i]));
+                    _llk_pack_<DstSync::SyncHalf, is_fp32_dest_acc_en, UNTILIZE>(i, L1_ADDRESS(dst + (i % 8) * 0x1000));
                 }
             }
             PROFILER_SYNC();
@@ -186,12 +194,18 @@ void run_kernel()
 
         for (uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
         {
-            _llk_packer_wait_for_math_done_();
-            for (int i = 0; i < TILE_CNT; ++i)
+            uint32_t remaining_tiles = TILE_CNT;
+            while (remaining_tiles > 0)
             {
-                _llk_pack_<DstSync::SyncHalf, is_fp32_dest_acc_en, UNTILIZE>(i, L1_ADDRESS(buffer_Res[i]));
+                uint32_t num_tiles = std::min(remaining_tiles, MAX_TILES_DEST);
+                _llk_packer_wait_for_math_done_();
+                for (uint32_t i = 0; i < num_tiles; ++i)
+                {
+                    _llk_pack_<DstSync::SyncHalf, is_fp32_dest_acc_en, UNTILIZE>(i, L1_ADDRESS(dst + (i % 8) * 0x1000));
+                }
+                _llk_pack_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+                remaining_tiles -= num_tiles;
             }
-            _llk_pack_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
         }
         PROFILER_SYNC();
     }


### PR DESCRIPTION
### Ticket
<!-- Link to Github Issue -->
#634 Continued

### Problem description
<!-- Provide context for the problem. -->
Removes limitation where test would hang  if `rt_dim*ct_dim >=4` 

### What's changed
<!-- Describe the approach used to solve the problem.
Summarize the changes made and its impact. -->

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
