### PR TITLE
feat: add polynomial evaluator

### DIFF
--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_polyval.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_polyval.h
@@ -46,7 +46,7 @@ struct PolynomialEvaluator
     /**
      * @brief Evaluates the polynomial at the given point.
      *
-     * @param coef Pointer to array of N coefficients in ascending order of powers
+     * @param coefficients Pointer to array of N coefficients in ascending order of powers
      * @param val The point at which to evaluate the polynomial
      * @return The value of the polynomial at the given point
      *
@@ -54,21 +54,12 @@ struct PolynomialEvaluator
      * @pre N should be positive for meaningful results
      *
      */
-    static constexpr T eval(const T* coef, T val)
+    static constexpr T eval(const T* coefficients, T val)
     {
-        if constexpr (N <= 0)
-        {
-            return T {0};
-        }
-        if constexpr (N == 1)
-        {
-            return coef[0];
-        }
-
-        T result = coef[N - 1];
+        T result = (N <= 0) ? T {0} : coefficients[N - 1];
         for (int i = N - 2; i >= 0; --i)
         {
-            result = result * val + coef[i];
+            result = result * val + coefficients[i];
         }
         return result;
     }

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_polyval.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_polyval.h
@@ -46,7 +46,7 @@ struct PolynomialEvaluator
     /**
      * @brief Evaluates the polynomial at the given point.
      *
-     * @param coef Pointer to array of N coefficients in ascending order of powers
+     * @param coefficients Pointer to array of N coefficients in ascending order of powers
      * @param val The point at which to evaluate the polynomial
      * @return The value of the polynomial at the given point
      *
@@ -54,21 +54,12 @@ struct PolynomialEvaluator
      * @pre N should be positive for meaningful results
      *
      */
-    static constexpr T eval(const T* coef, T val)
+    static constexpr T eval(const T* coefficients, T val)
     {
-        if constexpr (N <= 0)
-        {
-            return T {0};
-        }
-        if constexpr (N == 1)
-        {
-            return coef[0];
-        }
-
-        T result = coef[N - 1];
+        T result = (N <= 0) ? T {0} : coefficients[N - 1];
         for (int i = N - 2; i >= 0; --i)
         {
-            result = result * val + coef[i];
+            result = result * val + coefficients[i];
         }
         return result;
     }


### PR DESCRIPTION
### Ticket
None

### Problem description
The existing polynomial evaluation functions have several constraints:
- Only POLYVAL5 and POLYVAL7 are available, supporting only 5th and 7th degree polynomials
- Each polynomial degree requires a separate function with manually unrolled Horner's method
- Adding support for new polynomial degrees requires writing new functions
- Similar logic repeated across different degree functions
- Changes to the algorithm require updating multiple functions
- Each new polynomial degree adds another function to maintain

### What's changed
Add a new PolynomialEvaluator template struct to provide efficient, compile-time polynomial evaluation using Horner's method for arbitrary polynomial degrees. This implementation handles any polynomial degree at compile-time.

```cpp
constexpr double coef[] = {1.0, 2.0, 3.0};  // 1 + 2x + 3x^2
auto result = PolynomialEvaluator<3, double>::eval(coef, 2.0);  // = 17.0
```

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update