### PR TITLE
Adjust quadratic estimation constants for reciprocal (WH).

### DIFF
--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_recip.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_recip.h
@@ -123,10 +123,10 @@ inline void _init_reciprocal_()
     if constexpr (!legacy_compat)
     {
         // The polynomial y = k2 - k1*x + k0*x**2 minimises the maximum
-        // absolute error for 1/x over the interval [1,2), found via Sollya.
-        sfpi::vConstFloatPrgm0 = 0.343145549297332763671875f;
-        sfpi::vConstFloatPrgm1 = 1.51471805572509765625f;
-        sfpi::vConstFloatPrgm2 = 2.1642131805419921875f;
+        // relative error for 1/x over the interval [1,2), via Sollya.
+        sfpi::vConstFloatPrgm0 = 0.3232325017452239990234375f;
+        sfpi::vConstFloatPrgm1 = 1.4545459747314453125f;
+        sfpi::vConstFloatPrgm2 = 2.121212482452392578125f;
     }
 }
 


### PR DESCRIPTION
This improves the worst-case precision from 23.00b to 23.59b, by minimising the maximum relative error rather than minimising the maximum absolute error.  The maximum ulp error is now improved from 1.00 to 0.89.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
