### PR TITLE
[skip ci] ci: make test timeout configurable

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -32,6 +32,7 @@ jobs:
       runs_on: tt-ubuntu-2204-n150-stable
       test_splits: 10
       pytest_markers: ${{ inputs.pytest_markers || 'nightly' }}
+      timeout_minutes: 240
 
   nightly-test-blackhole:
     name: "🕳️ Nightly Tests (Blackhole)"
@@ -42,6 +43,7 @@ jobs:
       runs_on: tt-ubuntu-2204-p150b-stable
       test_splits: 10
       pytest_markers: ${{ inputs.pytest_markers || 'nightly' }}
+      timeout_minutes: 240
 
   nightly-summary:
     name: "📊 Nightly Summary"

--- a/.github/workflows/run-perf-tests.yml
+++ b/.github/workflows/run-perf-tests.yml
@@ -81,6 +81,7 @@ jobs:
       runs_on: tt-ubuntu-2204-n150-stable
       test_splits: 3
       pytest_markers: "perf"
+      timeout_minutes: 120
 
   setup-and-test-blackhole:
     name: "🕳️ Performance tests (Blackhole)"
@@ -95,6 +96,7 @@ jobs:
       runs_on: tt-ubuntu-2204-p150b-stable
       test_splits: 3
       pytest_markers: "perf"
+      timeout_minutes: 120
 
   check-all-green:
     name: "✅ Check all green"

--- a/.github/workflows/setup-and-test.yml
+++ b/.github/workflows/setup-and-test.yml
@@ -20,6 +20,11 @@ on:
         required: false
         default: "not perf"
         type: string
+      timeout_minutes:
+        description: "Timeout in minutes for the test job"
+        required: false
+        default: 80
+        type: number
 
 permissions:
   checks: write
@@ -38,7 +43,7 @@ jobs:
   setup-and-test:
     needs: generate-matrix
     runs-on: ${{ inputs.runs_on }}
-    timeout-minutes: 80
+    timeout-minutes: ${{ inputs.timeout_minutes }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
### Ticket
None

### Problem description
This PR makes the test timeout configurable in GitHub Actions workflows to address [timing out](https://github.com/tenstorrent/tt-llk/actions/runs/18053155525) nightly tests caused by new matmul tests. Instead of hardcoding the timeout value, it introduces a configurable parameter that allows different workflows to specify appropriate timeout values.

### What's changed
- Added a `timeout_minutes` input parameter to the `setup-and-test` workflow with a default of 80 minutes
- Updated `performance` test workflows to use 120-minute timeouts
- Set `nightly` test workflows to use 240-minute timeouts for longer-running tests

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update