### PR TITLE
feat: add POLYVAL7 function for higher degree polynomial evaluation

### DIFF
--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_polyval.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_polyval.h
@@ -16,7 +16,7 @@ constexpr T POLYVAL5(T coef4, T coef3, T coef2, T coef1, T coef0, T val)
 template <typename T>
 constexpr T POLYVAL7(T coef6, T coef5, T coef4, T coef3, T coef2, T coef1, T coef0, T val)
 {
-    return (val * (val * (val * (val * (val * (val * (coef6 * val + coef5) + coef4) + coef3) + coef2) + coef1) + coef0));
+    return (((((((coef6 * val) + coef5) * val + coef4) * val + coef3) * val + coef2) * val + coef1) * val + coef0);
 }
 
 } // namespace ckernel::sfpu

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_polyval.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_polyval.h
@@ -16,7 +16,7 @@ constexpr T POLYVAL5(T coef4, T coef3, T coef2, T coef1, T coef0, T val)
 template <typename T>
 constexpr T POLYVAL7(T coef6, T coef5, T coef4, T coef3, T coef2, T coef1, T coef0, T val)
 {
-    return (val * (val * (val * (val * (val * (val * (coef6 * val + coef5) + coef4) + coef3) + coef2) + coef1) + coef0));
+    return (((((((coef6 * val) + coef5) * val + coef4) * val + coef3) * val + coef2) * val + coef1) * val + coef0);
 }
 
 } // namespace ckernel::sfpu


### PR DESCRIPTION
### Ticket
NA

### Problem description
Only POLYVAL5 is there

### What's changed
Introduced a new constexpr function POLYVAL7 that evaluates a 7th degree polynomial using the provided coefficients and input value.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
