### PR TITLE
[skip ci] ci: unify LLK PAT name for calling different `tt-metal` workflows

### DIFF
--- a/.github/workflows/trigger-tt-metal-bump.yml
+++ b/.github/workflows/trigger-tt-metal-bump.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Send dispatch event to tt-metal
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.TT_METAL_PAT }}
+          github-token: ${{ secrets.LLK_UPLIFT_PAT }}
           retries: 3
           retry-exempt-status-codes: 400,401,403,404,422
           script: |


### PR DESCRIPTION
### Ticket
None

### Problem description
We've been using different PAT name for the same token throughout different repositories. Time to unify them under one name. It makes maintenance easier.

### What's changed
This PR updates the GitHub token secret used for triggering dispatch events to the tt-metal repository from TT_METAL_PAT to LLK_UPLIFT_PAT.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
