### PR TITLE
profiler + perf :zap:: port to pandas

### DIFF
--- a/tests/python_tests/helpers/profiler.py
+++ b/tests/python_tests/helpers/profiler.py
@@ -2,19 +2,16 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import csv
 import os
 import re
-from dataclasses import dataclass, fields
+from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
-from typing import Optional
 
+import pandas as pd
 from ttexalens.tt_exalens_lib import read_words_from_device
 
 from helpers.chip_architecture import get_chip_architecture
-from helpers.test_config import ProfilerBuild, generate_make_command
-from helpers.utils import run_shell_command
 
 
 @dataclass
@@ -23,37 +20,6 @@ class ProfilerFullMarker:
     file: str
     line: int
     id: int
-
-
-def build_with_profiler(test_config):
-    make_cmd = generate_make_command(test_config, ProfilerBuild.Yes)
-    run_shell_command(f"cd .. && {make_cmd}")
-
-
-@dataclass
-class ProfilerTimestamp:
-    full_marker: ProfilerFullMarker
-    timestamp: int
-    data: Optional[int] = None
-
-
-@dataclass
-class ProfilerZoneScoped:
-    full_marker: ProfilerFullMarker
-    start: int
-    end: int
-    duration: int
-
-
-@dataclass
-class ProfilerData:
-    unpack: list[ProfilerTimestamp | ProfilerZoneScoped]
-    math: list[ProfilerTimestamp | ProfilerZoneScoped]
-    pack: list[ProfilerTimestamp | ProfilerZoneScoped]
-
-    def __iter__(self):
-        for field in fields(self):
-            yield field.name, getattr(self, field.name)
 
 
 class Profiler:
@@ -85,71 +51,13 @@ class Profiler:
         ZONE_END = 0b1011
 
     @staticmethod
-    def dump_csv(profiler_data, filename: str = "profiler_data.csv") -> None:
-        rows = []
-        rows.append(
-            [
-                "thread",
-                "type",
-                "marker",
-                "timestamp",
-                "data",
-                "marker_id",
-                "file",
-                "line",
-            ]
-        )
-
-        for thread, entries in profiler_data:
-            for entry in entries:
-                full_marker = entry.full_marker
-
-                if isinstance(entry, ProfilerTimestamp):
-                    rows.append(
-                        [
-                            thread,
-                            "TIMESTAMP",
-                            full_marker.marker,
-                            entry.timestamp,
-                            entry.data,
-                            full_marker.id,
-                            full_marker.file,
-                            full_marker.line,
-                        ]
-                    )
-                elif isinstance(entry, ProfilerZoneScoped):
-                    # Add both start and end rows
-                    rows.append(
-                        [
-                            thread,
-                            "ZONE_START",
-                            full_marker.marker,
-                            entry.start,
-                            "",
-                            full_marker.id,
-                            full_marker.file,
-                            full_marker.line,
-                        ]
-                    )
-                    rows.append(
-                        [
-                            thread,
-                            "ZONE_END",
-                            full_marker.marker,
-                            entry.end,
-                            "",
-                            full_marker.id,
-                            full_marker.file,
-                            full_marker.line,
-                        ]
-                    )
-
+    def dump_csv(
+        profiler_data: pd.DataFrame, filename: str = "profiler_data.csv"
+    ) -> None:
         output_path = Path("../build") / filename
         output_path.parent.mkdir(parents=True, exist_ok=True)
 
-        with output_path.open("w", newline="") as f:
-            writer = csv.writer(f)
-            writer.writerows(rows)
+        profiler_data.to_csv(output_path, index=False)
 
     @staticmethod
     def _hash_meta(s: str) -> int:
@@ -212,12 +120,12 @@ class Profiler:
         return meta
 
     @staticmethod
-    def get_data(testname: str) -> ProfilerData:
+    def get_data(testname: str) -> pd.DataFrame:
         meta = Profiler._get_meta(testname)
         return Profiler._parse_buffers(Profiler._load_buffers(), meta)
 
     @staticmethod
