### PR TITLE
[skip ci] build: correct url path for metal headers

### DIFF
--- a/tests/setup_testing_env.sh
+++ b/tests/setup_testing_env.sh
@@ -49,12 +49,12 @@ download_headers() {
     echo "Downloading headers for ${chip_arch}..."
     mkdir -p "$header_dir"
 
-    local base_url="https://raw.githubusercontent.com/tenstorrent/tt-metal/refs/heads/main/tt_metal/hw/inc/${chip_arch}"
+    local base_url="https://raw.githubusercontent.com/tenstorrent/tt-metal/refs/heads/main/tt_metal/hw/inc/tt-1xx/${chip_arch}"
     local headers=("cfg_defines.h" "dev_mem_map.h" "tensix.h" "tensix_dev_map.h" "tensix_types.h")
 
     local specific_url=""
     if [[ "$chip_arch" == "wormhole" ]]; then
-        specific_url="https://raw.githubusercontent.com/tenstorrent/tt-metal/refs/heads/main/tt_metal/hw/inc/${chip_arch}/wormhole_b0_defines"
+        specific_url="https://raw.githubusercontent.com/tenstorrent/tt-metal/refs/heads/main/tt_metal/hw/inc/tt-1xx/${chip_arch}/wormhole_b0_defines"
     fi
 
     for header in "${headers[@]}"; do


### PR DESCRIPTION
### Ticket
None

### Problem description
tt-llk relies on several headers from tt-metal. These get downloaded prior to running tests.
These headers have been moved in https://github.com/tenstorrent/tt-metal/pull/29908, and we've started observing failures.

### What's changed
This PR fixes the url path of the required headers.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update