### PR TITLE
instrn-buffer TOS

### DIFF
--- a/tests/helpers/include/ckernel_helper.h
+++ b/tests/helpers/include/ckernel_helper.h
@@ -13,6 +13,7 @@ namespace ckernel
 {
 volatile std::uint32_t tt_reg_ptr *pc_buf_base     = reinterpret_cast<volatile std::uint32_t *>(PC_BUF_BASE);
 volatile std::uint32_t tt_reg_ptr *regfile         = reinterpret_cast<volatile std::uint32_t *>(REGFILE_BASE);
+volatile tt_reg_ptr uint32_t *const instrn_buffer  = reinterpret_cast<volatile uint32_t *>(INSTRN_BUF_BASE);
 volatile std::uint32_t tt_reg_ptr *mailbox_base[4] = {
     reinterpret_cast<volatile std::uint32_t tt_reg_ptr *>(TENSIX_MAILBOX0_BASE),
     reinterpret_cast<volatile std::uint32_t tt_reg_ptr *>(TENSIX_MAILBOX1_BASE),

--- a/tt_llk_blackhole/common/inc/ckernel.h
+++ b/tt_llk_blackhole/common/inc/ckernel.h
@@ -64,13 +64,8 @@ constexpr uint KERNEL_COMPLETE    = 1;
 extern volatile uint tt_reg_ptr *reg_base;
 extern volatile uint tt_reg_ptr *pc_buf_base;
 extern volatile uint tt_reg_ptr *regfile;
-} // namespace ckernel
-
-extern volatile uint32_t __instrn_buffer[];
-
-namespace ckernel
-{
-constexpr inline volatile uint32_t(tt_reg_ptr &instrn_buffer)[] = __instrn_buffer;
+#define __INSTRN_BUFFER_TOS 1
+extern volatile uint32_t tt_reg_ptr *const instrn_buffer;
 extern volatile uint tt_reg_ptr *mailbox_base[4];
 
 extern uint32_t cfg_state_id;

--- a/tt_llk_wormhole_b0/common/inc/ckernel.h
+++ b/tt_llk_wormhole_b0/common/inc/ckernel.h
@@ -55,13 +55,8 @@ constexpr uint KERNEL_COMPLETE    = 1;
 extern volatile uint tt_reg_ptr *reg_base;
 extern volatile uint tt_reg_ptr *pc_buf_base;
 extern volatile uint tt_reg_ptr *regfile;
-} // namespace ckernel
-
-extern volatile uint32_t __instrn_buffer[];
-
-namespace ckernel
-{
-constexpr inline volatile uint32_t(tt_reg_ptr &instrn_buffer)[] = __instrn_buffer;
+#define __INSTRN_BUFFER_TOS 1
+extern volatile uint32_t tt_reg_ptr *const instrn_buffer;
 extern volatile uint tt_reg_ptr *mailbox_base[4];
 
 extern uint32_t cfg_state_id;


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/33994

### Problem description

Some time ago I changed the way instrn_buffer was defined -- from a pointer initialized by a number, to an array at a linker-provided address. But that turns out to be awkward and prevents the compiler happening to notice that the address being referred to has zeros for its low 12 bits -- which means only one insn is needed to generate it.


### What's changed
See https://github.com/tenstorrent/tt-metal/pull/34078

This should not be committed until the tt-metal patch lands.

We can remove the shim once both have landed and tt-metal updates its tt-llk module.

### Type of change

- [Yes] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
