### PR TITLE
MPWI Support for Kernels <=32 Sticks

### DIFF
--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_max_pool_indices.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_max_pool_indices.h
@@ -197,10 +197,6 @@ inline void _calculate_max_pool_with_indices_generic_(const uint values_tile_idx
     // Face 0 Row 31
     // Face 1 Row 31
 
-    // LREG0         LREG2
-    //  F0 0,1,2,3   4,5,6,7
-    //  F1 0,1,2,3   4,5,6,7
-
     auto process_16_rows = [values_tile_offset, indices_tile_offset, eight_row_offset, instr_mod_index](const uint base_offset, const uint col_offset)
                                __attribute__((always_inline))
     {
@@ -216,7 +212,10 @@ inline void _calculate_max_pool_with_indices_generic_(const uint values_tile_idx
             TT_SFPLOAD(
                 p_sfpu::LREG2, InstrModLoadStore::DEFAULT, ADDR_MOD_7, values_tile_offset + eight_row_offset_val + base_offset + 8 + col_offset); // Row 4 and 5
             TT_SFPLOAD(
-                p_sfpu::LREG3, InstrModLoadStore::DEFAULT, ADDR_MOD_7, values_tile_offset + eight_row_offset_val + base_offset + 12 + col_offset); // Row 6 and 7
+                p_sfpu::LREG3,
+                InstrModLoadStore::DEFAULT,
+                ADDR_MOD_7,
+                values_tile_offset + eight_row_offset_val + base_offset + 12 + col_offset); // Row 6 and 7
             // index
             TT_SFPLOAD(p_sfpu::LREG4, instr_mod_index, ADDR_MOD_7, indices_tile_offset + eight_row_offset_val + base_offset + 0 + col_offset);
             TT_SFPLOAD(p_sfpu::LREG5, instr_mod_index, ADDR_MOD_7, indices_tile_offset + eight_row_offset_val + base_offset + 4 + col_offset);
@@ -265,7 +264,8 @@ inline void _calculate_max_pool_with_indices_generic_(const uint values_tile_idx
         // swap between the two sets of 8 rows
         TT_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, values_tile_offset + base_offset + 0 + col_offset); // Max(R0-7) for F0,1
         TT_SFPLOAD(p_sfpu::LREG4, instr_mod_index, ADDR_MOD_7, indices_tile_offset + base_offset + 0 + col_offset);
-        TT_SFPLOAD(p_sfpu::LREG1, InstrModLoadStore::DEFAULT, ADDR_MOD_7, values_tile_offset + eight_row_offset + base_offset + 0 + col_offset); // Max(R8-15) for F0,1
+        TT_SFPLOAD(
+            p_sfpu::LREG1, InstrModLoadStore::DEFAULT, ADDR_MOD_7, values_tile_offset + eight_row_offset + base_offset + 0 + col_offset); // Max(R8-15) for F0,1
         TT_SFPLOAD(p_sfpu::LREG5, instr_mod_index, ADDR_MOD_7, indices_tile_offset + eight_row_offset + base_offset + 0 + col_offset);
 
         TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG1, p_sfpswap::ALL_ROWS_MAX); // LREG0 contains Max(R0-15) (or Max(R16-31)) for F0,1

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_max_pool_indices.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_max_pool_indices.h
@@ -197,10 +197,6 @@ inline void _calculate_max_pool_with_indices_generic_(const uint values_tile_idx
     // Face 0 Row 31
     // Face 1 Row 31
 
-    // LREG0         LREG2
-    //  F0 0,1,2,3   4,5,6,7
-    //  F1 0,1,2,3   4,5,6,7
-
     auto process_16_rows = [values_tile_offset, indices_tile_offset, eight_row_offset, instr_mod_index](const uint base_offset, const uint col_offset)
                                __attribute__((always_inline))
     {
@@ -216,7 +212,10 @@ inline void _calculate_max_pool_with_indices_generic_(const uint values_tile_idx
             TT_SFPLOAD(
                 p_sfpu::LREG2, InstrModLoadStore::DEFAULT, ADDR_MOD_3, values_tile_offset + eight_row_offset_val + base_offset + 8 + col_offset); // Row 4 and 5
             TT_SFPLOAD(
-                p_sfpu::LREG3, InstrModLoadStore::DEFAULT, ADDR_MOD_3, values_tile_offset + eight_row_offset_val + base_offset + 12 + col_offset); // Row 6 and 7
+                p_sfpu::LREG3,
+                InstrModLoadStore::DEFAULT,
+                ADDR_MOD_3,
+                values_tile_offset + eight_row_offset_val + base_offset + 12 + col_offset); // Row 6 and 7
             // index
             TT_SFPLOAD(p_sfpu::LREG4, instr_mod_index, ADDR_MOD_3, indices_tile_offset + eight_row_offset_val + base_offset + 0 + col_offset);
             TT_SFPLOAD(p_sfpu::LREG5, instr_mod_index, ADDR_MOD_3, indices_tile_offset + eight_row_offset_val + base_offset + 4 + col_offset);
@@ -265,7 +264,8 @@ inline void _calculate_max_pool_with_indices_generic_(const uint values_tile_idx
         // swap between the two sets of 8 rows
         TT_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_3, values_tile_offset + base_offset + 0 + col_offset); // Max(R0-7) for F0,1
         TT_SFPLOAD(p_sfpu::LREG4, instr_mod_index, ADDR_MOD_3, indices_tile_offset + base_offset + 0 + col_offset);
-        TT_SFPLOAD(p_sfpu::LREG1, InstrModLoadStore::DEFAULT, ADDR_MOD_3, values_tile_offset + eight_row_offset + base_offset + 0 + col_offset); // Max(R8-15) for F0,1
+        TT_SFPLOAD(
+            p_sfpu::LREG1, InstrModLoadStore::DEFAULT, ADDR_MOD_3, values_tile_offset + eight_row_offset + base_offset + 0 + col_offset); // Max(R8-15) for F0,1
         TT_SFPLOAD(p_sfpu::LREG5, instr_mod_index, ADDR_MOD_3, indices_tile_offset + eight_row_offset + base_offset + 0 + col_offset);
 
         TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG1, p_sfpswap::ALL_ROWS_MAX); // LREG0 contains Max(R0-15) (or Max(R16-31)) for F0,1


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/27845

### Problem description
Currently MPWI only has LLK support for kernel sizes <=9 sticks.

### What's changed
A new LLK function has been added to support kernel sizes <= 32 which will allow TT-Metal to support arbitrary kernel sizes.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Current Perf Comparison
#### Test Trace Info:
NCHW = [1, 64, 159, 159]
Kernel = [3, 3]
Stride = Pad = Dilation = [1, 1]
Ceil Mode = False
Data Type = BF16
Sharding = Height

#### Results:
| System | Max Pool (us) | MPWI <=9 (us) | MPWI <=32 (us) |
| :------- | :------: | -------: | -------: |
| WH | 63.2 | 493.0 | 1311.3 |
| BH | 50.4 | 181.9 | 418.9 |
| -- | | | | |
| **WH Max Pool Relative:** | **1x** | **7.8x** | **20.7x** | 
| **BH Max Pool Relative:** | **1x** | **3.6x** | **8.3x** | 

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
