### PR TITLE
[skip ci] build: update sfpi to 7.2.0

### DIFF
--- a/tests/sfpi-version.sh
+++ b/tests/sfpi-version.sh
@@ -1,13 +1,14 @@
 # set SFPI release version information
 
-sfpi_version=7.1.0
+sfpi_version=7.2.0
 sfpi_url=https://github.com/tenstorrent/sfpi/releases/download
 
 # convert md5 file into these variables
 # sed 's/^\([0-9a-f]*\) \*sfpi_[-.0-9a-zA-Z]*_\([a-z0-9_A-Z]*\)\.\([a-z]*\)$/sfpi_\2_\3_md5=\1/'
-sfpi_aarch64_txz_md5=84349e5d816885a7db0d447a71311b6c
-sfpi_aarch64_deb_md5=ab74092edaf9d8effe22d5c3ee1a6641
-sfpi_aarch64_rpm_md5=33c2221bd643168479ce668e4967c18f
-sfpi_x86_64_txz_md5=92c59298aec2954b1a9c65e5a39cf9af
-sfpi_x86_64_deb_md5=46632ec6aa6c11605447b03284395bfb
-sfpi_x86_64_rpm_md5=10e3b833fddead540ddf6b240dd616c0
+
+sfpi_aarch64_deb_md5=a67c257092b55af74b16d1ca03305f05
+sfpi_aarch64_rpm_md5=3ec63a0a7b83485867f103c7fd3f5079
+sfpi_aarch64_txz_md5=6f0380cb9d50055e0c31f5b7e96fb638
+sfpi_x86_64_deb_md5=df7a206658fc40cf31fe7282343a2752
+sfpi_x86_64_rpm_md5=9634997e6101227dae10bd9701f046e8
+sfpi_x86_64_txz_md5=e408d57cc776d4d51055323c5e29cf02


### PR DESCRIPTION
### Ticket
None

### Problem description
SFPI update that doesn’t check ARCH_foo macros in sfpi header file, that interferes with Quasar development, which is using BH as a base.

### What's changed
New SFPI version 7.2.0

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
