### PR TITLE
[skip ci] ci: don't run trigger post commit workflow from forks

### DIFF
--- a/.github/workflows/trigger-tt-metal-post-commit.yml
+++ b/.github/workflows/trigger-tt-metal-post-commit.yml
@@ -25,6 +25,9 @@ jobs:
   setup-branch:
     name: "🔧 Setup branch for testing"
     runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      github.event.pull_request.head.repo.fork == false
     outputs:
       branch-to-run: ${{
         steps.check-fork.outputs.is-fork == 'true' &&


### PR DESCRIPTION
### Ticket
None

### Problem description
Running post-commit workflows from forks is not supported, since forked repos don't have access to our repo secrets. And this job always fails. Even though it is marked as optional, it still confuses external developers.
You can still run post-commit workflows on forked PRs manually, by starting it [here](https://github.com/tenstorrent/tt-llk/actions/workflows/trigger-tt-metal-post-commit.yml).

### What's changed
This PR puts guards to allow the workflow to run only in case of internal PRs.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update