### PR TITLE
Fix sqrt

### DIFF
--- a/tests/helpers/include/sfpu_operations.h
+++ b/tests/helpers/include/sfpu_operations.h
@@ -99,7 +99,7 @@ void call_sfpu_operation(SfpuType operation, uint32_t math_format = 0)
             break;
         case SfpuType::rsqrt:
             _init_rsqrt_<APPROX_MODE>();
-            _calculate_rsqrt_<APPROX_MODE, ITERATIONS, is_fp32_dest_acc_en>(ITERATIONS);
+            _calculate_rsqrt_<APPROX_MODE, ITERATIONS, is_fp32_dest_acc_en, false>(ITERATIONS);
             break;
         case SfpuType::silu:
             _calculate_silu_<APPROX_MODE, ITERATIONS>();
@@ -109,7 +109,7 @@ void call_sfpu_operation(SfpuType operation, uint32_t math_format = 0)
             break;
         case SfpuType::sqrt:
             _init_sqrt_<APPROX_MODE>();
-            _calculate_sqrt_<APPROX_MODE, ITERATIONS, is_fp32_dest_acc_en>(ITERATIONS);
+            _calculate_sqrt_<APPROX_MODE, ITERATIONS, is_fp32_dest_acc_en, false>(ITERATIONS);
             break;
         case SfpuType::square:
             _calculate_square_<APPROX_MODE, ITERATIONS>(ITERATIONS);

--- a/tests/sources/eltwise_unary_sfpu_test.cpp
+++ b/tests/sources/eltwise_unary_sfpu_test.cpp
@@ -83,14 +83,14 @@ void call_sfpu_operation(SfpuType operation, uint32_t math_format)
             break;
         case SfpuType::rsqrt:
             ckernel::sfpu::_init_rsqrt_<APPROX_MODE, false>();
-            ckernel::sfpu::_calculate_rsqrt_<APPROX_MODE, iterations, is_fp32_dest_acc_en, false>(iterations);
+            ckernel::sfpu::_calculate_rsqrt_<APPROX_MODE, iterations, is_fp32_dest_acc_en, false, false>(iterations);
             break;
         case SfpuType::sine:
             ckernel::sfpu::_calculate_sine_<APPROX_MODE, iterations>(iterations);
             break;
         case SfpuType::sqrt:
             ckernel::sfpu::_init_sqrt_<APPROX_MODE>();
-            ckernel::sfpu::_calculate_sqrt_<APPROX_MODE, iterations, is_fp32_dest_acc_en>(iterations);
+            ckernel::sfpu::_calculate_sqrt_<APPROX_MODE, iterations, is_fp32_dest_acc_en, false, false>(iterations);
             break;
         case SfpuType::square:
             ckernel::sfpu::_calculate_square_<APPROX_MODE, iterations>(iterations);

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_rsqrt.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_rsqrt.h
@@ -14,7 +14,7 @@ namespace ckernel
 namespace sfpu
 {
 
-template <bool APPROXIMATION_MODE, int ITERATIONS, bool fp32_dest_acc_en, bool legacy_compat = false>
+template <bool APPROXIMATION_MODE, int ITERATIONS, bool fp32_dest_acc_en, bool FAST_APPROX, bool legacy_compat = false>
 inline void _calculate_rsqrt_(int iterations)
 {
     if constexpr (legacy_compat)
@@ -23,7 +23,7 @@ inline void _calculate_rsqrt_(int iterations)
     }
     else
     {
-        return _calculate_sqrt_internal_<APPROXIMATION_MODE, ITERATIONS, fp32_dest_acc_en, true>(iterations);
+        return _calculate_sqrt_internal_<APPROXIMATION_MODE, ITERATIONS, fp32_dest_acc_en, true, FAST_APPROX>(iterations);
     }
 }
 

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_sqrt.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_sqrt.h
@@ -19,7 +19,7 @@ namespace sfpu
 // https://doi.org/10.1007/s11075-024-01932-7
 
 // Computes the square root or reciprocal square root of a positive floating point value x.
