### PR TITLE
ci: randomize nightly tests order in full

### DIFF
--- a/.github/workflows/setup-and-test.yml
+++ b/.github/workflows/setup-and-test.yml
@@ -86,7 +86,7 @@ jobs:
           SPLITS=$TEST_SPLITS
           cd tests/python_tests/
           pytest -m "${{ inputs.pytest_markers }}" \
-                ${{ inputs.random_order && '--random-order' || '' }} \
+                ${{ inputs.random_order && '--random-order-bucket=global' || '' }} \
                 --splits $SPLITS --group ${{ matrix.test_group }} \
                 --override-ini="addopts=-v" --timeout=60 \
                 --junitxml=pytest-report-${CHIP_ARCH}-${{ matrix.test_group }}.xml .


### PR DESCRIPTION
### Ticket
None

### Problem description
Previously, when we added `--random-order` to our test configuration, it only randomized tests at the module level. This means that while test parameters within each module get shuffled, tests from different modules still run in blocks - so you'd still execute all 150 matmul tests together, then all 100 untilize tests together, and so on.

With this proposed change, we're switching to individual test case randomization, which will interleave tests from different modules throughout the entire test run. We're doing this to uncover any hidden dependencies that are masked by test ordering. By randomizing individual test cases across all modules, we'll expose tests that inadvertently depend on the execution order or state left by other test types.

**Note:** In pytest context, a "module" refers to a test file (e.g., test_matmul.py, test_untilize.py). So module-level randomization shuffles test files, while individual test randomization shuffles every single test function across all files.

### What's changed
Switched from default "module" bucket, to a global one.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update