### PR TITLE
Simplify binary division.

### DIFF
--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_binary.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_binary.h
@@ -123,28 +123,7 @@ inline void _calculate_sfpu_binary_(const uint dst_index_in0, const uint dst_ind
         }
         else if constexpr (BINOP == BinaryOp::DIV)
         {
-            v_if (in1 == 0)
-            {
-                v_if (in0 == 0)
-                {
-                    result = std::numeric_limits<float>::quiet_NaN();
-                }
-                v_else
-                {
-                    result = std::numeric_limits<float>::infinity();
-                    result = sfpi::setsgn(result, in0);
-                }
-                v_endif;
-            }
-            v_elseif (in0 == in1)
-            {
-                result = sfpi::vConst1;
-            }
-            v_else
-            {
-                result = in0 * _sfpu_reciprocal_<2>(in1);
-            }
-            v_endif;
+            result = in0 * _sfpu_reciprocal_<2>(in1);
         }
         else if constexpr (BINOP == BinaryOp::RSUB)
         {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_binary.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_binary.h
@@ -123,28 +123,7 @@ inline void _calculate_sfpu_binary_(const uint dst_index_in0, const uint dst_ind
         }
         else if constexpr (BINOP == BinaryOp::DIV)
         {
-            v_if (in1 == 0)
-            {
-                v_if (in0 == 0)
-                {
-                    result = std::numeric_limits<float>::quiet_NaN();
-                }
-                v_else
-                {
-                    result = std::numeric_limits<float>::infinity();
-                    result = sfpi::setsgn(result, in0);
-                }
-                v_endif;
-            }
-            v_elseif (in0 == in1)
-            {
-                result = sfpi::vConst1;
-            }
-            v_else
-            {
-                result = in0 * _sfpu_reciprocal_<2>(in1);
-            }
-            v_endif;
+            result = in0 * _sfpu_reciprocal_<2>(in1);
         }
         else if constexpr (BINOP == BinaryOp::RSUB)
         {


### PR DESCRIPTION
Reciprocal now handles division by zero correctly, so these cases no longer need to be handled.

### Ticket

Closes https://github.com/tenstorrent/tt-metal/issues/36196

### Problem description

Division has unnecessary checks for division by zero, which are now handled correctly by reciprocal.

### What's changed

Remove conditional checks for division by zero, and checks for equality.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
