### PR TITLE
[skip ci] ci: in nightly runs execute both "on PR" tests and nightly tests

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -9,7 +9,7 @@ on:
       pytest_markers:
         description: "Pytest mark expression for testing (e.g., 'nightly', 'perf')"
         required: false
-        default: "nightly"
+        default: "not perf"
         type: string
 
 permissions:
@@ -31,7 +31,7 @@ jobs:
       docker_image: ${{ needs.build-images.outputs.docker-image }}
       runs_on: tt-ubuntu-2204-n150-stable
       test_splits: 10
-      pytest_markers: ${{ inputs.pytest_markers || 'nightly' }}
+      pytest_markers: ${{ inputs.pytest_markers || 'not perf' }}
       random_order: true
       timeout_minutes: 240
 
@@ -43,7 +43,7 @@ jobs:
       docker_image: ${{ needs.build-images.outputs.docker-image }}
       runs_on: tt-ubuntu-2204-p150b-stable
       test_splits: 10
-      pytest_markers: ${{ inputs.pytest_markers || 'nightly' }}
+      pytest_markers: ${{ inputs.pytest_markers || 'not perf' }}
       random_order: true
       timeout_minutes: 240
 


### PR DESCRIPTION
### Ticket
None

### Problem description
We've been running tests sequentially in both nightly runs and PR checks. This approach can hide flaky tests and subtle dependencies, when one test inadvertently sets up state that another test relies on, the dependent test passes only because of the execution order.
To catch these hidden dependencies, we've enabled randomized test ordering for nightly runs. However, PR tests remain sequential. This is intentional: randomization during PR checks could mask failures by selecting different passing tests on retry, defeating the purpose of quick feedback.
By running the full test suite in random order every night, we ensure tests are truly independent and catch issues that would otherwise only surface in production.

### What's changed
Added a set of tests that execute on PR into nightly batch.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
