### PR TITLE
feat: implement Slack notification for nightly test failures

### DIFF
--- a/.github/actions/report-failure/action.yml
+++ b/.github/actions/report-failure/action.yml
@@ -1,0 +1,44 @@
+name: 'Report Failure'
+description: 'Send Slack notification when tests fail'
+
+inputs:
+  test_name:
+    description: 'Name of the test suite that failed'
+    required: true
+    type: string
+
+runs:
+  using: composite
+  steps:
+    - name: Construct message
+      id: message
+      shell: bash
+      run: |
+        COMMIT_URL="https://github.com/tenstorrent/tt-metal/commit/${{ github.sha }}"
+        COMMIT_SHA="${GITHUB_SHA:0:7}"
+        RUN_BASE="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+        RUN_URL="$RUN_BASE/job/${{ job.check_run_id }}"
+        TRIGGERER="${{ github.event.sender.login }}"
+        if [ -z "$TRIGGERER" ]; then
+          TRIGGERER="scheduled run"
+        fi
+        MESSAGE=":alert: *${{ inputs.test_name }}* have failed :alert:"
+        MESSAGE="$MESSAGE\n\n⚠️ Looks like something broke! The nightly tests didn't complete successfully."
+        MESSAGE="$MESSAGE\n\nTriggered by: \`$TRIGGERER\`"
+        MESSAGE="$MESSAGE\nCommit: <$COMMIT_URL|$COMMIT_SHA>"
+        MESSAGE="$MESSAGE\n<${RUN_URL}|Check what went wrong>"
+        {
+          echo 'text<<EOF'
+          echo "$MESSAGE"
+          echo 'EOF'
+        } >> $GITHUB_OUTPUT
+    - name: Send Slack notification
+      uses: slackapi/slack-github-action@v2.1.1
+      with:
+        method: chat.postMessage
+        token: ${{ secrets.SLACK_BOT_TOKEN }}
+        payload: |
+          {
+            "channel": "${{ secrets.SLACK_CHANNEL_ID }}",
+            "text": "${{ steps.message.outputs.text }}"
+          }

--- a/.github/workflows/nightly-perf-tests.yml
+++ b/.github/workflows/nightly-perf-tests.yml
@@ -24,30 +24,7 @@ jobs:
     if: ${{ failure() }}
     needs: nightly-performance-tests
     steps:
-      - name: Construct message
-        id: message
-        run: |
-          COMMIT_URL="https://github.com/tenstorrent/tt-metal/commit/${{ github.sha }}"
-          COMMIT_SHA="${GITHUB_SHA:0:7}"
-          RUN_BASE="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          RUN_URL="$RUN_BASE/job/${{ job.check_run_id }}"
-          TRIGGERER="${{ github.event.sender.login }}"
-          if [ -z "$TRIGGERER" ]; then
-            TRIGGERER="scheduled run"
-          fi
-          MESSAGE=":alert: *Nightly Performance Tests* have failed :alert:"
-          MESSAGE="$MESSAGE\n\n⚠️ Looks like something broke! The nightly tests didn't complete successfully."
-          MESSAGE="$MESSAGE\n\nTriggered by: \`$TRIGGERER\`"
-          MESSAGE="$MESSAGE\nCommit: <$COMMIT_URL|$COMMIT_SHA>"
-          MESSAGE="$MESSAGE\n<${RUN_URL}|Check what went wrong>"
-          echo "text=$MESSAGE" >> $GITHUB_OUTPUT
-      - name: Send Slack notification
-        uses: slackapi/slack-github-action@v2.1.1
+      - name: Report failure
+        uses: ./.github/actions/report-failure
         with:
-          method: chat.postMessage
-          token: ${{ secrets.SLACK_BOT_TOKEN }}
-          payload: |
-            {
-              "channel": "${{ secrets.SLACK_CHANNEL_ID }}",
-              "text": "${{ steps.message.outputs.text }}"
-            }
+          test_name: "Nightly Performance Tests"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -69,30 +69,7 @@ jobs:
     if: ${{ failure() }}
     needs: nightly-summary
     steps:
-      - name: Construct message
-        id: message
-        run: |
-          COMMIT_URL="https://github.com/tenstorrent/tt-metal/commit/${{ github.sha }}"
-          COMMIT_SHA="${GITHUB_SHA:0:7}"
-          RUN_BASE="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          RUN_URL="$RUN_BASE/job/${{ job.check_run_id }}"
-          TRIGGERER="${{ github.event.sender.login }}"
-          if [ -z "$TRIGGERER" ]; then
-            TRIGGERER="scheduled run"
-          fi
-          MESSAGE=":alert: *Nightly Tests* have failed :alert:"
-          MESSAGE="$MESSAGE\n\n⚠️ Looks like something broke! The nightly tests didn't complete successfully."
-          MESSAGE="$MESSAGE\n\nTriggered by: \`$TRIGGERER\`"
-          MESSAGE="$MESSAGE\nCommit: <$COMMIT_URL|$COMMIT_SHA>"
-          MESSAGE="$MESSAGE\n<${RUN_URL}|Check what went wrong>"
-          echo "text=$MESSAGE" >> $GITHUB_OUTPUT
-      - name: Send Slack notification
-        uses: slackapi/slack-github-action@v2.1.1
+      - name: Report failure
+        uses: ./.github/actions/report-failure
         with:
-          method: chat.postMessage
-          token: ${{ secrets.SLACK_BOT_TOKEN }}
-          payload: |
-            {
-              "channel": "${{ secrets.SLACK_CHANNEL_ID }}",
-              "text": "${{ steps.message.outputs.text }}"
-            }
+          test_name: "Nightly Tests"


### PR DESCRIPTION
### Ticket
None

### Problem description
Until now, NIghtly test failures were not reported other than in GitHub Action. This meant that someone had to monitor the workflows every day.

### What's changed
Implemented Slack reporting mechanism to notify the LLK team about the failures.

<img width="531" height="138" alt="image" src="https://github.com/user-attachments/assets/6f899972-c933-41bb-a2d6-13e13c78c8d7" />

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update