### PR TITLE
bcast needs to check equality not PCC

### DIFF
--- a/tests/python_tests/test_bcast.py
+++ b/tests/python_tests/test_bcast.py
@@ -38,7 +38,6 @@ from helpers.test_variant_parameters import (
     UNPACK_TRANS_FACES,
     UNPACK_TRANS_WITHIN_FACE,
 )
-from helpers.utils import passed_test
 
 # SUPPORTED FORMATS FOR TEST
 supported_formats = [
@@ -412,6 +411,6 @@ def test_unpack_bcast(
     ), "Result tensor and golden tensor are not of the same length"
 
     res_tensor = torch.tensor(res_from_L1, dtype=format_dict[formats.output_format])
-    assert passed_test(
-        golden_tensor, res_tensor, formats.output_format
-    ), "Assert against golden failed"
+    assert torch.equal(
+        golden_tensor, res_tensor
+    ), "Result tensor and golden tensor are not equal"


### PR DESCRIPTION
accidentally regressed my bcast test when rebasing and didnt catch it earlier
this test needs to check equality, not PCC
to be very clear, there is no issue with the bcast kernel itself

@fvranicTT
Without this change, I get a false positive for Float32 precision. I tried to intentionally break my kernel so that it wouldn't handle the Lo16 bits and found my test was still passing. So basically I was only doing 16bits for a 32bit test. Now with checking equality I actually got a failure with my broken test (i put it back to normal, it does work)

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
