### PR TITLE
Fix packer reconfig to account for num_faces and partial_face

### DIFF
--- a/tt_llk_blackhole/llk_lib/llk_pack.h
+++ b/tt_llk_blackhole/llk_lib/llk_pack.h
@@ -486,7 +486,7 @@ inline void _llk_pack_reconfig_data_format_(
     const bool partial_face        = false,
     const bool narrow_tile         = false)
 {
-    reconfig_packer_data_format<is_fp32_dest_acc_en>(pack_src_format, pack_dst_format, tile_size, face_r_dim, tile_c_dim);
+    reconfig_packer_data_format<is_fp32_dest_acc_en>(pack_src_format, pack_dst_format, tile_size, face_r_dim, tile_c_dim, num_faces, partial_face);
 
     if constexpr (is_tile_dim_reconfig_en)
     {


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/27504?reload=1?reload=1?reload=1%3Freload%3D1?reload=1%3Freload%3D1%3Freload%3D1%3Freload%3D1

Problem description

Some OPs call hardware configure with artificial values of numfaces / partial tile /face_r_dim. From what I understand it is related to sharding. So when the packer reconfiguring function is called the registers which were affected by the specific call to hardware initialization may not be modified, leading to packer behaving not as expected.

What's changed

Reinitialized the config registers which are affected by num_faces, partial_tile and face_r_dim. This increases some performance cost which could be reduced if we had some form of tracking mechanism (which is outside the scope of this PR). Unlike PR https://github.com/tenstorrent/tt-llk/pull/692 , I do not modify the timing of the sync. I do not know the functional model of the Packer yet and it seems the code was written by someone who had internal knowledge of which registers are latched and which registers are not latched and some optimizations made. May be that part can be handled when that documentation is ready


### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
