### PR TITLE
Typecast: use `InstrModLoadStore::FP16B` instead of `2`.

### DIFF
--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_typecast.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_typecast.h
@@ -463,11 +463,11 @@ inline void _init_typecast_fp32_to_fp16b_()
     }
 
     // Misc: {
-    //   StoreMod0: 2,
+    //   StoreMod0: FP16B,
     //   UsesLoadMod0ForStore: {1,0},
     //   UnitDelayKind: {1,1}, (WaitForElapsedInstructions=1)
     // }
-    TTI_SFPCONFIG(0x312, 8, 1);
+    TTI_SFPCONFIG(0x310 | InstrModLoadStore::FP16B, 8, 1);
 }
 
 template <bool APPROXIMATION_MODE>
@@ -485,7 +485,7 @@ inline void _init_typecast_uint16_to_uint32_()
     }
 
     // Misc: {
-    //   StoreMod0: InstrModLoadStore::INT32,
+    //   StoreMod0: INT32,
     //   UsesLoadMod0ForStore: {0},
     //   UnitDelayKind: {1}, (WaitForElapsedInstructions=1)
     // }

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_typecast.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_typecast.h
@@ -460,11 +460,11 @@ inline void _init_typecast_fp32_to_fp16b_()
     }
 
     // Misc: {
-    //   StoreMod0: 2,
+    //   StoreMod0: FP16B,
     //   UsesLoadMod0ForStore: {1,0},
     //   UnitDelayKind: {1,1}, (WaitForElapsedInstructions=1)
     // }
-    TTI_SFPCONFIG(0x312, 8, 1);
+    TTI_SFPCONFIG(0x310 | InstrModLoadStore::FP16B, 8, 1);
 }
 
 template <bool APPROXIMATION_MODE>
@@ -482,7 +482,7 @@ inline void _init_typecast_uint16_to_uint32_()
     }
 
     // Misc: {
-    //   StoreMod0: InstrModLoadStore::INT32,
+    //   StoreMod0: INT32,
     //   UsesLoadMod0ForStore: {0},
     //   UnitDelayKind: {1}, (WaitForElapsedInstructions=1)
     // }


### PR DESCRIPTION
Use `InstrModLoadStore::FP16B` instead of `2`.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
