### PR TITLE
Select adequate TRISC reset mask based on chip architecture

### DIFF
--- a/tests/helpers/include/boot.h
+++ b/tests/helpers/include/boot.h
@@ -34,7 +34,11 @@ inline void device_setup()
 
 inline void clear_trisc_soft_reset()
 {
+#ifdef ARCH_QUASAR
+    constexpr uint32_t TRISC_SOFT_RESET_MASK = 0x3000;
+#else
     constexpr uint32_t TRISC_SOFT_RESET_MASK = 0x7000;
+#endif
 
     uint32_t soft_reset = ckernel::reg_read(RISCV_DEBUG_REG_SOFT_RESET_0);
     soft_reset &= ~TRISC_SOFT_RESET_MASK;


### PR DESCRIPTION
### Ticket
<!-- Link to Github Issue -->

### Problem description
Taking additional TRISC out of reset can cause random results.

### What's changed
Change the TRISC reset mask to only target three TRISCs. This is not a permanent fix and will have to be expanded in the future.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
