### PR TITLE
fix: mark unused parameters as such, remove unused variables, make compile rules more strict

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -53,11 +53,11 @@ OBJCOPY         := $(TOOL_PATH)/riscv32-tt-elf-objcopy
 # =========================
 # Compiler and Linker Flags
 # =========================
-OPTIONS_ALL	:= -g -O3 -mabi=ilp32 -std=$(CXX_VERSION) -ffast-math $(ARCH_CPU)
-OPTIONS_COMPILE := -fno-use-cxa-atexit -Wall -fpermissive -fno-exceptions -fno-rtti -Werror \
-				   -Wno-unknown-pragmas -Wno-error=multistatement-macros -Wno-error=parentheses \
-				   -Wno-error=unused-but-set-variable -Wno-unused-variable -DTENSIX_FIRMWARE \
-				   $(ARCH_DEFINE) -DCOMPILE_FOR_TRISC=
+OPTIONS_ALL	:= -g -fanalyzer -O3 -mabi=ilp32 -std=$(CXX_VERSION) -ffast-math $(ARCH_CPU)
+OPTIONS_COMPILE := -fno-use-cxa-atexit -Wall -fpermissive -fno-exceptions -fno-rtti -Werror -Wunused-parameter \
+				   -Wfloat-equal -Wpointer-arith -Wnull-dereference -Wredundant-decls -Wuninitialized -Wwrite-strings \
+				   -Wmaybe-uninitialized -Wlogical-op -Wduplicated-cond -Wduplicated-branches -Wcast-align \
+				   -DTENSIX_FIRMWARE $(ARCH_DEFINE) -DCOMPILE_FOR_TRISC=
 OPTIONS_LINK	:= -fexceptions -Wl,-z,max-page-size=16 -Wl,-z,common-page-size=16 -nostartfiles -Wl,--trace
 
 INCLUDES := -I../$(ARCH_LLK_ROOT)/llk_lib -I../$(ARCH_LLK_ROOT)/common/inc \

--- a/tt_llk_blackhole/common/inc/cpack_common.h
+++ b/tt_llk_blackhole/common/inc/cpack_common.h
@@ -162,11 +162,8 @@ inline void packer_addr_counter_init()
 }
 
 template <bool untilize = false, bool tilize = false>
