### PR TITLE
wh pack init setup calls

### DIFF
--- a/tt_llk_wormhole_b0/llk_lib/llk_pack.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_pack.h
@@ -149,7 +149,7 @@ inline void _llk_pack_init_(
     _llk_pack_configure_addrmod_<untilize>();
     _llk_pack_mop_config_<untilize, zero_output>(pack_dst_format, face_r_dim, num_faces, partial_face, narrow_tile);
 
-    set_packer_l1_offset(pack_dst_format);
+    set_packer_l1_offset(pack_dst_format, face_r_dim);
     const uint face_dim   = face_r_dim * FACE_C_DIM;
     const uint pack_x_dim = (narrow_tile || !untilize) ? face_dim : FACE_R_DIM;
     TT_SETADCXX(p_setadc::PAC, pack_x_dim - 1, 0x0);


### PR DESCRIPTION
### Ticket
N/A

### Problem description
<!-- Provide context for the problem. -->
On WH, `_llk_pack_init_` didn’t configure PAC, so kernels couldn’t safely use  pack and pack untilize together. The alternative init with include_setup_calls can’t be used because it adds an unused src_format parameter that breaks builds with -Wunused-variable.

### What's changed
<!-- Describe the approach used to solve the problem.
Summarize the changes made and its impact. -->
Add PAC setup into `_llk_pack_init_`, so the same kernel can use both pack and pack untilize

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