-    def _load_buffers(location="0,0", word_count=BUFFER_LENGTH):
+    def _load_buffers(location="0,0", word_count=BUFFER_LENGTH) -> list[list[int]]:
         """Load profiler buffers from device memory for each thread."""
         return [
             read_words_from_device(
@@ -227,16 +135,37 @@ class Profiler:
         ]
 
     @staticmethod
-    def _parse_buffers(buffers, profiler_meta):
-        return ProfilerData(
-            unpack=Profiler._parse_thread(buffers[0], profiler_meta),
-            math=Profiler._parse_thread(buffers[1], profiler_meta),
-            pack=Profiler._parse_thread(buffers[2], profiler_meta),
-        )
+    def _dataframe(rows: list[dict] | None = None) -> pd.DataFrame:
+        # Define the schema
+        schema = {
+            "thread": pd.CategoricalDtype(categories=["UNPACK", "MATH", "PACK"]),
+            "type": pd.CategoricalDtype(categories=["TIMESTAMP", "ZONE"]),
+            "marker": "string",
+            "timestamp": "int64",
+            "duration": "Int64",  # nullable
+            "data": "Int64",  # nullable
+            "marker_id": "int32",
+            "file": "string",
+            "line": "int32",
+        }
+
+        return pd.DataFrame(rows or [], columns=schema.keys()).astype(schema)
 
     @staticmethod
-    def _parse_thread(words, profiler_meta):
-        thread = []
+    def _parse_buffers(buffers, profiler_meta) -> pd.DataFrame:
+        THREADS = ["UNPACK", "MATH", "PACK"]
+
+        # Parse each thread and append to the DataFrame
+        threads = []
+        for thread, buffer in zip(THREADS, buffers):
+            threads.extend(Profiler._parse_thread(thread, buffer, profiler_meta))
+
+        df = Profiler._dataframe(threads)
+        return df.sort_values("timestamp").reset_index(drop=True)
+
+    @staticmethod
+    def _parse_thread(thread, words, profiler_meta) -> list[dict]:
+        rows = []
         zone_stack = []
         word_stream = iter(words)
         for word in word_stream:
@@ -244,7 +173,6 @@ class Profiler:
                 break
 
             type = (word & Profiler.ENTRY_TYPE_MASK) >> Profiler.ENTRY_TYPE_SHAMT
-
             marker_id = (word & Profiler.ENTRY_ID_MASK) >> Profiler.ENTRY_ID_SHAMT
 
             try:
@@ -261,13 +189,21 @@ class Profiler:
             entry_type = Profiler.EntryType(type)
             match entry_type:
                 case Profiler.EntryType.TIMESTAMP:
-                    thread.append(ProfilerTimestamp(marker, timestamp))
+                    rows.append(
+                        Profiler._row(
+                            thread, "TIMESTAMP", marker, timestamp, pd.NA, pd.NA
+                        )
+                    )
 
                 case Profiler.EntryType.TIMESTAMP_DATA:
                     data_high = next(word_stream)
                     data_low = next(word_stream)
                     data = (data_high << 32) | data_low
-                    thread.append(ProfilerTimestamp(marker, timestamp, data))
+                    rows.append(
+                        Profiler._row(
+                            thread, "TIMESTAMP", marker, timestamp, pd.NA, data
+                        )
+                    )
 
                 case Profiler.EntryType.ZONE_START:
                     zone_stack.append(timestamp)
@@ -276,6 +212,22 @@ class Profiler:
                     end = timestamp
                     start = zone_stack.pop()
                     duration = end - start
-                    thread.append(ProfilerZoneScoped(marker, start, end, duration))
+                    rows.append(
+                        Profiler._row(thread, "ZONE", marker, start, duration, pd.NA)
+                    )
 
-        return thread
+        return rows
+
+    @staticmethod
+    def _row(thread, type, marker, timestamp, duration, data) -> dict:
+        return {
+            "thread": thread,
+            "type": type,
+            "marker": marker.marker,
+            "timestamp": timestamp,
+            "duration": duration,
+            "data": data,
+            "marker_id": marker.id,
+            "file": marker.file,
+            "line": marker.line,
+        }

--- a/tests/python_tests/test_profiler_overhead.py
+++ b/tests/python_tests/test_profiler_overhead.py
@@ -26,25 +26,24 @@ def test_profiler_overhead():
 
     run_test(test_config, profiler_build=ProfilerBuild.Yes)
 
-    runtime = Profiler.get_data(test_config["testname"])
+    df = Profiler.get_data(test_config["testname"])
 
     # filter out all zones that don't have marker "OVERHEAD"
-    overhead_zones = [x for x in runtime.unpack if x.full_marker.marker == "OVERHEAD"]
+
+    overhead_zones = df[df["marker"] == "OVERHEAD"]
     assert (
         len(overhead_zones) == 32
     ), f"Expected 32 overhead zones, got {len(overhead_zones)}"
 
     # the first iteration is inconsistent, because code is not in icache
-    overhead_zones.pop(0)
+    overhead_zones = overhead_zones.iloc[1:].reset_index(drop=True)
 
-    for i, zone in enumerate(
-        overhead_zones, 9
-    ):  # enumerate from 9 because the first iteration is ignored
-        calculated_duration = 10 * i
-        overhead = zone.duration - calculated_duration
+    for i, zone in overhead_zones.iterrows():
+        calculated_duration = 10 * (i + 9)
+        overhead = zone["duration"] - calculated_duration
 
         expected_overhead = get_expected_overhead()
         assert overhead == pytest.approx(expected_overhead, abs=5), (
-            f"iterations: {i}, runtime: {zone.duration}/{i * 10} "
+            f"iterations: {i}, runtime: {zone['duration']}/{i * 10} "
             f"(actual/calculated), overhead {overhead}/{expected_overhead} (actual/expected)"
         )

--- a/tests/python_tests/test_profiler_primitives.py
+++ b/tests/python_tests/test_profiler_primitives.py
@@ -1,26 +1,27 @@
 # SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 # SPDX-License-Identifier: Apache-2.0
 
+import pandas as pd
 
 from helpers.profiler import Profiler
 from helpers.test_config import ProfilerBuild, run_test
 
 
 def assert_marker(
-    marker_obj, expected_marker, expected_file_suffix, expected_line, expected_id
+    entry, expected_marker, expected_file_suffix, expected_line, expected_id
 ):
     assert (
-        marker_obj.marker == expected_marker
-    ), f"Expected marker = '{expected_marker}', got {marker_obj.marker}"
-    assert marker_obj.file.endswith(
+        entry["marker"] == expected_marker
+    ), f"Expected marker = '{expected_marker}', got {entry['marker']}"
+    assert entry["file"].endswith(
         expected_file_suffix
-    ), f"Expected file to end with '{expected_file_suffix}', got {marker_obj.file}"
+    ), f"Expected file to end with '{expected_file_suffix}', got {entry['file']}"
     assert (
-        marker_obj.line == expected_line
-    ), f"Expected line = {expected_line}, got {marker_obj.line}"
+        entry["line"] == expected_line
+    ), f"Expected line = {expected_line}, got {entry['line']}"
     assert (
-        marker_obj.id == expected_id
-    ), f"Expected id = {expected_id}, got {marker_obj.id}"
+        entry["marker_id"] == expected_id
+    ), f"Expected marker_id = {expected_id}, got {entry['marker_id']}"
 
 
 def test_profiler_primitives():
