### PR TITLE
Convert mpwi to work on row major tiles

### DIFF
--- a/tt_llk_blackhole/common/inc/ckernel_defs.h
+++ b/tt_llk_blackhole/common/inc/ckernel_defs.h
@@ -69,7 +69,7 @@ enum DstTileFaceLayout
 
 enum class DataLayout
 {
-    TILE = 0,
+    TILE      = 0,
     ROW_MAJOR = 1
 };
 

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_max_pool_indices.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_max_pool_indices.h
@@ -39,7 +39,8 @@ inline void _calculate_max_pool_with_indices_(const uint values_tile_idx, const 
     constexpr uint face_offset        = 16;
     constexpr uint8_t instr_mod_index = is_fp32_dest_acc_en ? InstrModLoadStore::INT32 : InstrModLoadStore::LO16;
 
-    if constexpr (layout == ckernel::DataLayout::ROW_MAJOR) {
+    if constexpr (layout == ckernel::DataLayout::ROW_MAJOR)
+    {
         // ROW MAJOR DATA VERSION OF MPWI
         // DATA IS EXPECTED TO BE IN THE FOLLOWING ORDER IN DEST:
         // Face 0 Row 0
@@ -111,7 +112,9 @@ inline void _calculate_max_pool_with_indices_(const uint values_tile_idx, const 
 
         TT_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, values_tile_offset + 0 + odd_cols_offset);
         TT_SFPSTORE(p_sfpu::LREG4, instr_mod_index, ADDR_MOD_7, indices_tile_offset + 0 + odd_cols_offset);
-    } else {
+    }
+    else
+    {
         // TILE (ORIGINAL) VERSION OF MPWI
         // F0
         // data
@@ -183,7 +186,8 @@ inline void _init_max_pool_with_indices_()
     // and LREGs 4-7 will mirror the movement of the values in LREGs 0-3;
     _sfpu_load_config32_(0xF, 0x0, 0x4);
 
-    if constexpr (layout == ckernel::DataLayout::ROW_MAJOR) {
+    if constexpr (layout == ckernel::DataLayout::ROW_MAJOR)
+    {
         // Program replay buffer for row major layout
         load_replay_buf(
             0,
@@ -201,7 +205,9 @@ inline void _init_max_pool_with_indices_()
 
                 TTI_SFPTRANSP(0, 0, 0, 0);
             });
-    } else {
+    }
+    else
+    {
         // Program replay buffer for tiled layout (original)
         load_replay_buf(
             0,

--- a/tt_llk_wormhole_b0/common/inc/ckernel_defs.h
+++ b/tt_llk_wormhole_b0/common/inc/ckernel_defs.h
@@ -69,7 +69,7 @@ enum DstTileFaceLayout
 
 enum class DataLayout
 {
-    TILE = 0,
+    TILE      = 0,
     ROW_MAJOR = 1
 };
 

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_max_pool_indices.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_max_pool_indices.h
@@ -39,7 +39,8 @@ inline void _calculate_max_pool_with_indices_(const uint values_tile_idx, const 
     constexpr uint face_offset        = 16;
     constexpr uint8_t instr_mod_index = is_fp32_dest_acc_en ? InstrModLoadStore::INT32 : InstrModLoadStore::LO16;
 
-    if constexpr (layout == ckernel::DataLayout::ROW_MAJOR) {
+    if constexpr (layout == ckernel::DataLayout::ROW_MAJOR)
+    {
         // ROW MAJOR DATA VERSION OF MPWI
         // DATA IS EXPECTED TO BE IN THE FOLLOWING ORDER IN DEST:
         // Face 0 Row 0
@@ -110,7 +111,9 @@ inline void _calculate_max_pool_with_indices_(const uint values_tile_idx, const 
 
         TT_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_3, values_tile_offset + 0 + 2);
         TT_SFPSTORE(p_sfpu::LREG4, instr_mod_index, ADDR_MOD_3, indices_tile_offset + 0 + 2);
-    } else {
+    }
+    else
+    {
         // TILE (ORIGINAL) VERSION OF MPWI
         // F0
         // data
@@ -182,7 +185,8 @@ inline void _init_max_pool_with_indices_()
     // and LREGs 4-7 will mirror the movement of the values in LREGs 0-3;
     _sfpu_load_config32_(0xF, 0x0, 0x4);
 
-    if constexpr (layout == ckernel::DataLayout::ROW_MAJOR) {
+    if constexpr (layout == ckernel::DataLayout::ROW_MAJOR)
+    {
         // Program replay buffer for row major layout
         lltt::record(0, 7);
 
@@ -196,7 +200,9 @@ inline void _init_max_pool_with_indices_()
         TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG3, p_sfpswap::ALL_ROWS_MAX);
 
         TTI_SFPTRANSP(0, 0, 0, 0);
-    } else {
+    }
+    else
+    {
         // Program replay buffer for tiled layout (original)
         lltt::record(0, 7);
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/27845

### Problem description
We would prefer for MPWI to work on row major data to bypass reinitialization problems using tilize and untilize.  There is no downside to processing row major data since MPWI is done on the SFPU which does not require tiled data.

### What's changed
The `_calculate_max_pool_with_indices_` LLK function has been updated to work on row major data instead of tiled data.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
Breaks MPWI until https://github.com/tenstorrent/tt-metal/pull/29071 is merged
- [ ] Documentation update

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
