### PR TITLE
Bugfix for uint16 unary_bcast scalar

### DIFF
--- a/tt_llk_wormhole_b0/llk_lib/llk_unpack_A.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_unpack_A.h
@@ -125,7 +125,10 @@ inline void _llk_unpack_A_mop_config_(
         constexpr uint32_t innerloop = 1;
         ckernel_template tmp(outerloop, innerloop, unpack_srcb_inc_z_0);
         // ELWADD used in datacopy due to WH broadcast bug, use zerosrca regardless of acc_to_dest
-        tmp.set_start_op(unpack_srca_zerosrc_set_dvalid);
+        if (!(unpack_dst_format == (uint)DataFormat::UInt16))
+        {
+            tmp.set_start_op(unpack_srca_zerosrc_set_dvalid);
+        }
         tmp.program();
     }
     else


### PR DESCRIPTION
### Ticket
https://github.com/orgs/tenstorrent/projects/28/views/5?pane=issue&itemId=114612058&issue=tenstorrent%7Ctt-metal%7C23354

### Problem description
hang in metal for uint16 scalar unary_bcast

### What's changed
Don't set dvalid for this case in UPK, since FPU doesn't use ELWADD it uses MOVB2D

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
