### PR TITLE
Expand pack test to support face_r_dim < 16 and num_faces = 1 and num_faces = 2.

### DIFF
--- a/tests/python_tests/helpers/golden_generators.py
+++ b/tests/python_tests/helpers/golden_generators.py
@@ -1054,7 +1054,10 @@ class PackGolden:
 
         height, width = input_dimensions[0], input_dimensions[1]
 
-        tile_cnt = (height // 32) * (width // 32)
+        tile_width = 32
+        tile_height = 32 if face_r_dim == 16 else face_r_dim
+
+        tile_cnt = (height // tile_height) * (width // tile_width)
         tile_size = height * width // tile_cnt
 
         # Calculate elements based on variable face dimensions

--- a/tests/python_tests/helpers/test_variant_parameters.py
+++ b/tests/python_tests/helpers/test_variant_parameters.py
@@ -278,16 +278,18 @@ class INPUT_DIMENSIONS(TemplateParameter):
     srcB: Tuple[int, int]
     block_ct_dim: Optional[int] = None
     block_rt_dim: Optional[int] = None
+    num_rows: int = 32
+    num_cols: int = 32
 
     def covert_to_cpp(self) -> str:
-        num_rows, num_cols = 32, 32
-        validate_tile_dimensions(self.srcA[0], num_rows)
-        validate_tile_dimensions(self.srcA[1], num_cols)
-        validate_tile_dimensions(self.srcB[0], num_rows)
-        validate_tile_dimensions(self.srcB[1], num_cols)
 
-        full_ct_dim = self.srcB[1] // num_cols
-        full_rt_dim = self.srcA[0] // num_rows
+        validate_tile_dimensions(self.srcA[0], self.num_rows)
+        validate_tile_dimensions(self.srcA[1], self.num_cols)
+        validate_tile_dimensions(self.srcB[0], self.num_rows)
+        validate_tile_dimensions(self.srcB[1], self.num_cols)
+
+        full_ct_dim = self.srcB[1] // self.num_cols
+        full_rt_dim = self.srcA[0] // self.num_rows
 
         block_ct_dim = full_ct_dim if self.block_ct_dim is None else self.block_ct_dim
         block_rt_dim = full_rt_dim if self.block_rt_dim is None else self.block_rt_dim

--- a/tests/python_tests/test_pack.py
+++ b/tests/python_tests/test_pack.py
@@ -121,15 +121,15 @@ def is_relu_threshold_tolerance_issue(
         ]
     ),
     dest_acc=lambda formats: get_valid_dest_accumulation_modes(formats),
-    num_faces=[1, 2, 4],
-    face_r_dim=lambda num_faces: (
-        [1, 2, 4, 8, 16] if num_faces == 2 else [16]
-    ),  # Vary face_r_dim only for num_faces=2, that's the current limitation.
+    face_r_dim=[1, 2, 4, 8, 16],
+    num_faces=lambda face_r_dim: (
+        [1, 2, 4] if face_r_dim == 16 else [2]
+    ),  # Current limitation.
     input_dimensions=lambda face_r_dim: (
         [[face_r_dim, 32]]
         if face_r_dim < 16
         else [[32, 32], [64, 64], [32, 64], [64, 32]]
-    ),  # For partial faces, use single tile with face_r_dim < 16
+    ),  # For partial faces, use single tile with face_r_dim < 16.
     relu_type=[
         PackerReluType.NoRelu,
         PackerReluType.ZeroRelu,

--- a/tests/python_tests/test_pack.py
+++ b/tests/python_tests/test_pack.py
@@ -28,7 +28,6 @@ from helpers.test_config import TestConfig
 from helpers.test_variant_parameters import (
     DEST_INDEX,
     DEST_SYNC,
-    INPUT_DIMENSIONS,
     NUM_FACES,
     RELU_CONFIG,
     TEST_FACE_DIMS,
@@ -246,12 +245,6 @@ def test_pack(
         "sources/pack_test.cpp",
         formats,
         templates=[
-            INPUT_DIMENSIONS(
-                srcA=input_dimensions,
-                srcB=input_dimensions,
-                num_rows=face_r_dim if face_r_dim < 16 else input_dimensions[0],
-                num_cols=32,
-            ),
             TILIZE(),
             DEST_SYNC(dest_sync),
         ],

--- a/tests/python_tests/test_pack.py
+++ b/tests/python_tests/test_pack.py
@@ -10,6 +10,8 @@ Tests the LLK pack kernel with:
 - Destination sync modes (SyncHalf for double-buffering, SyncFull for single-buffering)
 """
 
+import os
+
 import pytest
 import torch
 from helpers.chip_architecture import ChipArchitecture, get_chip_architecture
@@ -28,13 +30,67 @@ from helpers.test_config import TestConfig
 from helpers.test_variant_parameters import (
     DEST_INDEX,
     DEST_SYNC,
-    INPUT_DIMENSIONS,
     NUM_FACES,
+    PARTIAL_FACE,
     RELU_CONFIG,
+    TEST_FACE_DIMS,
     TILE_COUNT,
-    TILIZE,
 )
 from helpers.utils import passed_test
+
+
+def save_tensors_to_file(golden_tensor, res_tensor, face_r_dim, num_faces, test_id):
+    """Save golden and result tensors to files with proper dimensional formatting"""
+
+    # Create debug directory if it doesn't exist
+    debug_dir = "debug_matrices"
+    os.makedirs(debug_dir, exist_ok=True)
+
+    # Format tensors according to face dimensions
+    face_size = face_r_dim * 16
+
+    def format_tensor_to_file(tensor, filename, tensor_name):
+        with open(os.path.join(debug_dir, filename), "w") as f:
+            f.write(f"{tensor_name} Tensor\n")
+            f.write(f"Shape: {tensor.shape}\n")
+            f.write(f"Face dimensions: {face_r_dim} x 16\n")
+            f.write(f"Number of faces: {num_faces}\n")
+            f.write("=" * 80 + "\n\n")
+
+            for face_idx in range(num_faces):
+                if num_faces > 1:
+                    f.write(f"Face {face_idx}:\n")
+
+                face_start = face_idx * face_size
+                face_end = face_start + face_size
+                face_data = tensor[face_start:face_end]
+
+                # Reshape to face_r_dim x 16 matrix
+                face_matrix = face_data.view(face_r_dim, 16)
+
+                for row_idx in range(face_r_dim):
+                    row_values = [f"{val:12.6f}" for val in face_matrix[row_idx]]
+                    f.write("  " + " ".join(row_values) + "\n")
+
+                if face_idx < num_faces - 1:
+                    f.write("\n")  # Blank line between faces
+
+            f.write("\n" + "=" * 80 + "\n")
+
+    # Generate unique filenames based on test parameters
+    base_name = f"test_fail_{test_id}_face{face_r_dim}x16_nf{num_faces}"
+
+    format_tensor_to_file(golden_tensor, f"{base_name}_golden.txt", "GOLDEN")
+    format_tensor_to_file(res_tensor, f"{base_name}_result.txt", "RESULT")
+
+    # Also save difference matrix
+    diff_tensor = torch.abs(golden_tensor - res_tensor)
+    format_tensor_to_file(diff_tensor, f"{base_name}_diff.txt", "ABSOLUTE DIFFERENCE")
+
+    print(f"Tensors saved to {debug_dir}/ directory:")
+    print(f"  - {base_name}_golden.txt")
+    print(f"  - {base_name}_result.txt")
+    print(f"  - {base_name}_diff.txt")
 
 
 def is_relu_threshold_tolerance_issue(
@@ -120,7 +176,12 @@ def is_relu_threshold_tolerance_issue(
         ]
     ),
     dest_acc=lambda formats: get_valid_dest_accumulation_modes(formats),
-    input_dimensions=[[32, 32], [64, 64], [32, 64], [64, 32]],
+    # face_r_dim = [1,2,4,8,16],
+    # num_faces= lambda face_r_dim: [1,2,4] if face_r_dim == 16 else [2],
+    # input_dimensions=lambda face_r_dim:[[32, 32], [64, 64]] if face_r_dim == 16 else [[face_r_dim, 32]],
+    face_r_dim=[16],
+    num_faces=[4],
+    input_dimensions=[[32, 32], [32, 64]],
     relu_type=[
         PackerReluType.NoRelu,
         PackerReluType.ZeroRelu,
@@ -128,9 +189,10 @@ def is_relu_threshold_tolerance_issue(
         PackerReluType.MaxThresholdRelu,
     ],
     dest_sync=[DestSync.Half, DestSync.Full],
-    dest_index=lambda dest_acc, dest_sync, input_dimensions: get_valid_dest_indices(
+    dest_index=lambda dest_acc, dest_sync, input_dimensions, face_r_dim: get_valid_dest_indices(
         dest_sync=dest_sync,
         dest_acc=dest_acc,
+        # tile_count=(1 if face_r_dim < 16 else (input_dimensions[0] * input_dimensions[1]) // (32 * 32)),
         tile_count=(input_dimensions[0] * input_dimensions[1]) // (32 * 32),
     ),
 )
@@ -141,8 +203,28 @@ def test_pack(
     relu_type,
     dest_sync,
     dest_index,
+    num_faces,
+    face_r_dim,
     workers_tensix_coordinates,
 ):
+    # Print test parameters at the start
+    print(f"\n=== RUNNING TEST ===")
+    print(f"Input format: {formats.input_format.name}")
+    print(f"Output format: {formats.output_format.name}")
+    print(f"Dest accumulation: {dest_acc.name}")
+    print(f"Input dimensions: {input_dimensions}")
+    print(f"ReLU type: {relu_type.name}")
+    print(f"Dest sync: {dest_sync.name}")
+    print(f"Dest index: {dest_index}")
+    print(f"Num faces: {num_faces}")
+    print(f"Face r_dim: {face_r_dim}")
+    print("=" * 40)
+
+    if face_r_dim < 16 and (
+        formats.input_format == DataFormat.Bfp8_b
+        or formats.output_format == DataFormat.Bfp8_b
+    ):
+        pytest.skip("Bfp8_b format is only supported for full faces (16x32).")
 
     if (formats.input_format == DataFormat.Int32) ^ (
         formats.output_format == DataFormat.Int32
@@ -156,6 +238,8 @@ def test_pack(
         input_dimensions_A=input_dimensions,
         stimuli_format_B=formats.input_format,
         input_dimensions_B=input_dimensions,
+        num_faces=num_faces,
+        face_r_dim=face_r_dim,
     )
 
     # Generate golden output
@@ -164,6 +248,8 @@ def test_pack(
         src_A,
         formats.output_format,
         input_dimensions=input_dimensions,
+        num_faces=num_faces,
+        face_r_dim=face_r_dim,
     )
 
     unpack_to_dest = (
@@ -215,19 +301,25 @@ def test_pack(
         data_formats.pack_src,
     )
 
+    partial_face = face_r_dim < 16
     configuration = TestConfig(
         "sources/pack_test.cpp",
         formats,
         templates=[
-            INPUT_DIMENSIONS(input_dimensions, input_dimensions),
-            TILIZE(),
             DEST_SYNC(dest_sync),
+            PARTIAL_FACE(
+                partial_a=partial_face,
+                partial_face_pack=partial_face,
+                partial_b=partial_face,
+                partial_face_math=partial_face,
+            ),
         ],
         runtimes=[
             TILE_COUNT(tile_cnt_A),
             DEST_INDEX(dest_index),
             RELU_CONFIG(relu_config),
-            NUM_FACES(num_faces=4),
+            NUM_FACES(num_faces),
+            TEST_FACE_DIMS(face_r_dim=face_r_dim),
         ],
         variant_stimuli=StimuliConfig(
             src_A,
@@ -238,6 +330,8 @@ def test_pack(
             tile_count_A=tile_cnt_A,
             tile_count_B=tile_cnt_B,
             tile_count_res=tile_cnt_A,
+            num_faces=num_faces,
+            face_r_dim=face_r_dim,
         ),
         dest_acc=dest_acc,
         unpack_to_dest=unpack_to_dest,
@@ -249,8 +343,7 @@ def test_pack(
         golden_tensor
     ), "Result tensor and golder tensor are not of the same length"
 
-    torch_format = format_dict[formats.output_format]
-    res_tensor = torch.tensor(res_from_L1, dtype=torch_format)
+    res_tensor = torch.tensor(res_from_L1, dtype=format_dict[formats.output_format])
 
     test_passed = passed_test(
         golden_tensor, res_tensor, formats.output_format, print_erros=False
@@ -276,5 +369,23 @@ def test_pack(
                 "the discrepancy is within tolerance and is considered acceptable."
             )
             test_passed = True
+    if not test_passed:
+        # Generate unique test identifier for file naming
+        test_id = f"{formats.input_format.name}_{formats.output_format.name}_{dest_acc.name}_{relu_type.name}_{dest_sync.name}"
+
+        print(f"\n=== TEST FAILURE ===")
+        print(f"Input format: {formats.input_format.name}")
+        print(f"Output format: {formats.output_format.name}")
+        print(f"Dest accumulation: {dest_acc.name}")
+        print(f"Input dimensions: {input_dimensions}")
+        print(f"ReLU type: {relu_type.name}")
+        print(f"Dest sync: {dest_sync.name}")
+        print(f"Dest index: {dest_index}")
+        print(f"Num faces: {num_faces}")
+        print(f"Face r_dim: {face_r_dim}")
+        print("=" * 40)
+
+        # Save tensors to files
+        save_tensors_to_file(golden_tensor, res_tensor, face_r_dim, num_faces, test_id)
 
     assert test_passed

--- a/tests/sources/pack_test.cpp
+++ b/tests/sources/pack_test.cpp
@@ -23,9 +23,16 @@ uint32_t math_sync_tile_dst_index = 0;
 void run_kernel(const volatile struct RuntimeParams* params)
 {
     _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
-        formats.unpack_src, formats.unpack_src, formats.unpack_dst, formats.unpack_dst, FACE_R_DIM, FACE_R_DIM, params->num_faces, params->num_faces);
+        formats.unpack_src,
+        formats.unpack_src,
+        formats.unpack_dst,
+        formats.unpack_dst,
+        params->TEST_FACE_R_DIM,
+        params->TEST_FACE_R_DIM,
+        params->num_faces,
+        params->num_faces);
     _llk_unpack_A_init_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
-        0, 0, FACE_R_DIM, params->num_faces, formats.unpack_src, formats.unpack_dst);
+        0, 0, params->TEST_FACE_R_DIM, params->num_faces, formats.unpack_src, formats.unpack_dst);
     for (int i = 0; i < params->TILE_CNT; ++i)
     {
         _llk_unpack_A_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
@@ -83,14 +90,29 @@ void run_kernel(const volatile struct RuntimeParams* params)
 void run_kernel(const volatile struct RuntimeParams* params)
 {
 #ifdef ARCH_BLACKHOLE
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, false, tilize_en>(
-        formats.pack_src, formats.pack_dst, 16 * 16 * 4, FACE_R_DIM, TILE_C_DIM, params->num_faces, false, false, params->RELU_CONFIG);
-    _llk_pack_init_<false, false, tilize_en>(formats.pack_dst, FACE_R_DIM, TILE_C_DIM, params->num_faces);
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, false, false>(
+        formats.pack_src,
+        formats.pack_dst,
+        params->TEST_FACE_R_DIM * params->TEST_FACE_C_DIM * 4,
+        params->TEST_FACE_R_DIM,
+        TILE_C_DIM,
+        params->num_faces,
+        false,
+        false,
+        params->RELU_CONFIG);
+    _llk_pack_init_<false, false, false>(formats.pack_dst, params->TEST_FACE_R_DIM, TILE_C_DIM, params->num_faces);
     _llk_pack_dest_init_<dest_sync, is_fp32_dest_acc_en>();
 #else
     _llk_pack_hw_configure_<is_fp32_dest_acc_en, false>(
-        formats.pack_src, formats.pack_dst, 16 * 16 * 4, FACE_R_DIM, params->num_faces, false, false, params->RELU_CONFIG);
-    _llk_pack_init_<false, false>(formats.pack_dst, FACE_R_DIM, params->num_faces);
+        formats.pack_src,
+        formats.pack_dst,
+        params->TEST_FACE_R_DIM * params->TEST_FACE_C_DIM * 4,
+        params->TEST_FACE_R_DIM,
+        params->num_faces,
+        false,
+        false,
+        params->RELU_CONFIG);
+    _llk_pack_init_<false, false>(formats.pack_dst, params->TEST_FACE_R_DIM, params->num_faces);
     _llk_pack_dest_init_<dest_sync, is_fp32_dest_acc_en, false>();
 #endif
     _llk_packer_wait_for_math_done_();


### PR DESCRIPTION
### Problem description
 - Pack test always relied on default num_faces=4 and default face_r_dim=16 parameters.
 - This PR expands the test to support sweeped num_faces and face_r_dim parameters.

### What's changed
 - Expanded test_pack.py
 - Changed INPUT_DIMENSIONS class in test_input_variants.py to support different row and column numbers. They were fixed to 32,32.

### Noticed
 - Our whole testing infrastructure supports only single-tiled input matrices when having face_r_dim < 16.
 - This should be changed in the future.
