### PR TITLE
[Test Infra] Update self.boot_mode with the default mode based on chip arch 

### DIFF
--- a/tests/python_tests/helpers/test_config.py
+++ b/tests/python_tests/helpers/test_config.py
@@ -769,7 +769,7 @@ class TestConfig:
 
     def run_elf_files(self, location="0,0") -> list:
         if self.boot_mode == BootMode.DEFAULT:
-            boot_mode = CHIP_DEFAULT_BOOT_MODES[TestConfig.CHIP_ARCH]
+            self.boot_mode = CHIP_DEFAULT_BOOT_MODES[TestConfig.CHIP_ARCH]
 
         if (
             TestConfig.CHIP_ARCH == ChipArchitecture.QUASAR
@@ -821,7 +821,7 @@ class TestConfig:
             location, TestConfig.TRISC_PROFILER_BARRIER_ADDRESS, [0, 0, 0]
         )
 
-        match boot_mode:
+        match self.boot_mode:
             case BootMode.BRISC:
                 if not TestConfig.BRISC_ELF_LOADED:
                     TestConfig.BRISC_ELF_LOADED = True


### PR DESCRIPTION
### Ticket
<!-- Link to Github Issue -->

### Problem description
raise ValueError("Quasar only supports TRISC boot mode") this error was raised when running tests for Quasar, because self.boot_mode was not properly updated.

### What's changed
<!-- Describe the approach used to solve the problem.
Summarize the changes made and its impact. -->

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
