### PR TITLE
build: add pytest-xdist to requirements

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -28,6 +28,7 @@ pytest-repeat==0.9.4
 pytest-split==0.10.0
 pytest-sugar==1.0.0
 pytest-timeout==2.4.0
+pytest-xdist==3.8.0
 sympy==1.14.0
 termcolor==3.1.0
 tomli==2.2.1


### PR DESCRIPTION
### Ticket
None

### Problem description
This is a pre-requisite for running tests in parallel

### What's changed
Ground work for test parallelization. This pytest plugin is required for executing tests in parallel using `-n <NUMBER_OF_TESTS>`.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update