### PR TITLE
[skip ci] ci: if only QSR tests are touched, do not run BH/WH checks.

### DIFF
--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -60,6 +60,8 @@ jobs:
                 - 'tt_llk_quasar/**'
               tests:
                 - 'tests/**'
+                - '!tests/sources/quasar/**'
+                - '!tests/python_tests/quasar/**'
               github:
                 - '.github/**'
               documentation:


### PR DESCRIPTION
### Ticket
None

### Problem description
We had a [PR](https://github.com/tenstorrent/tt-llk/pull/995) that was touching only Quasar tests, and yet it had to wait for BH/WH tests to execute because tests filter wasn't taking into account Quasar tests.

### What's changed
Improved filtering logic to prevent WH/BH tests from running if only QSR tests have been changed.
With this change, if other files in tests directory are touched, BH/WH tests would run, as they should. But if only QSR related tests are changed, no tests will be run.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
