### PR TITLE
Remove unneeded write to DISABLE_IMPLIED_SRCA_FMT

### DIFF
--- a/tt_llk_blackhole/llk_lib/llk_math_welfords_sfpu.h
+++ b/tt_llk_blackhole/llk_lib/llk_math_welfords_sfpu.h
@@ -41,9 +41,6 @@ inline void _llk_math_welfords_sfpu_done_()
     math::clear_dst_reg_addr();
 
     TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::WAIT_SFPU);
-    TTI_SETC16(DISABLE_IMPLIED_SRCA_FMT_Base_ADDR32, 0); // Equivalent to clear_addr_mod_base(): sets address modifier base for group 2 (addr mods 0..3) to 0.
-                                                         // Parameter '2' selects the address modifier group, and '0' resets the base. This direct hardware
-                                                         // instruction is used instead of the higher-level function for efficiency and explicit control.
 }
 
 inline void _llk_math_welfords_sfpu_inc_dst_face_addr_()


### PR DESCRIPTION
### Ticket
/

### Problem description
This register write does nothing (it writes zero to a register that is already always zero). The comment is also inaccurate, as it describes unrelated WH functionality that happens to live at the same register offset as this register on BH. The WH register in question no longer exists in BH.

### What's changed
Remove the register write and associated comment

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
