### PR TITLE
[skip ci] ci: run perf_tests on demand via label

### DIFF
--- a/.github/workflows/run-perf-tests.yml
+++ b/.github/workflows/run-perf-tests.yml
@@ -3,6 +3,8 @@ name: 🚀 Run Performance Tests
 on:
   workflow_dispatch:
   workflow_call:
+  pull_request:
+    types: [labeled, synchronize]
 
 permissions:
   checks: write


### PR DESCRIPTION
### Ticket
None

### Problem description
One can't run perf tests by adding a label. I removed this functionality some time ago, but I think I made a mistake.

### What's changed
Return the option for running perf tests on demand by adding `performance-tests` label.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update