### PR TITLE
chore: update tt-smi to 3.0.29

### DIFF
--- a/.github/scripts/install-smi.sh
+++ b/.github/scripts/install-smi.sh
@@ -5,7 +5,7 @@
 
 set -e
 
-TT_SMI_VERSION="3.0.28"
+TT_SMI_VERSION="3.0.29"
 TT_SMI_WHEEL="tt_smi-${TT_SMI_VERSION}-py3-none-any.whl"
 
 wget -O ${TT_SMI_WHEEL} \


### PR DESCRIPTION
### Ticket
None

### Problem description
This addresses the issue with smi reset of P100a cards that sometimes couldn’t be reset.

### What's changed
tt-smi version update to 3.0.29

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update