### PR TITLE
[skip ci] refactor: cache chip_architecture value in python code

### DIFF
--- a/tests/python_tests/helpers/chip_architecture.py
+++ b/tests/python_tests/helpers/chip_architecture.py
@@ -22,7 +22,6 @@ class ChipArchitecture(Enum):
                 "blackhole": cls.BLACKHOLE,
                 "quasar": cls.QUASAR,
                 "wormhole": cls.WORMHOLE,
-                "wormhole_b0": cls.WORMHOLE,
             }
         return cls._cached_string_map
 
@@ -49,6 +48,8 @@ def get_chip_architecture():
     if not chip_architecture:
         context = check_context()
         chip_architecture = context.devices[0]._arch
+        if chip_architecture == "wormhole_b0":
+            chip_architecture = "wormhole"
         os.environ["CHIP_ARCH"] = chip_architecture
 
     _cached_chip_architecture = ChipArchitecture.from_string(chip_architecture)


### PR DESCRIPTION
### Ticket
None

### Problem description
We are calling `get_chip_architecture()` all over our testing code. This fetches env variable, but we could cache the value in Python for convenience.

### What's changed
Implemented caching of chip_architecture value in our Python testing environment.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update