### PR TITLE
[Test Infra] Make UntilizeGolden more precise, add pack_untilize tests and skips

### DIFF
--- a/tests/python_tests/helpers/tilize_untilize.py
+++ b/tests/python_tests/helpers/tilize_untilize.py
@@ -143,7 +143,9 @@ def untilize_block(
     # Reshape input to have one block per 1024 elements
     input_reshaped = input_tensor.reshape(total_blocks, 1024)
 
-    untilized_blocks = torch.stack([untilize(block) for block in input_reshaped])
+    untilized_blocks = torch.stack(
+        [untilize(block, stimuli_format=stimuli_format) for block in input_reshaped]
+    )
 
     output = untilized_blocks.reshape(row_blocks, col_blocks, 32, 32)
 

--- a/tests/python_tests/test_pack_untilize.py
+++ b/tests/python_tests/test_pack_untilize.py
@@ -6,7 +6,7 @@ import torch
 from helpers.device import collect_results, write_stimuli_to_l1
 from helpers.format_config import DataFormat
 from helpers.golden_generators import UntilizeGolden, get_golden_generator
-from helpers.llk_params import format_dict
+from helpers.llk_params import DestAccumulation, format_dict
 from helpers.param_config import input_output_formats, parametrize
 from helpers.stimuli_generator import generate_stimuli
 from helpers.test_config import run_test
@@ -19,19 +19,28 @@ from helpers.utils import passed_test
         [
             DataFormat.Float16_b,
             DataFormat.Float16,
-            DataFormat.Float32,
+            DataFormat.Float32,  # Test Float32 with both 32bit mode dest (full precision) and 16bit mode dest (precision loss)
             DataFormat.Int32,
             DataFormat.Bfp8_b,
         ]  # Pack Untilize doesn't work for block float formats (Bfp8_b); we only include as input format in our test
     ),
+    dest_acc=[DestAccumulation.No, DestAccumulation.Yes],
 )
-def test_pack_untilize(test_name, formats):
+def test_pack_untilize(test_name, formats, dest_acc):
     if formats.output_format == DataFormat.Bfp8_b:
         pytest.skip("Pack Untilize does not support Bfp8_b format")
+
     if (formats.input_format == DataFormat.Int32) ^ (
         formats.output_format == DataFormat.Int32
     ):
         pytest.skip("Pack Untilize does not support mixing Int32 with other formats")
+
+    if (
+        formats.input_format == DataFormat.Int32
+        and formats.output_format == DataFormat.Int32
+        and dest_acc == DestAccumulation.No
+    ):
+        pytest.skip("Dest must be in 32bit mode when input and output are Int32")
 
     input_dimensions = [32, 128]
 
@@ -49,6 +58,7 @@ def test_pack_untilize(test_name, formats):
         "input_A_dimensions": input_dimensions,
         "input_B_dimensions": input_dimensions,
         "unpack_to_dest": formats.input_format.is_32_bit(),
+        "dest_acc": dest_acc,
     }
 
     res_address = write_stimuli_to_l1(


### PR DESCRIPTION
### Ticket
<!-- Link to Github Issue -->

### Problem description
UntilizeGolden calls the untilize_block function which then calls the untilize function. The untilize function has a data_format argument which was not passed from the unitize_block function, the default argument data format value (Fp16_b) was used instead. This made the UntilizeGolden less precise.

One of the cases tested was Int32, unpack_to_dest, dest_acc=No. This case forces dest into 32bit mode due to the int8_math_en chicken bit (bit 11), because Int32 requires dest to be in 32bit mode. Due to this it would be more clear to test the dest_acc=Yes case, and skip the dest_acc=No case.

### What's changed
The untilize function now takes the data format argument from untilize_block and does not use the default.

Number of pack_untilize tests increased from 13 to 25, because dest_acc=Yes was added to the combinations. Above mentioned test (Int32, dest_acc=No) is skipped. 

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