@@ -31,51 +32,75 @@ def test_profiler_primitives():
 
     run_test(test_config, profiler_build=ProfilerBuild.Yes)
 
-    runtime = Profiler.get_data(test_config["testname"])
+    df = Profiler.get_data(test_config["testname"])
 
-    # ZONE_SCOPED
-    zone = runtime.unpack[0]
+    # ZONE_SCOPED - Get first ZONE type entry from UNPACK thread
+    zones = df[
+        df[["thread", "type", "marker"]].eq(["UNPACK", "ZONE", "TEST_ZONE"]).all(axis=1)
+    ]
+    assert len(zones) > 0, "Expected at least one TEST_ZONE entry"
+    zone = zones.iloc[0]
+
     assert_marker(
-        zone.full_marker,
+        zone,
         "TEST_ZONE",
         "profiler_primitives_test.cpp",
         17,
         42158,
     )
-    assert zone.start > 0, f"Expected zone.start > 0, got {zone.start}"
-    assert zone.end > zone.start, f"Expected zone.end > {zone.start}, got {zone.end}"
     assert (
-        zone.duration == zone.end - zone.start
-    ), f"Expected zone.duration = {zone.end - zone.start}, got {zone.duration}"
+        zone["timestamp"] > 0
+    ), f"Expected zone timestamp > 0, got {zone['timestamp']}"
+    assert zone["duration"] > 0, f"Expected zone duration > 0, got {zone['duration']}"
 
