### PR TITLE
[skip ci] ci: add more info to meta-post-commit-tests workflow summary

### DIFF
--- a/.github/workflows/trigger-tt-metal-post-commit.yml
+++ b/.github/workflows/trigger-tt-metal-post-commit.yml
@@ -323,6 +323,62 @@ jobs:
             echo "run-id=" >> $GITHUB_OUTPUT
           fi
 
+      - name: Format test results
+        id: format-results
+        run: |
+          # Function to format test result line
+          format_test_result() {
+            local test_name="$1"
+            local run_flag="$2"
+            local status="$3"
+            local url="$4"
+            local workflow_result="$5"
+
+            if [ "$workflow_result" != "success" ] && [ "$workflow_result" != "failure" ]; then
+              echo ""
+              return
+            fi
+
+            local result=""
+            if [ "$run_flag" != "true" ]; then
+              result="⚪ Not run"
+            elif [ "$status" = "success" ]; then
+              result="🎯 Passed - [View run]($url)"
+            elif [ "$status" = "failure" ]; then
+              result="🛑 Failed - [View run]($url)"
+            elif [ "$status" = "timeout" ]; then
+              result="⏰ Timed out - [View run]($url)"
+            elif [ -n "$status" ]; then
+              result="⚪ $status - [View run]($url)"
+            elif [ "$workflow_result" = "failure" ]; then
+              result="🛑 Workflow Failed - Check logs for details"
+            else
+              result="⏳ Running..."
+            fi
+
+            echo "- $test_name tests: $result"
+          }
+
+          # Format Wormhole results
+          WH_RESULT=$(format_test_result "Wormhole" \
+            "${{ needs.detect-changes.outputs.run-wormhole }}" \
+            "${{ steps.parse-results.outputs.wh-status }}" \
+            "${{ steps.parse-results.outputs.wh-url }}" \
+            "${{ needs.trigger-tt-metal-tests.result }}")
+          echo "wormhole-result<<EOF" >> $GITHUB_OUTPUT
+          echo "$WH_RESULT" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+          # Format Blackhole results
+          BH_RESULT=$(format_test_result "Blackhole" \
+            "${{ needs.detect-changes.outputs.run-blackhole }}" \
+            "${{ steps.parse-results.outputs.bh-status }}" \
+            "${{ steps.parse-results.outputs.bh-url }}" \
+            "${{ needs.trigger-tt-metal-tests.result }}")
+          echo "blackhole-result<<EOF" >> $GITHUB_OUTPUT
+          echo "$BH_RESULT" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
       - name: Post comment on PR
         uses: mshick/add-pr-comment@v2
         with:
@@ -340,46 +396,8 @@ jobs:
                   '🟢 Enabled' || '⚪ Disabled' }}
 
             **Test Results:**
-            ${{
-              (needs.trigger-tt-metal-tests.result == 'success' || needs.trigger-tt-metal-tests.result == 'failure') &&
-              format('- Wormhole tests: {0}',
-                needs.detect-changes.outputs.run-wormhole == 'true' &&
-                (steps.parse-results.outputs.wh-status == 'success' &&
-                 format('🎯 Passed - [View run]({0})', steps.parse-results.outputs.wh-url) ||
-                 steps.parse-results.outputs.wh-status == 'failure' &&
-                 format('🛑 Failed - [View run]({0})', steps.parse-results.outputs.wh-url) ||
-                 steps.parse-results.outputs.wh-status == 'timeout' &&
-                 format('⏰ Timed out - [View run]({0})', steps.parse-results.outputs.wh-url) ||
-                 steps.parse-results.outputs.wh-status != '' &&
-                 format('⚪ {0} - [View run]({1})',
-                   steps.parse-results.outputs.wh-status,
-                   steps.parse-results.outputs.wh-url) ||
-                 needs.trigger-tt-metal-tests.result == 'failure' &&
-                 '🛑 Workflow Failed - Check logs for details' ||
-                 '⏳ Running...') ||
-                '⚪ Not run') ||
-              ''
-            }}
-            ${{
-              (needs.trigger-tt-metal-tests.result == 'success' || needs.trigger-tt-metal-tests.result == 'failure') &&
-              format('- Blackhole tests: {0}',
-                needs.detect-changes.outputs.run-blackhole == 'true' &&
-                (steps.parse-results.outputs.bh-status == 'success' &&
-                 format('🎯 Passed - [View run]({0})', steps.parse-results.outputs.bh-url) ||
-                 steps.parse-results.outputs.bh-status == 'failure' &&
-                 format('🛑 Failed - [View run]({0})', steps.parse-results.outputs.bh-url) ||
-                 steps.parse-results.outputs.bh-status == 'timeout' &&
-                 format('⏰ Timed out - [View run]({0})', steps.parse-results.outputs.bh-url) ||
-                 steps.parse-results.outputs.bh-status != '' &&
-                 format('⚪ {0} - [View run]({1})',
-                   steps.parse-results.outputs.bh-status,
-                   steps.parse-results.outputs.bh-url) ||
-                 needs.trigger-tt-metal-tests.result == 'failure' &&
-                 '🛑 Workflow Failed - Check logs for details' ||
-                 '⏳ Running...') ||
-                '⚪ Not run') ||
-              ''
-            }}
+            ${{ steps.format-results.outputs.wormhole-result }}
+            ${{ steps.format-results.outputs.blackhole-result }}
 
             ## 🔗 Links
             📊 **Post-commit workflow:** [#${{ github.run_id }}](${{


### PR DESCRIPTION
### Ticket
None

### Problem description
Using `metal-post-commit-tests` label works OK, but the comment made by the workflow is not descriptive enough.
This is how a PR comment that describes workflow result looks like at present:
<img width="842" height="439" alt="Screenshot 2025-09-02 at 17 02 22" src="https://github.com/user-attachments/assets/04ed3dd9-5345-4fc0-92c0-7382f1f3ead8" />

And this is how the proposed new status would look like:
<img width="842" height="491" alt="Screenshot 2025-09-02 at 19 53 15" src="https://github.com/user-attachments/assets/1cda8bbf-def2-42c1-a76a-7a0e7db5db28" />

In short, new summaries are more descriptive and require less hops to get to the required information.

tt-metal counterpart: https://github.com/tenstorrent/tt-metal/pull/27750

### What's changed
Workflow for launching metal post-commit tests has been updated to produce more descriptive outcomes.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update