### PR TITLE
ci: don't run expensive tests upon merging into main

### DIFF
--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -141,9 +141,10 @@ jobs:
     name: "🌀 Perform checks (Wormhole)"
     uses: ./.github/workflows/setup-and-test.yml
     needs: [build-images, detect-changes]
-    if: ${{ needs.detect-changes.outputs.wormhole == 'true' ||
-            needs.detect-changes.outputs.tests == 'true' ||
-            needs.detect-changes.outputs.github == 'true' }}
+    if: ${{ github.event_name != 'push' &&
+            (needs.detect-changes.outputs.wormhole == 'true' ||
+             needs.detect-changes.outputs.tests == 'true' ||
+             needs.detect-changes.outputs.github == 'true') }}
     with:
       docker_image: ${{ needs.build-images.outputs.docker-image }}
       runs_on: tt-ubuntu-2204-n150-stable
@@ -154,9 +155,10 @@ jobs:
     name: "🕳️ Perform checks (Blackhole)"
     uses: ./.github/workflows/setup-and-test.yml
     needs: [build-images, detect-changes]
-    if: ${{ needs.detect-changes.outputs.blackhole == 'true' ||
-            needs.detect-changes.outputs.tests == 'true' ||
-            needs.detect-changes.outputs.github == 'true' }}
+    if: ${{ github.event_name != 'push' &&
+            (needs.detect-changes.outputs.blackhole == 'true' ||
+             needs.detect-changes.outputs.tests == 'true' ||
+             needs.detect-changes.outputs.github == 'true') }}
     with:
       docker_image: ${{ needs.build-images.outputs.docker-image }}
       runs_on: tt-ubuntu-2204-p150b-stable
@@ -167,7 +169,8 @@ jobs:
     name: "⚡ Performance tests (${{ matrix.target }})"
     uses: ./.github/workflows/setup-and-test.yml
     needs: [build-images, detect-changes]
-    if: ${{ needs.detect-changes.outputs.performance == 'true' }}
+    if: ${{ github.event_name != 'push' &&
+            needs.detect-changes.outputs.performance == 'true' }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
### Ticket
None

### Problem description
We've been running tests:
1. on every push
2. in the merge queue
3. after merging to main

3rd one is not productive and not necessary

### What's changed
Condition was changed to avoid running tests after merging into main. This should save a lot of time of our runners.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update