-inline void set_packer_strides(const uint pack_src_format, const uint pack_dst_format, const uint tile_c_dim)
+inline void set_packer_strides(const uint pack_src_format, [[maybe_unused]] const uint pack_dst_format, const uint tile_c_dim)
 {
-    // Get pointer to registers for current state ID
-    volatile uint tt_reg_ptr* cfg = get_cfg_pointer();
-
     uint x_stride = (uint)(pack_src_format & 0x3) == static_cast<DataFormatType>(DataFormat::Float32)   ? 4
                     : (uint)(pack_src_format & 0x3) == static_cast<DataFormatType>(DataFormat::Float16) ? 2
                                                                                                         : 1;
@@ -380,18 +377,17 @@ inline void configure_pack(
     const uint pack_src_format,
     const uint pack_dst_format,
     const uint tile_size,
-    const uint face_r_dim   = FACE_R_DIM,
-    const uint tile_c_dim   = TILE_C_DIM,
-    const uint num_faces    = 4,
-    const bool partial_face = false,
-    const bool narrow_tile  = false,
-    const uint relu_config  = 0)
+    const uint face_r_dim                   = FACE_R_DIM,
+    const uint tile_c_dim                   = TILE_C_DIM,
+    const uint num_faces                    = 4,
+    const bool partial_face                 = false,
+    [[maybe_unused]] const bool narrow_tile = false,
+    const uint relu_config                  = 0)
 {
     // Get pointer to registers for current state ID
     volatile uint* cfg = get_cfg_pointer();
 
     const uint pack_output_src_format = (uint)pack_src_format & 0xF;
-    const uint pack_output_dst_format = (uint)pack_dst_format & 0xF;
 
     set_packer_strides<untilize, tilize>(pack_src_format, pack_dst_format, tile_c_dim);
 

--- a/tt_llk_blackhole/llk_lib/llk_math_eltwise_unary_datacopy.h
+++ b/tt_llk_blackhole/llk_lib/llk_math_eltwise_unary_datacopy.h
@@ -153,7 +153,6 @@ inline void eltwise_unary_configure_mop(uint rows_per_inst, uint total_rows, con
 
     if constexpr (type == A2D)
     {
-        uint addr_mod  = (rows_per_inst == p_mova2d::MOV_1_ROW) ? ADDR_MOD_0 : ADDR_MOD_2;
         uint innerloop = (rows_per_inst == p_mova2d::MOV_1_ROW) ? total_rows : (total_rows >> 3);
         uint outerloop = tilize ? 1 : num_faces;
 
@@ -232,10 +231,10 @@ inline void eltwise_unary_configure_mop(uint rows_per_inst, uint total_rows, con
 template <DataCopyType type, bool is_fp32_dest_acc_en, BroadcastType src_b_bcast_type = BroadcastType::NONE, bool tilize = false, bool is_int_fpu_en = false>
 // within_face_16x16_transpose is used by unpacker, math does not transpose
 inline void _llk_math_eltwise_unary_datacopy_init_(
-    const std::uint32_t transpose_of_faces          = 0 /*unused*/,
-    const std::uint32_t within_face_16x16_transpose = 0 /* unused */,
-    const std::uint32_t num_faces                   = 4,
-    const std::uint32_t dst_format                  = 255)
+    [[maybe_unused]] const std::uint32_t transpose_of_faces          = 0,
+    [[maybe_unused]] const std::uint32_t within_face_16x16_transpose = 0,
+    const std::uint32_t num_faces                                    = 4,
+    const std::uint32_t dst_format                                   = 255)
 {
     eltwise_unary_configure_addrmod<type, src_b_bcast_type>();
 

--- a/tt_llk_blackhole/llk_lib/llk_math_matmul.h
+++ b/tt_llk_blackhole/llk_lib/llk_math_matmul.h
@@ -21,9 +21,9 @@ using namespace ckernel;
 template <int MATH_FIDELITY_DESC, DstTileFaceLayout FaceLayout = DstTileFaceLayout::ColMajor, int THROTTLE_LEVEL>
 inline void matmul_configure_addrmod(
     const bool transpose,
-    const std::uint32_t ct_dim,
-    const std::uint32_t rt_dim,
-    const std::uint32_t kt_dim,
+    [[maybe_unused]] const std::uint32_t ct_dim,
+    [[maybe_unused]] const std::uint32_t rt_dim,
+    [[maybe_unused]] const std::uint32_t kt_dim,
     const std::uint32_t in0_tile_r_dim = TILE_R_DIM,
     const std::uint32_t in0_tile_c_dim = TILE_C_DIM,
     const std::uint32_t in1_tile_r_dim = TILE_R_DIM,
@@ -280,10 +280,10 @@ inline void matmul_configure_addrmod(
 
 template <int NUM_FIDELITY_PHASES, DstTileFaceLayout FaceLayout = DstTileFaceLayout::ColMajor>
 inline void matmul_configure_mop(
-    bool transpose,
+    [[maybe_unused]] bool transpose,
     const std::uint32_t ct_dim,
     const std::uint32_t rt_dim,
-    const std::uint32_t kt_dim,
+    [[maybe_unused]] const std::uint32_t kt_dim,
     const std::uint32_t in0_tile_r_dim = TILE_R_DIM,
     const std::uint32_t in0_tile_c_dim = TILE_C_DIM,
     const std::uint32_t in1_tile_r_dim = TILE_R_DIM,
@@ -629,7 +629,11 @@ inline void _llk_math_matmul_init_(
 
 template <int MATH_FIDELITY_DESC, DstTileFaceLayout FaceLayout = DstTileFaceLayout::ColMajor, int THROTTLE_LEVEL = 0>
 inline void _llk_math_matmul_(
-    uint dst_index, const bool transpose = false, const std::uint32_t ct_dim = 1, const std::uint32_t rt_dim = 1, const std::uint32_t kt_dim = 1)
+    uint dst_index,
+    [[maybe_unused]] const bool transpose       = false,
+    const std::uint32_t ct_dim                  = 1,
+    const std::uint32_t rt_dim                  = 1,
+    [[maybe_unused]] const std::uint32_t kt_dim = 1)
 {
     const bool reuse_a                = ct_dim >= rt_dim;
     const std::uint32_t t_dim         = reuse_a ? rt_dim : ct_dim;

--- a/tt_llk_blackhole/llk_lib/llk_pack.h
+++ b/tt_llk_blackhole/llk_lib/llk_pack.h
@@ -75,12 +75,12 @@ template <
     bool write_tile_header       = true,
     bool tilize                  = false>
 inline void _llk_pack_mop_config_(
-    const std::uint32_t pack_dst_format,
-    const std::uint32_t face_r_dim = FACE_R_DIM,
-    const std::uint32_t tile_c_dim = TILE_C_DIM,
-    const std::uint32_t num_faces  = 4,
-    const bool partial_face        = false,
-    const bool narrow_tile         = false)
+    [[maybe_unused]] const std::uint32_t pack_dst_format,
+    const std::uint32_t face_r_dim           = FACE_R_DIM,
+    const std::uint32_t tile_c_dim           = TILE_C_DIM,
+    const std::uint32_t num_faces            = 4,
+    [[maybe_unused]] const bool partial_face = false,
+    [[maybe_unused]] const bool narrow_tile  = false)
 {
     static_assert(FaceLayout == DstTileFaceLayout::RowMajor, "FaceLayout must be RowMajor");
 

--- a/tt_llk_blackhole/llk_lib/llk_pack_common.h
+++ b/tt_llk_blackhole/llk_lib/llk_pack_common.h
@@ -57,7 +57,8 @@ inline void _llk_pack_dest_section_done_()
 }
 
 template <DstSync Dst, DstTileFaceLayout FaceLayout>
-inline void _llk_init_packer_dest_offset_registers_(const std::uint32_t face_r_dim = FACE_R_DIM, const bool narrow_tile = false)
+inline void _llk_init_packer_dest_offset_registers_(
+    [[maybe_unused]] const std::uint32_t face_r_dim = FACE_R_DIM, [[maybe_unused]] const bool narrow_tile = false)
 {
     TTI_STALLWAIT(p_stall::STALL_TDMA | p_stall::STALL_THCON, p_stall::PACK); // wait for pack to finish
 

--- a/tt_llk_blackhole/llk_lib/llk_unpack_A.h
+++ b/tt_llk_blackhole/llk_lib/llk_unpack_A.h
@@ -192,12 +192,12 @@ template <
     EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE,
     bool unpack_to_dest                          = false>
 inline void _llk_unpack_A_init_(
-    const std::uint32_t transpose_of_faces          = 0,
-    const std::uint32_t within_face_16x16_transpose = 0,
-    const std::uint32_t face_r_dim                  = FACE_R_DIM,
-    const std::uint32_t num_faces                   = 4,
-    const std::uint32_t unpack_src_format           = 0,
-    const std::uint32_t unpack_dst_format           = 0)
+    const std::uint32_t transpose_of_faces                           = 0,
+    [[maybe_unused]] const std::uint32_t within_face_16x16_transpose = 0,
+    const std::uint32_t face_r_dim                                   = FACE_R_DIM,
+    const std::uint32_t num_faces                                    = 4,
+    const std::uint32_t unpack_src_format                            = 0,
+    const std::uint32_t unpack_dst_format                            = 0)
 {
     constexpr std::uint32_t UNP_SEL = (BType == BroadcastType::NONE) ? p_setadc::UNP_A : p_setadc::UNP_B;
     config_unpacker_x_end<UNP_SEL>(face_r_dim);
@@ -210,7 +210,10 @@ template <
     EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE,
     bool unpack_to_dest                          = false>
 inline void _llk_unpack_A_(
-    const std::uint32_t address, const bool transpose_of_faces = 0, const std::uint32_t unpack_src_format = 0, const std::uint32_t unpack_dst_format = 0)
+    const std::uint32_t address,
+    [[maybe_unused]] const bool transpose_of_faces = 0,
+    const std::uint32_t unpack_src_format          = 0,
+    const std::uint32_t unpack_dst_format          = 0)
 {
     // Clear z/w start counters
     TTI_SETADCZW(0b011, 0, 0, 0, 0, 0b1111);

--- a/tt_llk_blackhole/llk_lib/llk_unpack_AB_matmul.h
+++ b/tt_llk_blackhole/llk_lib/llk_unpack_AB_matmul.h
@@ -19,10 +19,10 @@ using namespace ckernel::unpacker;
 // transpose is unused, math is adjusted to take into account srca face layout when transpose=true
 template <std::uint32_t kernel_broadcast_a = 0, std::uint32_t kernel_broadcast_b = 0>
 inline void _llk_unpack_AB_matmul_mop_config_(
-    const bool transpose,
+    [[maybe_unused]] const bool transpose,
     const std::uint32_t ct_dim,
     const std::uint32_t rt_dim,
-    const std::uint32_t kt_dim,
+    [[maybe_unused]] const std::uint32_t kt_dim,
     const bool unpA_partial_face,
     const bool unpB_partial_face)
 {
@@ -242,8 +242,6 @@ __attribute__((always_inline)) inline void _llk_unpack_AB_matmul_init_(
     const bool unpA_partial_face        = false,
     const bool unpB_partial_face        = false)
 {
-    const bool reuse_a = ct_dim >= rt_dim;
-
     // also turn on within_face_16x16_transpose if it was turned off by datacopy at runtime
     // on WH, the unpacker performs both transpose of faces as well as transpose each face.
     // the former is configured in mop, the latter is configured in cfg register in hw_configure
@@ -291,13 +289,13 @@ inline void _llk_unpack_AB_matmul_(
     const std::uint32_t tile_index_b,
     const std::uint32_t tile_size_a,
     const std::uint32_t tile_size_b,
-    const std::uint32_t unpA_face_r_dim = FACE_R_DIM,
-    const std::uint32_t unpB_face_r_dim = FACE_R_DIM,
-    const bool unpA_partial_face        = false,
-    const bool unpB_partial_face        = false,
-    std::uint32_t ct_dim                = 1,
-    const std::uint32_t rt_dim          = 1,
-    const std::uint32_t kt_dim          = 1)
+    [[maybe_unused]] const std::uint32_t unpA_face_r_dim = FACE_R_DIM,
+    [[maybe_unused]] const std::uint32_t unpB_face_r_dim = FACE_R_DIM,
+    const bool unpA_partial_face                         = false,
+    const bool unpB_partial_face                         = false,
+    std::uint32_t ct_dim                                 = 1,
+    const std::uint32_t rt_dim                           = 1,
+    const std::uint32_t kt_dim                           = 1)
 {
     // In0/InA -> srcB (supports partial face)
     // In1/InB -> srcA

--- a/tt_llk_blackhole/llk_lib/llk_unpack_tilize.h
+++ b/tt_llk_blackhole/llk_lib/llk_unpack_tilize.h
@@ -16,7 +16,7 @@
 using namespace ckernel;
 using namespace ckernel::unpacker;
 
-inline void _llk_unpack_tilize_mop_config_(const bool narrow_tile = false, const bool unpack_to_dest = false)
+inline void _llk_unpack_tilize_mop_config_([[maybe_unused]] const bool narrow_tile = false, const bool unpack_to_dest = false)
 {
     static constexpr uint unpack_srca =
         TT_OP_UNPACR(SrcA, 0b1 /*Z inc*/, 0, 0, 0, 1 /* Set OvrdThreadId*/, 1 /*Set Dvalid*/, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
@@ -104,11 +104,11 @@ inline void _llk_unpack_tilize_init_(
 inline void _llk_unpack_tilize_(
     const std::uint32_t base_address,
     const std::uint32_t tile_index,
-    std::uint32_t unpack_src_format = 0,
-    std::uint32_t block_ct_dim      = 0,
-    const std::uint32_t face_r_dim  = FACE_R_DIM,
-    const std::uint32_t num_faces   = 4,
-    const bool narrow_tile          = false)
+    std::uint32_t unpack_src_format                 = 0,
+    [[maybe_unused]] std::uint32_t block_ct_dim     = 0,
+    [[maybe_unused]] const std::uint32_t face_r_dim = FACE_R_DIM,
+    [[maybe_unused]] const std::uint32_t num_faces  = 4,
+    const bool narrow_tile                          = false)
 {
     volatile uint tt_reg_ptr* cfg = get_cfg_pointer(); // get pointer to registers for current state ID
 
@@ -117,13 +117,6 @@ inline void _llk_unpack_tilize_(
                                 (unpack_src_format == static_cast<std::underlying_type_t<DataFormat>>(DataFormat::Int32));
 
     std::uint32_t top_face_offset_address = SCALE_DATUM_SIZE(unpack_src_format, tile_index) << (narrow_tile ? 0 : 1);
-    // Each iteration unpacks 2 face_r_dimx16 faces (1st 0,1 2nd 2,3 unless tile is <=16x32)
-    // For narrow tile we unpack 1 face in each iteration
-    // Offset address is in 16B words
-    // Datum count = tile_index*face_r_dim (/16 to get word count)
-
-    const std::uint32_t block_c_dim_16B   = block_ct_dim * (narrow_tile ? FACE_C_DIM / 16 : TILE_C_DIM / 16);
-    std::uint32_t bot_face_offset_address = SCALE_DATUM_SIZE(unpack_src_format, face_r_dim * block_c_dim_16B); //*N rows / 16 to get 16B word aligned address
 
     // Program srcA and srcB base addresses
     // FIXME MT: This should be revisited for narrow tiles

--- a/tt_llk_wormhole_b0/common/inc/cpack_common.h
+++ b/tt_llk_wormhole_b0/common/inc/cpack_common.h
@@ -159,11 +159,8 @@ inline void packer_addr_counter_init()
     TTI_SETADCZW(0b100, 0, 0, 0, 0, 0b1111);
 }
 
-inline void set_packer_strides(const uint pack_src_format, const uint pack_dst_format)
+inline void set_packer_strides(const uint pack_src_format, [[maybe_unused]] const uint pack_dst_format)
 {
-    // Get pointer to registers for current state ID
-    volatile uint tt_reg_ptr* cfg = get_cfg_pointer();
-
     uint x_stride = (uint)(pack_src_format & 0x3) == static_cast<DataFormatType>(DataFormat::Float32)   ? 4
                     : (uint)(pack_src_format & 0x3) == static_cast<DataFormatType>(DataFormat::Float16) ? 2
                                                                                                         : 1;

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_welfords.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_welfords.h
@@ -298,7 +298,7 @@ void _welfords_llk_entry_(
     uint32_t current_sample,
     const uint32_t final_sample,
     uint32_t skip_n_rows,
-    const uint32_t reciprocal_lut_ptr,
+    [[maybe_unused]] const uint32_t reciprocal_lut_ptr,
     const bool reformat_dst_to_col_on_end,
     const bool convert_M2_to_var)
 {

--- a/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_unary_datacopy.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_unary_datacopy.h
@@ -122,7 +122,6 @@ inline void eltwise_unary_configure_mop(uint rows_per_inst, uint total_rows, con
 
     if constexpr (type == A2D)
     {
-        uint addr_mod  = (rows_per_inst == p_mova2d::MOV_1_ROW) ? ADDR_MOD_0 : ADDR_MOD_2;
         uint innerloop = (rows_per_inst == p_mova2d::MOV_1_ROW) ? total_rows : (total_rows >> 3);
         uint outerloop = num_faces;
 
@@ -201,10 +200,10 @@ inline void eltwise_unary_configure_mop(uint rows_per_inst, uint total_rows, con
 template <DataCopyType type, bool is_fp32_dest_acc_en, BroadcastType src_b_bcast_type = BroadcastType::NONE, bool is_int_fpu_en = false>
 // within_face_16x16_transpose is used by unpacker, math does not transpose
 inline void _llk_math_eltwise_unary_datacopy_init_(
-    const std::uint32_t transpose_of_faces          = 0 /*unused*/,
-    const std::uint32_t within_face_16x16_transpose = 0 /* unused */,
-    const std::uint32_t num_faces                   = 4,
-    const std::uint32_t dst_format                  = 255)
+    [[maybe_unused]] const std::uint32_t transpose_of_faces          = 0,
+    [[maybe_unused]] const std::uint32_t within_face_16x16_transpose = 0,
+    const std::uint32_t num_faces                                    = 4,
+    const std::uint32_t dst_format                                   = 255)
 {
     eltwise_unary_configure_addrmod<type, src_b_bcast_type>();
 

--- a/tt_llk_wormhole_b0/llk_lib/llk_math_matmul.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_math_matmul.h
@@ -22,9 +22,9 @@ using namespace ckernel;
 template <int MATH_FIDELITY_DESC, DstTileFaceLayout FaceLayout = DstTileFaceLayout::ColMajor, int THROTTLE_LEVEL>
 inline void matmul_configure_addrmod(
     const bool transpose,
-    const std::uint32_t ct_dim,
-    const std::uint32_t rt_dim,
-    const std::uint32_t kt_dim,
+    [[maybe_unused]] const std::uint32_t ct_dim,
+    [[maybe_unused]] const std::uint32_t rt_dim,
+    [[maybe_unused]] const std::uint32_t kt_dim,
     const std::uint32_t in0_tile_r_dim = TILE_R_DIM,
     const std::uint32_t in0_tile_c_dim = TILE_C_DIM,
     const std::uint32_t in1_tile_r_dim = TILE_R_DIM,
@@ -86,10 +86,6 @@ inline void matmul_configure_addrmod(
         }
             .set(ADDR_MOD_6);
     }
-
-    const uint8_t srca_increment = transpose == false ? 16 : 32;
-    const uint8_t srca_set       = transpose == false ? 32 : 16;
-    const uint8_t dest_increment = transpose == false ? 8 : 24;
 
     if ((is_in0_16x32 && (!is_in1_32x16)) || is_in0_32x16)
     {
@@ -308,10 +304,10 @@ inline void matmul_configure_addrmod(
 
 template <int NUM_FIDELITY_PHASES, DstTileFaceLayout FaceLayout = DstTileFaceLayout::ColMajor>
 inline void matmul_configure_mop(
-    bool transpose,
+    [[maybe_unused]] bool transpose,
     const std::uint32_t ct_dim,
     const std::uint32_t rt_dim,
-    const std::uint32_t kt_dim,
+    [[maybe_unused]] const std::uint32_t kt_dim,
     const std::uint32_t in0_tile_r_dim = TILE_R_DIM,
     const std::uint32_t in0_tile_c_dim = TILE_C_DIM,
     const std::uint32_t in1_tile_r_dim = TILE_R_DIM,
@@ -735,7 +731,11 @@ inline void _llk_math_matmul_init_(
 
 template <int MATH_FIDELITY_DESC, DstTileFaceLayout FaceLayout = DstTileFaceLayout::ColMajor, int THROTTLE_LEVEL = 0>
 inline void _llk_math_matmul_(
-    uint dst_index, const bool transpose = false, const std::uint32_t ct_dim = 1, const std::uint32_t rt_dim = 1, const std::uint32_t kt_dim = 1)
+    uint dst_index,
+    [[maybe_unused]] const bool transpose       = false,
+    const std::uint32_t ct_dim                  = 1,
+    const std::uint32_t rt_dim                  = 1,
+    [[maybe_unused]] const std::uint32_t kt_dim = 1)
 {
     const bool reuse_a                = ct_dim >= rt_dim;
     const std::uint32_t t_dim         = reuse_a ? rt_dim : ct_dim;

--- a/tt_llk_wormhole_b0/llk_lib/llk_pack.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_pack.h
@@ -295,7 +295,7 @@ inline void _llk_pack_fast_tilize_addrmod_config_(const std::uint32_t unit_dim)
         .set(ADDR_MOD_3);
 }
 
-inline void _llk_pack_fast_tilize_mop_config_(const std::uint32_t unit_dim)
+inline void _llk_pack_fast_tilize_mop_config_([[maybe_unused]] const std::uint32_t unit_dim)
 {
     // UNPACR instructions are used with unit_dim 1 and 2 and SKIP instructions are used with unit_dim 3
     ckernel_unpack_template tmp = ckernel_unpack_template(

--- a/tt_llk_wormhole_b0/llk_lib/llk_unpack_A.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_unpack_A.h
@@ -189,12 +189,12 @@ template <
     EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE,
     bool unpack_to_dest                          = false>
 inline void _llk_unpack_A_init_(
-    const std::uint32_t transpose_of_faces          = 0,
-    const std::uint32_t within_face_16x16_transpose = 0,
-    const std::uint32_t face_r_dim                  = FACE_R_DIM,
-    const std::uint32_t num_faces                   = 4,
-    const std::uint32_t unpack_src_format           = 0,
-    const std::uint32_t unpack_dst_format           = 0)
+    const std::uint32_t transpose_of_faces                           = 0,
+    [[maybe_unused]] const std::uint32_t within_face_16x16_transpose = 0,
+    const std::uint32_t face_r_dim                                   = FACE_R_DIM,
+    const std::uint32_t num_faces                                    = 4,
+    const std::uint32_t unpack_src_format                            = 0,
+    const std::uint32_t unpack_dst_format                            = 0)
 {
     constexpr std::uint32_t UNP_SEL = (BType == BroadcastType::NONE) ? p_setadc::UNP_A : p_setadc::UNP_B;
     config_unpacker_x_end<UNP_SEL>(face_r_dim);
@@ -207,7 +207,10 @@ template <
     EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE,
     bool unpack_to_dest                          = false>
 inline void _llk_unpack_A_(
-    const std::uint32_t address, const bool transpose_of_faces = 0, const std::uint32_t unpack_src_format = 0, const std::uint32_t unpack_dst_format = 0)
+    const std::uint32_t address,
+    [[maybe_unused]] const bool transpose_of_faces = 0,
+    const std::uint32_t unpack_src_format          = 0,
+    const std::uint32_t unpack_dst_format          = 0)
 {
     // Clear z/w start counters
     TTI_SETADCZW(0b011, 0, 0, 0, 0, 0b1111);

--- a/tt_llk_wormhole_b0/llk_lib/llk_unpack_AB_matmul.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_unpack_AB_matmul.h
@@ -21,10 +21,10 @@ using namespace ckernel::unpacker;
 // transpose is unused, math is adjusted to take into account srca face layout when transpose=true
 template <std::uint32_t kernel_broadcast_a = 0, std::uint32_t kernel_broadcast_b = 0>
 inline void _llk_unpack_AB_matmul_mop_config_(
-    const bool transpose,
+    [[maybe_unused]] const bool transpose,
     const std::uint32_t ct_dim,
     const std::uint32_t rt_dim,
-    const std::uint32_t kt_dim,
+    [[maybe_unused]] const std::uint32_t kt_dim,
     const bool unpA_partial_face,
     const bool unpB_partial_face)
 {
@@ -210,8 +210,6 @@ __attribute__((always_inline)) inline void _llk_unpack_AB_matmul_init_(
     const bool unpA_partial_face        = false,
     const bool unpB_partial_face        = false)
 {
-    const bool reuse_a = ct_dim >= rt_dim;
-
     // also turn on within_face_16x16_transpose if it was turned off by datacopy at runtime
     // on WH, the unpacker performs both transpose of faces as well as transpose each face.
     // the former is configured in mop, the latter is configured in cfg register in hw_configure
@@ -259,13 +257,13 @@ inline void _llk_unpack_AB_matmul_(
     const std::uint32_t tile_index_b,
     const std::uint32_t tile_size_a,
     const std::uint32_t tile_size_b,
-    const std::uint32_t unpA_face_r_dim = FACE_R_DIM,
-    const std::uint32_t unpB_face_r_dim = FACE_R_DIM,
-    const bool unpA_partial_face        = false,
-    const bool unpB_partial_face        = false,
-    std::uint32_t ct_dim                = 1,
-    const std::uint32_t rt_dim          = 1,
-    const std::uint32_t kt_dim          = 1)
+    [[maybe_unused]] const std::uint32_t unpA_face_r_dim = FACE_R_DIM,
+    [[maybe_unused]] const std::uint32_t unpB_face_r_dim = FACE_R_DIM,
+    const bool unpA_partial_face                         = false,
+    const bool unpB_partial_face                         = false,
+    std::uint32_t ct_dim                                 = 1,
+    const std::uint32_t rt_dim                           = 1,
+    const std::uint32_t kt_dim                           = 1)
 {
     // In0/InA -> srcB (supports partial face)
     // In1/InB -> srcA

--- a/tt_llk_wormhole_b0/llk_lib/llk_unpack_tilize.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_unpack_tilize.h
@@ -469,11 +469,8 @@ inline void _llk_unpack_fast_tilize_hw_configure_(const std::uint32_t unpack_src
 inline void _llk_unpack_fast_tilize_mop_config_()
 {
     // Y moves to the next tile, Z moves to the next row (both ch0 and ch1)
-    constexpr uint8_t ADDRMOD_CH1Y_0_CH1Z_0_CH0Y_0_CH0Z_0 = 0b00'00'00'00;
     constexpr uint8_t ADDRMOD_CH1Y_0_CH1Z_2_CH0Y_0_CH0Z_1 = 0b00'10'00'01;
-    constexpr uint8_t ADDRMOD_CH1Y_0_CH1Z_0_CH0Y_2_CH0Z_0 = 0b00'00'10'00;
     constexpr uint8_t ADDRMOD_CH1Y_0_CH1Z_3_CH0Y_0_CH0Z_1 = 0b00'11'00'01;
-    constexpr uint8_t ADDRMOD_CH1Y_0_CH1Z_0_CH0Y_3_CH0Z_0 = 0b00'00'11'00;
 
     // UNPACR instructions are used with unit_dim 2 and SKIP instructions are used with unit_dim 3
     ckernel_unpack_template tmp = ckernel_unpack_template(
@@ -606,7 +603,6 @@ inline void _llk_unpack_fast_tilize_block_(
 
     // Y moves to the next tile, Z moves to the next row (both ch0 and ch1)
     constexpr uint8_t ADDRMOD_CH1Y_0_CH1Z_0_CH0Y_0_CH0Z_0 = 0b00'00'00'00;
-    constexpr uint8_t ADDRMOD_CH1Y_0_CH1Z_2_CH0Y_0_CH0Z_1 = 0b00'10'00'01;
     constexpr uint8_t ADDRMOD_CH1Y_0_CH1Z_0_CH0Y_2_CH0Z_0 = 0b00'00'10'00;
     constexpr uint8_t ADDRMOD_CH1Y_0_CH1Z_3_CH0Y_0_CH0Z_1 = 0b00'11'00'01;
     constexpr uint8_t ADDRMOD_CH1Y_0_CH1Z_0_CH0Y_3_CH0Z_0 = 0b00'00'11'00;


### PR DESCRIPTION
### Ticket
None

### Problem description
We've identified a number of unused function parameters that were previously untracked. While we have been ignoring them until now, they have caused confusion on the upper layers since e.g. op writers were expecting them to affect the outcome, but they haven't.

### What's changed
- This PR explicitly marks unused paramters as unused (with `[[maybe_unused]]`), so that developers are aware they do not affect the function's behavior.
- This PR removes unused variables that were making the code unnecessarily complex. Although the compiler eliminates them anyway, this cleanup helps improve code readability.
- Additionally, this PR enables automatic detection of such cases in the future, as they will now be flagged as compilation errors.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update