### PR TITLE
[skip ci] ci: add condition to skip CI trigger for specific commit messages

### DIFF
--- a/.github/workflows/trigger-tt-metal-bump.yml
+++ b/.github/workflows/trigger-tt-metal-bump.yml
@@ -15,7 +15,7 @@ jobs:
   trigger-ci:
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    if: !startsWith(github.event.head_commit.message, '[skip uplift]')
+    if: ${{ !startsWith(github.event.head_commit.message, '[skip uplift]') }}
     steps:
       - name: Send dispatch event to tt-metal
         uses: actions/github-script@v7


### PR DESCRIPTION
### What's changed
Introduced a condition to the CI workflow that prevents it from triggering the tt-metal uplift workflow if the commit message starts with '[skip uplift]'.
This can be used where separate metal PR is needed to merge without any CI failures

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
