### PR TITLE
[skip ci] ci: run performance tests if perf files are touched

### DIFF
--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -147,7 +147,7 @@ jobs:
     with:
       docker_image: ${{ needs.build-images.outputs.docker-image }}
       runs_on: tt-ubuntu-2204-n150-stable
-      test_splits: 3
+      test_splits: 4
       pytest_markers: "not perf and not nightly"
 
   setup-and-test-blackhole:
@@ -160,8 +160,32 @@ jobs:
     with:
       docker_image: ${{ needs.build-images.outputs.docker-image }}
       runs_on: tt-ubuntu-2204-p150b-stable
-      test_splits: 3
+      test_splits: 4
       pytest_markers: "not perf and not nightly"
+
+  perf-test-wormhole:
+    name: "⚡ Performance tests (Wormhole)"
+    uses: ./.github/workflows/setup-and-test.yml
+    needs: [build-images, detect-changes]
+    if: ${{ needs.detect-changes.outputs.performance == 'true' }}
+    with:
+      docker_image: ${{ needs.build-images.outputs.docker-image }}
+      runs_on: tt-ubuntu-2204-n150-stable
+      test_splits: 1
+      pytest_markers: "perf"
+      timeout_minutes: 120
+
+  perf-test-blackhole:
+    name: "⚡ Performance tests (Blackhole)"
+    uses: ./.github/workflows/setup-and-test.yml
+    needs: [build-images, detect-changes]
+    if: ${{ needs.detect-changes.outputs.performance == 'true' }}
+    with:
+      docker_image: ${{ needs.build-images.outputs.docker-image }}
+      runs_on: tt-ubuntu-2204-p150b-stable
+      test_splits: 1
+      pytest_markers: "perf"
+      timeout_minutes: 120
 
   check-all-green:
     name: "✅ Check all green"
@@ -171,10 +195,12 @@ jobs:
       - build-images
       - setup-and-test-wormhole
       - setup-and-test-blackhole
+      - perf-test-wormhole
+      - perf-test-blackhole
     runs-on: ubuntu-latest
     steps:
       - name: Check if the required jobs succeeded or failed
         uses: re-actors/alls-green@release/v1
         with:
           jobs: ${{ toJSON(needs) }}
-          allowed-skips: setup-and-test-wormhole, setup-and-test-blackhole
+          allowed-skips: setup-and-test-wormhole, setup-and-test-blackhole, perf-test-wormhole, perf-test-blackhole

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -163,26 +163,22 @@ jobs:
       test_splits: 4
       pytest_markers: "not perf and not nightly"
 
