### PR TITLE
#32032: ttnn.hardsigmoid lower than expected pcc for some values

### DIFF
--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_activations.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_activations.h
@@ -97,7 +97,8 @@ inline void _calculate_activation_()
 template <bool APPROXIMATION_MODE>
 void _init_hardsigmoid_()
 {
-    sfpi::vConstFloatPrgm0 = 0.1668f;
+    // For hardsigmoid slope is 1/6, FP32 IEEE 754 representation.
+    sfpi::vConstFloatPrgm0 = 0.1666666716337204f;
     sfpi::vConstFloatPrgm1 = 0.5f;
 }
 

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_activations.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_activations.h
@@ -97,7 +97,8 @@ inline void _calculate_activation_()
 template <bool APPROXIMATION_MODE>
 void _init_hardsigmoid_()
 {
-    sfpi::vConstFloatPrgm0 = 0.1668f;
+    // For hardsigmoid slope is 1/6, FP32 IEEE 754 representation.
+    sfpi::vConstFloatPrgm0 = 0.1666666716337204f;
     sfpi::vConstFloatPrgm1 = 0.5f;
 }
 


### PR DESCRIPTION
### Ticket
Issue [Link](https://github.com/tenstorrent/tt-metal/issues/32032)

### Problem description
For some values near zero, ttnn.hardsigmoid  pcc is `0.9999` but we are observing pcc of `0.9988481097968398`.

### What's changed
While the numerical discrepancies were generally small (0.0039062 for certain inputs), approximately 30 values exceeded 1 ULP, with a maximum deviation of 26 ULP. The hardsigmoid implementation must be closer to [pytorch](https://docs.pytorch.org/docs/stable/generated/torch.nn.Hardsigmoid.html).

The default implementation use the slope value as `0.1668f`, but the exact IEEE-754 FP32 representation of 1/6. The precise value is `0.16666667163372039794921875f`.

With this change, the maximum error is reduced to **1 ULP across the full workable range** of the op. Although this change **does not make any difference in the pcc for the test data points** reported in the issue. 
Attaching screenshots. 

<img width="3600" height="1800" alt="default_hard_sigmoid_bf16_ulp_errors (1)" src="https://github.com/user-attachments/assets/d1f56fde-8fbb-45d1-9068-f3e018aec9f8" />

<img width="3600" height="1800" alt="latest_new_hard_sigmoid_bf16_ulp_errors" src="https://github.com/user-attachments/assets/827f9404-2112-4940-8c41-3d71ddf02152" />
<img width="490" height="321" alt="compf32 col" src="https://github.com/user-attachments/assets/32d06e96-0358-41b5-bf25-ddacccbeaf4d" />


### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/19736486609) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/19736496377) CI passes
- [x] TT-Metal PR [Link](https://github.com/tenstorrent/tt-metal/pull/33335)
