### PR TITLE
chore: add lcov to Dockerfile.ird

### DIFF
--- a/.github/Dockerfile.ird
+++ b/.github/Dockerfile.ird
@@ -6,19 +6,20 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Install dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    ssh \
-    rsync \
-    sudo \
-    wget \
-    vim \
-    nano \
-    tmux \
-    python3-dev \
-    python3-venv \
-    python3-pip \
     clangd \
-    xxd \
-    fzf && \
+    fzf \
+    lcov \
+    nano \
+    python3-dev \
+    python3-pip \
+    python3-venv \
+    rsync \
+    ssh \
+    sudo \
+    tmux \
+    vim \
+    wget \
+    xxd && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Copy scripts into the image


### PR DESCRIPTION
### Ticket
<!-- Link to Github Issue -->

### Problem description
lcov is missing from the llk ird image (I only put it in the CI image initially, my oversight). Adding it.

### What's changed
Lcov installed in Docker IRD image.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
