### PR TITLE
Update clangd to gcc 15.1 paths

### DIFF
--- a/setup_clangd.sh
+++ b/setup_clangd.sh
@@ -100,7 +100,7 @@ setup_testing_environment() {
 # Function to validate sfpi installation
 validate_sfpi_installation() {
     local sfpi_dirs=(
-        "$ROOT_DIR/tests/sfpi/compiler/lib/gcc/riscv32-tt-elf/12.4.0/include/"
+        "$ROOT_DIR/tests/sfpi/compiler/lib/gcc/riscv32-tt-elf/15.1.0/include/"
         "$ROOT_DIR/tests/sfpi/compiler/riscv32-tt-elf/include"
         "$ROOT_DIR/tests/sfpi/include"
     )
@@ -130,13 +130,13 @@ generate_compile_flags() {
 -DLLK_TRISC_PACK
 
 -isystem
-$ROOT_DIR/tests/sfpi/compiler/lib/gcc/riscv32-tt-elf/12.4.0/include/
+$ROOT_DIR/tests/sfpi/compiler/lib/gcc/riscv32-tt-elf/15.1.0/include/
 -isystem
 $ROOT_DIR/tests/sfpi/compiler/riscv32-tt-elf/include
 -isystem
-$ROOT_DIR/tests/sfpi/compiler/riscv32-tt-elf/include/c++/12.4.0
+$ROOT_DIR/tests/sfpi/compiler/riscv32-tt-elf/include/c++/15.1.0
 -isystem
-$ROOT_DIR/tests/sfpi/compiler/riscv32-tt-elf/include/c++/12.4.0/riscv32-tt-elf
+$ROOT_DIR/tests/sfpi/compiler/riscv32-tt-elf/include/c++/15.1.0/riscv32-tt-elf
 -isystem
 $ROOT_DIR/tests/sfpi/include
 -I$ROOT_DIR/tests/firmware/riscv/common


### PR DESCRIPTION
### Ticket
NA
### Problem description
clangd's setup was pointing at gcc-12 paths.

### What's changed
Point at gcc-15 paths

### Type of change

- [YES] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
