### PR TITLE
revert: "Const qualify global pointers (#923)"

### DIFF
--- a/tests/helpers/include/ckernel_helper.h
+++ b/tests/helpers/include/ckernel_helper.h
@@ -11,9 +11,9 @@
 
 namespace ckernel
 {
-volatile std::uint32_t tt_reg_ptr *const pc_buf_base     = reinterpret_cast<volatile std::uint32_t *>(PC_BUF_BASE);
-volatile std::uint32_t tt_reg_ptr *const regfile         = reinterpret_cast<volatile std::uint32_t *>(REGFILE_BASE);
-volatile std::uint32_t tt_reg_ptr *const mailbox_base[4] = {
+volatile std::uint32_t tt_reg_ptr *pc_buf_base     = reinterpret_cast<volatile std::uint32_t *>(PC_BUF_BASE);
+volatile std::uint32_t tt_reg_ptr *regfile         = reinterpret_cast<volatile std::uint32_t *>(REGFILE_BASE);
+volatile std::uint32_t tt_reg_ptr *mailbox_base[4] = {
     reinterpret_cast<volatile std::uint32_t tt_reg_ptr *>(TENSIX_MAILBOX0_BASE),
     reinterpret_cast<volatile std::uint32_t tt_reg_ptr *>(TENSIX_MAILBOX1_BASE),
     reinterpret_cast<volatile std::uint32_t tt_reg_ptr *>(TENSIX_MAILBOX2_BASE),

--- a/tt_llk_blackhole/common/inc/ckernel.h
+++ b/tt_llk_blackhole/common/inc/ckernel.h
@@ -61,10 +61,9 @@ constexpr uint RESET_VAL          = 0;
 constexpr uint KERNEL_IN_PROGRESS = 15;
 constexpr uint KERNEL_COMPLETE    = 1;
 
-#define __PTR_CONST 1 // Transition shim
-extern volatile uint tt_reg_ptr *const reg_base;
-extern volatile uint tt_reg_ptr *const pc_buf_base;
-extern volatile uint tt_reg_ptr *const regfile;
+extern volatile uint tt_reg_ptr *reg_base;
+extern volatile uint tt_reg_ptr *pc_buf_base;
+extern volatile uint tt_reg_ptr *regfile;
 } // namespace ckernel
 
 extern volatile uint32_t __instrn_buffer[];
@@ -72,7 +71,7 @@ extern volatile uint32_t __instrn_buffer[];
 namespace ckernel
 {
 constexpr inline volatile uint32_t(tt_reg_ptr &instrn_buffer)[] = __instrn_buffer;
-extern volatile uint tt_reg_ptr *const mailbox_base[4];
+extern volatile uint tt_reg_ptr *mailbox_base[4];
 
 extern uint32_t cfg_state_id;
 extern uint32_t dest_offset_id;

--- a/tt_llk_wormhole_b0/common/inc/ckernel.h
+++ b/tt_llk_wormhole_b0/common/inc/ckernel.h
@@ -52,10 +52,9 @@ constexpr uint RESET_VAL          = 0;
 constexpr uint KERNEL_IN_PROGRESS = 15;
 constexpr uint KERNEL_COMPLETE    = 1;
 
-#define __PTR_CONST 1 // Transition shim
-extern volatile uint tt_reg_ptr *const reg_base;
-extern volatile uint tt_reg_ptr *const pc_buf_base;
-extern volatile uint tt_reg_ptr *const regfile;
+extern volatile uint tt_reg_ptr *reg_base;
+extern volatile uint tt_reg_ptr *pc_buf_base;
+extern volatile uint tt_reg_ptr *regfile;
 } // namespace ckernel
 
 extern volatile uint32_t __instrn_buffer[];
@@ -63,7 +62,7 @@ extern volatile uint32_t __instrn_buffer[];
 namespace ckernel
 {
 constexpr inline volatile uint32_t(tt_reg_ptr &instrn_buffer)[] = __instrn_buffer;
-extern volatile uint tt_reg_ptr *const mailbox_base[4];
+extern volatile uint tt_reg_ptr *mailbox_base[4];
 
 extern uint32_t cfg_state_id;
 extern uint32_t dest_offset_id;


### PR DESCRIPTION
### Ticket
None

### Problem description
There were some perf regressions observed [here](https://github.com/tenstorrent/tt-metal/actions/runs/20090379670/job/57636893298#step:17:181).

### What's changed
This reverts commit a01054dbf24db4476c908709e06dc01141267a81.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update