### PR TITLE
Fused mul and reduce #26434

### DIFF
--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_fill.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_fill.h
@@ -50,10 +50,11 @@ inline void _calculate_fill_bitcast_(const uint32_t value_bit_mask)
     }
 }
 
-inline void _populate_first_tile_with_ones_() {
+inline void _populate_first_tile_with_ones_()
+{
     // Reset destination counter to ensure we're pointing to the first tile
     TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_D);
-    
+
     // Use SFPU to fill with ones
     TT_SETC16(DEST_TARGET_REG_CFG_MATH_Offset_ADDR32, 0);
     _calculate_fill_<false, 32>(1.0f);
@@ -62,10 +63,11 @@ inline void _populate_first_tile_with_ones_() {
     TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_D);
 }
 
-inline void _populate_first_tile_with_zeroes_() {
+inline void _populate_first_tile_with_zeroes_()
+{
     // Reset destination counter to ensure we're pointing to the first tile
     TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_D);
-    
+
     // Use SFPU to fill with zeroes
     TT_SETC16(DEST_TARGET_REG_CFG_MATH_Offset_ADDR32, 0);
     _calculate_fill_<false, 32>(0.0f);

--- a/tt_llk_blackhole/llk_lib/llk_math_eltwise_binary.h
+++ b/tt_llk_blackhole/llk_lib/llk_math_eltwise_binary.h
@@ -35,7 +35,8 @@ inline void eltwise_binary_reuse_dest_as_src_tile(uint32_t idst = 0)
 {
     if constexpr (binary_reuse_dest == EltwiseBinaryReuseDestType::DEST_TO_SRCA)
     {
-        switch (idst) {
+        switch (idst)
+        {
             case 0:
                 // Reset destination target register to base address before moving data from destination to source A
                 TT_SETC16(DEST_TARGET_REG_CFG_MATH_Offset_ADDR32, 0);
@@ -190,11 +191,10 @@ inline void eltwise_binary_reuse_dest_as_src_tile(uint32_t idst = 0)
     }
     else if constexpr (binary_reuse_dest == EltwiseBinaryReuseDestType::DEST_TO_SRCB)
     {
-
         // Explicitly reset D (dest read) and B (srcB write) counters to 0
         TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_D);
         TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_B);
-        
+
         // Move all 64 rows from dest to srcB (4 rows at a time, 16 instructions total)
         TTI_MOVD2B(0, p_movd2b::SRC_ZERO_OFFSET + 0, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 0);
         TTI_MOVD2B(0, p_movd2b::SRC_ZERO_OFFSET + 4, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 4);
@@ -228,7 +228,7 @@ inline void _llk_math_eltwise_binary_(const std::uint32_t num_faces, uint dst_in
     constexpr uint32_t ZERO_ACC_MODE = p_zeroacc::CLR_16;
 
     math::set_dst_write_addr<DstTileLayout::Default, DstTileShape::Tile32x32>(dst_index);
-    
+
     // CRITICAL FIX: Reset dest RWC counter to 0 after setting base address
     // set_dst_write_addr sets the base, but D counter is separate and may have stale values
     // Without this, writes go to base_addr + stale_D_counter instead of base_addr + 0

--- a/tt_llk_blackhole/llk_lib/llk_unpack_AB.h
+++ b/tt_llk_blackhole/llk_lib/llk_unpack_AB.h
@@ -152,14 +152,13 @@ inline void _llk_unpack_AB_(const std::uint32_t address_a, const std::uint32_t a
     switch_config_context(unp_cfg_context);
 }
 
-
 inline void _llk_unpack_AB_fused_()
 {
     TTI_SETADCZW(0b011, 0, 0, 0, 0, 0b1111); // reset counters
 
     // Trisc::SEMPOST for context acquire
     semaphore_post(semaphore::UNPACK_SYNC);
-    
+
     TTI_UNPACR_NOP(SrcA, 0, 0, p_unpacr_nop::SET_DVALID, 0, 0, 0, 0, p_unpacr_nop::UNP_ZEROSRC);
     TTI_UNPACR_NOP(SrcB, 0, 0, p_unpacr_nop::SET_DVALID, 0, 0, 0, 0, p_unpacr_nop::UNP_ZEROSRC);
 


### PR DESCRIPTION
### Fused mul and reduce #26434
https://github.com/tenstorrent/tt-metal/issues/26434

### Problem description
As part of https://github.com/tenstorrent/tt-metal/issues/25523, a fused eltwise multiply and sum-reduce operation is needed to optimize the depthwise convolution path.

Currently, the depthwise path in conv2d lacks a dedicated implementation and falls back to the conventional matmul-based approach. This PR introduces an optimized solution using element-wise multiplication followed by reduction, with both operations fused together for improved performance. By fusing these operations, we eliminate the unpacking overhead between stages, which is currently a major performance bottleneck. The operation processes three operands: activation, weight, and scalar. Based on initial performance estimates, this fused implementation could nearly double the throughput compared to the current proof-of-concept where multiplication and reduction are executed as separate operations.

### What's changed
This PR adds comprehensive support for fused binary eltwise and column reduction operations across multiple components:

**Eltwise Binary Math (`llk_math_eltwise_binary.h`)**: Implemented destination register reuse functionality, enabling seamless data flow from binary operations directly to reduction without intermediate steps(Packer/Unpacker).

**Reduce Math (`llk_math_reduce.h`)**: Added `_llk_math_reduce_column_()` method that performs column reduction directly on source operand A without requiring unpacker involvement. Also introduced `_llk_math_reduce_clear_dvalid_after_for_loop_()` for proper data valid flag management in fused operation contexts.

**Unpacker (`llk_unpack_AB.h`)**: Enhanced unpacker configuration to support the specialized data flow requirements of fused operations. No unpacking is actually done for the reduce operation, the unpacker simply sets the dvalid flags for the math to begin.

**SFPU Utilities (`ckernel_sfpu_fill.h`)**: Added destination initialization functions including `_populate_first_tile_with_zeroes_()` to properly prepare accumulation buffers for reduction. Note that while zero initialization can alternatively be achieved via destination flags (faster), the SFPU-based approach was implemented for enhanced debugging capabilities and explicit control during development.

**Implementation notes**: Several SETRWC (set window counter) instructions have been added throughout the implementation. While some may appear redundant, they proved invaluable for debugging destination addressing issues, a common source of complexity when implementing fused operations. Some of them can be deleted in future iterations. Also, when moving the scaler from destination register to operand B, the better thing to do would be to move only the very first face of the tile, since it is the only one being used as a scaler, since srcB counter is never incremented in the fused operation. The LLK changes are located in the `tt_llk_blackhole` directory and are implemented only for the Blackhole-specific architecture.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
