### PR TITLE
refactor: eliminate redundant conversions in _calculate_clamp_

### DIFF
--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_clamp.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_clamp.h
@@ -23,8 +23,9 @@ inline void _calculate_clamp_(const int iterations, uint param0, uint param1, ui
     sfpi::s2vFloat16::Format format = sfpi::s2vFloat16::fp16a;
 
     // SFPU microcode
-    sfpi::vFloat min = sfpi::s2vFloat16(param0, format);
-    sfpi::vFloat max = sfpi::s2vFloat16(param1, format);
+    sfpi::vFloat min    = sfpi::s2vFloat16(param0, format);
+    sfpi::vFloat max    = sfpi::s2vFloat16(param1, format);
+    sfpi::vFloat offset = sfpi::s2vFloat16b(param2); // 12 bits
 #pragma GCC unroll 0
     for (int d = 0; d < iterations; d++)
     {
@@ -32,15 +33,15 @@ inline void _calculate_clamp_(const int iterations, uint param0, uint param1, ui
 
         v_if (val < min)
         {
-            val = sfpi::s2vFloat16(param0, format);
+            val = min;
         }
         v_elseif (val >= max)
         {
-            val = sfpi::s2vFloat16(param1, format);
+            val = max;
         }
         v_endif;
 
-        sfpi::dst_reg[0] = val + sfpi::s2vFloat16b(param2); // 12 bits
+        sfpi::dst_reg[0] = val + offset;
 
         sfpi::dst_reg++;
     }

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_clamp.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_clamp.h
@@ -23,8 +23,9 @@ inline void _calculate_clamp_(const int iterations, uint param0, uint param1, ui
     sfpi::s2vFloat16::Format format = sfpi::s2vFloat16::fp16a;
 
     // SFPU microcode
-    sfpi::vFloat min = sfpi::s2vFloat16(param0, format);
-    sfpi::vFloat max = sfpi::s2vFloat16(param1, format);
+    sfpi::vFloat min    = sfpi::s2vFloat16(param0, format);
+    sfpi::vFloat max    = sfpi::s2vFloat16(param1, format);
+    sfpi::vFloat offset = sfpi::s2vFloat16b(param2); // 12 bits
 #pragma GCC unroll 0
     for (int d = 0; d < iterations; d++)
     {
@@ -32,15 +33,15 @@ inline void _calculate_clamp_(const int iterations, uint param0, uint param1, ui
 
         v_if (val < min)
         {
-            val = sfpi::s2vFloat16(param0, format);
+            val = min;
         }
         v_elseif (val >= max)
         {
-            val = sfpi::s2vFloat16(param1, format);
+            val = max;
         }
         v_endif;
 
-        sfpi::dst_reg[0] = val + sfpi::s2vFloat16b(param2); // 12 bits
+        sfpi::dst_reg[0] = val + offset;
 
         sfpi::dst_reg++;
     }


### PR DESCRIPTION
### Ticket
None

### Problem description
[This comment](https://github.com/tenstorrent/tt-metal/pull/27998#discussion_r2353071377) made me look into `_calculate_clamp_` and I found a few redundant calls happening on every iteration.

### What's changed
The original code had 3 redundant conversions per iteration:
- s2vFloat16(param0, format) -> replaced with pre-computed min
- s2vFloat16(param1, format) -> replaced with pre-computed max
- s2vFloat16b(param2) -> hoisted outside loop as offset

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
