### PR TITLE
Fix incorrect SFP_STOCH_RND usage

### DIFF
--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_mul_int.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_mul_int.h
@@ -60,12 +60,12 @@ inline void _mul_int_(const uint dst_index_in0, const uint dst_index_in1, const 
         TTI_SFPMAD(p_sfpu::LREG2, p_sfpu::LREG1, p_sfpu::LCONST_0, p_sfpu::LREG2, 0);
 
         // lo = rnd(lo)
-        TTI_SFP_STOCH_RND(2, 0, 0, p_sfpu::LREG0, p_sfpu::LREG0, 6);
+        TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG0, p_sfpu::LREG0, 6);
 
         // hi1 = rnd(hi1)
-        TTI_SFP_STOCH_RND(2, 0, 0, p_sfpu::LREG2, p_sfpu::LREG2, 6);
+        TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG2, p_sfpu::LREG2, 6);
         // hi0 = rnd(hi0)
-        TTI_SFP_STOCH_RND(2, 0, 0, p_sfpu::LREG3, p_sfpu::LREG3, 6);
+        TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG3, p_sfpu::LREG3, 6);
 
         // hi = hi0 + hi1
         TTI_SFPIADD(0, p_sfpu::LREG3, p_sfpu::LREG2, sfpi::SFPIADD_MOD1_CC_NONE);


### PR DESCRIPTION
### Ticket
none

### Problem description
The value 2 was being given to StochastingRounding, a 1 bit field.

### What's changed
Change the 2 to 0.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
