### PR TITLE
[Quasar LLK] Set Dest counter for both UNP_A and UNP_B

### DIFF
--- a/tt_llk_quasar/llk_lib/llk_unpack_binary_broadcast_operands.h
+++ b/tt_llk_quasar/llk_lib/llk_unpack_binary_broadcast_operands.h
@@ -95,7 +95,8 @@ inline void _llk_unpack_binary_broadcast_operands_(const uint start_l1_tile_idx_
     // Set Source counter to L1 base + offset
     TT_SET_SRC_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, p_unpacr::UNP_A, start_l1_tile_idx_0);
     TT_SET_SRC_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, p_unpacr::UNP_B, start_l1_tile_idx_1);
-    TTI_SET_DST_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, p_unpacr::UNP_A | p_unpacr::UNP_B, 0);
+    TTI_SET_DST_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, p_unpacr::UNP_A, 0);
+    TTI_SET_DST_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, p_unpacr::UNP_B, 0);
 
     // Runs MOP
     ckernel::ckernel_template::run_bank0_sw_cntl(instrn_buffer);

--- a/tt_llk_quasar/llk_lib/llk_unpack_binary_operands.h
+++ b/tt_llk_quasar/llk_lib/llk_unpack_binary_operands.h
@@ -64,7 +64,8 @@ inline void _llk_unpack_binary_operands_(const uint start_l1_tile_idx_0, const u
     // Set Source counter to L1 base + offset
     TT_SET_SRC_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, p_unpacr::UNP_A, start_l1_tile_idx_0);
     TT_SET_SRC_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, p_unpacr::UNP_B, start_l1_tile_idx_1);
-    TTI_SET_DST_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, p_unpacr::UNP_A | p_unpacr::UNP_B, 0);
+    TTI_SET_DST_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, p_unpacr::UNP_A, 0);
+    TTI_SET_DST_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, p_unpacr::UNP_B, 0);
 
     // Runs MOP
     ckernel::ckernel_template::run_bank0_sw_cntl(instrn_buffer);

--- a/tt_llk_quasar/llk_lib/llk_unpack_matmul.h
+++ b/tt_llk_quasar/llk_lib/llk_unpack_matmul.h
@@ -104,7 +104,8 @@ template <uint32_t BUF_DESC_ID_0, uint32_t BUF_DESC_ID_1, std::uint8_t CT_DIM, s
 inline void _llk_unpack_matmul_(const std::uint32_t start_l1_tile_idx_0, const std::uint32_t start_l1_tile_idx_1)
 {
     // Reset Dest counters for Unpacker to 0
-    TTI_SET_DST_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, p_unpacr::UNP_A | p_unpacr::UNP_B, 0);
+    TTI_SET_DST_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, p_unpacr::UNP_A, 0);
+    TTI_SET_DST_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, p_unpacr::UNP_B, 0);
 
     constexpr bool reuse_a        = CT_DIM >= RT_DIM;
     constexpr std::uint32_t t_dim = reuse_a ? RT_DIM : CT_DIM;

--- a/tt_llk_quasar/llk_lib/llk_unpack_reduce.h
+++ b/tt_llk_quasar/llk_lib/llk_unpack_reduce.h
@@ -82,7 +82,8 @@ inline void _llk_unpack_reduce_(const uint start_l1_tile_idx_0, const uint start
     // Set Source counter to L1 base + offset
     TT_SET_SRC_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, p_unpacr::UNP_A, start_l1_tile_idx_0);
     TT_SET_SRC_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, p_unpacr::UNP_B, start_l1_tile_idx_1);
-    TTI_SET_DST_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, p_unpacr::UNP_A | p_unpacr::UNP_B, 0);
+    TTI_SET_DST_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, p_unpacr::UNP_A, 0);
+    TTI_SET_DST_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, p_unpacr::UNP_B, 0);
 
     // Runs MOP
     ckernel::ckernel_template::run_bank0_sw_cntl(instrn_buffer);


### PR DESCRIPTION
### Ticket
<!-- Link to Github Issue -->

### Problem description
`p_unpacr::UNP_A | p_unpacr::UNP_B` sets the Dest counter only for p_unpacr::UNP_B. In assembly.yaml:
```
SET_DST_TILE_FACE_ROW_IDX:
        - name: EngineSel
          description: "Engine selection :
                        3'b000 - Unpacker0
                        3'b001 - Unpacker1      // p_unpacr::UNP_A | p_unpacr::UNP_B  = 1 so only Unp1 will be selected
                        3'b010 - Unpacker2
                        3'b011 - Packer0
                        3'b100 - Packer1
                        3'b101 - All Unpackers
                        3'b110 - All Packers
                        3'b111 - All Unpackers and Packers"
```


### What's changed
Two separate instructions are needed to set the Dest counter for both UNP_A and UNP_B.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
