### PR TITLE
[skip ci] ci: account for movement of some C++ tests from BH workflow to L2 nightly workflow

### DIFF
--- a/.github/workflows/trigger-tt-metal-post-commit.yml
+++ b/.github/workflows/trigger-tt-metal-post-commit.yml
@@ -388,7 +388,7 @@ jobs:
           RUN_WH="${{ needs.detect-changes.outputs.run-wormhole }}"
           RUN_BH="${{ needs.detect-changes.outputs.run-blackhole }}"
           [[ "$RUN_WH" == "true" || "$RUN_BH" == "true" ]] && RUN_L2="true" || RUN_L2="false"
-          L2_RESULT=$(format_test_result "C++ post-commit tests" \
+          L2_RESULT=$(format_test_result "C++ post-commit" \
             "$RUN_L2" \
             "${{ steps.parse-results.outputs.l2-status }}" \
             "${{ steps.parse-results.outputs.l2-url }}" \


### PR DESCRIPTION
### Ticket
None

### Problem description
During LLK submodule checks, we previously executed L2 APC tests only
when there were Wormhole changes. Recently, some C++ Blackhole tests
were moved to the L2 workflow. This requires us to run this workflow for
LLK uplifts containing Blackhole changes as well.

### What's changed
- Changed the L2 test name from "Wormhole C++" to "C++ post-commit tests" to reflect that it runs for both architectures
- Added conditional logic to set RUN_L2 to true when either run-wormhole or run-blackhole is true
- Updated the comment to clarify that L2 tests run for both Wormhole and Blackhole changes