-  perf-test-wormhole:
-    name: "⚡ Performance tests (Wormhole)"
+  perf-tests:
+    name: "⚡ Performance tests (${{ matrix.target }})"
     uses: ./.github/workflows/setup-and-test.yml
     needs: [build-images, detect-changes]
     if: ${{ needs.detect-changes.outputs.performance == 'true' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: Wormhole
+            runs_on: tt-ubuntu-2204-n150-stable
+          - target: Blackhole
+            runs_on: tt-ubuntu-2204-p150b-stable
     with:
       docker_image: ${{ needs.build-images.outputs.docker-image }}
-      runs_on: tt-ubuntu-2204-n150-stable
-      test_splits: 1
-      pytest_markers: "perf"
-      timeout_minutes: 120
-
-  perf-test-blackhole:
-    name: "⚡ Performance tests (Blackhole)"
-    uses: ./.github/workflows/setup-and-test.yml
-    needs: [build-images, detect-changes]
-    if: ${{ needs.detect-changes.outputs.performance == 'true' }}
-    with:
-      docker_image: ${{ needs.build-images.outputs.docker-image }}
-      runs_on: tt-ubuntu-2204-p150b-stable
+      runs_on: ${{ matrix.runs_on }}
       test_splits: 1
       pytest_markers: "perf"
       timeout_minutes: 120
@@ -195,12 +191,11 @@ jobs:
       - build-images
       - setup-and-test-wormhole
       - setup-and-test-blackhole
-      - perf-test-wormhole
-      - perf-test-blackhole
+      - perf-tests
     runs-on: ubuntu-latest
     steps:
       - name: Check if the required jobs succeeded or failed
         uses: re-actors/alls-green@release/v1
         with:
           jobs: ${{ toJSON(needs) }}
-          allowed-skips: setup-and-test-wormhole, setup-and-test-blackhole, perf-test-wormhole, perf-test-blackhole
+          allowed-skips: setup-and-test-wormhole, setup-and-test-blackhole, perf-tests

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -179,7 +179,7 @@ jobs:
     with:
       docker_image: ${{ needs.build-images.outputs.docker-image }}
       runs_on: ${{ matrix.runs_on }}
-      test_splits: 3
+      test_splits: 4
       pytest_markers: "perf"
       timeout_minutes: 120
 

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -179,7 +179,7 @@ jobs:
     with:
       docker_image: ${{ needs.build-images.outputs.docker-image }}
       runs_on: ${{ matrix.runs_on }}
-      test_splits: 1
+      test_splits: 3
       pytest_markers: "perf"
       timeout_minutes: 120
 

--- a/.github/workflows/run-perf-tests.yml
+++ b/.github/workflows/run-perf-tests.yml
@@ -1,8 +1,6 @@
 name: 🚀 Run Performance Tests
 
 on:
-  pull_request:
-    types: [labeled, synchronize]
   workflow_dispatch:
   workflow_call:
 

--- a/.github/workflows/setup-and-test.yml
+++ b/.github/workflows/setup-and-test.yml
@@ -106,8 +106,9 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: >-
-            ${{ contains(inputs.pytest_markers, 'perf') && 'perf-' || '' }}junit-report-
+          name: |-
+            ${{ (contains(inputs.pytest_markers, 'perf') &&
+                 !contains(inputs.pytest_markers, 'not perf')) && 'perf-' || '' }}junit-report-
             ${{ env.CHIP_ARCH }}-${{ matrix.test_group }}
           path: tests/python_tests/pytest-report-${{ env.CHIP_ARCH }}-${{ matrix.test_group }}.xml
 

--- a/.github/workflows/setup-and-test.yml
+++ b/.github/workflows/setup-and-test.yml
@@ -107,7 +107,7 @@ jobs:
         if: always()
         with:
           name: >-
-            ${{ (contains(inputs.pytest_markers, 'perf') && !contains(inputs.pytest_markers, 'not perf')) 
+            ${{ (contains(inputs.pytest_markers, 'perf') && !contains(inputs.pytest_markers, 'not perf'))
                 && 'perf-' || '' }}junit-report-${{ env.CHIP_ARCH }}-${{ matrix.test_group }}
           path: tests/python_tests/pytest-report-${{ env.CHIP_ARCH }}-${{ matrix.test_group }}.xml
 

--- a/.github/workflows/setup-and-test.yml
+++ b/.github/workflows/setup-and-test.yml
@@ -106,10 +106,9 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: |-
-            ${{ (contains(inputs.pytest_markers, 'perf') &&
-                 !contains(inputs.pytest_markers, 'not perf')) && 'perf-' || '' }}junit-report-
-            ${{ env.CHIP_ARCH }}-${{ matrix.test_group }}
+          name: >-
+            ${{ (contains(inputs.pytest_markers, 'perf') && !contains(inputs.pytest_markers, 'not perf')) 
+                && 'perf-' || '' }}junit-report-${{ env.CHIP_ARCH }}-${{ matrix.test_group }}
           path: tests/python_tests/pytest-report-${{ env.CHIP_ARCH }}-${{ matrix.test_group }}.xml
 
       # Step 7: Publish the test results

--- a/.github/workflows/setup-and-test.yml
+++ b/.github/workflows/setup-and-test.yml
@@ -106,7 +106,9 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: junit-report-${{ env.CHIP_ARCH }}-${{ matrix.test_group }}
+          name: >-
+            ${{ contains(inputs.pytest_markers, 'perf') && 'perf-' || '' }}junit-report-
+            ${{ env.CHIP_ARCH }}-${{ matrix.test_group }}
           path: tests/python_tests/pytest-report-${{ env.CHIP_ARCH }}-${{ matrix.test_group }}.xml
 
       # Step 7: Publish the test results

--- a/tests/python_tests/perf_math_transpose.py
+++ b/tests/python_tests/perf_math_transpose.py
@@ -42,7 +42,7 @@ def test_perf_math_transpose(
         unpack_transpose_faces == Transpose.Yes
         and math_transpose_faces == Transpose.Yes
     ):
-        pytest.skip("Skip transposing faces twice")
+        pytest.skip("Skip transposing faces twice.")
 
     dest_acc = (
         DestAccumulation.Yes

--- a/tests/python_tests/perf_math_transpose.py
+++ b/tests/python_tests/perf_math_transpose.py
@@ -42,7 +42,7 @@ def test_perf_math_transpose(
         unpack_transpose_faces == Transpose.Yes
         and math_transpose_faces == Transpose.Yes
     ):
-        pytest.skip("Skip transposing faces twice.")
+        pytest.skip("Skip transposing faces twice")
 
     dest_acc = (
         DestAccumulation.Yes


### PR DESCRIPTION
### Ticket
None

### Problem description
Perf tests haven't been running so far, except during nightly runs. That opened a space for regressions if the perf files are touched without checking. This makes that step mandatory.

### What's changed
- Introduce 2 performance test steps (for BH and WH) and tied them to changes in performance files
- Added additional test split group to accommodate for the increased number of tests

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
