### PR TITLE
Add test_unpack_A: broadcast golden models, BFP8_b handling, Z3 const…

### DIFF
--- a/tests/python_tests/helpers/device.py
+++ b/tests/python_tests/helpers/device.py
@@ -20,10 +20,7 @@ from ttexalens.tt_exalens_lib import (
 
 from helpers.chip_architecture import ChipArchitecture, get_chip_architecture
 
-from .format_arg_mapping import (
-    DestAccumulation,
-    Mailbox,
-)
+from .format_arg_mapping import DestAccumulation, Mailbox
 from .format_config import DataFormat, FormatConfig
 from .pack import (
     pack_bfp8_b,

--- a/tests/python_tests/helpers/format_config.py
+++ b/tests/python_tests/helpers/format_config.py
@@ -77,6 +77,27 @@ class DataFormat(Enum):
         return (self.size * num_datums) + num_exponents
 
 
+class BroadcastType(Enum):
+    """
+    Enum for broadcast types in LLK kernels.
+    """
+
+    None_ = "NONE"
+    Column = "COL"
+    Row = "ROW"
+    Scalar = "SCALAR"
+
+
+class EltwiseBinaryReuseDestType(Enum):
+    """
+    Enum for destination reuse types in elementwise binary ops.
+    """
+
+    NONE = 0
+    DEST_TO_SRCA = 1
+    DEST_TO_SRCB = 2
+
+
 @dataclass
 class FormatConfig:
     """

--- a/tests/python_tests/helpers/pack.py
+++ b/tests/python_tests/helpers/pack.py
@@ -97,10 +97,29 @@ def float_to_bfp8_block(block):
 
 
 def pack_bfp8_b(tensor, block_size=16, num_faces=4):
-    faces_per_tile = 4
+    """Pack tensor into BFP8_b format.
+
+    BFP8_b uses 16-element blocks, each with a shared exponent and 8-bit mantissas.
+    Only the first (256 * num_faces) elements are packed.
+
+    Args:
+        tensor: Input tensor (typically 1024 elements for full tile)
+        block_size: Elements per block (always 16 for BFP8_b)
+        num_faces: Number of faces to pack (1, 2, or 4)
+
+    Returns:
+        List of packed bytes: [exponents...] + [mantissas...]
+    """
     flattened_tensor = tensor.flatten()
+
+    # Only pack the first (256 * num_faces) elements
+    elements_to_pack = 256 * num_faces
+    assert (
+        len(flattened_tensor) >= elements_to_pack
+    ), f"Tensor has {len(flattened_tensor)} elements, but need at least {elements_to_pack} for {num_faces} face(s)"
+    flattened_tensor = flattened_tensor[:elements_to_pack]
+
     num_blocks = len(flattened_tensor) // block_size
-    num_blocks = num_blocks * num_faces // faces_per_tile
 
     exponents = []
     mantissas = []

--- a/tests/python_tests/helpers/test_config.py
+++ b/tests/python_tests/helpers/test_config.py
@@ -112,19 +112,25 @@ def generate_build_header(test_config):
     header_content.append(f"constexpr bool UNPACKING_TO_DEST = {unpack_to_dest};")
 
     # Unpack transpose faces
-    unpack_transpose_faces = test_config.get(
-        "unpack_transpose_faces", Transpose.No
-    ).value
+    unpack_transpose_faces = test_config.get("unpack_transpose_faces", Transpose.No)
+    if isinstance(unpack_transpose_faces, int):
+        unpack_transpose_faces = bool(unpack_transpose_faces)
+    else:
+        unpack_transpose_faces = unpack_transpose_faces.value
     header_content.append(
-        f"constexpr bool UNPACK_TRANSPOSE_FACES = {unpack_transpose_faces};"
+        f"constexpr bool UNPACK_TRANSPOSE_FACES = {str(unpack_transpose_faces).lower()};"
     )
 
     # Unpack transpose within face
     unpack_transpose_within_face = test_config.get(
         "unpack_transpose_within_face", Transpose.No
-    ).value
+    )
+    if isinstance(unpack_transpose_within_face, int):
+        unpack_transpose_within_face = bool(unpack_transpose_within_face)
+    else:
+        unpack_transpose_within_face = unpack_transpose_within_face.value
     header_content.append(
-        f"constexpr bool UNPACK_TRANSPOSE_WITHIN_FACE = {unpack_transpose_within_face};"
+        f"constexpr bool UNPACK_TRANSPOSE_WITHIN_FACE = {str(unpack_transpose_within_face).lower()};"
     )
 
     # Throttle level
@@ -151,6 +157,39 @@ def generate_build_header(test_config):
     header_content.append(
         f"constexpr std::uint32_t L1_to_L1_ITERATIONS = {fused_L1_to_L1};"
     )
+
+    # Broadcast type
+    if "broadcast_type" in test_config:
+        broadcast_type = test_config["broadcast_type"]
+        header_content.append(
+            f"constexpr auto BROADCAST_TYPE = ckernel::BroadcastType::{broadcast_type.value};"
+        )
+
+    # Accumulate to dest
+    if "acc_to_dest" in test_config:
+        acc_to_dest = str(test_config["acc_to_dest"]).lower()
+        header_content.append(f"constexpr bool ACC_TO_DEST = {acc_to_dest};")
+
+    # Reuse destination type
+    if "reuse_dest" in test_config:
+        reuse_dest = test_config["reuse_dest"]
+        header_content.append(
+            f"constexpr auto REUSE_DEST_TYPE = ckernel::EltwiseBinaryReuseDestType::{reuse_dest.name};"
+        )
+
+    if "disable_src_zero_flag" in test_config:
+        disable_src_zero_flag = str(test_config["disable_src_zero_flag"]).lower()
+        header_content.append(
+            f"constexpr bool disable_src_zero_flag = {disable_src_zero_flag};"
+        )
+
+    if "num_faces" in test_config:
+        num_faces = test_config["num_faces"]
+        header_content.append(f"constexpr std::uint32_t NUM_FACES = {num_faces};")
+
+    if "narrow_tile" in test_config:
+        narrow_tile = str(test_config["narrow_tile"]).lower()
+        header_content.append(f"constexpr bool NARROW_TILE = {narrow_tile};")
 
     # Math fidelity & Approximation mode
     header_content.append(

--- a/tests/python_tests/test_unpack_A.py
+++ b/tests/python_tests/test_unpack_A.py
@@ -1,0 +1,479 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from itertools import product
+
+import pytest
+from z3 import And, BoolVal, If, Implies, IntVal, Not, Or, Solver, sat
+
+from helpers.chip_architecture import ChipArchitecture, get_chip_architecture
+from helpers.device import collect_results, write_stimuli_to_l1
+from helpers.format_arg_mapping import DestAccumulation, StochasticRounding, format_dict
+from helpers.format_config import BroadcastType, DataFormat, EltwiseBinaryReuseDestType
+from helpers.golden_generators import (
+    ColumnBroadcastGolden,
+    DataCopyGolden,
+    RowBroadcastGolden,
+    ScalarBroadcastGolden,
+    TransposeGolden,
+    get_golden_generator,
+)
+from helpers.param_config import generate_params, input_output_formats
+from helpers.stimuli_generator import generate_stimuli
+from helpers.test_config import run_test
+from helpers.utils import passed_test
+
+# SUPPORTED FORMATS FOR TEST
+supported_formats = [
+    DataFormat.Float32,
+    DataFormat.Float16,
+    DataFormat.Float16_b,
+    DataFormat.Bfp8_b,
+]
+
+# Define parameter lists
+broadcast_types = [
+    BroadcastType.None_,
+    BroadcastType.Column,
+    BroadcastType.Row,
+    BroadcastType.Scalar,
+]
+dest_acc = [DestAccumulation.Yes, DestAccumulation.No]
+disable_src_zero_flags = [False, True]
+acc_to_dest_flags = [False, True]
+stochastic_rnd = [
+    StochasticRounding.No,
+    StochasticRounding.Fpu,
+    StochasticRounding.Pack,
+    StochasticRounding.All,
+]
+reuse_dest_types = [
+    EltwiseBinaryReuseDestType.NONE,
+    EltwiseBinaryReuseDestType.DEST_TO_SRCA,
+    EltwiseBinaryReuseDestType.DEST_TO_SRCB,
+]
+transpose_of_faces_values = [0, 1]
+within_face_16x16_transpose_values = [0, 1]
+num_faces_values = [1, 2, 4]
+
+
+# Use only cross_test_formats as it already includes same-format combinations
+test_formats = input_output_formats(supported_formats, False)
+
+
+# Generate unpack_A specific parameter combinations using itertools.product
+unpack_A_param_combinations = list(
+    product(
+        broadcast_types,
+        disable_src_zero_flags,
+        acc_to_dest_flags,
+        stochastic_rnd,
+        reuse_dest_types,
+        transpose_of_faces_values,
+        within_face_16x16_transpose_values,
+        num_faces_values,
+    )
+)
+
+# Create unified parameter combinations
+# This combines the power of generate_params with unpack_A specific parameters
+all_params = []
+testname = ["unpack_A_test"]
+
+# Use generate_params for base parameter structure (like datacopy test)
+base_params = list(
+    generate_params(testnames=testname, formats=test_formats)
+)  # Convert itertools.product to list
+
+# Extend base params with unpack_A specific parameters
+for base_param in base_params:
+    # base_param = (testname, format_config) - new format from main branch
+    base_testname = base_param[0]
+    formats = base_param[1]
+
+    for unpack_params in unpack_A_param_combinations:
+        # unpack_params = (broadcast_type, disable_src_zero,
+        #                  acc_to_dest, stoch_rnd_type, reuse_dest, transpose_of_faces,
+        #                  within_face_16x16_transpose, num_faces)
+
+        broadcast_type = unpack_params[0]
+        disable_src_zero = unpack_params[1]
+        acc_to_dest = unpack_params[2]
+        stochastic_rnd = unpack_params[3]
+        reuse_dest = unpack_params[4]
+        transpose_of_faces = unpack_params[5]
+        within_face_16x16_transpose = unpack_params[6]
+        num_faces = unpack_params[7]
+
+        # Create complete parameter tuple matching test signature
+        combined_params = (
+            base_testname,  # testname
+            formats,  # formats
+            broadcast_type,  # broadcast_type
+            disable_src_zero,  # disable_src_zero
+            acc_to_dest,  # acc_to_dest
+            stochastic_rnd,  # stochastic_rnd
+            reuse_dest,  # reuse_dest
+            transpose_of_faces,  # transpose_of_faces
+            within_face_16x16_transpose,  # within_face_16x16_transpose
+            num_faces,  # num_faces
+        )
+        all_params.append(combined_params)
+
+
+def filter_params_with_z3(all_params):
+    """Use Z3 to filter valid parameter combinations based on hardware constraints"""
+
+    arch = get_chip_architecture()
+    valid_params = []
+
+    for params in all_params:
+        # Extract parameters from tuple
+        (
+            testname,
+            formats,
+            broadcast_type,
+            disable_src_zero,
+            acc_to_dest,
+            stochastic_rnd,
+            reuse_dest,
+            transpose_of_faces,
+            within_face_16x16_transpose,
+            num_faces,
+        ) = params
+
+        # Create Z3 solver
+        s = Solver()
+
+        # Convert enum values to integers for Z3
+        # Map BroadcastType string values to integers
+        broadcast_mapping = {"NONE": 0, "COL": 1, "ROW": 2, "SCALAR": 3}
+        if hasattr(broadcast_type, "value") and isinstance(broadcast_type.value, str):
+            broadcast_val = broadcast_mapping.get(broadcast_type.value, 0)
+        else:
+            broadcast_val = (
+                broadcast_type.value if hasattr(broadcast_type, "value") else 0
+            )
+
+        reuse_dest_val = reuse_dest.value if hasattr(reuse_dest, "value") else 0
+        stoch_rnd_val = stochastic_rnd.value if hasattr(stochastic_rnd, "value") else 0
+
+        # Z3 variables representing our parameters
+        broadcast = IntVal(broadcast_val)  # 0=NONE, 1=COL, 2=ROW, 3=SCALAR
+        acc_to_dest_z3 = BoolVal(acc_to_dest)
+        reuse_dest_z3 = IntVal(reuse_dest_val)  # 0=NONE, 1=DEST_TO_SRCA, 2=DEST_TO_SRCB
+        transpose_faces = BoolVal(transpose_of_faces == 1)
+        num_faces_z3 = IntVal(num_faces)
+        unpack_to_dest = BoolVal(formats.input_format.is_32_bit() and acc_to_dest)
+        is_blackhole = BoolVal(arch == ChipArchitecture.BLACKHOLE)
+        is_wormhole = BoolVal(arch == ChipArchitecture.WORMHOLE)
+
+        # Define constraint predicates using Z3
+        broadcast_none = broadcast == 0
+        broadcast_col = broadcast == 1
+        broadcast_row = broadcast == 2
+        broadcast_scalar = broadcast == 3
+
+        reuse_none = reuse_dest_z3 == 0
+        reuse_srca = reuse_dest_z3 == 1
+        reuse_srcb = reuse_dest_z3 == 2
+
+        # Broadcast incompatible with DEST_TO_SRCB/SRCA (regardless of acc_to_dest)
+        constraint1 = And(
+            # Non-NONE broadcast + DEST_TO_SRCB not supported
+            Not(And(Not(broadcast_none), reuse_srcb)),
+            # Non-NONE broadcast + DEST_TO_SRCA not supported
+            Not(And(Not(broadcast_none), reuse_srca)),
+        )
+
+        # Static assertion 2: unpack_to_dest configuration restrictions
+        valid_unpack_config = Or(
+            And(broadcast_none, Not(acc_to_dest_z3), reuse_none), Not(unpack_to_dest)
+        )
+        constraint2 = valid_unpack_config
+
+        # Static assertion 3: SCALAR broadcast + acc_to_dest
+        constraint3 = Not(And(broadcast_scalar, acc_to_dest_z3))
+
+        # unpack_to_dest specific constraints
+        unpack_constraints = If(
+            unpack_to_dest,
+            And(
+                # unpack_to_dest + transpose_of_faces requires exactly 4 faces
+                Implies(transpose_faces, num_faces_z3 == 4)
+            ),
+            True,
+        )
+
+        # User constraint: transpose_of_faces and within_face_16x16_transpose are mutually inclusive
+        within_face_transpose = BoolVal(within_face_16x16_transpose == 1)
+        transpose_mutual_constraint = transpose_faces == within_face_transpose
+
+        # Exclude acc_to_dest=True for simple datacopy operations
+        # Hardware produces 2x scaling when both srcA and srcB load same data
+        datacopy_acc_to_dest_constraint = Not(
+            And(acc_to_dest_z3, Not(transpose_faces), broadcast_none, reuse_none)
+        )
+
+        # Block Bfp8_b output with stochastic rounding (Pack or All)
+        # Hardware does not support Pack/All stochastic rounding modes for BFP8_b
+        bfp8_stochastic_constraint = Not(
+            And(
+                BoolVal(formats.output_format == DataFormat.Bfp8_b),
+                Or(
+                    BoolVal(stochastic_rnd == StochasticRounding.Pack),
+                    BoolVal(stochastic_rnd == StochasticRounding.All),
+                ),
+            )
+        )
+
+        # BROADCAST + ACC_TO_DEST: ALL COMBINATIONS BROKEN (BLOCK ENTIRELY)
+        # - COL + acc_to_dest: Packer timeout (TODO in llk_unpack_A.h:72)
+        # - ROW + acc_to_dest: Unpacker timeout (TODO in llk_unpack_A.h:91)
+        # - SCALAR + acc_to_dest: Static assertion blocks it (llk_unpack_A.h:107)
+        broadcast_acc_to_dest_constraint = Implies(
+            Not(broadcast_none), Not(acc_to_dest_z3)
+        )
+
+        # COL/SCALAR broadcast constraints (when acc_to_dest=False)
+        # COL: Faces 0-1 use Face 0's column, Faces 2-3 use Face 2's column
+        # Math stage calls run() twice: 1st processes faces 0-1, 2nd processes faces 2-3
+        # SCALAR broadcasts: 1 iteration with replication logic
+        col_scalar_broadcast_constraint = And(
+            # COL broadcast without acc_to_dest: Support 2 or 4 faces
+            Implies(broadcast_col, Or(num_faces_z3 == 2, num_faces_z3 == 4)),
+            # Block SCALAR broadcasts unless num_faces=1
+            Implies(broadcast_scalar, num_faces_z3 == 1),
+        )
+
+        # ROW broadcast constraint (ARCHITECTURE-SPECIFIC)
+        # BLACKHOLE: innerloop=2, outerloop=2 → 4 iterations, but srcb_clear_z resets Z
+        #            Only faces 0-1 processed (twice) → REQUIRES num_faces=2
+        # WORMHOLE:  innerloop=1, outerloop=1 → 1 iteration → REQUIRES num_faces=1
+        row_broadcast_constraint = If(
+            is_blackhole,
+            Implies(broadcast_row, num_faces_z3 == 2),
+            Implies(broadcast_row, num_faces_z3 == 1),  # Wormhole
+        )
+
+        # Add all constraints to solver
+        s.add(
+            constraint1,
+            constraint2,
+            constraint3,
+            unpack_constraints,
+            broadcast_acc_to_dest_constraint,
+            col_scalar_broadcast_constraint,
+            row_broadcast_constraint,
+            transpose_mutual_constraint,
+            datacopy_acc_to_dest_constraint,
+            bfp8_stochastic_constraint,
+        )
+
+        # Check if this parameter combination is valid
+        if s.check() == sat:
+            valid_params.append(params)
+
+    return valid_params
+
+
+# Apply Z3 constraint filtering
+all_params = filter_params_with_z3(all_params)
+
+
+def create_simple_ids(all_params):
+    """Create comprehensive but readable IDs for unpack_A tests"""
+    ids = []
+    for i, params in enumerate(all_params):
+        # params = (testname, formats, broadcast_type, disable_src_zero,
+        #           acc_to_dest, stoch_rnd_type, reuse_dest, transpose_of_faces,
+        #           within_face_16x16_transpose, num_faces)
+
+        testname = params[0]
+        formats = params[1]
+        broadcast_type = params[2]
+        disable_src_zero = params[3]
+        acc_to_dest = params[4]
+        stochastic_rnd = params[5]
+        reuse_dest = params[6]
+        transpose_of_faces = params[7]
+        within_face_16x16_transpose = params[8]
+        num_faces = params[9]
+
+        # Create a comprehensive but readable ID
+        id_parts = [
+            f"in_{formats.input_format.name}",
+            f"out_{formats.output_format.name}",
+            f"bcast_{broadcast_type.name}",
+            f"disable_src_zero_{disable_src_zero}",
+            f"acc_to_dest_{acc_to_dest}",
+            f"stoch_rnd_{stochastic_rnd.name}",
+            f"reuse_dest_{reuse_dest.name}",
+            f"transpose_faces_{transpose_of_faces}",
+            f"within_face_transpose_{within_face_16x16_transpose}",
+            f"num_faces_{num_faces}",
+        ]
+
+        id_str = "-".join(id_parts)
+        ids.append(id_str)
+
+    return ids
+
+
+param_ids = create_simple_ids(all_params)
+
+
+@pytest.mark.parametrize(
+    "testname, formats, broadcast_type, disable_src_zero, acc_to_dest, "
+    "stochastic_rnd, reuse_dest, transpose_of_faces, "
+    "within_face_16x16_transpose, num_faces",
+    all_params,
+    ids=param_ids,
+)
+def test_unpack_comprehensive(
+    testname,
+    formats,
+    broadcast_type,
+    disable_src_zero,
+    acc_to_dest,
+    stochastic_rnd,
+    reuse_dest,
+    transpose_of_faces,
+    within_face_16x16_transpose,
+    num_faces,
+):
+    import torch
+
+    # Compute unpack_to_dest based on format and accumulation mode
+    unpack_to_dest = formats.input_format.is_32_bit() and acc_to_dest
+
+    # Note: All constraint validation has been done by Z3 during parameter generation
+    # No need for pytest.skip() calls - invalid combinations have been filtered out
+
+    input_dimensions = [32, 32]
+
+    src_A, src_B, tile_cnt = generate_stimuli(
+        formats.input_format,
+        formats.input_format,
+        input_dimensions=input_dimensions,
+    )
+
+    # generate golden tensor with proper broadcast and transpose handling
+    # PRIORITY: Broadcast types take precedence over transpose operations
+    if broadcast_type == BroadcastType.Scalar:
+        # Scalar broadcast: replicate first element across entire tile
+        # Transpose operations don't change uniform data
+        generate_golden = get_golden_generator(ScalarBroadcastGolden)
+        golden_tensor = generate_golden(
+            src_A, formats.output_format, num_faces, input_dimensions
+        )
+    elif broadcast_type == BroadcastType.Column:
+        # Column broadcast: broadcast column values across rows
+        generate_golden = get_golden_generator(ColumnBroadcastGolden)
+        golden_tensor = generate_golden(
+            src_A, formats.output_format, num_faces, input_dimensions
+        )
+    elif broadcast_type == BroadcastType.Row:
+        # Row broadcast: broadcast row values down columns
+        generate_golden = get_golden_generator(RowBroadcastGolden)
+        golden_tensor = generate_golden(
+            src_A, formats.output_format, num_faces, input_dimensions
+        )
+    elif transpose_of_faces == 1:
+        # Both transpose flags are ALWAYS on together (mutually inclusive constraint)
+        transpose_golden = get_golden_generator(TransposeGolden)
+        # First apply within-face transpose, then face transpose
+        temp_tensor = transpose_golden.transpose_within_faces(
+            src_A, formats.output_format, input_dimensions, num_faces
+        )
+        golden_tensor = transpose_golden.transpose_faces(
+            temp_tensor, formats.output_format, input_dimensions, num_faces
+        )
+    else:
+        # No transpose - handle based on reuse_dest behavior
+        if reuse_dest == EltwiseBinaryReuseDestType.DEST_TO_SRCA and acc_to_dest:
+            # DEST_TO_SRCA: destination registers get moved to srcA for reuse
+            # This creates a feedback loop where processed data gets reused as source
+
+            input_tensor = torch.tensor(src_A, dtype=format_dict[formats.input_format])
+            face_size = 256  # 16x16 face
+
+            if num_faces == 1:
+                # Single face with DEST_TO_SRCA + acc_to_dest:
+                # Hardware processes first half of face (128 elements), then reuses/duplicates for second half
+                # DEST_TO_SRCA causes the first 128 elements to be processed, then repeated for elements 128-255
+                input_face = input_tensor[:face_size].to(
+                    format_dict[formats.output_format]
+                )
+                first_half = input_face[:128]  # First 128 elements
+                # Duplicate first half for second half due to DEST_TO_SRCA register reuse
+                golden_tensor = torch.cat([first_half, first_half])
+            else:
+                # Multiple faces: DEST_TO_SRCA applies duplication pattern within each face
+                # Each face behaves like single face - first 128 elements duplicated for second 128 elements
+                result = torch.zeros(
+                    face_size * num_faces, dtype=format_dict[formats.output_format]
+                )
+
+                for face_idx in range(num_faces):
+                    face_start = face_idx * face_size
+                    face_end = face_start + face_size
+                    input_face = input_tensor[face_start:face_end].to(
+                        format_dict[formats.output_format]
+                    )
+
+                    # Apply same duplication pattern as single face within each face
+                    first_half = input_face[:128]  # First 128 elements of this face
+                    face_output = torch.cat(
+                        [first_half, first_half]
+                    )  # Duplicate first half
+                    result[face_start:face_end] = face_output
+
+                golden_tensor = result
+        else:
+            # Regular data copy for other reuse types or no acc_to_dest
+            generate_golden = get_golden_generator(DataCopyGolden)
+            golden_tensor = generate_golden(
+                src_A, formats.output_format, num_faces, input_dimensions
+            )
+
+    # BUILD THE COMPLETE TEST CONFIG
+    test_config = {
+        "formats": formats,
+        "testname": testname,
+        "tile_cnt": tile_cnt,
+        "input_dimensions": input_dimensions,
+        "broadcast_type": broadcast_type,
+        "acc_to_dest": acc_to_dest,
+        "reuse_dest": reuse_dest,
+        "unpack_to_dest": unpack_to_dest,
+        "stochastic_rnd": stochastic_rnd,
+        "dest_acc": DestAccumulation.Yes if acc_to_dest else DestAccumulation.No,
+        "disable_src_zero_flag": disable_src_zero,
+        "unpack_transpose_faces": transpose_of_faces,
+        "unpack_transpose_within_face": within_face_16x16_transpose,
+        "num_faces": num_faces,
+    }
+
+    res_address = write_stimuli_to_l1(
+        test_config,
+        src_A,
+        src_B,
+        formats.input_format,
+        formats.input_format,
+        tile_count_A=tile_cnt,
+        tile_count_B=tile_cnt,
+        num_faces=num_faces,
+    )
+
+    run_test(test_config)
+
+    # Collect and validate results
+    res_from_L1 = collect_results(
+        formats, tile_count=tile_cnt, address=res_address, num_faces=num_faces
+    )
+    assert len(res_from_L1) == len(golden_tensor)
+
+    res_tensor = torch.tensor(res_from_L1, dtype=format_dict[formats.output_format])
+    assert passed_test(golden_tensor, res_tensor, formats.output_format)

--- a/tests/sources/unpack_A_test.cpp
+++ b/tests/sources/unpack_A_test.cpp
@@ -1,0 +1,105 @@
+
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdio>
+
+#include "ckernel.h"
+#include "llk_defs.h"
+
+// Globals
+uint32_t unp_cfg_context          = 0;
+uint32_t pack_sync_tile_dst_ptr   = 0;
+uint32_t math_sync_tile_dst_index = 0;
+
+#ifdef LLK_TRISC_UNPACK
+
+#include "llk_unpack_A.h"
+#include "llk_unpack_common.h"
+#include "params.h"
+
+void run_kernel()
+{
+    _llk_unpack_A_init_<BROADCAST_TYPE, ACC_TO_DEST, REUSE_DEST_TYPE, unpack_to_dest>(
+        UNPACK_TRANSPOSE_FACES, UNPACK_TRANSPOSE_WITHIN_FACE, FACE_R_DIM, NUM_FACES, formats.unpack_src, formats.unpack_dst);
+    _llk_unpack_A_hw_configure_<is_fp32_dest_acc_en, STOCHASTIC_RND, disable_src_zero_flag>(
+        formats.unpack_src, formats.unpack_dst, FACE_R_DIM, UNPACK_TRANSPOSE_WITHIN_FACE, NUM_FACES);
+
+    for (int i = 0; i < TILE_CNT; ++i)
+    {
+        _llk_unpack_A_<BROADCAST_TYPE, ACC_TO_DEST, REUSE_DEST_TYPE, unpack_to_dest>(
+            L1_ADDRESS(buffer_A[i]), UNPACK_TRANSPOSE_FACES, formats.unpack_src, formats.unpack_dst);
+    }
+}
+
+#endif
+
+#ifdef LLK_TRISC_MATH
+
+#ifdef FORMAT_INT32
+const bool is_int_fpu_en = true;
+#else
+const bool is_int_fpu_en = false;
+#endif
+
+#include "llk_math_common.h"
+#include "llk_math_eltwise_unary_datacopy.h"
+#include "params.h"
+
+using namespace ckernel;
+
+void run_kernel()
+{
+    // copy srca to dest
+    // Use B2D for all broadcasts except NONE (data in srcB), A2D for NONE (data in srcA)
+    constexpr DataCopyType copy_type = (BROADCAST_TYPE == BroadcastType::NONE) ? DataCopyType::A2D : DataCopyType::B2D;
+#ifdef ARCH_BLACKHOLE
+    _llk_math_eltwise_unary_datacopy_init_<copy_type, is_fp32_dest_acc_en, BROADCAST_TYPE, false, is_int_fpu_en>(0, 0, NUM_FACES, formats.math);
+#else
+    _llk_math_eltwise_unary_datacopy_init_<copy_type, is_fp32_dest_acc_en, BROADCAST_TYPE, is_int_fpu_en>(0, 0, NUM_FACES, formats.math);
+#endif
+    _llk_math_pack_sync_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+    _llk_math_hw_configure_<false, false>(formats.math, formats.math);
+    _llk_math_wait_for_dest_available_<DstSync::SyncHalf>();
+    for (int i = 0; i < TILE_CNT; ++i)
+    {
+        _llk_math_eltwise_unary_datacopy_<copy_type, DstSync::SyncHalf, is_fp32_dest_acc_en, BROADCAST_TYPE, unpack_to_dest>(i, formats.math, formats.math);
+    }
+    _llk_math_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+}
+
+#endif
+
+#ifdef LLK_TRISC_PACK
+
+#include "llk_pack.h"
+#include "llk_pack_common.h"
+#include "params.h"
+
+void run_kernel()
+{
+#ifdef ARCH_BLACKHOLE
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, false, false>(formats.pack_src, formats.pack_dst, 16 * 16 * 4, FACE_R_DIM, TILE_C_DIM, NUM_FACES);
+    _llk_pack_init_<false, false, DstTileFaceLayout::RowMajor, false>(formats.pack_dst, FACE_R_DIM, TILE_C_DIM, NUM_FACES);
+#else
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, false>(formats.pack_src, formats.pack_dst, 16 * 16 * 4, FACE_R_DIM, NUM_FACES);
+    _llk_pack_init_<false, false, DstTileFaceLayout::RowMajor, false>(formats.pack_dst, FACE_R_DIM, NUM_FACES);
+#endif
+
+#ifdef ARCH_BLACKHOLE
+    _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en, DstTileFaceLayout::RowMajor>();
+#else
+    _llk_pack_dest_init_<DstSync::SyncHalf, false, DstTileFaceLayout::RowMajor, false>();
+#endif
+
+    _llk_packer_wait_for_math_done_();
+    for (int i = 0; i < TILE_CNT; ++i)
+    {
+        _llk_pack_<DstSync::SyncHalf, is_fp32_dest_acc_en, false>(i, L1_ADDRESS(buffer_Res[i]));
+    }
+    _llk_pack_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+}
+#endif


### PR DESCRIPTION
## Add test_unpack_A: broadcast golden models, BFP8_b handling, Z3 constraints
### Ticket
<!-- Link to Github Issue -->

### Problem description
<!-- The test infrastructure lacked comprehensive testing for unpack_A operations with:
- **Broadcast operations** (NONE, COL, ROW, SCALAR) - no golden models existed
- **BFP8_b format with partial tiles** (num_faces < 4) - broken data handling
- **Transpose operations with varying num_faces** - golden models assumed 4 faces
- **Hardware constraint validation** - no Z3-based parameter filtering
 -->

### What's changed
<!--  **`test_unpack_A.py`** - Comprehensive test with 4172+ parameter combinations
  - Z3 solver with 10 hardware constraints (architecture-specific)
  - Tests all broadcast types, transpose modes, num_faces (1/2/4), stochastic rounding
  - Blocks invalid combinations (e.g., broadcast + acc_to_dest causes hardware timeouts) -->

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
