### PR TITLE
Use TT instructions instead of TTI in cunpack_common.h on BH when passing runtime arguments

### DIFF
--- a/tt_llk_blackhole/common/inc/cunpack_common.h
+++ b/tt_llk_blackhole/common/inc/cunpack_common.h
@@ -363,8 +363,8 @@ inline void configure_unpack_AB(
     }
 
     uint unpA_x_end = (unpA_face_r_dim == 0) ? 1 : (unpA_face_r_dim << 4) - 1;
-    TTI_SETADCXX(p_setadc::UNP_A, unpA_x_end, 0x0);
-    TTI_SETADCXX(p_setadc::UNP_B, (unpB_face_r_dim << 4) - 1, 0x0);
+    TT_SETADCXX(p_setadc::UNP_A, unpA_x_end, 0x0);
+    TT_SETADCXX(p_setadc::UNP_B, (unpB_face_r_dim << 4) - 1, 0x0);
 
     // Program base address for all 2 sections (each section address is loaded to corresponding context)
     // Load dummy data to unused location if face height is 0


### PR DESCRIPTION
### Ticket
/

### Problem description
So far, the functions in llk_operands.h and llk_outputs.h were returning hard-coded values for BH. 
[The PR that fixes tiny tiles on BH](https://github.com/tenstorrent/tt-metal/pull/31043) changes this. However, it exposes that we are using TTI instructions with runtime variables. 

### What's changed
Change TTI instructions to TT, as face_r_dims are not hardcoded anymore. 
### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
