### PR TITLE
[skip ci] ci: fix missing permissions for performance nightly workflow

### DIFF
--- a/.github/workflows/nightly-perf-tests.yml
+++ b/.github/workflows/nightly-perf-tests.yml
@@ -10,6 +10,7 @@ permissions:
   checks: write
   contents: read
   packages: write
+  pull-requests: write
 
 jobs:
   nightly-performance-tests:


### PR DESCRIPTION
### Ticket
None

### Problem description
Workflow execution failed due to insufficient permissions - the caller has a narrower permission scope than required by the callee.

### What's changed
Added missing permissions

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update