### PR TITLE
#29825 remove, now unneeded, mabi option

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -61,7 +61,7 @@ OBJCOPY         := $(TOOL_PATH)/riscv-tt-elf-objcopy
 # =========================
 # Compiler and Linker Flags
 # =========================
-OPTIONS_ALL	:= -g -O3 -mabi=ilp32 -std=$(CXX_VERSION) -ffast-math
+OPTIONS_ALL	:= -g -O3 -std=$(CXX_VERSION) -ffast-math
 OPTIONS_COMPILE := -fno-use-cxa-atexit -Wall -fno-exceptions -fno-rtti -Werror -Wunused-parameter \
 				   -Wfloat-equal -Wpointer-arith -Wnull-dereference -Wredundant-decls -Wuninitialized \
 				   -Wmaybe-uninitialized -DTENSIX_FIRMWARE $(ARCH_DEFINE)


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/29825

### Problem description
The mabi option will be different for quasar

### What's changed
The compiler now defaults the ABI depending on the cpu selected. Thus no need for the user to specify (and get wrong).

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [YES ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
