### PR TITLE
Add runtime assert for mm throttling

### DIFF
--- a/tt_llk_blackhole/common/inc/ckernel.h
+++ b/tt_llk_blackhole/common/inc/ckernel.h
@@ -6,6 +6,7 @@
 
 #include "ckernel_instr_params.h"
 #include "ckernel_ops.h"
+#include "llk_assert.h"
 #include "llk_defs.h"
 #include "risc_attribs.h"
 

--- a/tt_llk_blackhole/llk_lib/llk_math_matmul.h
+++ b/tt_llk_blackhole/llk_lib/llk_math_matmul.h
@@ -538,6 +538,9 @@ inline void matmul_configure_mop_throttled(
 
     constexpr bool high_fidelity = NUM_FIDELITY_PHASES > 0;
     static_assert((THROTTLE_LEVEL > 0) && (THROTTLE_LEVEL <= 5), "MM throttling only enabled for THROTTLE_LEVEL={1,2,3,4,5}");
+    LLK_ASSERT(
+        (in0_tile_r_dim == TILE_R_DIM) && (in0_tile_c_dim == TILE_C_DIM) && (in1_tile_r_dim == TILE_R_DIM) && (in1_tile_c_dim == TILE_C_DIM) && !partial_face,
+        "MM throttling only enabled for full 32x32 tile size");
 
     const bool reuse_a = ct_dim >= rt_dim;
 

--- a/tt_llk_wormhole_b0/common/inc/ckernel.h
+++ b/tt_llk_wormhole_b0/common/inc/ckernel.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "ckernel_instr_params.h"
+#include "llk_assert.h"
 #include "llk_defs.h"
 #include "risc_attribs.h"
 

--- a/tt_llk_wormhole_b0/llk_lib/llk_math_matmul.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_math_matmul.h
@@ -619,6 +619,9 @@ inline void matmul_configure_mop_throttled(
 
     constexpr bool high_fidelity = NUM_FIDELITY_PHASES > 0;
     static_assert((THROTTLE_LEVEL > 0) && (THROTTLE_LEVEL <= 5), "MM throttling only enabled for THROTTLE_LEVEL={1,2,3,4,5}");
+    LLK_ASSERT(
+        (in0_tile_r_dim == TILE_R_DIM) && (in0_tile_c_dim == TILE_C_DIM) && (in1_tile_r_dim == TILE_R_DIM) && (in1_tile_c_dim == TILE_C_DIM) && !partial_face,
+        "MM throttling only enabled for full 32x32 tile size");
 
     const bool reuse_a        = ct_dim >= rt_dim;
     const std::uint32_t t_dim = reuse_a ? rt_dim : ct_dim;


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/21295)

### Problem description
Using the new asserts to prevent misuse of MM throttling, since it only works for 32x32 tiles.

### What's changed
Add the new LLK_ASSERT for BH and WH

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

### Checklist
- [ ] https://github.com/tenstorrent/tt-metal/actions/runs/19903723630
- [ ] https://github.com/tenstorrent/tt-metal/actions/runs/19903729963
- [ ] https://github.com/tenstorrent/tt-metal/actions/runs/19903737897
- [ ] https://github.com/tenstorrent/tt-metal/actions/runs/19903741240
- [ ] https://github.com/tenstorrent/tt-metal/actions/runs/19898129475
