### PR TITLE
[skip ci] ci: increase test splits from 3 to 5 in perf test workflows

### DIFF
--- a/.github/workflows/run-perf-tests.yml
+++ b/.github/workflows/run-perf-tests.yml
@@ -77,7 +77,7 @@ jobs:
     with:
       docker_image: ${{ needs.build-images.outputs.docker-image }}
       runs_on: tt-ubuntu-2204-n150-stable
-      test_splits: 3
+      test_splits: 5
       pytest_markers: "perf"
       timeout_minutes: 240
 
@@ -92,7 +92,7 @@ jobs:
     with:
       docker_image: ${{ needs.build-images.outputs.docker-image }}
       runs_on: tt-ubuntu-2204-p150b-stable
-      test_splits: 3
+      test_splits: 5
       pytest_markers: "perf"
       timeout_minutes: 240
 


### PR DESCRIPTION
### Ticket
None

### Problem description
Currently, perf tests are failing due to timeout, after a new batch of tests has been added.

### What's changed
Instead of simply increasing timeout, let's try to scale horizontally and run tests on more runners.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update