### PR TITLE
fix: use named constants instead of magic numbers for stochastic rouning

### DIFF
--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_rounding_ops.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_rounding_ops.h
@@ -177,7 +177,7 @@ inline void _calculate_stochastic_round_()
         TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);
         // SFP_STOCH_RND(rnd_mode, imm8_math, lreg_src_b, lreg_src_c, lreg_dest, instr_mod1)
         // rnd_mode=1 (stochastic), lreg_src_c=LREG0, lreg_dest=LREG0, instr_mod1=1 (fp32->fp16b)
-        TTI_SFP_STOCH_RND(1, 0, p_sfpu::LREG0, p_sfpu::LREG0, p_sfpu::LREG0, 1);
+        TTI_SFP_STOCH_RND(sfpi::SFPSTOCHRND_RND_STOCH, 0, p_sfpu::LREG0, p_sfpu::LREG0, p_sfpu::LREG0, sfpi::SFPSTOCHRND_MOD1_FP32_TO_FP16B);
         TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);
         sfpi::dst_reg++;
     }

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_rounding_ops.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_rounding_ops.h
@@ -186,7 +186,7 @@ inline void _calculate_stochastic_round_()
         TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_3, 0);
         // SFP_STOCH_RND(rnd_mode, imm8_math, lreg_src_b, lreg_src_c, lreg_dest, instr_mod1)
         // rnd_mode=1 (stochastic), lreg_src_c=LREG0, lreg_dest=LREG0, instr_mod1=1 (fp32->fp16b)
-        TTI_SFP_STOCH_RND(1, 0, p_sfpu::LREG0, p_sfpu::LREG0, p_sfpu::LREG0, 1);
+        TTI_SFP_STOCH_RND(sfpi::SFPSTOCHRND_RND_STOCH, 0, p_sfpu::LREG0, p_sfpu::LREG0, p_sfpu::LREG0, sfpi::SFPSTOCHRND_MOD1_FP32_TO_FP16B);
         TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_3, 0);
         sfpi::dst_reg++;
     }


### PR DESCRIPTION
### Ticket
None

### Problem description
In https://github.com/tenstorrent/tt-llk/pull/942 we merged the code with some magic numbers. This should help read the code later.

### What's changed
Added named constants from sfpi namespace that represent rounding and instruction modes.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update