### PR TITLE
SFPI 7.3.0: Drop '32' from toolchain name

### DIFF
--- a/setup_clangd.sh
+++ b/setup_clangd.sh
@@ -100,8 +100,8 @@ setup_testing_environment() {
 # Function to validate sfpi installation
 validate_sfpi_installation() {
     local sfpi_dirs=(
-        "$ROOT_DIR/tests/sfpi/compiler/lib/gcc/riscv32-tt-elf/15.1.0/include/"
-        "$ROOT_DIR/tests/sfpi/compiler/riscv32-tt-elf/include"
+        "$ROOT_DIR/tests/sfpi/compiler/lib/gcc/riscv-tt-elf/15.1.0/include/"
+        "$ROOT_DIR/tests/sfpi/compiler/riscv-tt-elf/include"
         "$ROOT_DIR/tests/sfpi/include"
     )
 
@@ -130,13 +130,13 @@ generate_compile_flags() {
 -DLLK_TRISC_PACK
 
 -isystem
-$ROOT_DIR/tests/sfpi/compiler/lib/gcc/riscv32-tt-elf/15.1.0/include/
+$ROOT_DIR/tests/sfpi/compiler/lib/gcc/riscv-tt-elf/15.1.0/include/
 -isystem
-$ROOT_DIR/tests/sfpi/compiler/riscv32-tt-elf/include
+$ROOT_DIR/tests/sfpi/compiler/riscv-tt-elf/include
 -isystem
-$ROOT_DIR/tests/sfpi/compiler/riscv32-tt-elf/include/c++/15.1.0
+$ROOT_DIR/tests/sfpi/compiler/riscv-tt-elf/include/c++/15.1.0
 -isystem
-$ROOT_DIR/tests/sfpi/compiler/riscv32-tt-elf/include/c++/15.1.0/riscv32-tt-elf
+$ROOT_DIR/tests/sfpi/compiler/riscv-tt-elf/include/c++/15.1.0/riscv-tt-elf
 -isystem
 $ROOT_DIR/tests/sfpi/include
 -I$ROOT_DIR/tests/firmware/riscv/common

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -51,9 +51,9 @@ LINKER_SCRIPTS  := $(HELPERS)/ld
 HEADER_DIR      := hw_specific/$(ARCH)/inc
 RMDIR           := rm -rf
 
-GXX             := $(TOOL_PATH)/riscv32-tt-elf-g++
-OBJDUMP         := $(TOOL_PATH)/riscv32-tt-elf-objdump
-OBJCOPY         := $(TOOL_PATH)/riscv32-tt-elf-objcopy
+GXX             := $(TOOL_PATH)/riscv-tt-elf-g++
+OBJDUMP         := $(TOOL_PATH)/riscv-tt-elf-objdump
+OBJCOPY         := $(TOOL_PATH)/riscv-tt-elf-objcopy
 
 # =========================
 # Compiler and Linker Flags

--- a/tests/sfpi-version.sh
+++ b/tests/sfpi-version.sh
@@ -1,14 +1,13 @@
 # set SFPI release version information
 
-sfpi_version=7.2.0
 sfpi_url=https://github.com/tenstorrent/sfpi/releases/download
 
 # convert md5 file into these variables
-# sed 's/^\([0-9a-f]*\) \*sfpi_[-.0-9a-zA-Z]*_\([a-z0-9_A-Z]*\)\.\([a-z]*\)$/sfpi_\2_\3_md5=\1/'
-
-sfpi_aarch64_deb_md5=a67c257092b55af74b16d1ca03305f05
-sfpi_aarch64_rpm_md5=3ec63a0a7b83485867f103c7fd3f5079
-sfpi_aarch64_txz_md5=6f0380cb9d50055e0c31f5b7e96fb638
-sfpi_x86_64_deb_md5=df7a206658fc40cf31fe7282343a2752
-sfpi_x86_64_rpm_md5=9634997e6101227dae10bd9701f046e8
-sfpi_x86_64_txz_md5=e408d57cc776d4d51055323c5e29cf02
+# sed 's/^\([0-9a-f]*\) \*sfpi_\([-.0-9a-zA-Z]*\)_\([a-z0-9_A-Z]*\)\.\([a-z]*\)$/sfpi_version=\2'"\n"'sfpi_\3_\4_md5=\1/' *-build/sfpi_*.md5 | sort -u
+sfpi_aarch64_deb_md5=bbe267282dc8c36554bc91354e47fc7d
+sfpi_aarch64_rpm_md5=f146cc686ffd08f5d5bf55055f2010f2
+sfpi_aarch64_txz_md5=d03da69379ea08386ce88dfb2bcdb88c
+sfpi_version=7.3.0
+sfpi_x86_64_deb_md5=100e9834fe6877a186440b241f69da65
+sfpi_x86_64_rpm_md5=38def21cfa7cfebef8e9def61019f7cc
+sfpi_x86_64_txz_md5=17970c8034b039f269d9a9db8e841e45


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/29186

### Problem description
Quasar is 64-bit, the '32' in the toolchain will become more confusing.

### What's changed
Adjust all mentions of the target triple to drop the '32'

### Type of change

- [YES] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
