### PR TITLE
Move ADDR_MOD_3 into if constexpr to avoid increasing DRAM utilization for other kernels

### DIFF
--- a/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_unary_datacopy.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_unary_datacopy.h
@@ -176,13 +176,6 @@ inline void _llk_math_eltwise_unary_datacopy_(const std::uint32_t dst_index, con
 template <DataCopyType type, BroadcastType bcast_type = BroadcastType::NONE>
 inline void eltwise_unary_configure_addrmod(const uint dst_format)
 {
-    addr_mod_t {
-        .srca = {.incr = 0},
-        .srcb = {.incr = 0},
-        .dest = {.incr = 0},
-    }
-        .set(ADDR_MOD_3);
-
     // Use srcA for data movement
     if constexpr (type == A2D)
     {
@@ -200,6 +193,16 @@ inline void eltwise_unary_configure_addrmod(const uint dst_format)
             .dest = {.incr = 8},
         }
             .set(ADDR_MOD_2);
+
+        if constexpr (bcast_type != BroadcastType::NONE)
+        {
+            addr_mod_t {
+                .srca = {.incr = 0},
+                .srcb = {.incr = 0},
+                .dest = {.incr = 0},
+            }
+                .set(ADDR_MOD_3);
+        }
     }
     else
     {


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/actions/runs/20869591670
TT-train test which checks DRAM utilization is failing. It checks against hard-coded size and this additional line passed some threshold and caused the DRAM utilization to change by 2KB.
Hiding this ADDR_MOD behind a constexpr will prevent it from being compiled in the test.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue) 
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/20882958225) CI passes