### PR TITLE
[Test Infra] Disable format outliers check for Quasar

### DIFF
--- a/tests/python_tests/helpers/data_format_inference.py
+++ b/tests/python_tests/helpers/data_format_inference.py
@@ -58,7 +58,7 @@ def infer_unpack_out(
     based on the input format in L1 and whether unpacking targets the source or destination register.
 
     Note:
-        For Quasar, the unpacker can perform data conversions, but for now only conversions using the packer are tested.
+        For Quasar, the unpacker can perform data conversions, but for now only conversions performed by the packer are tested.
         For Quasar, the conditions determining which format Float32 truncates to are designed to minimize exponent mixing, but are not a hardware limitation.
 
     Args:
@@ -123,9 +123,9 @@ def infer_pack_in(
             # When dest register is in 16-bit mode, input_fmt=Fp16/16_b -> output_fmt=Fp32 is not valid
             # because pack_in=Fp16/16_b and pack_out=Fp32, which is not a supported packer conversion.
             raise ValueError(
-                "Quasar packer does not support Float16/16_b to Float32 conversion"
+                "Quasar packer does not support {input_format.name} to Float32 conversion when the dest register is in 16-bit mode"
             )
-        # When the dest register is in 32-bit mode, the packer input format is 32bit
+        # When the dest register is in 32-bit mode, the packer input format is 32-bit
         return (
             DataFormat.Float32
             if is_fp32_dest_acc_en == DestAccumulation.Yes

--- a/tests/python_tests/helpers/test_config.py
+++ b/tests/python_tests/helpers/test_config.py
@@ -347,7 +347,7 @@ def generate_build_header(test_config):
         raise ValueError("Format Config not passed in test config")
 
     # Check if this is an outlier format combination that requires dest_acc to be enabled
-    # This check is not relevant for Quasar as Quasar packer can handle 8bit exp to 5bit exp conversion
+    # This check is not relevant for Quasar as Quasar packer can handle 8-bit exp to 5-bit exp conversion
     if (
         is_format_combination_outlier(
             formats.input_format, formats.output_format, dest_acc


### PR DESCRIPTION
### Ticket
<!-- Link to Github Issue -->

### Problem description
Forcing 32bit mode dest in the case of a format outlier (8bit exp to 5bit exp) should not be done on Quasar, as Quasar packer can perform these conversions.

### What's changed
- Do format outliers check only for WH, BH.
- Added Qsr data inference comments and error raise for unsupported Fp16/16_b -> Fp32 packer conversion.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
