### PR TITLE
Add stochastic rounding SFPI kernels for wormhole and blackhole

### DIFF
--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_rounding_ops.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_rounding_ops.h
@@ -177,7 +177,7 @@ inline void _calculate_stochastic_round_()
         TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);
         // SFP_STOCH_RND(rnd_mode, imm8_math, lreg_src_b, lreg_src_c, lreg_dest, instr_mod1)
         // rnd_mode=1 (stochastic), lreg_src_c=LREG0, lreg_dest=LREG0, instr_mod1=1 (fp32->fp16b)
-        TTI_SFP_STOCH_RND(1, 0, 0, p_sfpu::LREG0, p_sfpu::LREG0, 1);
+        TTI_SFP_STOCH_RND(1, 0, p_sfpu::LREG0, p_sfpu::LREG0, p_sfpu::LREG0, 1);
         TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);
         sfpi::dst_reg++;
     }

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_rounding_ops.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_rounding_ops.h
@@ -186,7 +186,7 @@ inline void _calculate_stochastic_round_()
         TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_3, 0);
         // SFP_STOCH_RND(rnd_mode, imm8_math, lreg_src_b, lreg_src_c, lreg_dest, instr_mod1)
         // rnd_mode=1 (stochastic), lreg_src_c=LREG0, lreg_dest=LREG0, instr_mod1=1 (fp32->fp16b)
-        TTI_SFP_STOCH_RND(1, 0, 0, p_sfpu::LREG0, p_sfpu::LREG0, 1);
+        TTI_SFP_STOCH_RND(1, 0, p_sfpu::LREG0, p_sfpu::LREG0, p_sfpu::LREG0, 1);
         TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_3, 0);
         sfpi::dst_reg++;
     }


### PR DESCRIPTION
### Ticket
None

### Summary:
This PR introduces SFPI kernels for stochastic rounding.
Full scope of changes: [link](https://github.com/tenstorrent/tt-metal/pull/34498)
**This PR should be merged first!**

### Changes:
+ Added SFPI kernels in
`tt_metal/third_party/tt_llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_rounding_ops.h`
`tt_metal/third_party/tt_llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_rounding_ops.h`

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/20355468741) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
