### PR TITLE
Streamline mailbox operations and add BriscThreadId

### DIFF
--- a/tt_llk_blackhole/common/inc/ckernel.h
+++ b/tt_llk_blackhole/common/inc/ckernel.h
@@ -392,32 +392,16 @@ inline void cfg_reg_rmw_tensix(uint32_t val)
 
 inline void mailbox_write(const uint8_t thread, const uint32_t data)
 {
-    mailbox_base[thread + 1][0] = data;
+    mailbox_base[thread][0] = data;
 }
 
 // Blocking read
 inline uint32_t mailbox_read(const uint8_t thread)
 {
-    return mailbox_base[thread + 1][0];
-}
-
-inline bool mailbox_not_empty(const uint8_t thread)
-{
-    return mailbox_base[thread + 1][1] > 0;
-}
-
-inline void mailbox_write_full(const uint8_t thread, const uint32_t data)
-{
-    mailbox_base[thread][0] = data;
-}
-
-// Blocking read
-inline uint32_t mailbox_read_full(const uint8_t thread)
-{
     return mailbox_base[thread][0];
 }
 
-inline bool mailbox_not_empty_full(const uint8_t thread)
+inline bool mailbox_not_empty(const uint8_t thread)
 {
     return mailbox_base[thread][1] > 0;
 }

--- a/tt_llk_blackhole/common/inc/ckernel_defs.h
+++ b/tt_llk_blackhole/common/inc/ckernel_defs.h
@@ -44,9 +44,10 @@ enum DstClear
 
 enum ThreadId
 {
-    UnpackThreadId = 0,
-    MathThreadId   = 1,
-    PackThreadId   = 2
+    BriscThreadId  = 0,
+    UnpackThreadId = 1,
+    MathThreadId   = 2,
+    PackThreadId   = 3
 };
 
 enum DstTileLayout

--- a/tt_llk_wormhole_b0/common/inc/ckernel.h
+++ b/tt_llk_wormhole_b0/common/inc/ckernel.h
@@ -383,32 +383,16 @@ inline void cfg_reg_rmw_tensix(uint32_t val)
 
 inline void mailbox_write(const uint8_t thread, const uint32_t data)
 {
-    mailbox_base[thread + 1][0] = data;
+    mailbox_base[thread][0] = data;
 }
 
 // Blocking read
 inline uint32_t mailbox_read(const uint8_t thread)
 {
-    return mailbox_base[thread + 1][0];
-}
-
-inline bool mailbox_not_empty(const uint8_t thread)
-{
-    return mailbox_base[thread + 1][1] > 0;
-}
-
-inline void mailbox_write_full(const uint8_t thread, const uint32_t data)
-{
-    mailbox_base[thread][0] = data;
-}
-
-// Blocking read
-inline uint32_t mailbox_read_full(const uint8_t thread)
-{
     return mailbox_base[thread][0];
 }
 
-inline bool mailbox_not_empty_full(const uint8_t thread)
+inline bool mailbox_not_empty(const uint8_t thread)
 {
     return mailbox_base[thread][1] > 0;
 }

--- a/tt_llk_wormhole_b0/common/inc/ckernel_defs.h
+++ b/tt_llk_wormhole_b0/common/inc/ckernel_defs.h
@@ -44,9 +44,10 @@ enum DstClear
 
 enum ThreadId
 {
-    UnpackThreadId = 0,
-    MathThreadId   = 1,
-    PackThreadId   = 2
+    BriscThreadId  = 0,
+    UnpackThreadId = 1,
+    MathThreadId   = 2,
+    PackThreadId   = 3
 };
 
 enum DstTileLayout


### PR DESCRIPTION
### Ticket
[#] https://github.com/tenstorrent/tt-metal/issues/27979

### Problem description
ThreadId enum did not include BriscThreadId and mailbox operations had two versions, one set worked with the existing enum and another esoteric set that would allow the use with brisc thread but was never called. 


### What's changed
Add BriscThreadId to the enum structure for thread IDs, and remove the mailbox_*_full versions wheras the mailbox_* operations will work as the full versions with the widened enum range. 


### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
