### PR TITLE
`where` LLKs: remove `dst_index_out` and write output to `dst_index_in0` instead.

### DIFF
--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_where.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_where.h
@@ -11,7 +11,7 @@ namespace ckernel::sfpu
 {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_where_fp16_b_(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_in2, const uint dst_index_out)
+inline void _calculate_where_fp16_b_(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_in2)
 {
     // size of each tile in Dest is 64 rows
     constexpr uint dst_tile_size = 64;
@@ -34,15 +34,15 @@ inline void _calculate_where_fp16_b_(const uint dst_index_in0, const uint dst_in
             TT_SFPLOAD(p_sfpu::LREG3, InstrModLoadStore::LO16, ADDR_MOD_7, dst_index_in1 * dst_tile_size);
         }
         v_endif;
-        // sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = output_tensor;
-        TT_SFPSTORE(p_sfpu::LREG3, InstrModLoadStore::LO16, ADDR_MOD_7, dst_index_out * dst_tile_size);
+        // sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi] = output_tensor;
+        TT_SFPSTORE(p_sfpu::LREG3, InstrModLoadStore::LO16, ADDR_MOD_7, dst_index_in0 * dst_tile_size);
 
         sfpi::dst_reg++;
     }
 }
 
 template <typename T, bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_where_impl_(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_in2, const uint dst_index_out)
+inline void _calculate_where_impl_(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_in2)
 {
     constexpr uint dst_tile_size_sfpi = 32;
 
@@ -61,13 +61,13 @@ inline void _calculate_where_impl_(const uint dst_index_in0, const uint dst_inde
         }
         v_endif;
 
-        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = output_tensor;
+        sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi] = output_tensor;
         sfpi::dst_reg++;
     }
 }
 
 template <bool APPROXIMATION_MODE, DataFormat data_format, int ITERATIONS>
