### PR TITLE
Add workaround for incorrect bank switching

### DIFF
--- a/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_unary_datacopy.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_unary_datacopy.h
@@ -327,7 +327,10 @@ inline void eltwise_unary_configure_mop(uint rows_per_inst, uint total_rows, con
             else
             {
                 ckernel_template tmp(outerloop, innerloop, TT_OP_ELWADD(0, 0, broadcast_type, addr_mod, 0));
-                tmp.set_end_op(TT_OP_SETRWC(p_setrwc::CLR_AB, 0, 0, 0, 0, 0));
+
+                // SETRWC triggers a bug in WH here after a certain sequence of tests
+                // https://github.com/tenstorrent/tt-metal/issues/21244
+                tmp.set_end_op(TT_OP_CLEARDVALID(p_setrwc::CLR_AB, 0x1));
                 tmp.program();
             }
         }


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/21244

### Problem description
Bank switches incorrectly when SETRWC is called after a certain sequence of tests on WH.

### What's changed
Avoided using SETRWC and used CLEARDVALID instead in reset mode

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
