### PR TITLE
Make PolynomialEvaluator::eval() sfpi_inline

### DIFF
--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_polyval.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_polyval.h
@@ -49,20 +49,20 @@ struct PolynomialEvaluator
 
     // Base case: f(x) = 0 (empty polynomial)
     template <typename U>
-    static constexpr auto eval(U x)
+    sfpi_inline static constexpr auto eval(U x)
     {
         return U {0};
     }
 
     template <typename U, typename Coefficient0>
-    static constexpr auto eval(U x, Coefficient0 coeff0)
+    sfpi_inline static constexpr auto eval(U x, Coefficient0 coeff0)
     {
         // Base case: f(x) = coeff0 (0-th degree polynomial)
         return coeff0;
     }
 
     template <typename U, typename Coefficient0, typename... OtherCoefficients>
-    static constexpr auto eval(U x, Coefficient0 coeff0, OtherCoefficients... other_coefficients)
+    sfpi_inline static constexpr auto eval(U x, Coefficient0 coeff0, OtherCoefficients... other_coefficients)
     {
         // Recursive case: Horner's method
         return coeff0 + x * eval(x, other_coefficients...);

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_polyval.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_polyval.h
@@ -49,20 +49,20 @@ struct PolynomialEvaluator
 
     // Base case: f(x) = 0 (empty polynomial)
     template <typename U>
-    static constexpr auto eval(U x)
+    sfpi_inline static constexpr auto eval(U x)
     {
         return U {0};
     }
 
     template <typename U, typename Coefficient0>
-    static constexpr auto eval(U x, Coefficient0 coeff0)
+    sfpi_inline static constexpr auto eval(U x, Coefficient0 coeff0)
     {
         // Base case: f(x) = coeff0 (0-th degree polynomial)
         return coeff0;
     }
 
     template <typename U, typename Coefficient0, typename... OtherCoefficients>
-    static constexpr auto eval(U x, Coefficient0 coeff0, OtherCoefficients... other_coefficients)
+    sfpi_inline static constexpr auto eval(U x, Coefficient0 coeff0, OtherCoefficients... other_coefficients)
     {
         // Recursive case: Horner's method
         return coeff0 + x * eval(x, other_coefficients...);


### PR DESCRIPTION
### Ticket
#981


### Problem description
`PolynomialEvaluator::eval()` is defined as template but not sfpi_inline. This may lead to compiler errors if compiler tries to non-inline it. 

### What's changed
Add `sfpi_inline` in front of of `PolynomialEvaluator::eval()` functions

With this PR, the `python -m pytest tests/ttnn/unit_tests/operations/eltwise/test_activation.py::test_mish_golden_verification` commands succeed with accurate [tanh](https://github.com/tenstorrent/tt-metal/pull/34927) (without it, tests fails due to compiler error as described in Issue).

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist

Note: Running same pipeline as https://github.com/tenstorrent/tt-metal/pull/34927 since it depends on this branch + it is where the error happens. 

<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes [OK](https://github.com/tenstorrent/tt-metal/actions/runs/20439391916)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable) [OK, failures from main](https://github.com/tenstorrent/tt-metal/actions/runs/20447105976)
