### PR TITLE
ci: split perf tests into 3 groups

### DIFF
--- a/.github/workflows/run-perf-tests.yml
+++ b/.github/workflows/run-perf-tests.yml
@@ -66,7 +66,7 @@ jobs:
     with:
       docker_image: ${{ needs.build-images.outputs.docker-image }}
       runs_on: tt-ubuntu-2204-n150-stable
-      test_splits: 1
+      test_splits: 3
       pytest_markers: "perf"
 
   setup-and-test-blackhole:
@@ -80,7 +80,7 @@ jobs:
     with:
       docker_image: ${{ needs.build-images.outputs.docker-image }}
       runs_on: tt-ubuntu-2204-p150b-stable
-      test_splits: 1
+      test_splits: 3
       pytest_markers: "perf"
 
   check-all-green:


### PR DESCRIPTION
### Ticket
None

### Problem description
After the first run of perf tests (can be seen [here](https://github.com/tenstorrent/tt-llk/actions/runs/17830518650/job/50694105025?pr=668)), it seems prudent to split them into several groups, to speed up testing. Initially, I split them into 3 groups, each executing on a separate runner. That should give us feedback fast enough.

### What's changed
Updated workflow file to split perf tests into 3 groups.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
