### PR TITLE
Change PolynomialEvaluator to support vFloat coefficients

### DIFF
--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_polyval.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_polyval.h
@@ -47,7 +47,7 @@ struct PolynomialEvaluator
      * @note Coefficients can be either float, sfpi::vFloat, ... (scalar and sfpi typed arguments can be mixed)
      */
 
-    // Base case: f(x) = 0 (rank-0 polynomial)
+    // Base case: f(x) = 0 (empty polynomial)
     template <typename U>
     static constexpr auto eval(U x)
     {
@@ -57,7 +57,7 @@ struct PolynomialEvaluator
     template <typename U, typename Coefficient0>
     static constexpr auto eval(U x, Coefficient0 coeff0)
     {
-        // Base case: f(x) = coeff0 (rank-0 polynomial)
+        // Base case: f(x) = coeff0 (0-th degree polynomial)
         return coeff0;
     }
 

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_polyval.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_polyval.h
@@ -47,7 +47,7 @@ struct PolynomialEvaluator
      * @note Coefficients can be either float, sfpi::vFloat, ... (scalar and sfpi typed arguments can be mixed)
      */
 
-    // Base case: f(x) = 0 (rank-0 polynomial)
+    // Base case: f(x) = 0 (empty polynomial)
     template <typename U>
     static constexpr auto eval(U x)
     {
@@ -57,7 +57,7 @@ struct PolynomialEvaluator
     template <typename U, typename Coefficient0>
     static constexpr auto eval(U x, Coefficient0 coeff0)
     {
-        // Base case: f(x) = coeff0 (rank-0 polynomial)
+        // Base case: f(x) = coeff0 (0-th degree polynomial)
         return coeff0;
     }
 


### PR DESCRIPTION
### Ticket
##818

### Problem description

As mentioned in this [comment](https://github.com/tenstorrent/tt-metal/pull/31685#discussion_r2490797334), `PolynomialEvaluator::eval()` takes coefficients as array , which make it difficult to use with `sfpi::vFloat` (especially fixed and programmable constants). 

### What's changed

Replaced `PolynomialEvaluator` implementation with a recursive one that one variadic templates.

This allows for evaluations with mixed `float` and `sfpi::vFloat` coefficients such as the following:

```cpp
sfpi::vFloat result = PolynomialEvaluator::eval(
        val, 
        sfpi::vConst0, 
        0.999004364013671875, 
        3.0897438526153564453125e-2, 
        -0.4890659749507904052734375,
        sfpi::vConstFloatPrgm2,
        sfpi::vConstFloatPrgm1,
        sfpi::vConstFloatPrgm0);
```

Recursion depth should be okay: since C++11, the maximum recursion depth in templates is 1024 ([although gcc is limited to 900](https://gcc.gnu.org/onlinedocs/gcc/C_002b_002b-Dialect-Options.html)). 

Most polynomial approximations should not exceed 20 arguments (biggest one I've seen so far in metal is gelu with POLYVAL15). We should also be able to set an upper bound through `static_assert(sizeof...(Reset) < MAX_DEPTH)` (if `static_assert` evaluated before 'recursion').


### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

This is a technically a breaking change, but `PolynomialEvaluator` is not yet used in Metal (pending [accurate pow PR](https://github.com/tenstorrent/tt-metal/pull/30986) ). 

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes [OK](https://github.com/tenstorrent/tt-metal/actions/runs/19147554722)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable) [https://github.com/tenstorrent/tt-metal/actions/runs/19147559999]
