### PR TITLE
ci: fix link in reporting action

### DIFF
--- a/.github/actions/report-failure/action.yml
+++ b/.github/actions/report-failure/action.yml
@@ -32,10 +32,10 @@ runs:
           TRIGGERER="scheduled run"
         fi
         MESSAGE=":alert: *${{ inputs.test_name }}* have failed :alert:"
-        MESSAGE="$MESSAGE\n\nLooks like something broke! Some tests didn't complete successfully."
+        MESSAGE="$MESSAGE\n\nLooks like something broke! Something broke in the scheduled run."
         MESSAGE="$MESSAGE\n\nTriggered by: \`$TRIGGERER\`"
         MESSAGE="$MESSAGE\nCommit: <$COMMIT_URL|$COMMIT_SHA>"
-        MESSAGE="$MESSAGE\n<${RUN_URL}|Check what went wrong>"
+        MESSAGE="$MESSAGE\n<${RUN_URL}|Take a a look at the logs to investigate.>"
         {
           echo 'text<<EOF'
           echo "$MESSAGE"


### PR DESCRIPTION
### Ticket
None

### Problem description
A link in the Slack message was broken, leading to an invalid commit.

### What's changed
A typo was fixed pointing to this repo instead of TT-metal.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update