### PR TITLE
Add uint32 support for where llk

### DIFF
--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_where.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_where.h
@@ -19,11 +19,9 @@ inline void _calculate_where_fp16_b_(const uint dst_index_in0, const uint dst_in
     constexpr uint dst_tile_size_sfpi = 32;
     // both are needed since this kernel mixes the use of sfpi and TT calls for load/store
 
-    sfpi::vFloat cond = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
-
     for (int i = 0; i < ITERATIONS; i++)
     {
-        cond = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
+        sfpi::vFloat cond = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
 
         v_if (cond == 0.0f)
         {
@@ -43,61 +41,26 @@ inline void _calculate_where_fp16_b_(const uint dst_index_in0, const uint dst_in
     }
 }
 
-template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_where_fp32_(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_in2, const uint dst_index_out)
+template <typename T, bool APPROXIMATION_MODE, int ITERATIONS>
+inline void _calculate_where_impl_(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_in2, const uint dst_index_out)
 {
-    // size of each tile in Dest is 64/SFP_DESTREG_STRIDE = 32 rows when using sfpi to load/store
     constexpr uint dst_tile_size_sfpi = 32;
-
-    sfpi::vFloat output_tensor = 0;
-    sfpi::vFloat true_tensor   = 0;
-    sfpi::vFloat false_tensor  = 0;
-    sfpi::vFloat cond          = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
 
     for (int i = 0; i < ITERATIONS; i++)
     {
-        cond         = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
-        true_tensor  = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi];
-        false_tensor = sfpi::dst_reg[dst_index_in2 * dst_tile_size_sfpi];
-
-        v_if (cond != 0.0f)
-        {
-            output_tensor = true_tensor;
-        }
-        v_else
-        {
-            output_tensor = false_tensor;
-        }
-        v_endif;
-
-        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = output_tensor;
-        sfpi::dst_reg++;
-    }
-}
-
-template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_where_int32_(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_in2, const uint dst_index_out)
-{
-    // size of each tile in Dest is 64/SFP_DESTREG_STRIDE = 32 rows when using sfpi to load/store
-    constexpr uint dst_tile_size_sfpi = 32;
-
-    sfpi::vInt output_tensor = 0;
-    sfpi::vInt true_tensor   = 0;
-    sfpi::vInt false_tensor  = 0;
-    sfpi::vInt cond          = 0;
-
-    for (int i = 0; i < ITERATIONS; i++)
-    {
-        cond          = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
-        true_tensor   = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi];
-        false_tensor  = sfpi::dst_reg[dst_index_in2 * dst_tile_size_sfpi];
-        output_tensor = false_tensor;
+        T cond          = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
+        T output_tensor = 0;
 
         v_if (cond != 0)
         {
-            output_tensor = true_tensor;
+            output_tensor = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi];
+        }
+        v_else
+        {
+            output_tensor = sfpi::dst_reg[dst_index_in2 * dst_tile_size_sfpi];
         }
         v_endif;
+
         sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = output_tensor;
         sfpi::dst_reg++;
     }
@@ -106,21 +69,29 @@ inline void _calculate_where_int32_(const uint dst_index_in0, const uint dst_ind
 template <bool APPROXIMATION_MODE, DataFormat data_format, int ITERATIONS>
 inline void _calculate_where_(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_in2, const uint dst_index_out)
 {
-    // Add a compile-time check to ensure only supported formats are used.
     static_assert(
-        data_format == DataFormat::Float32 || data_format == DataFormat::Float16_b || data_format == DataFormat::Int32,
-        "Unsupported data format for _calculate_where_(). Only Float32, Int32, and Float16_b are allowed.");
-    if constexpr (data_format == DataFormat::Float32)
+        data_format == DataFormat::Float32 || data_format == DataFormat::Float16_b || data_format == DataFormat::Int32 || data_format == DataFormat::UInt32,
+        "Unsupported data format for _calculate_where_(). Only Float32, Int32, UInt32, and Float16_b are allowed.");
+
+    if constexpr (data_format == DataFormat::Float16_b)
     {
-        _calculate_where_fp32_<APPROXIMATION_MODE, ITERATIONS>(dst_index_in0, dst_index_in1, dst_index_in2, dst_index_out);
+        _calculate_where_fp16_b_<APPROXIMATION_MODE, ITERATIONS>(dst_index_in0, dst_index_in1, dst_index_in2, dst_index_out);
+    }
+    else if constexpr (data_format == DataFormat::Float32)
+    {
+        _calculate_where_impl_<sfpi::vFloat, APPROXIMATION_MODE, ITERATIONS>(dst_index_in0, dst_index_in1, dst_index_in2, dst_index_out);
     }
     else if constexpr (data_format == DataFormat::Int32)
     {
-        _calculate_where_int32_<APPROXIMATION_MODE, ITERATIONS>(dst_index_in0, dst_index_in1, dst_index_in2, dst_index_out);
+        _calculate_where_impl_<sfpi::vInt, APPROXIMATION_MODE, ITERATIONS>(dst_index_in0, dst_index_in1, dst_index_in2, dst_index_out);
+    }
+    else if constexpr (data_format == DataFormat::UInt32)
+    {
+        _calculate_where_impl_<sfpi::vUInt, APPROXIMATION_MODE, ITERATIONS>(dst_index_in0, dst_index_in1, dst_index_in2, dst_index_out);
     }
     else
     {
-        _calculate_where_fp16_b_<APPROXIMATION_MODE, ITERATIONS>(dst_index_in0, dst_index_in1, dst_index_in2, dst_index_out);
+        static_assert(false, "Unsupported data format for _calculate_where_(). Only Float32, Int32, UInt32, and Float16_b are allowed.");
     }
 }
 

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_where.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_where.h
@@ -37,61 +37,26 @@ inline void _calculate_where_fp16_b_(const uint dst_index_in0, const uint dst_in
     }
 }
 
