### PR TITLE
Increase nonlegacy recip accuracy for fp32 approximate case

### DIFF
--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_recip.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_recip.h
@@ -215,7 +215,7 @@ inline void _calculate_reciprocal_internal_(const int iterations)
 {
     if constexpr (APPROXIMATION_MODE)
     {
-        if (is_fp32_dest_acc_en)
+        if constexpr (is_fp32_dest_acc_en)
         {
             _calculate_reciprocal_fast_8b_3c_(iterations);
         }


### PR DESCRIPTION
### Ticket
[#28373](https://github.com/tenstorrent/tt-metal/issues/28373)

### Problem description
When enabling non-legacy reciprocal, it seems that in fp32 approximate case accuracy is not enough. In particular, when computing softmax, as measured by tests/ttnn/unit_tests/operations/fused/test_softmax.py::test_softmax_accuracy[shape=(1, 1, 16384, 256)-fp32_acc_en=True-math_approx_mode=True-expected_ulp=9-numeric_stable=True] test, new implementation drops accuracy from 9 to 10 ULPs.

### What's changed
Switched fp32 approximate case from _calculate_reciprocal_fast_7b_ to _calculate_reciprocal_fast_8b_3c_.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