-template <bool APPROXIMATE = false, bool RECIPROCAL = false>
+template <bool APPROXIMATE = false, bool RECIPROCAL = false, bool FAST_APPROX = false>
 sfpi_inline sfpi::vFloat _calculate_sqrt_body_(const sfpi::vFloat x)
 {
     sfpi::vInt i   = sfpi::reinterpret<sfpi::vInt>(sfpi::reinterpret<sfpi::vUInt>(x) >> 1);
@@ -102,16 +102,25 @@ sfpi_inline sfpi::vFloat _calculate_sqrt_body_(const sfpi::vFloat x)
         }
     }
 
+    if constexpr (!FAST_APPROX)
+    {
+        v_if (x < 0.0f)
+        {
+            y = std::numeric_limits<float>::quiet_NaN();
+        }
+        v_endif;
+    }
+
     return y;
 }
 
-template <bool APPROXIMATION_MODE, int ITERATIONS, bool fp32_dest_acc_en, bool RECIPROCAL>
+template <bool APPROXIMATION_MODE, int ITERATIONS, bool fp32_dest_acc_en, bool RECIPROCAL, bool FAST_APPROX>
 inline void _calculate_sqrt_internal_(const int iterations)
 {
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
     {
-        sfpi::vFloat tmp = _calculate_sqrt_body_<APPROXIMATION_MODE, RECIPROCAL>(sfpi::dst_reg[0]);
+        sfpi::vFloat tmp = _calculate_sqrt_body_<APPROXIMATION_MODE, RECIPROCAL, FAST_APPROX>(sfpi::dst_reg[0]);
         if constexpr (fp32_dest_acc_en)
         {
             sfpi::dst_reg[0] = tmp;
@@ -124,7 +133,7 @@ inline void _calculate_sqrt_internal_(const int iterations)
     }
 }
 
-template <bool APPROXIMATION_MODE, int ITERATIONS, bool fp32_dest_acc_en, bool legacy_compat = false>
+template <bool APPROXIMATION_MODE, int ITERATIONS, bool fp32_dest_acc_en, bool FAST_APPROX, bool legacy_compat = false>
 inline void _calculate_sqrt_(int iterations)
 {
     if constexpr (legacy_compat)
@@ -133,7 +142,7 @@ inline void _calculate_sqrt_(int iterations)
     }
     else
     {
-        return _calculate_sqrt_internal_<APPROXIMATION_MODE, ITERATIONS, fp32_dest_acc_en, false>(iterations);
+        return _calculate_sqrt_internal_<APPROXIMATION_MODE, ITERATIONS, fp32_dest_acc_en, false, FAST_APPROX>(iterations);
     }
 }
 

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_rsqrt.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_rsqrt.h
@@ -14,7 +14,7 @@ namespace ckernel
 namespace sfpu
 {
 
-template <bool APPROXIMATION_MODE, int ITERATIONS, bool fp32_dest_acc_en, bool legacy_compat = false>
+template <bool APPROXIMATION_MODE, int ITERATIONS, bool fp32_dest_acc_en, bool FAST_APPROX, bool legacy_compat = false>
 inline void _calculate_rsqrt_(int iterations)
 {
     if constexpr (legacy_compat)
@@ -23,7 +23,7 @@ inline void _calculate_rsqrt_(int iterations)
     }
     else
     {
-        return _calculate_sqrt_internal_<APPROXIMATION_MODE, ITERATIONS, fp32_dest_acc_en, true>(iterations);
+        return _calculate_sqrt_internal_<APPROXIMATION_MODE, ITERATIONS, fp32_dest_acc_en, true, FAST_APPROX>(iterations);
     }
 }
 


### PR DESCRIPTION
### Ticket
 Link to Github Issue https://github.com/tenstorrent/tt-metal/issues/23166

### Problem description
Both sqrt and rsqrt doesn't not returns nan for negative inputs.

### What's changed
Added a check to return nan for negative inputs.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
