### PR TITLE
fix: correct calls that were hitting asserts in BH nightly tests

### DIFF
--- a/tests/sources/math_matmul_test.cpp
+++ b/tests/sources/math_matmul_test.cpp
@@ -88,7 +88,8 @@ void run_kernel()
 #ifdef ARCH_BLACKHOLE
     _llk_pack_hw_configure_<is_fp32_dest_acc_en, false, false>(
         formats.pack_src, formats.pack_dst, TILE_SIZE_PACK, FACE_R_DIM, TILE_C_DIM, num_faces, PARTIAL_FACE_PACK);
-    _llk_pack_init_<false, false, DstTileFaceLayout::RowMajor, false, false>(formats.pack_dst, FACE_R_DIM, TILE_C_DIM, num_faces, PARTIAL_FACE_PACK);
+    _llk_pack_init_<false, false, DstTileFaceLayout::RowMajor, false, false>(
+        formats.pack_dst, FACE_R_DIM, TILE_C_DIM, num_faces, false /* partial_face parameter is unused on BH */);
     _llk_pack_dest_init_<dest_sync, is_fp32_dest_acc_en, DstTileFaceLayout::RowMajor>();
 #else
     _llk_pack_hw_configure_<is_fp32_dest_acc_en, false>(formats.pack_src, formats.pack_dst, TILE_SIZE_PACK, FACE_R_DIM, num_faces, PARTIAL_FACE_PACK);

--- a/tests/sources/unpack_matmul_test.cpp
+++ b/tests/sources/unpack_matmul_test.cpp
@@ -90,7 +90,8 @@ void run_kernel()
 #ifdef ARCH_BLACKHOLE
     _llk_pack_hw_configure_<is_fp32_dest_acc_en, false, false>(
         formats.pack_src, formats.pack_dst, TILE_SIZE_PACK, FACE_R_DIM, TILE_C_DIM, num_faces, PARTIAL_FACE_PACK);
-    _llk_pack_init_<false, false, DstTileFaceLayout::RowMajor, false, false>(formats.pack_dst, FACE_R_DIM, TILE_C_DIM, num_faces, PARTIAL_FACE_PACK);
+    _llk_pack_init_<false, false, DstTileFaceLayout::RowMajor, false, false>(
+        formats.pack_dst, FACE_R_DIM, TILE_C_DIM, num_faces, false /* partial_face parameter is unused on BH */);
     _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en, DstTileFaceLayout::RowMajor>();
 #else
     _llk_pack_hw_configure_<is_fp32_dest_acc_en, false>(formats.pack_src, formats.pack_dst, TILE_SIZE_PACK, FACE_R_DIM, num_faces, PARTIAL_FACE_PACK);


### PR DESCRIPTION
### Ticket
None

### Problem
Eating our own dog food after adding the assertions for unused variables.

### What's changed
Locked some of the unused parameters to avoid tripping the asserts.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
