### PR TITLE
Add Stable Sort flag for TopK

### DIFF
--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_topk.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_topk.h
@@ -433,15 +433,15 @@ inline void _bitonic_topk_phases_steps(const int idir, const int i_end_phase, co
                             {
                                 lltt::replay(0, 8);
                             }
-                            constexpr int phase_replay_id = STABLE_SORT ? 6 : 4;
+                            constexpr int replay_count = STABLE_SORT ? 6 : 4;
                             if (init_phase)
                             {
-                                load_replay_buf<Exec>(16, phase_replay_id, [] { bitonic_topk_ph0_st1_to_1<STABLE_SORT>(); });
+                                load_replay_buf<Exec>(16, replay_count, [] { bitonic_topk_ph0_st1_to_1<STABLE_SORT>(); });
                                 init_phase = false;
                             }
                             else
                             {
-                                lltt::replay(16, phase_replay_id);
+                                lltt::replay(16, replay_count);
                             }
                             if (init_store)
                             {
@@ -459,15 +459,15 @@ inline void _bitonic_topk_phases_steps(const int idir, const int i_end_phase, co
                         for (int d = 0; d < 4; d++)
                         {
                             lltt::replay(0, 8);
-                            constexpr int phase_replay_id = STABLE_SORT ? 10 : 6;
+                            constexpr int replay_count = STABLE_SORT ? 10 : 6;
                             if (init_phase)
                             {
-                                load_replay_buf<Exec>(16, phase_replay_id, [] { bitonic_topk_ph1_st2_to_1<STABLE_SORT>(); });
+                                load_replay_buf<Exec>(16, replay_count, [] { bitonic_topk_ph1_st2_to_1<STABLE_SORT>(); });
                                 init_phase = false;
                             }
                             else
                             {
-                                lltt::replay(16, phase_replay_id);
+                                lltt::replay(16, replay_count);
                             }
                             lltt::replay(8, 8);
                         }
@@ -476,15 +476,15 @@ inline void _bitonic_topk_phases_steps(const int idir, const int i_end_phase, co
                         for (int d = 0; d < 4; d++)
                         {
                             lltt::replay(0, 8);
-                            constexpr int phase_replay_id = STABLE_SORT ? 14 : 9;
+                            constexpr int replay_count = STABLE_SORT ? 14 : 9;
                             if (init_phase)
                             {
-                                load_replay_buf<Exec>(16, phase_replay_id, [] { bitonic_topk_ph2_st3_to_1<STABLE_SORT>(); });
+                                load_replay_buf<Exec>(16, replay_count, [] { bitonic_topk_ph2_st3_to_1<STABLE_SORT>(); });
                                 init_phase = false;
                             }
                             else
                             {
-                                lltt::replay(16, phase_replay_id);
+                                lltt::replay(16, replay_count);
                             }
                             lltt::replay(8, 8);
                         }

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_topk.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_topk.h
@@ -423,16 +423,16 @@ inline void _bitonic_topk_phases_steps(const int idir, const int i_end_phase, co
                             {
                                 lltt::replay(0, 8);
                             }
-                            constexpr int phase_replay_id = STABLE_SORT ? 6 : 4;
+                            constexpr int replay_count = STABLE_SORT ? 6 : 4;
                             if (init_phase)
                             {
-                                lltt::record<lltt::Exec>(16, phase_replay_id);
+                                lltt::record<lltt::Exec>(16, replay_count);
                                 bitonic_topk_ph0_st1_to_1<STABLE_SORT>();
                                 init_phase = false;
                             }
                             else
                             {
-                                lltt::replay(16, phase_replay_id);
+                                lltt::replay(16, replay_count);
                             }
                             if (init_store)
                             {
@@ -451,16 +451,16 @@ inline void _bitonic_topk_phases_steps(const int idir, const int i_end_phase, co
                         {
                             // Groups of 16 datums being sorted at the same time
                             lltt::replay(0, 8);
-                            constexpr int phase_replay_id = STABLE_SORT ? 10 : 6;
+                            constexpr int replay_count = STABLE_SORT ? 10 : 6;
                             if (init_phase)
                             {
-                                lltt::record<lltt::Exec>(16, phase_replay_id);
+                                lltt::record<lltt::Exec>(16, replay_count);
                                 bitonic_topk_ph1_st2_to_1<STABLE_SORT>();
                                 init_phase = false;
                             }
                             else
                             {
-                                lltt::replay(16, phase_replay_id);
+                                lltt::replay(16, replay_count);
                             }
                             lltt::replay(8, 8);
                         }
@@ -469,16 +469,16 @@ inline void _bitonic_topk_phases_steps(const int idir, const int i_end_phase, co
                         for (int d = 0; d < 4; d++)
                         {
                             lltt::replay(0, 8);
-                            constexpr int phase_replay_id = STABLE_SORT ? 14 : 9;
+                            constexpr int replay_count = STABLE_SORT ? 14 : 9;
                             if (init_phase)
                             {
-                                lltt::record<lltt::Exec>(16, phase_replay_id);
+                                lltt::record<lltt::Exec>(16, replay_count);
                                 bitonic_topk_ph2_st3_to_1<STABLE_SORT>();
                                 init_phase = false;
                             }
                             else
                             {
-                                lltt::replay(16, phase_replay_id);
+                                lltt::replay(16, replay_count);
                             }
                             lltt::replay(8, 8);
                         }


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/20625

### Problem description
TopK sorting algo will sometimes swap indices which have the same value, while it does give the correct topk values, there are applications in metal for maintaining the original order when looking at the indices

### What's changed
- Modified SFPU code to ensure indices with the same value maintain their ordering at all steps
- Performed initial round of optimizations for stable sort, also improving code clarity
- Cleaned up the UNCONDITIONAL swaps in some of the phase steps for both stable and unstable implementations
- Removed an unused template parameter (ITERATIONS)

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/19125147831
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/19125151749
