### PR TITLE
ci: unify tt-exalens and tt-smi versioning

### DIFF
--- a/.github/Dockerfile.ci
+++ b/.github/Dockerfile.ci
@@ -10,6 +10,7 @@ COPY tests/requirements.txt /tmp/requirements_tests.txt
 COPY .github/scripts/install-tests-dependencies.sh \
      .github/scripts/install-exalens.sh \
      .github/scripts/install-smi.sh \
+     .github/scripts/versions.sh \
      /tmp/scripts/
 
 # Install all dependencies in a single layer and clean up

--- a/.github/scripts/get-docker-tag.sh
+++ b/.github/scripts/get-docker-tag.sh
@@ -13,6 +13,7 @@ DOCKERFILE_HASH_FILES=".github/Dockerfile.base \
     .github/scripts/build-docker-images.sh \
     .github/scripts/install-exalens.sh \
     .github/scripts/install-smi.sh \
-    .github/scripts/install-tests-dependencies.sh"
+    .github/scripts/install-tests-dependencies.sh \
+    .github/scripts/versions.sh"
 DOCKERFILE_HASH=$(sha256sum $DOCKERFILE_HASH_FILES | sha256sum | cut -d ' ' -f 1)
 echo dt-$DOCKERFILE_HASH

--- a/.github/scripts/install-exalens.sh
+++ b/.github/scripts/install-exalens.sh
@@ -5,11 +5,11 @@
 
 set -e
 
-EXALENS_VERSION="0.1.251103+dev.7172499-cp310-cp310-linux_x86_64"
-EXALENS_TAG="${EXALENS_VERSION%%+*}"
-EXALENS_WHEEL="ttexalens-${EXALENS_VERSION}.whl"
+# Source centralized version configuration
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=.github/scripts/versions.sh
+source "${SCRIPT_DIR}/versions.sh"
 
-wget -O ${EXALENS_WHEEL} \
-    https://github.com/tenstorrent/tt-exalens/releases/download/${EXALENS_TAG}/${EXALENS_WHEEL} || exit 1
-pip install --no-cache-dir ${EXALENS_WHEEL}
-rm ${EXALENS_WHEEL}
+wget -O "${EXALENS_WHEEL}" "${EXALENS_URL}" || exit 1
+pip install --no-cache-dir "${EXALENS_WHEEL}"
+rm "${EXALENS_WHEEL}"

--- a/.github/scripts/install-smi.sh
+++ b/.github/scripts/install-smi.sh
@@ -5,10 +5,11 @@
 
 set -e
 
-TT_SMI_VERSION="3.0.34"
-TT_SMI_WHEEL="tt_smi-${TT_SMI_VERSION}-py3-none-any.whl"
+# Source centralized version configuration
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=.github/scripts/versions.sh
+source "${SCRIPT_DIR}/versions.sh"
 
-wget -O ${TT_SMI_WHEEL} \
-    https://github.com/tenstorrent/tt-smi/releases/download/v${TT_SMI_VERSION}/${TT_SMI_WHEEL} || exit 1
-pip install --no-cache-dir ${TT_SMI_WHEEL}
-rm ${TT_SMI_WHEEL}
+wget -O "${TT_SMI_WHEEL}" "${TT_SMI_URL}" || exit 1
+pip install --no-cache-dir "${TT_SMI_WHEEL}"
+rm "${TT_SMI_WHEEL}"

--- a/.github/scripts/versions.sh
+++ b/.github/scripts/versions.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Single source of truth for external dependency versions
+# This file should be sourced by installation scripts
+
+# tt-exalens configuration
+export EXALENS_VERSION="0.1.251103+dev.7172499-cp310-cp310-linux_x86_64"
+export EXALENS_TAG="${EXALENS_VERSION%%+*}"
+export EXALENS_WHEEL="ttexalens-${EXALENS_VERSION}.whl"
+export EXALENS_URL="https://github.com/tenstorrent/tt-exalens/releases/download/${EXALENS_TAG}/${EXALENS_WHEEL}"
+
+# tt-smi configuration
+export TT_SMI_VERSION="3.0.34"
+export TT_SMI_WHEEL="tt_smi-${TT_SMI_VERSION}-py3-none-any.whl"
+export TT_SMI_URL="https://github.com/tenstorrent/tt-smi/releases/download/v${TT_SMI_VERSION}/${TT_SMI_WHEEL}"


### PR DESCRIPTION
### Ticket
None

### Problem description
Previously, we were setting exalens and smi versions in two places: one when building our Docker images and another in the setup_external_testing_env.sh script, meant for users who don't use our Docker containers. On a few occasions, this became problematic because we weren't updating versions in lockstep, leading to situations where the Docker container had one version and external developers had another.

### What's changed
- Created versions.sh as a centralized configuration file for tt-smi and tt-exalens versions and download URLs
- Updated all installation scripts to source the centralized version configuration
- Simplified `setup_external_testing_env.sh` by removing tt-smi repository cloning and downloading wheels directly instead

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update