### PR TITLE
[skip ci] ci: split test runs into 4 groups for WH

### DIFF
--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -147,7 +147,7 @@ jobs:
     with:
       docker_image: ${{ needs.build-images.outputs.docker-image }}
       runs_on: tt-ubuntu-2204-n150-stable
-      test_splits: 3
+      test_splits: 4
       pytest_markers: "not perf and not nightly"
 
   setup-and-test-blackhole:


### PR DESCRIPTION
### Ticket
None

### Problem description
This PR increases the parallelization of WH test runs from 3 to 4 groups to address test execution times that have exceeded 30 minutes. This is a CI optimization change to improve build pipeline performance through horizontal scaling.

### What's changed
Increased the number of groups for running WH tests from 3 to 4.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
