### PR TITLE
Add stallwait to reconfigure_packer_l1_acc

### DIFF
--- a/tt_llk_blackhole/common/inc/cpack_common.h
+++ b/tt_llk_blackhole/common/inc/cpack_common.h
@@ -572,7 +572,8 @@ inline void reconfigure_packer_l1_acc(const std::uint32_t pack_l1_acc)
     // TTI_STALLWAIT(p_stall::STALL_PACK, p_stall::TRISC_CFG);
 
     const uint32_t pack_l1_acc_disable_pack_zero_flag = pack_l1_acc ? (0b11) : (0b00);
-
+    // Stall cfg_reg_rmw_tensix done by CFG until PACK is done
+    TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::PACK);
     cfg_reg_rmw_tensix<
         THCON_SEC0_REG1_Pack_L1_Acc_ADDR32,
         THCON_SEC0_REG1_Pack_L1_Acc_SHAMT,

--- a/tt_llk_wormhole_b0/common/inc/cpack_common.h
+++ b/tt_llk_wormhole_b0/common/inc/cpack_common.h
@@ -736,7 +736,8 @@ inline void reconfigure_packer_l1_acc(const std::uint32_t pack_l1_acc)
     // TTI_STALLWAIT(p_stall::STALL_PACK, p_stall::TRISC_CFG);
 
     const uint32_t pack_l1_acc_disable_pack_zero_flag = pack_l1_acc ? (0b11) : (0b00);
-
+    // Stall cfg_reg_rmw_tensix done by CFG until PACK is done
+    TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::PACK);
     cfg_reg_rmw_tensix<
         THCON_SEC0_REG1_Pack_L1_Acc_ADDR32,
         THCON_SEC0_REG1_Pack_L1_Acc_SHAMT,


### PR DESCRIPTION
### Ticket
<!-- Link to Github Issue -->
[Link to Github Issue](https://github.com/tenstorrent/tt-llk/issues/747)

### Problem description
<!-- Provide context for the problem. -->
Some reconfigs and uninits are missing the proper stallwaits that should be in place for safety.

### What's changed
<!-- Describe the approach used to solve the problem.
Summarize the changes made and its impact. -->
Adds stallwait to the start of reconfigure_packer_l1_acc

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
