### PR TITLE
log :ledger:: implement low-overhead logging

### DIFF
--- a/setup_clangd.sh
+++ b/setup_clangd.sh
@@ -129,6 +129,8 @@ generate_compile_flags() {
 -DLLK_TRISC_MATH
 -DLLK_TRISC_PACK
 
+-DLLK_LOG_ENABLE
+
 -isystem
 $ROOT_DIR/tests/sfpi/compiler/lib/gcc/riscv32-tt-elf/12.4.0/include/
 -isystem

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -39,6 +39,7 @@ DIS_DIR         := $(TEST_DIR)/dis
 ELF_DIR         := $(TEST_DIR)/elf
 
 PROFILER_DIR    := $(TEST_DIR)/profiler
+LOG_DIR         := $(TEST_DIR)/log
 
 HELPERS         := helpers
 RISCV_SOURCES   := $(HELPERS)/src
@@ -89,6 +90,9 @@ profiler: $(PROFILER_DIR)/unpack.meta.bin \
 	  $(PROFILER_DIR)/math.meta.bin \
 	  $(PROFILER_DIR)/pack.meta.bin
 
+log: $(LOG_DIR)/unpack.meta.bin \
+	 $(LOG_DIR)/math.meta.bin \
+	 $(LOG_DIR)/pack.meta.bin
 
 # =========================
 # Build Rules
@@ -97,7 +101,11 @@ profiler: $(PROFILER_DIR)/unpack.meta.bin \
 
 # extract profiler metadata from .elf
 $(PROFILER_DIR)/%.meta.bin: $(ELF_DIR)/%.elf | $(PROFILER_DIR)
-	$(OBJCOPY) -O binary -j .profiler_meta $< $@
+	$(OBJCOPY) --set-section-flags .profiler_meta=alloc -O binary -j .profiler_meta $< $@
+
+# extract log metadata from .elf
+$(LOG_DIR)/%.meta.bin: $(ELF_DIR)/%.elf | $(LOG_DIR)
+	$(OBJCOPY) --set-section-flags .log_meta=alloc -O binary -j .log_meta $< $@
 
 # disassemble unpack.elf, math.elf, pack.elf
 $(DIS_DIR)/%.S: $(ELF_DIR)/%.elf | $(DIS_DIR)
@@ -155,7 +163,7 @@ $(SHARED_OBJ_DIR) $(SHARED_DEPS_DIR) $(SHARED_DIS_DIR) $(SHARED_ELF_DIR):
 	mkdir -p $@
 
 # create folder structure for test specific files
-$(OBJ_DIR) $(DEPS_DIR) $(DIS_DIR) $(ELF_DIR) $(PROFILER_DIR):
+$(OBJ_DIR) $(DEPS_DIR) $(DIS_DIR) $(ELF_DIR) $(PROFILER_DIR) $(LOG_DIR):
 	mkdir -p $@
 
 

--- a/tests/helpers/include/log.h
+++ b/tests/helpers/include/log.h
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+#include <cstddef>
+#include <cstdint>
+
+// FIXME: add to build.h
+#define LLK_LOG_ENABLE 1
+
+#ifndef LLK_LOG_ENABLE
+
+#define LOG(fmt, ...)
+
+#else
+
+#define CONCAT_IMPL(a, b) a##b
+#define CONCAT(a, b)      CONCAT_IMPL(a, b)
+#define STRINGIZE(x)      #x
+
+#define LOG_IMPL(symbol, fmt, ...)                                    \
+    do                                                                \
+    {                                                                 \
+        asm volatile(".pushsection .log_meta, \"\", @progbits\n\t"  \
+                     ".type " STRINGIZE(symbol) ", @object\n\t"      \
+                     ".local " STRINGIZE(symbol) "\n\t"              \
+                     STRINGIZE(symbol) ":\n\t"                       \
+                     ".string \"" fmt "\"\n\t"                       \
+                     ".size " STRINGIZE(symbol) ", .-" STRINGIZE(symbol) "\n\t" \
+                     ".popsection"); \
+        extern const char symbol[];                                   \
+        llk_log::verify(fmt, ##__VA_ARGS__);                          \
+        llk_log::write(symbol, ##__VA_ARGS__);                        \
+    } while (false)
+
+#define LOG(fmt, ...) LOG_IMPL(CONCAT(_log_meta_, __COUNTER__), fmt, ##__VA_ARGS__)
+
+namespace llk_log
+{
+
+template <size_t N, typename... Ts>
+static constexpr void verify(const char (&fmt)[N], Ts... args)
+{
+    // FIXME: Format string should be validated, because if it is not valid,
+    // the host might not be able to parse the log messages going forward
+}
+
+static inline volatile uint32_t* allocate(size_t bytes)
+{
+    // TODO: Implement a way to reserve bytes in the buffer
+
+    // THEORY:
+    //  use TTI_ATINCGET to allocate on WH
+    //  use AMOADD to reserve on BH an QSR
+
+    asm volatile("fence r, rw" ::: "memory"); // Acquire barrier (compiler hint on WH)
+
+    return (volatile uint32_t*)0x16A000;
+}
+
+template <typename... Ts>
+static constexpr size_t get_size(const void* fmt, Ts... args)
+{
+    size_t size = sizeof(fmt);
+    size += (sizeof(args) + ...); // sums sizeof each argument
+    return size;
+}
+
+static inline void push(volatile uint32_t*& buffer, const void* ptr)
+{
+    uintptr_t addr = reinterpret_cast<uintptr_t>(ptr);
+    *buffer++      = static_cast<uint32_t>(addr);
+}
+
+static inline void push(volatile uint32_t*& buffer, const uint32_t arg)
+{
+    *buffer++ = arg;
+}
+
+template <typename... Ts>
+inline void write(const void* fmt, const Ts... args)
+{
+    const size_t size         = get_size(fmt, args...);
+    volatile uint32_t* buffer = allocate(size);
+
+    push(buffer, fmt);
+    (push(buffer, args), ...);
+}
+} // namespace llk_log
+
+#endif

--- a/tests/helpers/ld/sections.ld
+++ b/tests/helpers/ld/sections.ld
@@ -148,7 +148,11 @@ SECTIONS
    . += __firmware_stack_size;
     __stack_top = .;
   } > REGION_STACK
-  .profiler_meta 0 : { *(.profiler_meta) }
+
+  /* These sections are used to pass compile time metadata to the host */
+  .profiler_meta 0 : { KEEP(*(.profiler_meta)) }
+  .log_meta 0 : { KEEP(*(.log_meta)) }
+
   .stab 0 : { *(.stab) }
   .stabstr 0 : { *(.stabstr) }
   .stab.excl 0 : { *(.stab.excl) }

--- a/tests/python_tests/helpers/test_config.py
+++ b/tests/python_tests/helpers/test_config.py
@@ -375,6 +375,9 @@ def generate_make_command(
     if profiler_build == ProfilerBuild.Yes:
         make_cmd += "profiler "
 
+    # FIXME: Add switch to enable/disable logging
+    make_cmd += "log "
+
     return make_cmd
 
 


### PR DESCRIPTION
### Ticket
<!-- Link to Github Issue -->

### Problem description
<!-- Provide context for the problem. -->
***Looking for feedback on the idea***

This PR is supposed to add a minimal overhead logs on device. The logs would have minimal impact on execution on TRISC and L1 because the strings that are going into the log won't be constructed on device.

the API will look like the C language `printf`.

`LOG("Example example example example message %d, %d", int1, int2);` would do the following:
 - At Compile Time:
     - Put the format string into a dummy section in the ELF file, which won't be loaded onto the device
     - Verify if the format string type compatible with the arguments.
 - At Runtime:
     - Reserve space in a buffer for the data that is getting logged
     - Store the address of the format string from the dummy section in the reserved buffer
     - Store all of the arguments as they are passed in the buffer

This way the example LOG would only take up 12 bytes in the shared buffer (4 for the address of the format string, 2*4 for the two integer values)

When the device is done, or the timeout is written, the infra will read the whole buffer from the device and reconstruct the log messages. It can get the original format string from the ELF file based on the address in the buffer, and because C style format strings contain type information, it will be able to peek forward into the buffer to read the data that was passed to the log.

Sadly if we do go forward with this approach we cannot easily follow the interface of the original DPRINT in metal, but we get a lot of benefits that it simply can't do.

### What's changed
<!-- Describe the approach used to solve the problem.
Summarize the changes made and its impact. -->

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
