### PR TITLE
[skip ci] ci: collect results of APC tests that were moved to L2 workflow

### DIFF
--- a/.github/workflows/trigger-tt-metal-post-commit.yml
+++ b/.github/workflows/trigger-tt-metal-post-commit.yml
@@ -277,6 +277,18 @@ jobs:
             echo "bh-url=" >> $GITHUB_OUTPUT
           fi
 
+          # Parse L2 Nightly test results
+          L2_RESULT="${{ needs.trigger-tt-metal-tests.outputs.tt-metal-l2-nightly-result || '' }}"
+          if [ -n "$L2_RESULT" ]; then
+            L2_STATUS=$(echo "$L2_RESULT" | cut -d: -f1)
+            L2_URL=$(echo "$L2_RESULT" | cut -d: -f2-)
+            echo "l2-status=$L2_STATUS" >> $GITHUB_OUTPUT
+            echo "l2-url=$L2_URL" >> $GITHUB_OUTPUT
+          else
+            echo "l2-status=" >> $GITHUB_OUTPUT
+            echo "l2-url=" >> $GITHUB_OUTPUT
+          fi
+
       - name: Find tt-metal workflow run
         id: find-run
         if: needs.trigger-tt-metal-tests.result == 'success'
@@ -369,6 +381,16 @@ jobs:
           echo "$WH_RESULT" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
+          # Format L2 Nightly results (runs with All post-commit tests)
+          L2_RESULT=$(format_test_result "L2 Nightly APC" \
+            "${{ needs.detect-changes.outputs.run-wormhole }}" \
+            "${{ steps.parse-results.outputs.l2-status }}" \
+            "${{ steps.parse-results.outputs.l2-url }}" \
+            "${{ needs.trigger-tt-metal-tests.result }}")
+          echo "l2-nightly-result<<EOF" >> $GITHUB_OUTPUT
+          echo "$L2_RESULT" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
           # Format Blackhole results
           BH_RESULT=$(format_test_result "Blackhole" \
             "${{ needs.detect-changes.outputs.run-blackhole }}" \
@@ -398,6 +420,7 @@ jobs:
             **Test Results:**
             ${{ steps.format-results.outputs.wormhole-result }}
             ${{ steps.format-results.outputs.blackhole-result }}
+            ${{ steps.format-results.outputs.l2-nightly-result }}
 
             ## 🔗 Links
             📊 **Post-commit workflow:** [#${{ github.run_id }}](${{


### PR DESCRIPTION
### Ticket
None

### Problem description
This is tt-llk counterpart of https://github.com/tenstorrent/tt-metal/pull/29023
This PR updates the GitHub workflow to collect and display test results from the L2 Nightly workflow when triggered from the tt-llk repository. Previously, some APC (All post-commit) tests were moved to the L2 workflow but their results weren't being captured during dry runs.

### What's changed
Updated workflow to collect results of L2 runs when called from tt-llk repo.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
