### PR TITLE
Add inf and nan handling in rounding ops

### DIFF
--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_rounding_ops.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_rounding_ops.h
@@ -9,13 +9,13 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
+#include "ckernel_sfpu_isinf_isnan.h"
 #include "sfpi.h"
 
 namespace ckernel
 {
 namespace sfpu
 {
-
 inline sfpi::vInt _float_to_int32_(sfpi::vFloat in)
 {
     sfpi::vInt result;
@@ -114,6 +114,12 @@ inline void _calculate_floor_()
             v_endif;
         }
 
+        v_if (sfpi::vConst0 == _calculate_isfinite_<APPROXIMATION_MODE>(v))
+        {
+            result = v;
+        }
+        v_endif;
+
         sfpi::dst_reg[0] = result;
         sfpi::dst_reg++;
     }
@@ -205,6 +211,12 @@ inline void _calculate_trunc_()
         v_if (in < 0)
         {
             result = 0 - result;
+        }
+        v_endif;
+
+        v_if (sfpi::vConst0 == _calculate_isfinite_<APPROXIMATION_MODE>(in))
+        {
+            result = in;
         }
         v_endif;
 

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_rounding_ops.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_rounding_ops.h
@@ -9,13 +9,13 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
+#include "ckernel_sfpu_isinf_isnan.h"
 #include "sfpi.h"
 
 namespace ckernel
 {
 namespace sfpu
 {
-
 inline sfpi::vInt _float_to_int32_(sfpi::vFloat in)
 {
     sfpi::vInt result;
@@ -113,6 +113,11 @@ inline void _calculate_floor_()
             }
             v_endif;
         }
+        v_if (sfpi::vConst0 == _calculate_isfinite_<APPROXIMATION_MODE>(v))
+        {
+            result = v;
+        }
+        v_endif;
 
         sfpi::dst_reg[0] = result;
         sfpi::dst_reg++;
@@ -205,6 +210,12 @@ inline void _calculate_trunc_()
         v_if (in < 0)
         {
             result = 0 - result;
+        }
+        v_endif;
+
+        v_if (sfpi::vConst0 == _calculate_isfinite_<APPROXIMATION_MODE>(in))
+        {
+            result = in;
         }
         v_endif;
 


### PR DESCRIPTION
### Ticket
Link to Github Issue https://github.com/tenstorrent/tt-metal/issues/29506

### Problem description
Floor and trunc returns int max limit for nan and inf.

### What's changed
Updated floor and trunc to return inf and nan

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
