### PR TITLE
Added transpose of faces for srcA when BType is COL or ROW.

### DIFF
--- a/tests/python_tests/test_eltwise_binary_transpose_bcast.py
+++ b/tests/python_tests/test_eltwise_binary_transpose_bcast.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import torch
-from conftest import skip_for_blackhole
 from helpers.format_config import DataFormat
 from helpers.golden_generators import (
     BroadcastGolden,
@@ -36,7 +35,6 @@ from helpers.tilize_untilize import tilize, tilize_block
 from helpers.utils import passed_test
 
 
-@skip_for_blackhole
 @parametrize(
     formats=input_output_formats(
         [

--- a/tt_llk_blackhole/llk_lib/llk_unpack_AB.h
+++ b/tt_llk_blackhole/llk_lib/llk_unpack_AB.h
@@ -22,24 +22,19 @@ template <BroadcastType BType = BroadcastType::NONE>
 inline void _llk_unpack_AB_mop_config_(const bool transpose_of_faces = false, const std::uint32_t num_faces = 4, const bool narrow_tile = false)
 {
     LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be 1, 2, or 4");
-<<<<<<< HEAD
-    static constexpr std::uint32_t unpack_srca           = TT_OP_UNPACR(SrcA, 0b1, 0, 0, 0, 1, 1, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
-    static constexpr std::uint32_t unpack_srcb           = TT_OP_UNPACR(SrcB, 0b1, 0, 0, 0, 1, 1, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
-=======
 
     if (transpose_of_faces)
     {
         LLK_ASSERT(num_faces == 4, "num_faces must be 4 when transpose_of_faces is true");
     }
 
-    static constexpr uint unpack_srca           = TT_OP_UNPACR(SrcA, 0b1, 0, 0, 0, 1, 1, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
-    static constexpr uint unpack_srcb           = TT_OP_UNPACR(SrcB, 0b1, 0, 0, 0, 1, 1, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
->>>>>>> 03e9d2ef (Added num_faces==4 check for transpose of faces.)
-    static constexpr uint unpack_srca_transpose = TT_OP_UNPACR(SrcA, 0b10, 0, 0, 0, 1, 1, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
-    const uint srca_op                          = transpose_of_faces ? unpack_srca_transpose : unpack_srca;
-    const uint srca_end_op                      = TT_OP_SETADCZW(p_setadc::UNP_A, 0, 0, 0, 1, 0b0001);
+    static constexpr std::uint32_t unpack_srca           = TT_OP_UNPACR(SrcA, 0b1, 0, 0, 0, 1, 1, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
+    static constexpr std::uint32_t unpack_srcb           = TT_OP_UNPACR(SrcB, 0b1, 0, 0, 0, 1, 1, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
+    static constexpr std::uint32_t unpack_srca_transpose = TT_OP_UNPACR(SrcA, 0b10, 0, 0, 0, 1, 1, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
+    const std::uint32_t srca_op                          = transpose_of_faces ? unpack_srca_transpose : unpack_srca;
+    const std::uint32_t srca_end_op                      = TT_OP_SETADCZW(p_setadc::UNP_A, 0, 0, 0, 1, 0b0001);
 
-    auto set_end_op_with_transpose = [&](ckernel_template &tmp, uint primary_end_op)
+    auto set_end_op_with_transpose = [&](ckernel_template &tmp, std::uint32_t primary_end_op)
     {
         if (transpose_of_faces)
         {


### PR DESCRIPTION
### Problem description
 - When running sweep test for unpack_AB api, there is a problem on blackhole when we turn on transpose and we have COL and ROW broadcast for srcB.
 - On Wormhole the transpose in srcA happens with no issue, while on blackhole the option for srcA transpose with those two broadcasts on srcB was simply left out for some reason.
 - This test discovered that hole:
 https://github.com/tenstorrent/tt-llk/pull/1103


### What's changed
_llk_unpack_AB_mop_config_ for blackhole has a new feature in 
    if constexpr (BType == BroadcastType::COL)
and
    else if constexpr (BType == BroadcastType::ROW)
branches

### Important:
This change is needed for the above test to pass. Otherwise if blackhole shouldn't support transpose by default for those two if branches then test should skip that scenario.
