### PR TITLE
Const qualify global pointers

### DIFF
--- a/tests/helpers/include/ckernel_helper.h
+++ b/tests/helpers/include/ckernel_helper.h
@@ -11,9 +11,9 @@
 
 namespace ckernel
 {
-volatile std::uint32_t tt_reg_ptr *pc_buf_base     = reinterpret_cast<volatile std::uint32_t *>(PC_BUF_BASE);
-volatile std::uint32_t tt_reg_ptr *regfile         = reinterpret_cast<volatile std::uint32_t *>(REGFILE_BASE);
-volatile std::uint32_t tt_reg_ptr *mailbox_base[4] = {
+volatile std::uint32_t tt_reg_ptr *const pc_buf_base     = reinterpret_cast<volatile std::uint32_t *>(PC_BUF_BASE);
+volatile std::uint32_t tt_reg_ptr *const regfile         = reinterpret_cast<volatile std::uint32_t *>(REGFILE_BASE);
+volatile std::uint32_t tt_reg_ptr *const mailbox_base[4] = {
     reinterpret_cast<volatile std::uint32_t tt_reg_ptr *>(TENSIX_MAILBOX0_BASE),
     reinterpret_cast<volatile std::uint32_t tt_reg_ptr *>(TENSIX_MAILBOX1_BASE),
     reinterpret_cast<volatile std::uint32_t tt_reg_ptr *>(TENSIX_MAILBOX2_BASE),

--- a/tt_llk_blackhole/common/inc/ckernel.h
+++ b/tt_llk_blackhole/common/inc/ckernel.h
@@ -61,9 +61,10 @@ constexpr uint RESET_VAL          = 0;
 constexpr uint KERNEL_IN_PROGRESS = 15;
 constexpr uint KERNEL_COMPLETE    = 1;
 
-extern volatile uint tt_reg_ptr *reg_base;
-extern volatile uint tt_reg_ptr *pc_buf_base;
-extern volatile uint tt_reg_ptr *regfile;
+#define __PTR_CONST 1 // Transition shim
+extern volatile uint tt_reg_ptr *const reg_base;
+extern volatile uint tt_reg_ptr *const pc_buf_base;
+extern volatile uint tt_reg_ptr *const regfile;
 } // namespace ckernel
 
 extern volatile uint32_t __instrn_buffer[];
@@ -71,7 +72,7 @@ extern volatile uint32_t __instrn_buffer[];
 namespace ckernel
 {
 constexpr inline volatile uint32_t(tt_reg_ptr &instrn_buffer)[] = __instrn_buffer;
-extern volatile uint tt_reg_ptr *mailbox_base[4];
+extern volatile uint tt_reg_ptr *const mailbox_base[4];
 
 extern uint32_t cfg_state_id;
 extern uint32_t dest_offset_id;

--- a/tt_llk_wormhole_b0/common/inc/ckernel.h
+++ b/tt_llk_wormhole_b0/common/inc/ckernel.h
@@ -52,9 +52,10 @@ constexpr uint RESET_VAL          = 0;
 constexpr uint KERNEL_IN_PROGRESS = 15;
 constexpr uint KERNEL_COMPLETE    = 1;
 
-extern volatile uint tt_reg_ptr *reg_base;
-extern volatile uint tt_reg_ptr *pc_buf_base;
-extern volatile uint tt_reg_ptr *regfile;
+#define __PTR_CONST 1 // Transition shim
+extern volatile uint tt_reg_ptr *const reg_base;
+extern volatile uint tt_reg_ptr *const pc_buf_base;
+extern volatile uint tt_reg_ptr *const regfile;
 } // namespace ckernel
 
 extern volatile uint32_t __instrn_buffer[];
@@ -62,7 +63,7 @@ extern volatile uint32_t __instrn_buffer[];
 namespace ckernel
 {
 constexpr inline volatile uint32_t(tt_reg_ptr &instrn_buffer)[] = __instrn_buffer;
-extern volatile uint tt_reg_ptr *mailbox_base[4];
+extern volatile uint tt_reg_ptr *const mailbox_base[4];
 
 extern uint32_t cfg_state_id;
 extern uint32_t dest_offset_id;


### PR DESCRIPTION
### Ticket
NA

### Problem description
Some global pointers are const and should be declared so.

### What's changed
In addition to declaring them const, we need to inform tt-metal, where their definitions reside, so that we do not have to atomically update both repos.  So temporarily define a macro indicating the constness.

tt-metal PR: https://github.com/tenstorrent/tt-metal/pull/34015

The tt-metal PR must be applied before tt-metal's llk submodule is updated to one containing this patch.


### Type of change

- [ YES] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
