### PR TITLE
ci: don’t randomize test order in nightly runs

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -32,7 +32,7 @@ jobs:
       runs_on: tt-ubuntu-2204-n150-stable
       test_splits: 10
       pytest_markers: ${{ inputs.pytest_markers || 'not perf and not quasar' }}
-      random_order: true
+      random_order: false
       timeout_minutes: 360
 
   nightly-test-blackhole:
@@ -44,7 +44,7 @@ jobs:
       runs_on: tt-ubuntu-2204-p150b-stable
       test_splits: 10
       pytest_markers: ${{ inputs.pytest_markers || 'not perf and not quasar' }}
-      random_order: true
+      random_order: false
       timeout_minutes: 360
 
   nightly-summary:


### PR DESCRIPTION

### Ticket
None

### Problem description
Tests are failing when executed in random order. Until we find the reason why, we need to turn of order randomization.

### What's changed
Temporarily disabled randomization of test order. Tests from the same suite will execute one after another and only then new suite will start.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