-    # TIMESTAMP
-    timestamp = runtime.math[0]
+    # TIMESTAMP - Get first TIMESTAMP type entry from MATH thread
+    timestamps = df[
+        df[["thread", "type", "marker"]]
+        .eq(["MATH", "TIMESTAMP", "TEST_TIMESTAMP"])
+        .all(axis=1)
+    ]
+    assert len(timestamps) == 1, "Expected exactly one TEST_TIMESTAMP entry"
+    timestamp = timestamps.iloc[0]
+
     assert_marker(
-        timestamp.full_marker,
+        timestamp,
         "TEST_TIMESTAMP",
         "profiler_primitives_test.cpp",
         26,
         28111,
     )
     assert (
-        timestamp.timestamp > 0
-    ), f"Expected timestamp.timestamp > 0, got {timestamp.timestamp}"
-    assert (
-        timestamp.data is None
-    ), f"Expected timestamp.data to be None, got {timestamp.data}"
+        timestamp["timestamp"] > 0
+    ), f"Expected timestamp > 0, got {timestamp['timestamp']}"
+    assert pd.isna(
+        timestamp["duration"]
+    ), f"Expected duration to be None/NaN, got {timestamp['duration']}"
+    assert pd.isna(
+        timestamp["data"]
+    ), f"Expected timestamp data to be None/NaN, got {timestamp['data']}"
 
-    # TIMESTAMP_DATA
-    timestamp_data = runtime.pack[0]
+    # TIMESTAMP_DATA - Get first TIMESTAMP type entry from PACK thread with data
+    data_timestamps = df[
+        df[["thread", "type", "marker"]]
+        .eq(["PACK", "TIMESTAMP", "TEST_TIMESTAMP_DATA"])
+        .all(axis=1)
+    ]
+    assert len(data_timestamps) == 1, "Expected exactly one TEST_TIMESTAMP_DATA entry"
+    timestamp_data = data_timestamps.iloc[0]
+
     assert_marker(
-        timestamp_data.full_marker,
+        timestamp_data,
         "TEST_TIMESTAMP_DATA",
         "profiler_primitives_test.cpp",
         35,
         18694,
     )
     assert (
-        timestamp_data.timestamp > 0
-    ), f"Expected timestamp_data.timestamp > 0, got {timestamp_data.timestamp}"
+        timestamp_data["timestamp"] > 0
+    ), f"Expected timestamp > 0, got {timestamp_data['timestamp']}"
+    assert pd.isna(
+        timestamp_data["duration"]
+    ), f"Expected duration to be None/NaN, got {timestamp_data['duration']}"
     assert (
-        timestamp_data.data == 0xBADC0FFE0DDF00D
-    ), f"Expected timestamp_data.data = 0xBADC0FFE0DDF00D, got {hex(timestamp_data.data)}"
+        timestamp_data["data"] == 0xBADC0FFE0DDF00D
+    ), f"Expected data = 0xBADC0FFE0DDF00D, got {hex(int(timestamp_data['data']))}"

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -13,6 +13,7 @@ narwhals==1.46.0
 networkx==3.4.2
 numpy==2.2.6
 packaging==25.0
+pandas==2.3.2
 plotly==6.3.0
 pluggy==1.6.0
 pre-commit==4.3.0


### PR DESCRIPTION
### Ticket
<!-- Link to Github Issue -->

### Problem description
<!-- Provide context for the problem. -->
To make analysis of the performance benchmark data easier, I will be porting most of the logic in the suite to Pandas. This will make it easier to create reports, do statistical analysis etc. 

### What's changed
<!-- Describe the approach used to solve the problem.
Summarize the changes made and its impact. -->

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
