### PR TITLE
fix :bug:: wrong tile count correction for matmul perf

### DIFF
--- a/tests/python_tests/perf_matmul.py
+++ b/tests/python_tests/perf_matmul.py
@@ -70,19 +70,19 @@ def test_perf_matmul(perf_report, test_name, combos, math_fidelity):
     run_types = [PerfRunType.L1_TO_L1]
 
     # Calculate all matmul dimensions using helper function
-    matmul_dims = generate_tile_dims((matrix_a, matrix_b))
+    dims = generate_tile_dims((matrix_a, matrix_b))
 
     test_config = {
         "formats": formats,
         "testname": test_name,
         "loop_factor": 16,
-        "tile_cnt": matmul_dims.output_tile_cnt,
+        "tile_cnt": dims.rt_dim * dims.ct_dim * dims.kt_dim,
         "input_A_dimensions": matrix_a,
         "input_B_dimensions": matrix_b,
-        "output_dimensions": matmul_dims.output_dimensions,
-        "rt_dim": matmul_dims.rt_dim,
-        "ct_dim": matmul_dims.ct_dim,
-        "kt_dim": matmul_dims.kt_dim,
+        "output_dimensions": dims.output_dimensions,
+        "rt_dim": dims.rt_dim,
+        "ct_dim": dims.ct_dim,
+        "kt_dim": dims.kt_dim,
         "dest_acc": dest_acc,
         "math_fidelity": math_fidelity,
     }

--- a/tests/sources/matmul_perf.cpp
+++ b/tests/sources/matmul_perf.cpp
@@ -21,6 +21,7 @@ uint32_t math_sync_tile_dst_index = 0;
 static constexpr uint32_t MAX_TILES_DEST = is_fp32_dest_acc_en ? 4 : 8;
 
 static_assert(CT_DIM * RT_DIM <= MAX_TILES_DEST, "CT_DIM * RT_DIM must be less than or equal to MAX_TILES_DEST");
+static_assert(RT_DIM * CT_DIM * KT_DIM == TILE_CNT, "RT_DIM * CT_DIM * KT_DIM must be equal to TILE_CNT");
 
 #ifdef LLK_TRISC_UNPACK
 


### PR DESCRIPTION
### Ticket
<!-- Link to Github Issue -->
#766 

### Problem description
Before these changes, the Matmul benchmark wasn't correctly accounting the amount of processed tiles, setting
`tile_cnt = rt_dim * ct_dim` instead of `tile_cnt = rt_dim * ct_dim * kt_dim`

### What's changed
Introduced a small fix that should make sure that the cycles/tile metric is properly calculated

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
