### PR TITLE
perf :zap:: benchmark _llk_pack_untilize_

### DIFF
--- a/tests/helpers/include/data_format_inference.h
+++ b/tests/helpers/include/data_format_inference.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <array>
+#include <cstddef>
 #include <type_traits>
 #include <utility>
 
@@ -239,7 +240,7 @@ constexpr std::array<FormatConfig, N> build_data_formats(std::index_sequence<Is.
  *
  * @tparam INPUT    The input data format for all pipeline runs.
  * @tparam OUTPUT   The output data format for the final pipeline run.
- * @tparam FP32_ACC Whether FP32 accumulation is enabled.
+ * @tparam FP32_ACC Whether FP32 accumulation is     enabled.
  * @tparam N        The number of pipeline runs (iterations), determines array length.
  *
  * @return A constexpr std::array of FormatConfig objects of length N.

--- a/tests/helpers/include/perf.h
+++ b/tests/helpers/include/perf.h
@@ -8,6 +8,18 @@
 
 #include "ckernel.h"
 
+// FIXME: this shouldn't be statically allocated
+constexpr uint32_t PERF_INPUT_A = 0x1A000;
+constexpr uint32_t PERF_INPUT_B = PERF_INPUT_A + 16 * 4096;
+constexpr uint32_t PERF_INPUT_C = PERF_INPUT_B + 16 * 4096;
+constexpr uint32_t PERF_OUTPUT  = PERF_INPUT_C + 16 * 4096;
+
+constexpr uint32_t PERF_ADDRESS(uint32_t buffer, uint32_t tile)
+{
+    uint32_t address = buffer + (tile % 16) * 4096; // Loop every 16 tiles, to prevent escaping memory
+    return address / 16 - 1;                        // Correct the L1 Address for Tensix
+}
+
 enum class PerfRunType
 {
     L1_TO_L1,

--- a/tests/python_tests/helpers/test_config.py
+++ b/tests/python_tests/helpers/test_config.py
@@ -329,12 +329,17 @@ def generate_build_header(
     validate_tile_dimensions(input_A_dimensions[1], num_cols)
     validate_tile_dimensions(input_B_dimensions[0], num_rows)
     validate_tile_dimensions(input_B_dimensions[1], num_cols)
-    block_rt_dim = input_A_dimensions[0] // num_rows
-    block_ct_dim = input_B_dimensions[1] // num_cols
+    full_rt_dim = input_A_dimensions[0] // num_rows
+    full_ct_dim = input_B_dimensions[1] // num_cols
+
+    block_rt_dim = test_config.get("block_rt_dim", full_rt_dim)
+    block_ct_dim = test_config.get("block_ct_dim", full_ct_dim)
 
     header_content.extend(
         [
             "#if defined(TEST_KERNEL)",
+            f"constexpr uint32_t FULL_RT_DIM = {full_rt_dim};",
+            f"constexpr uint32_t FULL_CT_DIM = {full_ct_dim};",
             f"constexpr uint32_t BLOCK_CT_DIM = {block_ct_dim};",
             f"constexpr uint32_t BLOCK_RT_DIM = {block_rt_dim};",
             "#endif",

--- a/tests/python_tests/perf_pack_untilize.py
+++ b/tests/python_tests/perf_pack_untilize.py
@@ -20,14 +20,15 @@ from helpers.perf import PerfRunType, perf_benchmark, update_report
             DataFormat.Float32,
             DataFormat.Int32,
             DataFormat.Bfp8_b,
-        ]  # Pack Untilize doesn't work for block float formats (Bfp8_b); we only include as input format in our test
+        ]
     ),
     full_rt_dim=[1, 2, 3, 4, 5, 6, 7, 8],
     full_ct_dim=[1, 2, 3, 4, 5, 6, 7, 8],
 )
 def test_perf_pack_untilize(perf_report, test_name, formats, full_rt_dim, full_ct_dim):
     if formats.output_format == DataFormat.Bfp8_b:
-        pytest.skip("Pack Untilize does not support Bfp8_b format")
+        pytest.skip("Pack Untilize does not support Bfp8_b output")
+
     if (formats.input_format == DataFormat.Int32) ^ (
         formats.output_format == DataFormat.Int32
     ):

--- a/tests/python_tests/perf_pack_untilize.py
+++ b/tests/python_tests/perf_pack_untilize.py
@@ -11,6 +11,7 @@ from helpers.param_config import (
 from helpers.perf import PerfRunType, perf_benchmark, update_report
 
 
+@pytest.mark.perf
 @parametrize(
     test_name="pack_untilize_perf",
     formats=input_output_formats(

--- a/tests/python_tests/perf_pack_untilize.py
+++ b/tests/python_tests/perf_pack_untilize.py
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from helpers.format_config import DataFormat
+from helpers.param_config import (
+    input_output_formats,
+    parametrize,
+)
+from helpers.perf import PerfRunType, perf_benchmark, update_report
+
+
+@parametrize(
+    test_name="pack_untilize_perf",
+    formats=input_output_formats(
+        [
+            DataFormat.Float16_b,
+            DataFormat.Float16,
+            DataFormat.Float32,
+            DataFormat.Int32,
+            DataFormat.Bfp8_b,
+        ]  # Pack Untilize doesn't work for block float formats (Bfp8_b); we only include as input format in our test
+    ),
+    full_rt_dim=[1, 2, 3, 4, 5, 6, 7, 8],
+    full_ct_dim=[1, 2, 3, 4, 5, 6, 7, 8],
+)
+def test_perf_pack_untilize(perf_report, test_name, formats, full_rt_dim, full_ct_dim):
+    if formats.output_format == DataFormat.Bfp8_b:
+        pytest.skip("Pack Untilize does not support Bfp8_b format")
+    if (formats.input_format == DataFormat.Int32) ^ (
+        formats.output_format == DataFormat.Int32
+    ):
+        pytest.skip("Pack Untilize does not support mixing Int32 with other formats")
+
+    max_block_dim = 4 if formats.input_format.is_32_bit() else 8
+
+    # fixme: handle format outlier case properly
+    if (
+        formats.input_format == DataFormat.Float16_b
+        or formats.input_format == DataFormat.Bfp8_b
+    ) and formats.output_format == DataFormat.Float16:
+        max_block_dim = 4
+
+    # Find the maximum block size that divides full_ct_dim and is <= max_block_dim
+    block_ct_dim = 1
+    for candidate in range(min(full_ct_dim, max_block_dim), 0, -1):
+        if full_ct_dim % candidate == 0:
+            block_ct_dim = candidate
+            break
+
+    run_types = [
+        PerfRunType.L1_TO_L1,
+        PerfRunType.PACK_ISOLATE,
+        PerfRunType.L1_CONGESTION,
+    ]
+
+    tile_count = full_rt_dim * full_ct_dim
+    dimensions = [full_rt_dim * 32, full_ct_dim * 32]
+
+    test_config = {
+        "formats": formats,
+        "testname": test_name,
+        "tile_cnt": tile_count,
+        "input_A_dimensions": dimensions,
+        "input_B_dimensions": dimensions,
+        "block_ct_dim": block_ct_dim,
+        "unpack_to_dest": formats.input_format.is_32_bit(),
+    }
+
+    results = perf_benchmark(test_config, run_types)
+    update_report(perf_report, test_config, results)

--- a/tests/sources/math_transpose_perf.cpp
+++ b/tests/sources/math_transpose_perf.cpp
@@ -60,6 +60,7 @@ void run_kernel()
 
 void run_kernel()
 {
+    // FIXME: Properly handle expB -> FP16
     constexpr bool is32 = is_32bit_format(static_cast<DataFormat>(formats.math));
 
     {

--- a/tests/sources/pack_untilize_perf.cpp
+++ b/tests/sources/pack_untilize_perf.cpp
@@ -1,0 +1,195 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdio>
+
+#include "ckernel.h"
+#include "llk_defs.h"
+#include "params.h"
+#include "perf.h"
+#include "profiler.h"
+
+// Globals
+uint32_t unp_cfg_context          = 0;
+uint32_t pack_sync_tile_dst_ptr   = 0;
+uint32_t math_sync_tile_dst_index = 0;
+
+// Only modes supported are L1_TO_L1, PACK_ISOLATE and L1_CONGESTION
+static_assert(PERF_RUN_TYPE != PerfRunType::MATH_ISOLATE, "Math isolation not supported for this benchmark");
+static_assert(PERF_RUN_TYPE != PerfRunType::UNPACK_ISOLATE, "Unpack isolation not supported this benchmark");
+
+static constexpr uint32_t MAX_TILES_DEST = is_fp32_dest_acc_en ? 4 : 8;
+
+// Algorithm invariants
+static_assert(BLOCK_CT_DIM <= MAX_TILES_DEST, "Block must fit in Dest register");
+static_assert(FULL_CT_DIM % BLOCK_CT_DIM == 0, "FULL_CT_DIM must be divisible by BLOCK_CT_DIM");
+
+// Test assumptions
+static_assert(FULL_RT_DIM * FULL_CT_DIM == TILE_CNT, "BLOCK_RT_DIM * BLOCK_CT_DIM must be equal to TILE_CNT");
+
+#ifdef LLK_TRISC_UNPACK
+
+#include "llk_unpack_A.h"
+#include "llk_unpack_common.h"
+
+void run_kernel()
+{
+    {
+        ZONE_SCOPED("INIT")
+        _llk_unpack_A_init_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
+            0, 0, FACE_R_DIM, 4, formats.unpack_src, formats.unpack_dst);
+        _llk_unpack_A_hw_configure_<is_fp32_dest_acc_en, StochRndType::None>(formats.unpack_src, formats.unpack_dst, FACE_R_DIM, 0, 4);
+        PROFILER_SYNC();
+    }
+
+    {
+        ZONE_SCOPED("TILE_LOOP")
+        if (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE)
+        {
+            return;
+        }
+
+        for (uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
+        {
+            for (int i = 0; i < TILE_CNT; ++i)
+            {
+                _llk_unpack_A_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
+                    PERF_ADDRESS(PERF_INPUT_A, i), 0, formats.unpack_src, formats.unpack_dst);
+            }
+        }
+        PROFILER_SYNC();
+    }
+}
+
+#endif
+
+#ifdef LLK_TRISC_MATH
+
+#include "llk_math_common.h"
+#include "llk_math_eltwise_unary_datacopy.h"
+
+using namespace ckernel;
+
+void run_kernel()
+{
+    constexpr bool is_int_fpu_en = false;
+
+    {
+        ZONE_SCOPED("INIT")
+
+#ifdef ARCH_BLACKHOLE
+        _llk_math_eltwise_unary_datacopy_init_<DataCopyType::A2D, is_fp32_dest_acc_en, BroadcastType::NONE, false, is_int_fpu_en>(0, 0, 4, formats.math);
+#else
+        _llk_math_eltwise_unary_datacopy_init_<DataCopyType::A2D, is_fp32_dest_acc_en, BroadcastType::NONE, is_int_fpu_en>(0, 0, 4, formats.math);
+#endif
+        _llk_math_pack_sync_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+        _llk_math_hw_configure_<true, false>(formats.math, formats.math);
+        PROFILER_SYNC();
+    }
+
+    {
+        ZONE_SCOPED("TILE_LOOP")
+
+        if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE)
+        {
+            return;
+        }
+        else if constexpr (PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
+        {
+            if constexpr (!unpack_to_dest)
+            {
+                _perf_math_loop_clear_valid<true, true>(LOOP_FACTOR * TILE_CNT * TILE_NUM_FACES);
+                return;
+            }
+
+            // FIXME: Currently have no way to mock math for unpack to dest
+            for (uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
+            {
+                for (uint32_t block = 0; block < TILE_CNT / BLOCK_CT_DIM; block++)
+                {
+                    for (uint32_t block_tile = 0; block_tile < BLOCK_CT_DIM; block_tile++)
+                    {
+                        _llk_math_eltwise_unary_datacopy_<DataCopyType::A2D, DstSync::SyncHalf, is_fp32_dest_acc_en, BroadcastType::NONE, unpack_to_dest>(
+                            block_tile, formats.math, formats.math);
+                    }
+                }
+            }
+            return;
+        }
+
+        for (uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
+        {
+            for (uint32_t block = 0; block < TILE_CNT / BLOCK_CT_DIM; block++)
+            {
+                _llk_math_wait_for_dest_available_<DstSync::SyncHalf>();
+                for (uint32_t block_tile = 0; block_tile < BLOCK_CT_DIM; block_tile++)
+                {
+                    _llk_math_eltwise_unary_datacopy_<DataCopyType::A2D, DstSync::SyncHalf, is_fp32_dest_acc_en, BroadcastType::NONE, unpack_to_dest>(
+                        block_tile, formats.math, formats.math);
+                }
+                _llk_math_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+            }
+        }
+        PROFILER_SYNC();
+    }
+}
+
+#endif
+
+#ifdef LLK_TRISC_PACK
+
+#include "llk_pack.h"
+#include "llk_pack_common.h"
+
+void run_kernel()
+{
+    constexpr bool UNTILIZE = true;
+
+    {
+        ZONE_SCOPED("INIT")
+
+#ifdef ARCH_BLACKHOLE
+        _llk_pack_hw_configure_<is_fp32_dest_acc_en, UNTILIZE, false>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
+        _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en, DstTileFaceLayout::RowMajor>();
+        _llk_pack_untilize_init_<BLOCK_CT_DIM, FULL_CT_DIM>(formats.pack_src, formats.pack_dst, FACE_R_DIM, 4);
+#else
+        _llk_pack_hw_configure_<is_fp32_dest_acc_en, UNTILIZE>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
+        _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en, DstTileFaceLayout::RowMajor, UNTILIZE>();
+        _llk_pack_untilize_init_<BLOCK_CT_DIM, FULL_CT_DIM>(formats.pack_dst, FACE_R_DIM, 4);
+#endif
+        PROFILER_SYNC();
+    }
+
+    {
+        ZONE_SCOPED("TILE_LOOP")
+
+        if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
+        {
+            for (uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
+            {
+                for (uint32_t tile = 0; tile < TILE_CNT; tile += BLOCK_CT_DIM)
+                {
+                    _llk_pack_untilize_<BLOCK_CT_DIM, FULL_CT_DIM>(PERF_ADDRESS(PERF_OUTPUT, tile), formats.pack_dst, FACE_R_DIM, 4, 0);
+                }
+            }
+            PROFILER_SYNC();
+            return;
+        }
+
+        for (uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
+        {
+            for (uint32_t i = 0; i < TILE_CNT; i += BLOCK_CT_DIM)
+            {
+                _llk_packer_wait_for_math_done_();
+                _llk_pack_untilize_<BLOCK_CT_DIM, FULL_CT_DIM>(PERF_ADDRESS(PERF_OUTPUT, i), formats.pack_dst, FACE_R_DIM, 4, 0);
+                _llk_pack_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+            }
+        }
+        PROFILER_SYNC();
+    }
+}
+
+#endif

--- a/tests/sources/pack_untilize_perf.cpp
+++ b/tests/sources/pack_untilize_perf.cpp
@@ -19,7 +19,7 @@ uint32_t math_sync_tile_dst_index = 0;
 
 // Only modes supported are L1_TO_L1, PACK_ISOLATE and L1_CONGESTION
 static_assert(PERF_RUN_TYPE != PerfRunType::MATH_ISOLATE, "Math isolation not supported for this benchmark");
-static_assert(PERF_RUN_TYPE != PerfRunType::UNPACK_ISOLATE, "Unpack isolation not supported this benchmark");
+static_assert(PERF_RUN_TYPE != PerfRunType::UNPACK_ISOLATE, "Unpack isolation not supported for this benchmark");
 
 static constexpr uint32_t MAX_TILES_DEST = is_fp32_dest_acc_en ? 4 : 8;
 
@@ -28,7 +28,7 @@ static_assert(BLOCK_CT_DIM <= MAX_TILES_DEST, "Block must fit in Dest register")
 static_assert(FULL_CT_DIM % BLOCK_CT_DIM == 0, "FULL_CT_DIM must be divisible by BLOCK_CT_DIM");
 
 // Test assumptions
-static_assert(FULL_RT_DIM * FULL_CT_DIM == TILE_CNT, "BLOCK_RT_DIM * BLOCK_CT_DIM must be equal to TILE_CNT");
+static_assert(FULL_RT_DIM * FULL_CT_DIM == TILE_CNT, "FULL_RT_DIM * FULL_CT_DIM must be equal to TILE_CNT");
 
 #ifdef LLK_TRISC_UNPACK
 


### PR DESCRIPTION
### Ticket
<!-- Link to Github Issue -->
#432 

### Problem description
<!-- Provide context for the problem. -->
Adds new performance benchmark for _llk_pack_untilize_
Supports 3 modes:
- L1 to L1
- Pack isolate
- L1 Congested

### What's changed
<!-- Describe the approach used to solve the problem.
Summarize the changes made and its impact. -->

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