-template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_where_fp32_(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_in2, const uint dst_index_out)
+template <typename T, bool APPROXIMATION_MODE, int ITERATIONS>
+inline void _calculate_where_impl_(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_in2, const uint dst_index_out)
 {
-    // size of each tile in Dest is 64/SFP_DESTREG_STRIDE = 32 rows when using sfpi to load/store
     constexpr uint dst_tile_size_sfpi = 32;
-
-    sfpi::vFloat output_tensor = 0;
-    sfpi::vFloat true_tensor   = 0;
-    sfpi::vFloat false_tensor  = 0;
-    sfpi::vFloat cond          = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
 
     for (int i = 0; i < ITERATIONS; i++)
     {
-        cond         = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
-        true_tensor  = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi];
-        false_tensor = sfpi::dst_reg[dst_index_in2 * dst_tile_size_sfpi];
-
-        v_if (cond != 0.0f)
-        {
-            output_tensor = true_tensor;
-        }
-        v_else
-        {
-            output_tensor = false_tensor;
-        }
-        v_endif;
-
-        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = output_tensor;
-        sfpi::dst_reg++;
-    }
-}
-
-template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_where_int32_(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_in2, const uint dst_index_out)
-{
-    // size of each tile in Dest is 64/SFP_DESTREG_STRIDE = 32 rows when using sfpi to load/store
-    constexpr uint dst_tile_size_sfpi = 32;
-
-    sfpi::vInt output_tensor = 0;
-    sfpi::vInt true_tensor   = 0;
-    sfpi::vInt false_tensor  = 0;
-    sfpi::vInt cond          = 0;
-
-    for (int i = 0; i < ITERATIONS; i++)
-    {
-        cond          = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
-        true_tensor   = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi];
-        false_tensor  = sfpi::dst_reg[dst_index_in2 * dst_tile_size_sfpi];
-        output_tensor = false_tensor;
+        T cond          = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
+        T output_tensor = 0;
 
         v_if (cond != 0)
         {
-            output_tensor = true_tensor;
+            output_tensor = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi];
+        }
+        v_else
+        {
+            output_tensor = sfpi::dst_reg[dst_index_in2 * dst_tile_size_sfpi];
         }
         v_endif;
+
         sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = output_tensor;
         sfpi::dst_reg++;
     }
@@ -100,21 +65,29 @@ inline void _calculate_where_int32_(const uint dst_index_in0, const uint dst_ind
 template <bool APPROXIMATION_MODE, DataFormat data_format, int ITERATIONS>
 inline void _calculate_where_(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_in2, const uint dst_index_out)
 {
-    // Add a compile-time check to ensure only supported formats are used.
     static_assert(
-        data_format == DataFormat::Float32 || data_format == DataFormat::Float16_b || data_format == DataFormat::Int32,
-        "Unsupported data format for _calculate_where_(). Only Float32, Int32, and Float16_b are allowed.");
-    if constexpr (data_format == DataFormat::Float32)
+        data_format == DataFormat::Float32 || data_format == DataFormat::Float16_b || data_format == DataFormat::Int32 || data_format == DataFormat::UInt32,
+        "Unsupported data format for _calculate_where_(). Only Float32, Int32, UInt32, and Float16_b are allowed.");
+
+    if constexpr (data_format == DataFormat::Float16_b)
     {
-        _calculate_where_fp32_<APPROXIMATION_MODE, ITERATIONS>(dst_index_in0, dst_index_in1, dst_index_in2, dst_index_out);
+        _calculate_where_fp16_b_<APPROXIMATION_MODE, ITERATIONS>(dst_index_in0, dst_index_in1, dst_index_in2, dst_index_out);
+    }
+    else if constexpr (data_format == DataFormat::Float32)
+    {
+        _calculate_where_impl_<sfpi::vFloat, APPROXIMATION_MODE, ITERATIONS>(dst_index_in0, dst_index_in1, dst_index_in2, dst_index_out);
     }
     else if constexpr (data_format == DataFormat::Int32)
     {
-        _calculate_where_int32_<APPROXIMATION_MODE, ITERATIONS>(dst_index_in0, dst_index_in1, dst_index_in2, dst_index_out);
+        _calculate_where_impl_<sfpi::vInt, APPROXIMATION_MODE, ITERATIONS>(dst_index_in0, dst_index_in1, dst_index_in2, dst_index_out);
+    }
+    else if constexpr (data_format == DataFormat::UInt32)
+    {
+        _calculate_where_impl_<sfpi::vUInt, APPROXIMATION_MODE, ITERATIONS>(dst_index_in0, dst_index_in1, dst_index_in2, dst_index_out);
     }
     else
     {
-        _calculate_where_fp16_b_<APPROXIMATION_MODE, ITERATIONS>(dst_index_in0, dst_index_in1, dst_index_in2, dst_index_out);
+        static_assert(false, "Unsupported data format for _calculate_where_(). Only Float32, Int32, UInt32, and Float16_b are allowed.");
     }
 }
 


### PR DESCRIPTION
### Ticket
Link to Github Issue https://github.com/tenstorrent/tt-metal/issues/30280

### What's changed
Added uint32 support  for where llk.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
