### PR TITLE
Ldjurovic/sfpu reduce max patch

### DIFF
--- a/tests/python_tests/test_sfpu_reduce_sdpa.py
+++ b/tests/python_tests/test_sfpu_reduce_sdpa.py
@@ -28,12 +28,9 @@ from helpers.utils import passed_test
     reduce_pool=[ReducePool.Max],  # Only MAX is supported for SDPA reduce
     input_dimensions=[
         [32, 32],
-        [32, 64],
         [64, 32],
-        [128, 64],
-        [64, 128],
-        [32, 128],
         [128, 32],
+        [256, 32],
     ],
 )
 def test_sfpu_reduce_sdpa(

--- a/tests/python_tests/test_sfpu_reduce_sdpa.py
+++ b/tests/python_tests/test_sfpu_reduce_sdpa.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import torch
-from helpers.conftest import skip_for_blackhole
+from conftest import skip_for_blackhole
 from helpers.device import collect_results, write_stimuli_to_l1
 from helpers.format_config import DataFormat
 from helpers.llk_params import (

--- a/tests/python_tests/test_sfpu_reduce_sdpa.py
+++ b/tests/python_tests/test_sfpu_reduce_sdpa.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import torch
+from helpers.conftest import skip_for_blackhole
 from helpers.device import collect_results, write_stimuli_to_l1
 from helpers.format_config import DataFormat
 from helpers.llk_params import (
@@ -17,6 +18,7 @@ from helpers.tilize_untilize import tilize_block, untilize_block
 from helpers.utils import passed_test
 
 
+@skip_for_blackhole
 @parametrize(
     test_name="sfpu_reduce_sdpa_test",
     formats=input_output_formats(

--- a/tests/sources/sfpu_reduce_sdpa_test.cpp
+++ b/tests/sources/sfpu_reduce_sdpa_test.cpp
@@ -111,8 +111,9 @@ void run_kernel()
     _llk_math_eltwise_unary_sfpu_init_<SfpuType::reduce>();
     _llk_math_eltwise_unary_sfpu_start_<DstSync::SyncHalf>(0);
 
-    ckernel::sfpu::_init_reduce_<PoolType::MAX, DataFormat::Float16_b>();
     ckernel::sfpu::sfpu_reduce_max_load_initial_values();
+    ckernel::sfpu::_init_reduce_<PoolType::MAX, DataFormat::Float16_b>();
+
     ckernel::sfpu::_calculate_reduce_<PoolType::MAX, REDUCE_COL, DataFormat::Float16_b>(BLOCK_RT_DIM);
 
     // Call epilogue once after processing all tiles

--- a/tests/sources/sfpu_reduce_sdpa_test.cpp
+++ b/tests/sources/sfpu_reduce_sdpa_test.cpp
@@ -112,6 +112,7 @@ void run_kernel()
     _llk_math_eltwise_unary_sfpu_start_<DstSync::SyncHalf>(0);
 
     ckernel::sfpu::_init_reduce_<PoolType::MAX, DataFormat::Float16_b>();
+    ckernel::sfpu::sfpu_reduce_max_load_initial_values();
     ckernel::sfpu::_calculate_reduce_<PoolType::MAX, REDUCE_COL, DataFormat::Float16_b>(BLOCK_RT_DIM);
 
     // Call epilogue once after processing all tiles

--- a/tests/sources/sfpu_reduce_sdpa_test.cpp
+++ b/tests/sources/sfpu_reduce_sdpa_test.cpp
@@ -109,14 +109,13 @@ void run_kernel()
     // SFPU part
     // Initialize SFPU for reduce operation
     _llk_math_eltwise_unary_sfpu_init_<SfpuType::reduce>();
+    _llk_math_eltwise_unary_sfpu_start_<DstSync::SyncHalf>(0);
 
-    ckernel::sfpu::_init_reduce_<PoolType::MAX, DataFormat::Float16_b>(BLOCK_CT_DIM);
+    ckernel::sfpu::_init_reduce_<PoolType::MAX, DataFormat::Float16_b>();
+    ckernel::sfpu::_calculate_reduce_<PoolType::MAX, REDUCE_COL, DataFormat::Float16_b>(BLOCK_RT_DIM);
 
-    for (uint32_t i = 0; i < BLOCK_CT_DIM; i++)
-    {
-        _llk_math_eltwise_unary_sfpu_start_<DstSync::SyncHalf>(i);
-        ckernel::sfpu::_calculate_reduce_<PoolType::MAX, REDUCE_COL, DataFormat::Float16_b>(BLOCK_RT_DIM);
-    }
+    // Call epilogue once after processing all tiles
+    ckernel::sfpu::epilogue_reduce_max_col_();
 
     _llk_math_eltwise_unary_sfpu_done_();
 

--- a/tests/sources/sfpu_reduce_sdpa_test.cpp
+++ b/tests/sources/sfpu_reduce_sdpa_test.cpp
@@ -111,8 +111,8 @@ void run_kernel()
     _llk_math_eltwise_unary_sfpu_init_<SfpuType::reduce>();
     _llk_math_eltwise_unary_sfpu_start_<DstSync::SyncHalf>(0);
 
-    ckernel::sfpu::sfpu_reduce_max_load_initial_values();
     ckernel::sfpu::_init_reduce_<PoolType::MAX, DataFormat::Float16_b>();
+    ckernel::sfpu::sfpu_reduce_max_load_initial_values();
 
     ckernel::sfpu::_calculate_reduce_<PoolType::MAX, REDUCE_COL, DataFormat::Float16_b>(BLOCK_RT_DIM);
 

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_reduce.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_reduce.h
@@ -231,12 +231,13 @@ constexpr bool is_supported_reduce_format(DataFormat format)
 //**************************************************************
 inline void sfpu_reduce_max_col_configure_addrmod()
 {
+    // ADDR_MOD_3: No increment mode - used for all SFPU operations
     addr_mod_t {
         .srca = {.incr = 0},
         .srcb = {.incr = 0},
         .dest = {.incr = 0},
     }
-        .set(ADDR_MOD_7);
+        .set(ADDR_MOD_3);
 }
 
 template <DataFormat format>
@@ -269,7 +270,7 @@ inline void _init_reduce_max_col_()
     TTI_SFPLOADI(0, 0x8, 0x0000); // Upper 16 bits: slot2=0x00, slot3=0x00
     TTI_SFPCONFIG(0, 5, 0);       // Store in Macro Sequence Register 1 (dest=5)
 
-    TTI_SFPCONFIG(0x0100, 0xF /*SFPU control*/, 0x1); // invert swap direction
+    // TTI_SFPCONFIG(0x0100, 0xF /*SFPU control*/, 0x1); // invert swap direction
 
     // ***********************************************************
 
@@ -306,10 +307,13 @@ inline void _calculate_reduce_max_col_(const uint32_t block_height)
 
             // Compare and swap to keep maximum values in LREG6/LREG7
             TTI_SFPSWAP(0 /*unused*/, p_sfpu::LREG7 /*lreg_src_c*/, p_sfpu::LREG1 /*lreg_dest*/, 1 /*instr_mod1*/);
+            TTI_SFPNOP;
             TTI_SFPSWAP(0 /*unused*/, p_sfpu::LREG6 /*lreg_src_c*/, p_sfpu::LREG0 /*lreg_dest*/, 1 /*instr_mod1*/);
+            TTI_SFPNOP;
 
             // Load next pair and compare with LREG4/LREG5
             TT_SFPLOADMACRO(0, InstrModLoadStore::FP16B, ADDR_MOD_3, i * 64 + loadmacro0_offsets[row_group]);
+            TTI_SFPNOP;
             TTI_SFPNOP;
         }
     }

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_reduce.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_reduce.h
@@ -229,36 +229,30 @@ constexpr bool is_supported_reduce_format(DataFormat format)
 //**************************************************************
 // SFPU REDUCE MAX COL IMPLEMENTATION
 //**************************************************************
-inline void sfpu_reduce_max_col_configure_addrmod(uint32_t num_cols)
+inline void sfpu_reduce_max_col_configure_addrmod()
 {
-    uint32_t skip_rows = (num_cols - 1) * 64;
-
     addr_mod_t {
         .srca = {.incr = 0},
         .srcb = {.incr = 0},
         .dest = {.incr = 0},
     }
         .set(ADDR_MOD_7);
-
-    addr_mod_t {
-        .srca = {.incr = 0},
-        .srcb = {.incr = 0},
-        .dest = {.incr = 16},
-    }
-        .set(ADDR_MOD_6);
-
-    addr_mod_t {
-        .srca = {.incr = 0},
-        .srcb = {.incr = 0},
-        .dest = {.incr = static_cast<int16_t>(skip_rows)},
-    }
-        .set(ADDR_MOD_5);
 }
 
 template <DataFormat format>
-inline void _init_reduce_max_col_(uint32_t num_cols)
+inline void _init_reduce_max_col_()
 {
     static_assert(format == DataFormat::Float16_b, "Unsupported data format. Supported formats: Float16_b");
+
+    constexpr uint16_t neg_inf_fp16b = 0xFF80;
+
+    // F0 - Initialize with negative infinity
+    TTI_SFPLOADI(p_sfpu::LREG4, InstrModLoadStore::FP16B, neg_inf_fp16b);
+    TTI_SFPLOADI(p_sfpu::LREG5, InstrModLoadStore::FP16B, neg_inf_fp16b);
+
+    // F1 - Initialize with negative infinity
+    TTI_SFPLOADI(p_sfpu::LREG6, InstrModLoadStore::FP16B, neg_inf_fp16b);
+    TTI_SFPLOADI(p_sfpu::LREG7, InstrModLoadStore::FP16B, neg_inf_fp16b);
 
     // ***********************************************************
     // SFPU LOADMACRO CONFIGURATION
@@ -280,86 +274,49 @@ inline void _init_reduce_max_col_(uint32_t num_cols)
     // ***********************************************************
 
     _init_sfpu_config_reg();
-    sfpu_reduce_max_col_configure_addrmod(num_cols);
-
-    // ***********************************************************
-    // Record replay buffer
-    lltt::record<lltt::NoExec>(0, 11);
-    TTI_INCRWC(0, 4, 0, 0); // increment dest counter by 4
-
-    // Use LOADMACRO with lreg_ind=5 (loads to LREG5, uses sequence 1 since bits[3:2]=01)
-    TTI_SFPLOADMACRO(5, InstrModLoadStore::FP16B, ADDR_MOD_7, 2);
-
-    TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::FP16B, ADDR_MOD_7, 16);
-    TTI_SFPLOAD(p_sfpu::LREG1, InstrModLoadStore::FP16B, ADDR_MOD_7, 18);
-    TTI_SFPSWAP(0 /*unused*/, p_sfpu::LREG7 /*lreg_src_c*/, p_sfpu::LREG1 /*lreg_dest*/, 1 /*instr_mod1*/);
-    TTI_SFPNOP;
-    TTI_SFPSWAP(0 /*unused*/, p_sfpu::LREG6 /*lreg_src_c*/, p_sfpu::LREG0 /*lreg_dest*/, 1 /*instr_mod1*/);
-    TTI_SFPNOP;
-
-    // Use LOADMACRO with lreg_ind=0 (loads to LREG0, uses sequence 0)
-    TTI_SFPLOADMACRO(0, InstrModLoadStore::FP16B, ADDR_MOD_7, 0);
-
-    // Dummy loads used to increment dest counters
-    TTI_SFPLOAD(8, InstrModLoadStore::FP16B, ADDR_MOD_6, 0);
-    TTI_SFPLOAD(8, InstrModLoadStore::FP16B, ADDR_MOD_5, 0);
-    // ***********************************************************
+    sfpu_reduce_max_col_configure_addrmod();
 }
 
 template <PoolType pool_type, ReduceDim reduce_dim, DataFormat format>
-inline void _calculate_reduce_max_col_(const uint32_t block_height /*, const uint32_t block_width*/)
+inline void _calculate_reduce_max_col_(const uint32_t block_height)
 {
+    TTI_STALLWAIT(p_stall::STALL_SFPU, p_stall::PACK);
+
     static_assert(reduce_dim == REDUCE_COL, "Only column reduction (REDUCE_COL) is currently supported");
     static_assert(pool_type == PoolType::MAX, "Only MAX pool type is currently supported");
     static_assert(format == DataFormat::Float16_b, "SFPU reduce max col only supports Float16_b format");
 
-    constexpr uint32_t replay_buffer_offset    = 9;
-    constexpr uint32_t replay_buffer_next_face = 10;
-
-    /*
-    Initial loads of LREGS 0-3 which will hold maximum values of columns
-    They will spread across F0 and F1 so in each pass full tile width will be reduced
-    */
-
-    // F0
-    TTI_SFPLOAD(p_sfpu::LREG4, InstrModLoadStore::FP16B, ADDR_MOD_7, 0);
-    TTI_SFPLOAD(p_sfpu::LREG5, InstrModLoadStore::FP16B, ADDR_MOD_7, 2);
-
-    // F1
-    TTI_SFPLOAD(p_sfpu::LREG6, InstrModLoadStore::FP16B, ADDR_MOD_7, 16);
-    TTI_SFPLOAD(p_sfpu::LREG7, InstrModLoadStore::FP16B, ADDR_MOD_7, 18);
-
-    // Do the first tile since it differs a bit from the rest
-    // F0 and F1
-    lltt::replay(0, replay_buffer_offset);
-    lltt::replay(0, replay_buffer_offset);
-    lltt::replay(0, replay_buffer_next_face);
-
-    // F2 and F3
-    lltt::replay(0, replay_buffer_offset);
-    lltt::replay(0, replay_buffer_offset);
-    lltt::replay(0, replay_buffer_offset);
-    lltt::replay(0, replay_buffer_next_face + 1);
-
-    // All other tiles but first one
-    for (uint32_t i = 0; i < block_height - 1; i++)
+    for (uint32_t i = 0; i < block_height; i++)
     {
-        // F0 and F1
-        lltt::replay(0, replay_buffer_offset);
-        lltt::replay(0, replay_buffer_offset);
-        lltt::replay(0, replay_buffer_offset);
-        lltt::replay(0, replay_buffer_next_face);
+        // Process 8 row groups (4 rows each) to reduce 32 rows to 1
+        // Each iteration processes 4 rows and compares them against the accumulators
+        constexpr uint32_t num_row_groups = 8;
 
-        // F2 and F3
-        lltt::replay(0, replay_buffer_offset);
-        lltt::replay(0, replay_buffer_offset);
-        lltt::replay(0, replay_buffer_offset);
-        lltt::replay(0, replay_buffer_next_face + 1);
+        // Arrays to define the offset patterns for each row group
+        constexpr uint32_t loadmacro5_offsets[num_row_groups] = {2, 6, 10, 14, 34, 38, 42, 46};
+        constexpr uint32_t load_offsets[num_row_groups]       = {16, 20, 24, 28, 48, 52, 56, 60};
+        constexpr uint32_t loadmacro0_offsets[num_row_groups] = {0, 4, 8, 12, 32, 36, 40, 44};
+
+        for (uint32_t row_group = 0; row_group < num_row_groups; row_group++)
+        {
+            // Load 4 values from current row group
+            TT_SFPLOADMACRO(5, InstrModLoadStore::FP16B, ADDR_MOD_3, i * 64 + loadmacro5_offsets[row_group]);
+            TT_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::FP16B, ADDR_MOD_3, i * 64 + load_offsets[row_group]);
+            TT_SFPLOAD(p_sfpu::LREG1, InstrModLoadStore::FP16B, ADDR_MOD_3, i * 64 + load_offsets[row_group] + 2);
+
+            // Compare and swap to keep maximum values in LREG6/LREG7
+            TTI_SFPSWAP(0 /*unused*/, p_sfpu::LREG7 /*lreg_src_c*/, p_sfpu::LREG1 /*lreg_dest*/, 1 /*instr_mod1*/);
+            TTI_SFPSWAP(0 /*unused*/, p_sfpu::LREG6 /*lreg_src_c*/, p_sfpu::LREG0 /*lreg_dest*/, 1 /*instr_mod1*/);
+
+            // Load next pair and compare with LREG4/LREG5
+            TT_SFPLOADMACRO(0, InstrModLoadStore::FP16B, ADDR_MOD_3, i * 64 + loadmacro0_offsets[row_group]);
+            TTI_SFPNOP;
+        }
     }
+}
 
-    // Reset dest RWC back to 0
-    TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_D);
-
+inline void epilogue_reduce_max_col_()
+{
     // Epilogue code.
     // Finalize sorting values in LREGS 0-3 and place maximum into Dest reg row 0
 
@@ -377,12 +334,12 @@ inline void _calculate_reduce_max_col_(const uint32_t block_height /*, const uin
     TTI_SFPTRANSP(0, 0, 0, 0); // all arguments are unused
 
     // F0
-    TTI_SFPSTORE(p_sfpu::LREG4, InstrModLoadStore::FP16B, ADDR_MOD_7, 0);
-    TTI_SFPSTORE(p_sfpu::LREG5, InstrModLoadStore::FP16B, ADDR_MOD_7, 2);
+    TTI_SFPSTORE(p_sfpu::LREG4, InstrModLoadStore::FP16B, ADDR_MOD_3, 0);
+    TTI_SFPSTORE(p_sfpu::LREG5, InstrModLoadStore::FP16B, ADDR_MOD_3, 2);
 
     // F1
-    TTI_SFPSTORE(p_sfpu::LREG6, InstrModLoadStore::FP16B, ADDR_MOD_7, 16);
-    TTI_SFPSTORE(p_sfpu::LREG7, InstrModLoadStore::FP16B, ADDR_MOD_7, 18);
+    TTI_SFPSTORE(p_sfpu::LREG6, InstrModLoadStore::FP16B, ADDR_MOD_3, 16);
+    TTI_SFPSTORE(p_sfpu::LREG7, InstrModLoadStore::FP16B, ADDR_MOD_3, 18);
 }
 
 /**
@@ -432,7 +389,7 @@ inline void _calculate_reduce_(uint32_t block_rt_dim = 0 /* used in reduce max c
  *                - Supported floating-point formats: Float32 (uses floating-point initialization)
  */
 template <PoolType pool_type, DataFormat format>
-inline void _init_reduce_(uint32_t block_ct_dim = 0 /* used in reduce max col*/)
+inline void _init_reduce_()
 {
     static_assert(is_supported_reduce_format(format), "Unsupported data format. Supported formats: Int32, UInt32, Float32, Float16_b");
 
@@ -453,7 +410,7 @@ inline void _init_reduce_(uint32_t block_ct_dim = 0 /* used in reduce max col*/)
 
     if constexpr (pool_type == PoolType::MAX)
     {
-        _init_reduce_max_col_<format>(block_ct_dim);
+        _init_reduce_max_col_<format>();
     }
     else
     {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_reduce.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_reduce.h
@@ -241,11 +241,8 @@ inline void sfpu_reduce_max_col_configure_addrmod()
         .set(ADDR_MOD_7);
 }
 
-template <DataFormat format>
-inline void _init_reduce_max_col_()
+inline void sfpu_reduce_max_load_initial_values()
 {
-    static_assert(format == DataFormat::Float16_b, "Unsupported data format. Supported formats: Float16_b");
-
     constexpr uint16_t neg_inf_fp16b = 0xFF80;
 
     // F0 - Initialize with negative infinity
@@ -255,6 +252,12 @@ inline void _init_reduce_max_col_()
     // F1 - Initialize with negative infinity
     TTI_SFPLOADI(p_sfpu::LREG6, InstrModLoadStore::FP16B, neg_inf_fp16b);
     TTI_SFPLOADI(p_sfpu::LREG7, InstrModLoadStore::FP16B, neg_inf_fp16b);
+}
+
+template <DataFormat format>
+inline void _init_reduce_max_col_()
+{
+    static_assert(format == DataFormat::Float16_b, "Unsupported data format. Supported formats: Float16_b");
 
     // ***********************************************************
     // SFPU LOADMACRO CONFIGURATION
@@ -275,50 +278,7 @@ inline void _init_reduce_max_col_()
 
     // ***********************************************************
 
-    _init_sfpu_config_reg();
-    sfpu_reduce_max_col_configure_addrmod();
-}
-
-template <PoolType pool_type, ReduceDim reduce_dim, DataFormat format>
-inline void _calculate_reduce_max_col_(const uint32_t block_height)
-{
-    TTI_STALLWAIT(p_stall::STALL_SFPU, p_stall::PACK);
-
-    static_assert(reduce_dim == REDUCE_COL, "Only column reduction (REDUCE_COL) is currently supported");
-    static_assert(pool_type == PoolType::MAX, "Only MAX pool type is currently supported");
-    static_assert(format == DataFormat::Float16_b, "SFPU reduce max col only supports Float16_b format");
-
-    for (uint32_t i = 0; i < block_height; i++)
-    {
-        // Process 8 row groups (4 rows each) to reduce 32 rows to 1
-        // Each iteration processes 4 rows and compares them against the accumulators
-        constexpr uint32_t num_row_groups = 8;
-
-        // Arrays to define the offset patterns for each row group
-        constexpr uint32_t loadmacro5_offsets[num_row_groups] = {2, 6, 10, 14, 34, 38, 42, 46};
-        constexpr uint32_t load_offsets[num_row_groups]       = {16, 20, 24, 28, 48, 52, 56, 60};
-        constexpr uint32_t loadmacro0_offsets[num_row_groups] = {0, 4, 8, 12, 32, 36, 40, 44};
-
-        for (uint32_t row_group = 0; row_group < num_row_groups; row_group++)
-        {
-            // Load 4 values from current row group
-            TT_SFPLOADMACRO(5, InstrModLoadStore::FP16B, ADDR_MOD_3, i * 64 + loadmacro5_offsets[row_group]);
-            TT_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::FP16B, ADDR_MOD_3, i * 64 + load_offsets[row_group]);
-            TT_SFPLOAD(p_sfpu::LREG1, InstrModLoadStore::FP16B, ADDR_MOD_3, i * 64 + load_offsets[row_group] + 2);
-
-            // Compare and swap to keep maximum values in LREG6/LREG7
-            TTI_SFPSWAP(0 /*unused*/, p_sfpu::LREG7 /*lreg_src_c*/, p_sfpu::LREG1 /*lreg_dest*/, 1 /*instr_mod1*/);
-            TTI_SFPSWAP(0 /*unused*/, p_sfpu::LREG6 /*lreg_src_c*/, p_sfpu::LREG0 /*lreg_dest*/, 1 /*instr_mod1*/);
-
-            // Load next pair and compare with LREG4/LREG5
-            TT_SFPLOADMACRO(0, InstrModLoadStore::FP16B, ADDR_MOD_3, i * 64 + loadmacro0_offsets[row_group]);
-            TTI_SFPNOP;
-        }
-    }
-}
-
-inline void epilogue_reduce_max_col_()
-{
+    lltt::record<lltt::NoExec>(0, 9);
     // Epilogue code.
     // Finalize sorting values in LREGS 0-3 and place maximum into Dest reg row 0
 
@@ -342,6 +302,53 @@ inline void epilogue_reduce_max_col_()
     // F1
     TTI_SFPSTORE(p_sfpu::LREG6, InstrModLoadStore::FP16B, ADDR_MOD_3, 16);
     TTI_SFPSTORE(p_sfpu::LREG7, InstrModLoadStore::FP16B, ADDR_MOD_3, 18);
+
+    _init_sfpu_config_reg();
+    sfpu_reduce_max_col_configure_addrmod();
+}
+
+template <PoolType pool_type, ReduceDim reduce_dim, DataFormat format>
+inline void _calculate_reduce_max_col_(const uint32_t block_height)
+{
+    TTI_STALLWAIT(p_stall::STALL_SFPU, p_stall::PACK);
+
+    static_assert(reduce_dim == REDUCE_COL, "Only column reduction (REDUCE_COL) is currently supported");
+    static_assert(pool_type == PoolType::MAX, "Only MAX pool type is currently supported");
+    static_assert(format == DataFormat::Float16_b, "SFPU reduce max col only supports Float16_b format");
+
+    // Process 8 row groups (4 rows each) to reduce 32 rows to 1
+    // Each iteration processes 4 rows and compares them against the accumulators
+    constexpr uint32_t num_row_groups = 8;
+
+    // Arrays to define the offset patterns for each row group
+    constexpr uint32_t loadmacro5_offsets[num_row_groups] = {2, 6, 10, 14, 34, 38, 42, 46};
+    constexpr uint32_t load_offsets[num_row_groups]       = {16, 20, 24, 28, 48, 52, 56, 60};
+    constexpr uint32_t loadmacro0_offsets[num_row_groups] = {0, 4, 8, 12, 32, 36, 40, 44};
+
+    for (uint32_t i = 0; i < block_height; i++)
+    {
+        for (uint32_t row_group = 0; row_group < num_row_groups; row_group++)
+        {
+            // Load 4 values from current row group
+            TT_SFPLOADMACRO(5, InstrModLoadStore::FP16B, ADDR_MOD_3, i * 64 + loadmacro5_offsets[row_group]);
+            TT_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::FP16B, ADDR_MOD_3, i * 64 + load_offsets[row_group]);
+            TT_SFPLOAD(p_sfpu::LREG1, InstrModLoadStore::FP16B, ADDR_MOD_3, i * 64 + load_offsets[row_group] + 2);
+
+            // Compare and swap to keep maximum values in LREG6/LREG7
+            TTI_SFPSWAP(0 /*unused*/, p_sfpu::LREG7 /*lreg_src_c*/, p_sfpu::LREG1 /*lreg_dest*/, 1 /*instr_mod1*/);
+            TTI_SFPSWAP(0 /*unused*/, p_sfpu::LREG6 /*lreg_src_c*/, p_sfpu::LREG0 /*lreg_dest*/, 1 /*instr_mod1*/);
+
+            // Load next pair and compare with LREG4/LREG5
+            TT_SFPLOADMACRO(0, InstrModLoadStore::FP16B, ADDR_MOD_3, i * 64 + loadmacro0_offsets[row_group]);
+            TTI_NOP;
+            TTI_NOP;
+        }
+    }
+}
+
+inline void epilogue_reduce_max_col_()
+{
+    lltt::replay(0, 9);
 }
 
 /**

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_reduce.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_reduce.h
@@ -274,8 +274,6 @@ inline void _init_reduce_max_col_()
     TTI_SFPLOADI(0, 0x8, 0x0000); // Upper 16 bits: slot2=0x00, slot3=0x00
     TTI_SFPCONFIG(0, 5, 0);       // Store in Macro Sequence Register 1 (dest=5)
 
-    TTI_SFPCONFIG(0x0100, 0xF /*SFPU control*/, 0x1); // invert swap direction
-
     // ***********************************************************
 
     lltt::record<lltt::NoExec>(0, 9);
@@ -340,14 +338,15 @@ inline void _calculate_reduce_max_col_(const uint32_t block_height)
 
             // Load next pair and compare with LREG4/LREG5
             TT_SFPLOADMACRO(0, InstrModLoadStore::FP16B, ADDR_MOD_3, i * 64 + loadmacro0_offsets[row_group]);
-            TTI_NOP;
-            TTI_NOP;
         }
     }
 }
 
 inline void epilogue_reduce_max_col_()
 {
+    // to wait after last loadmacro
+    TTI_NOP;
+    TTI_NOP;
     lltt::replay(0, 9);
 }
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/26699

### Problem description
SFPU reduce max needed to be updated in order to be able to use subblock_w=1 to accumulate over whole column of tensor and only after that store results in dest.

### What's changed
Changed implementation of sfpu reduce column max LLK, and changed test case to resemble real SDPA use case. In future both will be expanded to be flexible and usable on random dimensions.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

