### PR TITLE
[skip ci] ci: retrieve information on perf test results during dry runs

### DIFF
--- a/.github/workflows/trigger-tt-metal-post-commit.yml
+++ b/.github/workflows/trigger-tt-metal-post-commit.yml
@@ -400,6 +400,7 @@ jobs:
           RUN_WH="${{ needs.detect-changes.outputs.run-wormhole }}"
           RUN_BH="${{ needs.detect-changes.outputs.run-blackhole }}"
           [[ "$RUN_WH" == "true" || "$RUN_BH" == "true" ]] && RUN_L2="true" || RUN_L2="false"
+          [[ "$RUN_WH" == "true" || "$RUN_BH" == "true" ]] && RUN_PERF="true" || RUN_PERF="false"
           L2_RESULT=$(format_test_result "C++ post-commit" \
             "$RUN_L2" \
             "${{ steps.parse-results.outputs.l2-status }}" \
@@ -421,7 +422,7 @@ jobs:
 
           # Format Device Perf Models results (runs for both Wormhole and Blackhole changes)
           PERF_RESULT=$(format_test_result "Device perf regressions" \
-            "$RUN_L2" \
+            "$RUN_PERF" \
             "${{ steps.parse-results.outputs.perf-status }}" \
             "${{ steps.parse-results.outputs.perf-url }}" \
             "${{ needs.trigger-tt-metal-tests.result }}")


### PR DESCRIPTION
### Ticket
None

### Problem description
Metal workflow for testing the llk changes has been extended to track results of performance regression workflow. However LLK workflow monitoring the metal workflow was missing logic for capturing this result.

### What's changed
This PR adds support for retrieving and displaying Device Perf Models test results during dry runs of the tt-metal post-commit CI workflow. The change enables better visibility into performance regression test outcomes alongside existing test suite results.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