-inline void _calculate_where_(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_in2, const uint dst_index_out)
+inline void _calculate_where_(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_in2)
 {
     static_assert(
         data_format == DataFormat::Float32 || data_format == DataFormat::Float16_b || data_format == DataFormat::Int32 || data_format == DataFormat::UInt32,
@@ -75,19 +75,19 @@ inline void _calculate_where_(const uint dst_index_in0, const uint dst_index_in1
 
     if constexpr (data_format == DataFormat::Float16_b)
     {
-        _calculate_where_fp16_b_<APPROXIMATION_MODE, ITERATIONS>(dst_index_in0, dst_index_in1, dst_index_in2, dst_index_out);
+        _calculate_where_fp16_b_<APPROXIMATION_MODE, ITERATIONS>(dst_index_in0, dst_index_in1, dst_index_in2);
     }
     else if constexpr (data_format == DataFormat::Float32)
     {
-        _calculate_where_impl_<sfpi::vFloat, APPROXIMATION_MODE, ITERATIONS>(dst_index_in0, dst_index_in1, dst_index_in2, dst_index_out);
+        _calculate_where_impl_<sfpi::vFloat, APPROXIMATION_MODE, ITERATIONS>(dst_index_in0, dst_index_in1, dst_index_in2);
     }
     else if constexpr (data_format == DataFormat::Int32)
     {
-        _calculate_where_impl_<sfpi::vInt, APPROXIMATION_MODE, ITERATIONS>(dst_index_in0, dst_index_in1, dst_index_in2, dst_index_out);
+        _calculate_where_impl_<sfpi::vInt, APPROXIMATION_MODE, ITERATIONS>(dst_index_in0, dst_index_in1, dst_index_in2);
     }
     else if constexpr (data_format == DataFormat::UInt32)
     {
-        _calculate_where_impl_<sfpi::vUInt, APPROXIMATION_MODE, ITERATIONS>(dst_index_in0, dst_index_in1, dst_index_in2, dst_index_out);
+        _calculate_where_impl_<sfpi::vUInt, APPROXIMATION_MODE, ITERATIONS>(dst_index_in0, dst_index_in1, dst_index_in2);
     }
     else
     {

--- a/tt_llk_blackhole/llk_lib/llk_math_eltwise_ternary_sfpu_params.h
+++ b/tt_llk_blackhole/llk_lib/llk_math_eltwise_ternary_sfpu_params.h
@@ -10,7 +10,7 @@
 
 template <bool APPROXIMATE, typename Callable, typename... Args>
 inline void _llk_math_eltwise_ternary_sfpu_params_(
-    Callable&& sfpu_func, uint dst_index_in0, uint dst_index_in1, uint dst_index_in2, uint dst_index_out, int vector_mode = (int)VectorMode::RC, Args&&... args)
+    Callable&& sfpu_func, uint dst_index_in0, uint dst_index_in1, uint dst_index_in2, int vector_mode = (int)VectorMode::RC, Args&&... args)
 {
     _llk_math_eltwise_ternary_sfpu_start_<DST_SYNC_MODE>(0); // Reuse same sync primitive
 
@@ -19,7 +19,7 @@ inline void _llk_math_eltwise_ternary_sfpu_params_(
         // Row vector - Face0 + Face1
         for (int face = 0; face < 2; face++)
         {
-            std::forward<Callable>(sfpu_func)(dst_index_in0, dst_index_in1, dst_index_in2, dst_index_out, std::forward<Args>(args)...);
+            std::forward<Callable>(sfpu_func)(dst_index_in0, dst_index_in1, dst_index_in2, std::forward<Args>(args)...);
             TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_D, 8, 0, 0, p_setrwc::SET_D); // repeat 2x
             TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_D, 8, 0, 0, p_setrwc::SET_D);
         }
@@ -34,7 +34,7 @@ inline void _llk_math_eltwise_ternary_sfpu_params_(
         // Column vector - Face0 + Face2
         for (int face = 0; face < 2; face++)
         {
-            std::forward<Callable>(sfpu_func)(dst_index_in0, dst_index_in1, dst_index_in2, dst_index_out, std::forward<Args>(args)...);
+            std::forward<Callable>(sfpu_func)(dst_index_in0, dst_index_in1, dst_index_in2, std::forward<Args>(args)...);
             for (int i = 0; i < 4; ++i)
             {
                 TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_D, 8, 0, 0, p_setrwc::SET_D);
@@ -46,7 +46,7 @@ inline void _llk_math_eltwise_ternary_sfpu_params_(
         // All 4 faces
         for (int face = 0; face < 4; face++)
         {
-            std::forward<Callable>(sfpu_func)(dst_index_in0, dst_index_in1, dst_index_in2, dst_index_out, std::forward<Args>(args)...);
+            std::forward<Callable>(sfpu_func)(dst_index_in0, dst_index_in1, dst_index_in2, std::forward<Args>(args)...);
             TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_D, 8, 0, 0, p_setrwc::SET_D);
             TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_D, 8, 0, 0, p_setrwc::SET_D);
         }
@@ -54,7 +54,7 @@ inline void _llk_math_eltwise_ternary_sfpu_params_(
     else
     {
         // Default: single face pass-through
-        std::forward<Callable>(sfpu_func)(dst_index_in0, dst_index_in1, dst_index_in2, dst_index_out, std::forward<Args>(args)...);
+        std::forward<Callable>(sfpu_func)(dst_index_in0, dst_index_in1, dst_index_in2, std::forward<Args>(args)...);
     }
     _llk_math_eltwise_ternary_sfpu_done_(); // Finalize
 }

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_where.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_where.h
@@ -11,7 +11,7 @@ namespace ckernel::sfpu
 {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_where_fp16_b_(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_in2, const uint dst_index_out)
+inline void _calculate_where_fp16_b_(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_in2)
 {
     // size of each tile in Dest is 64 rows
     constexpr uint dst_tile_size = 64;
@@ -31,14 +31,14 @@ inline void _calculate_where_fp16_b_(const uint dst_index_in0, const uint dst_in
         TTI_SFPENCC(0 /*imm12_math*/, 0 /*unused*/, 0 /*unused*/, 0 /*reset cc*/);
 
         // store result
-        TT_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::LO16, ADDR_MOD_3, dst_index_out * dst_tile_size);
+        TT_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::LO16, ADDR_MOD_3, dst_index_in0 * dst_tile_size);
 
         sfpi::dst_reg++;
     }
 }
 
 template <typename T, bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_where_impl_(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_in2, const uint dst_index_out)
+inline void _calculate_where_impl_(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_in2)
 {
     constexpr uint dst_tile_size_sfpi = 32;
 
@@ -57,13 +57,13 @@ inline void _calculate_where_impl_(const uint dst_index_in0, const uint dst_inde
         }
         v_endif;
 
-        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = output_tensor;
+        sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi] = output_tensor;
         sfpi::dst_reg++;
     }
 }
 
 template <bool APPROXIMATION_MODE, DataFormat data_format, int ITERATIONS>
-inline void _calculate_where_(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_in2, const uint dst_index_out)
+inline void _calculate_where_(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_in2)
 {
     static_assert(
         data_format == DataFormat::Float32 || data_format == DataFormat::Float16_b || data_format == DataFormat::Int32 || data_format == DataFormat::UInt32,
@@ -71,19 +71,19 @@ inline void _calculate_where_(const uint dst_index_in0, const uint dst_index_in1
 
     if constexpr (data_format == DataFormat::Float16_b)
     {
-        _calculate_where_fp16_b_<APPROXIMATION_MODE, ITERATIONS>(dst_index_in0, dst_index_in1, dst_index_in2, dst_index_out);
+        _calculate_where_fp16_b_<APPROXIMATION_MODE, ITERATIONS>(dst_index_in0, dst_index_in1, dst_index_in2);
     }
     else if constexpr (data_format == DataFormat::Float32)
     {
-        _calculate_where_impl_<sfpi::vFloat, APPROXIMATION_MODE, ITERATIONS>(dst_index_in0, dst_index_in1, dst_index_in2, dst_index_out);
+        _calculate_where_impl_<sfpi::vFloat, APPROXIMATION_MODE, ITERATIONS>(dst_index_in0, dst_index_in1, dst_index_in2);
     }
     else if constexpr (data_format == DataFormat::Int32)
     {
-        _calculate_where_impl_<sfpi::vInt, APPROXIMATION_MODE, ITERATIONS>(dst_index_in0, dst_index_in1, dst_index_in2, dst_index_out);
+        _calculate_where_impl_<sfpi::vInt, APPROXIMATION_MODE, ITERATIONS>(dst_index_in0, dst_index_in1, dst_index_in2);
     }
     else if constexpr (data_format == DataFormat::UInt32)
     {
-        _calculate_where_impl_<sfpi::vUInt, APPROXIMATION_MODE, ITERATIONS>(dst_index_in0, dst_index_in1, dst_index_in2, dst_index_out);
+        _calculate_where_impl_<sfpi::vUInt, APPROXIMATION_MODE, ITERATIONS>(dst_index_in0, dst_index_in1, dst_index_in2);
     }
     else
     {

--- a/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_ternary_sfpu_params.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_ternary_sfpu_params.h
@@ -10,7 +10,7 @@
 
 template <bool APPROXIMATE, typename Callable, typename... Args>
 inline void _llk_math_eltwise_ternary_sfpu_params_(
-    Callable&& sfpu_func, uint dst_index_in0, uint dst_index_in1, uint dst_index_in2, uint dst_index_out, int vector_mode = (int)VectorMode::RC, Args&&... args)
+    Callable&& sfpu_func, uint dst_index_in0, uint dst_index_in1, uint dst_index_in2, int vector_mode = (int)VectorMode::RC, Args&&... args)
 {
     _llk_math_eltwise_ternary_sfpu_start_<DST_SYNC_MODE>(0); // Reuse same sync primitive
 
@@ -19,7 +19,7 @@ inline void _llk_math_eltwise_ternary_sfpu_params_(
         // Row vector - Face0 + Face1
         for (int face = 0; face < 2; face++)
         {
-            std::forward<Callable>(sfpu_func)(dst_index_in0, dst_index_in1, dst_index_in2, dst_index_out, std::forward<Args>(args)...);
+            std::forward<Callable>(sfpu_func)(dst_index_in0, dst_index_in1, dst_index_in2, std::forward<Args>(args)...);
             TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_D, 8, 0, 0, p_setrwc::SET_D); // repeat 2x
             TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_D, 8, 0, 0, p_setrwc::SET_D);
         }
@@ -34,7 +34,7 @@ inline void _llk_math_eltwise_ternary_sfpu_params_(
         // Column vector - Face0 + Face2
         for (int face = 0; face < 2; face++)
         {
-            std::forward<Callable>(sfpu_func)(dst_index_in0, dst_index_in1, dst_index_in2, dst_index_out, std::forward<Args>(args)...);
+            std::forward<Callable>(sfpu_func)(dst_index_in0, dst_index_in1, dst_index_in2, std::forward<Args>(args)...);
             for (int i = 0; i < 4; ++i)
             {
                 TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_D, 8, 0, 0, p_setrwc::SET_D);
@@ -46,7 +46,7 @@ inline void _llk_math_eltwise_ternary_sfpu_params_(
         // All 4 faces
         for (int face = 0; face < 4; face++)
         {
-            std::forward<Callable>(sfpu_func)(dst_index_in0, dst_index_in1, dst_index_in2, dst_index_out, std::forward<Args>(args)...);
+            std::forward<Callable>(sfpu_func)(dst_index_in0, dst_index_in1, dst_index_in2, std::forward<Args>(args)...);
             TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_D, 8, 0, 0, p_setrwc::SET_D);
             TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_D, 8, 0, 0, p_setrwc::SET_D);
         }
@@ -54,7 +54,7 @@ inline void _llk_math_eltwise_ternary_sfpu_params_(
     else
     {
         // Default: single face pass-through
-        std::forward<Callable>(sfpu_func)(dst_index_in0, dst_index_in1, dst_index_in2, dst_index_out, std::forward<Args>(args)...);
+        std::forward<Callable>(sfpu_func)(dst_index_in0, dst_index_in1, dst_index_in2, std::forward<Args>(args)...);
     }
     _llk_math_eltwise_ternary_sfpu_done_(); // Finalize
 }


### PR DESCRIPTION
### Ticket

https://github.com/tenstorrent/tt-metal/issues/31621

### Problem description

Right now the ternary op structure has 4 arguments: 3 input indexes and 1 output index.  However, all uses of `where` (the only ternary op) write the output to the same index as the first input index (see ticket for more details).

This change will also allow future optimisations that rely on only using 3 distinct indexes.

This LLK change needs to be merged in sync with the relevant tt-metal changes.

### What's changed

Removed the 4th argument to the `where` LLKs and write output to the first input index instead.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
