### PR TITLE
[skip ci] ci: force perf nightly to run on both cards, independent of the last change in main

### DIFF
--- a/.github/workflows/run-perf-tests.yml
+++ b/.github/workflows/run-perf-tests.yml
@@ -48,7 +48,7 @@ jobs:
               performance:
                 - '**/*perf**'
                 - '**/*profiler**'
-  
+
       - name: Resolve test triggers (nightly vs changes)
         id: set
         run: |


### PR DESCRIPTION
### Ticket
None

### Problem description
Perf nightly [hasn't run](https://github.com/tenstorrent/tt-llk/actions/runs/17847490431) because detect changes job shouldn't run on schedule.

### What's changed
Improved logic for detecting which tests to run in nightly perf testing.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update