### PR TITLE
[skip ci] ci: stop overwriting messages with post-commit workflow results

### DIFF
--- a/.github/workflows/trigger-tt-metal-post-commit.yml
+++ b/.github/workflows/trigger-tt-metal-post-commit.yml
@@ -405,6 +405,8 @@ jobs:
         uses: mshick/add-pr-comment@v2
         with:
           issue: ${{ steps.get-pr-number.outputs.pr-number }}
+          # using run_id to ensure it's unique for every workflow run
+          message-id: llk-${{ github.run_id }}
           message: |
             ## 🚀 tt-metal post-commit tests
 


### PR DESCRIPTION
### Ticket
None

### Problem description
This PR fixes an issue where post-commit workflow status messages were overwriting each other by adding unique message identifiers. The workflow was previously writing test results to the same message box, making messages "sticky" and only showing the latest results.

### What's changed
- Added unique message-id parameter using GitHub's run_id to prevent message overwriting
- Ensures each workflow run creates a separate status message for better tracking

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
