### PR TITLE
ci: use latest versions of tt-smi and tt-exalens

### DIFF
--- a/.github/scripts/versions.sh
+++ b/.github/scripts/versions.sh
@@ -7,12 +7,12 @@
 # This file should be sourced by installation scripts
 
 # tt-exalens configuration
-export EXALENS_VERSION="0.1.251118+dev.0bb2d30-cp310-cp310-linux_x86_64"
+export EXALENS_VERSION="0.1.251201+dev.a71ca0e-cp310-cp310-linux_x86_64"
 export EXALENS_TAG="${EXALENS_VERSION%%+*}"
 export EXALENS_WHEEL="ttexalens-${EXALENS_VERSION}.whl"
 export EXALENS_URL="https://github.com/tenstorrent/tt-exalens/releases/download/${EXALENS_TAG}/${EXALENS_WHEEL}"
 
 # tt-smi configuration
-export TT_SMI_VERSION="3.0.34"
+export TT_SMI_VERSION="3.0.38"
 export TT_SMI_WHEEL="tt_smi-${TT_SMI_VERSION}-py3-none-any.whl"
 export TT_SMI_URL="https://github.com/tenstorrent/tt-smi/releases/download/v${TT_SMI_VERSION}/${TT_SMI_WHEEL}"

--- a/tests/python_tests/conftest.py
+++ b/tests/python_tests/conftest.py
@@ -187,8 +187,7 @@ def _send_arc_message(message_type: str, device_id: int):
         device_id=device_id,
         msg_code=ARC_COMMON_PREFIX | message_codes[message_type],
         wait_for_done=True,
-        arg0=0,
-        arg1=0,
+        args=[0, 0],
         timeout=datetime.timedelta(seconds=10),
     )
 


### PR DESCRIPTION
### Ticket
None

### Problem description
New versions of tools have been released, containing some important fixes and a breaking change.

### What's changed
Intaking the latest versions of tools:
- tt-smi 3.0.38 (from 3.0.34)
- tt-exalens 0.1.251201 (from 0.1.251118)

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update