### PR TITLE
ci: update exalens to v0.1.6

### DIFF
--- a/.github/scripts/versions.sh
+++ b/.github/scripts/versions.sh
@@ -9,7 +9,7 @@
 # tt-exalens configuration
 export EXALENS_VERSION="0.1.6-cp310-cp310-linux_x86_64"
 export EXALENS_TAG="v${EXALENS_VERSION%%-*}"
-export EXALENS_WHEEL="ttexalens-${EXALENS_VERSION}.whl"
+export EXALENS_WHEEL="tt_exalens-${EXALENS_VERSION}.whl"
 export EXALENS_URL="https://github.com/tenstorrent/tt-exalens/releases/download/${EXALENS_TAG}/${EXALENS_WHEEL}"
 
 # tt-smi configuration


### PR DESCRIPTION
### Ticket
None

### Problem description
Current version of exalens has issues with timeout when using vcs simulator.

### What's changed
Updated to the latest exalens version which has a fix for the issue.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update