### PR TITLE
Fix math reconfig, update data format

### DIFF
--- a/tt_llk_wormhole_b0/llk_lib/llk_math_common.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_math_common.h
@@ -115,6 +115,11 @@ inline void _llk_math_reconfig_data_format_srca_(const std::uint32_t srca_data_f
         constexpr uint config_mask = ALU_FORMAT_SPEC_REG0_SrcA_MASK | ALU_ACC_CTRL_INT8_math_enabled_MASK;
         cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG0_SrcA_ADDR32, 0, config_mask>(config_data);
     }
+    else
+    {
+        TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::MATH | p_stall::WAIT_SFPU);
+        cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG0_SrcA_RMW>(srca_data_format);
+    }
 }
 
 template <bool is_fp32_dest_acc_en, bool to_from_int8 = false>
@@ -127,7 +132,12 @@ inline void _llk_math_reconfig_data_format_srcb_(const std::uint32_t srcb_data_f
         uint int8_math_enabled     = ((uint)(srcb_data_format & 0xF) == (uint)DataFormat::Int8) || ((uint)srcb_data_format == (uint)DataFormat::Int32);
         uint config_data           = (srcb_data_format << ALU_FORMAT_SPEC_REG1_SrcB_SHAMT) | (int8_math_enabled << ALU_ACC_CTRL_INT8_math_enabled_SHAMT);
         constexpr uint config_mask = ALU_FORMAT_SPEC_REG1_SrcB_MASK | ALU_ACC_CTRL_INT8_math_enabled_MASK;
-        cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG0_SrcA_ADDR32, 0, config_mask>(config_data);
+        cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG1_SrcB_ADDR32, 0, config_mask>(config_data);
+    }
+    else
+    {
+        TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::MATH | p_stall::WAIT_SFPU);
+        cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG1_SrcB_RMW>(srcb_data_format);
     }
 }
 
@@ -143,6 +153,13 @@ inline void _llk_math_reconfig_data_format_(const std::uint32_t srca_data_format
         uint config_data = (srca_data_format << ALU_FORMAT_SPEC_REG0_SrcA_SHAMT) | (srcb_data_format << ALU_FORMAT_SPEC_REG1_SrcB_SHAMT) |
                            (int8_math_enabled << ALU_ACC_CTRL_INT8_math_enabled_SHAMT);
         constexpr uint config_mask = ALU_FORMAT_SPEC_REG0_SrcA_MASK | ALU_FORMAT_SPEC_REG1_SrcB_MASK | ALU_ACC_CTRL_INT8_math_enabled_MASK;
+        cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG0_SrcA_ADDR32, 0, config_mask>(config_data);
+    }
+    else
+    {
+        TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::MATH | p_stall::WAIT_SFPU);
+        uint config_data           = (srca_data_format << ALU_FORMAT_SPEC_REG0_SrcA_SHAMT) | (srcb_data_format << ALU_FORMAT_SPEC_REG1_SrcB_SHAMT);
+        constexpr uint config_mask = ALU_FORMAT_SPEC_REG0_SrcA_MASK | ALU_FORMAT_SPEC_REG1_SrcB_MASK;
         cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG0_SrcA_ADDR32, 0, config_mask>(config_data);
     }
 }


### PR DESCRIPTION
Ticket

(https://github.com/tenstorrent/tt-metal/issues/27334)

Problem description

When a kernel changes its data type to something like TF32, the reconfiguration call for math was ignoring the format change thus leading to lower than expected PCC compared to calling full init function.

What's changed

Made sure format is changed for ALU when reconfiguring.

There are two problems still.

This change is still based on the assumption that the last format was not of integer type, as we would need to add a little bit more code in that case. In general kernels do not mix integer & non integer code. As they would have failed without this change. Will open a separate issue for that.

There is some code in the unpackers hardware init function that touches the maths format registers, and this part of the code does not use a semaphore. Is there any chance of race condition with a hardware init function ? The assumption is that we will not be calling a full init function paired with a reconfiguring and unpacker will not touch the register during reconfiguration or short inits. Should we remove the code from unpackers hardware configure ? Why was it there anyways ?

Note this change also lowers PCC in certain cases. For example the kernel used in the issue gets a PCC boost compared to calling the short init functions because of proper reconfiguring, but it seems like the kernel itself has a bug where it is calling reconfigure with a lower precision data type, thus resulting in lower PCC. This can be confirmed, as I changed reconfiguring function only to reconfigure to a higher precision data type and got back the high PCC.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
