### PR TITLE
fix: correct operator precedence in asserts

### DIFF
--- a/tt_llk_blackhole/llk_lib/llk_assert.h
+++ b/tt_llk_blackhole/llk_lib/llk_assert.h
@@ -31,6 +31,6 @@
 
 #else
 
-#define LLK_ASSERT(condition, message) ((void)condition)
+#define LLK_ASSERT(condition, message) ((void)(condition), (void)(message))
 
 #endif // ENABLE_LLK_ASSERT

--- a/tt_llk_wormhole_b0/llk_lib/llk_assert.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_assert.h
@@ -31,6 +31,6 @@
 
 #else
 
-#define LLK_ASSERT(condition, message) ((void)condition)
+#define LLK_ASSERT(condition, message) ((void)(condition), (void)(message))
 
 #endif // ENABLE_LLK_ASSERT


### PR DESCRIPTION
### Ticket
None

### Problem description
The disabled `LLK_ASSERT` macro had an operator precedence issue:

```cpp
#define LLK_ASSERT(condition, message) ((void)condition)
```
When called with a compound expression:
```cpp
LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be 1, 2, or 4");
```
is expanded to:
```cpp
((void)num_faces == 1 || num_faces == 2 || num_faces == 4)
```
Since the `(void)` cast has higher precedence than `==`, it binds only to `num_faces`, resulting in:
```cpp
(((void)num_faces) == 1 || ...)
```
This causes a compilation error: `invalid operands of types 'void' and 'int' to binary 'operator=='`.

### What's changed
Wrapped macro parameters in parentheses to ensure correct evaluation order:
```cpp
#define LLK_ASSERT(condition, message) ((void)(condition), (void)(message))
```
Now the entire condition expression is evaluated first, then cast to `void`.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
