### PR TITLE
Removed the coverage skip from test_pack_untilize.py

### DIFF
--- a/tests/python_tests/test_pack_untilize.py
+++ b/tests/python_tests/test_pack_untilize.py
@@ -41,10 +41,6 @@ from helpers.utils import passed_test
 def test_pack_untilize(
     formats, dest_acc, input_dimensions, dest_sync, workers_tensix_coordinates
 ):
-    if TestConfig.WITH_COVERAGE and input_dimensions == [96, 288]:
-        pytest.skip(
-            "Skipping large dimension test in coverage mode, check issue: #1063 on TT-LLK repo"
-        )
 
     if formats.output_format == DataFormat.Bfp8_b:
         pytest.skip("Pack Untilize does not support Bfp8_b format")


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-llk/issues/1063

### Problem description
This test with input dimensions [96,288] was failing with coverage turned on.

It appears that issue is fixed now?
@ajankovicTT 

### What's changed
Removed the test skip.