### PR TITLE
[skip ci] chore: deduplicate “tests tests”

### DIFF
--- a/.github/workflows/trigger-tt-metal-post-commit.yml
+++ b/.github/workflows/trigger-tt-metal-post-commit.yml
@@ -385,7 +385,7 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
 
           # Format L2 Nightly results (runs with All post-commit tests)
-          L2_RESULT=$(format_test_result "Wormhole C++ tests" \
+          L2_RESULT=$(format_test_result "Wormhole C++" \
             "${{ needs.detect-changes.outputs.run-wormhole }}" \
             "${{ steps.parse-results.outputs.l2-status }}" \
             "${{ steps.parse-results.outputs.l2-url }}" \


### PR DESCRIPTION
### Ticket
None

### Problem description
There is typo when displaying post-commit test results. For the newly added APC C++ tests we display tests tests text.

![image](https://github.com/user-attachments/assets/4a58c094-fda8-4956-a588-253d68d8a646)

### What's changed
Removed extra “tests”.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
