### PR TITLE
build: remove switch to install packages as local when creating venv

### DIFF
--- a/tests/setup_external_testing_env.sh
+++ b/tests/setup_external_testing_env.sh
@@ -94,7 +94,7 @@ if [[ "$REUSE" == false || ! -d "$VENV_DIR" ]]; then
 
     # Install all Python dependencies
     echo "Installing Python dependencies..."
-    uv pip install -q --system --index-strategy unsafe-best-match --no-cache-dir -r requirements.txt
+    uv pip install -q --index-strategy unsafe-best-match --no-cache-dir -r requirements.txt
 
     # Download and extract SFPI release
     ./setup_testing_env.sh


### PR DESCRIPTION

### Ticket
None

### Problem description
`--system` is forcing uv to try to install packages in root, which is wrong as we are trying to create virtual environment via `setup_external_testing_env.sh`.

### What's changed
Removed `--system` argument because of the above.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
