### PR TITLE
fix: initialize semaphores properly

### DIFF
--- a/tests/helpers/include/boot.h
+++ b/tests/helpers/include/boot.h
@@ -26,9 +26,9 @@ inline void device_setup()
 
 #ifndef ARCH_QUASAR
     // Initialize tensix semaphores
-    TTI_SEMINIT(1, 0, 1 << ckernel::semaphore::UNPACK_TO_DEST);
-    TTI_SEMINIT(1, 0, 1 << ckernel::semaphore::MATH_DONE);
-    TTI_SEMINIT(1, 0, 1 << ckernel::semaphore::PACK_DONE);
+    ckernel::t6_semaphore_init(ckernel::semaphore::UNPACK_TO_DEST, 0, 1);
+    ckernel::t6_semaphore_init(ckernel::semaphore::MATH_DONE, 0, 1);
+    ckernel::t6_semaphore_init(ckernel::semaphore::PACK_DONE, 0, 1);
 #endif
 }
 


### PR DESCRIPTION
### Ticket
None

### Problem description
SemaphoreMask is calculated as `1 << SemaphoreIndex`, while we were just setting it as `SemaphoreIndex`.
It seems everything worked by coincidence. This was caught by the ttsim.

### What's changed
Replacing bare TTI instructions with ckernel helper methods that perform init and take care of the shifting.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
