### PR TITLE
Perf SFPU tests fix - call SFPU for each tile

### DIFF
--- a/tests/python_tests/perf_eltwise_unary_sfpu.py
+++ b/tests/python_tests/perf_eltwise_unary_sfpu.py
@@ -49,6 +49,7 @@ from helpers.test_variant_parameters import (
     mathop=[
         MathOperation.Reciprocal,
         MathOperation.Sqrt,
+        MathOperation.Rsqrt,
         MathOperation.Silu,
         MathOperation.Gelu,
         MathOperation.Exp,

--- a/tests/sources/eltwise_binary_sfpu_perf.cpp
+++ b/tests/sources/eltwise_binary_sfpu_perf.cpp
@@ -16,10 +16,12 @@
 
 // Globals
 // Globals
-std::uint32_t unp_cfg_context          = 0;
-std::uint32_t pack_sync_tile_dst_ptr   = 0;
-std::uint32_t math_sync_tile_dst_index = 0;
-static constexpr int MAX_TILES_DEST    = is_fp32_dest_acc_en ? 4 : 8;
+std::uint32_t unp_cfg_context                          = 0;
+std::uint32_t pack_sync_tile_dst_ptr                   = 0;
+std::uint32_t math_sync_tile_dst_index                 = 0;
+static constexpr int MAX_TILES_DEST                    = is_fp32_dest_acc_en ? 4 : 8;
+static constexpr ckernel::DstSync DST_SYNC_MODE        = ckernel::DstSync::SyncHalf;
+static constexpr ckernel::BroadcastType BROADCAST_TYPE = ckernel::BroadcastType::NONE;
 
 #ifdef LLK_TRISC_UNPACK
 
@@ -28,13 +30,15 @@ static constexpr int MAX_TILES_DEST    = is_fp32_dest_acc_en ? 4 : 8;
 
 void run_kernel(const volatile struct RuntimeParams* params)
 {
+    const EltwiseBinaryReuseDestType reuse_dest_type = EltwiseBinaryReuseDestType::NONE;
+
     {
         ZONE_SCOPED("INIT")
 
         _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
             formats.unpack_src, formats.unpack_src, formats.unpack_dst, formats.unpack_dst, FACE_R_DIM, FACE_R_DIM, params->num_faces, params->num_faces);
 
-        _llk_unpack_A_init_<BroadcastType::NONE, is_fp32_dest_acc_en, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
+        _llk_unpack_A_init_<BROADCAST_TYPE, is_fp32_dest_acc_en, reuse_dest_type, unpack_to_dest>(
             params->UNPACK_TRANSPOSE_FACES, params->UNPACK_TRANSPOSE_WITHIN_FACE, FACE_R_DIM, params->num_faces, formats.unpack_src, formats.unpack_dst);
         PROFILER_SYNC();
     }
@@ -43,6 +47,10 @@ void run_kernel(const volatile struct RuntimeParams* params)
 
         if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
         {
+            // In case of math isolate, we don't want any software synchronization from unpack to math.
+            // So we just set/clear valid bits here - which is unavoidable hardware synchronization.
+            // When unpack_to_dest is used, we assume the data is immediately ready in destination register.
+            // Otherwise, we assume the data is immediately ready in source A/B registers.
             if (!unpack_to_dest)
             {
                 // Set valid for source A always.
@@ -54,13 +62,13 @@ void run_kernel(const volatile struct RuntimeParams* params)
                     /* iterations*/ params->num_faces * params->TILE_CNT * params->LOOP_FACTOR);
             }
         }
-        else if constexpr (PERF_RUN_TYPE != PerfRunType::PACK_ISOLATE)
+        else if constexpr (PERF_RUN_TYPE != PerfRunType::PACK_ISOLATE) // UNPACK_ISOLATE, L1_TO_L1, L1_CONGESTION
         {
             for (int loop = 0; loop < params->LOOP_FACTOR; ++loop)
             {
                 for (int i = 0; i < params->TILE_CNT; ++i)
                 {
-                    _llk_unpack_A_<BroadcastType::NONE, is_fp32_dest_acc_en, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
+                    _llk_unpack_A_<BROADCAST_TYPE, is_fp32_dest_acc_en, reuse_dest_type, unpack_to_dest>(
                         PERF_ADDRESS(PERF_INPUT_A, /* tile_idx */ i), formats.unpack_src, formats.unpack_dst);
                 }
             }
@@ -79,11 +87,13 @@ void run_kernel(const volatile struct RuntimeParams* params)
 
 void run_kernel(const volatile struct RuntimeParams* params)
 {
+    const DataCopyType data_copy_type = DataCopyType::A2D;
+
     {
         ZONE_SCOPED("INIT")
 
-        _llk_math_eltwise_unary_datacopy_init_<DataCopyType::A2D, is_fp32_dest_acc_en>(params->num_faces, formats.math);
-        _llk_math_pack_sync_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+        _llk_math_eltwise_unary_datacopy_init_<data_copy_type, is_fp32_dest_acc_en>(params->num_faces, formats.math);
+        _llk_math_pack_sync_init_<DST_SYNC_MODE, is_fp32_dest_acc_en>();
         _llk_math_hw_configure_<is_fp32_dest_acc_en>(formats.math, formats.math);
 
         _llk_math_eltwise_binary_sfpu_init_<SfpuType::add1>();
@@ -94,67 +104,63 @@ void run_kernel(const volatile struct RuntimeParams* params)
 
         if constexpr (PERF_RUN_TYPE == PerfRunType::UNPACK_ISOLATE)
         {
-            if constexpr (unpack_to_dest)
+            for (int loop = 0; loop < params->LOOP_FACTOR; ++loop)
             {
-                for (int loop = 0; loop < params->LOOP_FACTOR; ++loop)
+                for (int i = 0; i < params->TILE_CNT; ++i)
                 {
-                    for (int i = 0; i < params->TILE_CNT; ++i)
+                    // For unpack isolate scenario, math should only perform necessary synchronization and nothing else.
+                    if constexpr (unpack_to_dest)
                     {
-                        // Only perform synchronization with unpacker, it does not copy
-                        // the data when unpack_to_dest is true - as data is already in dest.
-                        _llk_math_eltwise_unary_datacopy_<DataCopyType::A2D, DstSync::SyncHalf, is_fp32_dest_acc_en, BroadcastType::NONE, unpack_to_dest>(
-                            i, formats.math, formats.math);
+                        // In this case, unpacker needs software synchronization from math - to acknowledge that destination register is
+                        // "consumed" and can be overwritten with new data.
+                        // Due to the fact that BROADCAST_TYPE is always NONE in the test and combination of unpack_to_dest and 32b data is always set,
+                        // this method will perform synchronization only and no actual data copy.
+                        _llk_math_eltwise_unary_datacopy_<data_copy_type, DST_SYNC_MODE, is_fp32_dest_acc_en, BROADCAST_TYPE, unpack_to_dest>(
+                            i % MAX_TILES_DEST, formats.math, formats.math);
+                    }
+                    else
+                    {
+                        // Perform only necessary hardware synchronization to indicate that source registers are consumed.
+                        _perf_math_loop_clear_valid<
+                            /* src A */ true,
+                            /* src B */ true>(
+                            /* iterations*/ params->num_faces);
                     }
                 }
-            }
-            else
-            {
-                // Clear valid for sources A and B
-                _perf_math_loop_clear_valid<
-                    /* src A */ true,
-                    /* src B */ true>(
-                    /* iterations*/ params->num_faces * params->TILE_CNT * params->LOOP_FACTOR);
             }
         }
         else if constexpr (PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
         {
-            if constexpr (unpack_to_dest)
+            for (int loop = 0; loop < params->LOOP_FACTOR; ++loop)
             {
-                for (int loop = 0; loop < params->LOOP_FACTOR; ++loop)
+                for (int block_start = 0; block_start < params->TILE_CNT; block_start += MAX_TILES_DEST)
                 {
-                    for (int block_start = 0; block_start < params->TILE_CNT; block_start += MAX_TILES_DEST)
-                    {
-                        int block_tiles = std::min(params->TILE_CNT - block_start, MAX_TILES_DEST);
+                    int block_tiles = std::min(params->TILE_CNT - block_start, MAX_TILES_DEST);
 
-                        for (int block_tile = 0; block_tile < block_tiles; ++block_tile)
+                    _llk_math_wait_for_dest_available_<DST_SYNC_MODE>();
+
+                    for (int block_tile = 0; block_tile < block_tiles; ++block_tile)
+                    {
+                        if constexpr (unpack_to_dest)
                         {
-                            _llk_math_eltwise_unary_datacopy_<DataCopyType::A2D, DstSync::SyncHalf, is_fp32_dest_acc_en, BroadcastType::NONE, unpack_to_dest>(
-                                block_start + block_tile, formats.math, formats.math);
+                            // In this case, unpacker needs software synchronization from math - to acknowledge that destination register is
+                            // "consumed" and can be overwritten with new data.
+                            // Due to the fact that BROADCAST_TYPE is always NONE in the test and combination of unpack_to_dest and 32b data is always set,
+                            // this method will perform synchronization only and no actual data copy.
+                            _llk_math_eltwise_unary_datacopy_<data_copy_type, DST_SYNC_MODE, is_fp32_dest_acc_en, BROADCAST_TYPE, unpack_to_dest>(
+                                block_tile, formats.math, formats.math);
                         }
-
-                        _llk_math_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
-                    }
-                }
-            }
-            else
-            {
-                for (int loop = 0; loop < params->LOOP_FACTOR; ++loop)
-                {
-                    for (int block_start = 0; block_start < params->TILE_CNT; block_start += MAX_TILES_DEST)
-                    {
-                        int block_tiles = std::min(params->TILE_CNT - block_start, MAX_TILES_DEST);
-
-                        for (int block_tile = 0; block_tile < block_tiles; ++block_tile)
+                        else
                         {
+                            // Perform only necessary hardware synchronization to indicate that source registers are consumed.
                             _perf_math_loop_clear_valid<
                                 /* src A */ true,
                                 /* src B */ true>(
                                 /* iterations*/ params->num_faces);
                         }
-
-                        _llk_math_wait_for_dest_available_<DstSync::SyncHalf>();
-                        _llk_math_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
                     }
+
+                    _llk_math_dest_section_done_<DST_SYNC_MODE, is_fp32_dest_acc_en>();
                 }
             }
         }
@@ -164,26 +170,26 @@ void run_kernel(const volatile struct RuntimeParams* params)
             {
                 for (int block_start = 0; block_start < params->TILE_CNT; block_start += MAX_TILES_DEST)
                 {
-                    if constexpr (!unpack_to_dest)
+                    int block_tiles = std::min(params->TILE_CNT - block_start, MAX_TILES_DEST);
+
+                    for (int block_tile = 0; block_tile < block_tiles; ++block_tile)
                     {
-                        int block_tiles = std::min(params->TILE_CNT - block_start, MAX_TILES_DEST);
-
-                        for (int block_tile = 0; block_tile < block_tiles; ++block_tile)
+                        // When data is not unpacked to dest, math needs to copy data from srcA to dest before starting SFPU operation.
+                        // Otherwise, data is immediately ready in destination register.
+                        if constexpr (!unpack_to_dest)
                         {
-                            _llk_math_eltwise_unary_datacopy_<DataCopyType::A2D, DstSync::SyncHalf, is_fp32_dest_acc_en, BroadcastType::NONE, unpack_to_dest>(
-                                block_start + block_tile, formats.math, formats.math);
+                            _llk_math_eltwise_unary_datacopy_<data_copy_type, DST_SYNC_MODE, is_fp32_dest_acc_en, BROADCAST_TYPE, unpack_to_dest>(
+                                block_tile, formats.math, formats.math);
                         }
+
+                        _llk_math_eltwise_binary_sfpu_start_<DST_SYNC_MODE>(/* dst_index */ block_tile);
+                        test_utils::call_binary_sfpu_operation<APPROX_MODE, SFPU_BINARY_OPERATION, ITERATIONS>((block_tile + 1) % MAX_TILES_DEST, formats.math);
+                        _llk_math_eltwise_binary_sfpu_done_();
                     }
-
-                    _llk_math_eltwise_binary_sfpu_start_<DstSync::SyncHalf>(/* dst_index */ block_start);
-
-                    test_utils::call_binary_sfpu_operation<APPROX_MODE, SFPU_BINARY_OPERATION, ITERATIONS>(block_start, formats.math);
-
-                    _llk_math_eltwise_binary_sfpu_done_();
                 }
             }
         }
-        else if constexpr (PERF_RUN_TYPE != PerfRunType::PACK_ISOLATE)
+        else if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1)
         {
             for (int loop = 0; loop < params->LOOP_FACTOR; ++loop)
             {
@@ -191,22 +197,21 @@ void run_kernel(const volatile struct RuntimeParams* params)
                 {
                     int block_tiles = std::min(params->TILE_CNT - block_start, MAX_TILES_DEST);
 
-                    _llk_math_wait_for_dest_available_<DstSync::SyncHalf>();
+                    _llk_math_wait_for_dest_available_<DST_SYNC_MODE>();
 
                     // Copy from srcA to dest
                     for (int block_tile = 0; block_tile < block_tiles; ++block_tile)
                     {
-                        _llk_math_eltwise_unary_datacopy_<DataCopyType::A2D, DstSync::SyncHalf, is_fp32_dest_acc_en, BroadcastType::NONE, unpack_to_dest>(
-                            block_start + block_tile, formats.math, formats.math);
+                        _llk_math_eltwise_unary_datacopy_<data_copy_type, DST_SYNC_MODE, is_fp32_dest_acc_en, BROADCAST_TYPE, unpack_to_dest>(
+                            block_tile, formats.math, formats.math);
+
+                        // Start SFPU binary operation
+                        _llk_math_eltwise_binary_sfpu_start_<DST_SYNC_MODE>(/* dst_index */ block_tile);
+                        test_utils::call_binary_sfpu_operation<APPROX_MODE, SFPU_BINARY_OPERATION, ITERATIONS>((block_tile + 1) % MAX_TILES_DEST, formats.math);
+                        _llk_math_eltwise_binary_sfpu_done_();
                     }
 
-                    // Start SFPU binary operation
-                    _llk_math_eltwise_binary_sfpu_start_<DstSync::SyncHalf>(/* dst_index */ block_start);
-
-                    test_utils::call_binary_sfpu_operation<APPROX_MODE, SFPU_BINARY_OPERATION, ITERATIONS>(block_start, formats.math);
-
-                    _llk_math_eltwise_binary_sfpu_done_();
-                    _llk_math_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+                    _llk_math_dest_section_done_<DST_SYNC_MODE, is_fp32_dest_acc_en>();
                 }
             }
         }
@@ -235,7 +240,7 @@ void run_kernel(const volatile struct RuntimeParams* params)
         _llk_pack_init_<false, false>(formats.pack_dst, FACE_R_DIM, params->num_faces);
 #endif
         // Initialize destination for packing
-        _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+        _llk_pack_dest_init_<DST_SYNC_MODE, is_fp32_dest_acc_en>();
 
         PROFILER_SYNC();
     }
@@ -252,7 +257,7 @@ void run_kernel(const volatile struct RuntimeParams* params)
 
                     for (int block_tile = 0; block_tile < block_tiles; block_tile++)
                     {
-                        _llk_pack_<DstSync::SyncHalf, is_fp32_dest_acc_en>(block_tile, PERF_ADDRESS(PERF_OUTPUT, block_start + block_tile));
+                        _llk_pack_<DST_SYNC_MODE, is_fp32_dest_acc_en>(block_tile, PERF_ADDRESS(PERF_OUTPUT, block_start + block_tile));
                     }
                 }
             }
@@ -268,9 +273,9 @@ void run_kernel(const volatile struct RuntimeParams* params)
                     _llk_packer_wait_for_math_done_();
                     for (int block_tile = 0; block_tile < block_tiles; block_tile++)
                     {
-                        _llk_pack_<DstSync::SyncHalf, is_fp32_dest_acc_en>(block_tile, PERF_ADDRESS(PERF_OUTPUT, block_start + block_tile));
+                        _llk_pack_<DST_SYNC_MODE, is_fp32_dest_acc_en>(block_tile, PERF_ADDRESS(PERF_OUTPUT, block_start + block_tile));
                     }
-                    _llk_pack_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+                    _llk_pack_dest_section_done_<DST_SYNC_MODE, is_fp32_dest_acc_en>();
                 }
             }
         }

--- a/tests/sources/eltwise_unary_sfpu_perf.cpp
+++ b/tests/sources/eltwise_unary_sfpu_perf.cpp
@@ -9,16 +9,19 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
+#include "ckernel_ops.h"
 #include "llk_defs.h"
 #include "params.h"
 #include "perf.h"
 #include "profiler.h"
 
 // Globals
-std::uint32_t unp_cfg_context          = 0;
-std::uint32_t pack_sync_tile_dst_ptr   = 0;
-std::uint32_t math_sync_tile_dst_index = 0;
-static constexpr int MAX_TILES_DEST    = is_fp32_dest_acc_en ? 4 : 8;
+std::uint32_t unp_cfg_context                          = 0;
+std::uint32_t pack_sync_tile_dst_ptr                   = 0;
+std::uint32_t math_sync_tile_dst_index                 = 0;
+static constexpr int MAX_TILES_DEST                    = is_fp32_dest_acc_en ? 4 : 8;
+static constexpr ckernel::DstSync DST_SYNC_MODE        = ckernel::DstSync::SyncHalf;
+static constexpr ckernel::BroadcastType BROADCAST_TYPE = ckernel::BroadcastType::NONE;
 
 #ifdef LLK_TRISC_UNPACK
 
@@ -27,13 +30,15 @@ static constexpr int MAX_TILES_DEST    = is_fp32_dest_acc_en ? 4 : 8;
 
 void run_kernel(const volatile struct RuntimeParams* params)
 {
+    const EltwiseBinaryReuseDestType reuse_dest_type = EltwiseBinaryReuseDestType::NONE;
+
     {
         ZONE_SCOPED("INIT")
 
         _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
             formats.unpack_src, formats.unpack_src, formats.unpack_dst, formats.unpack_dst, FACE_R_DIM, FACE_R_DIM, params->num_faces, params->num_faces);
 
-        _llk_unpack_A_init_<BroadcastType::NONE, is_fp32_dest_acc_en, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
+        _llk_unpack_A_init_<BROADCAST_TYPE, is_fp32_dest_acc_en, reuse_dest_type, unpack_to_dest>(
             params->UNPACK_TRANSPOSE_FACES, params->UNPACK_TRANSPOSE_WITHIN_FACE, FACE_R_DIM, params->num_faces, formats.unpack_src, formats.unpack_dst);
         PROFILER_SYNC();
     }
@@ -42,6 +47,10 @@ void run_kernel(const volatile struct RuntimeParams* params)
 
         if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
         {
+            // In case of math isolate, we don't want any software synchronization from unpack to math.
+            // So we just set/clear valid bits here - which is unavoidable hardware synchronization.
+            // When unpack_to_dest is used, we assume the data is immediately ready in destination register.
+            // Otherwise, we assume the data is immediately ready in source A/B registers.
             if (!unpack_to_dest)
             {
                 // Set valid for source A always.
@@ -53,13 +62,13 @@ void run_kernel(const volatile struct RuntimeParams* params)
                     /* iterations*/ params->num_faces * params->TILE_CNT * params->LOOP_FACTOR);
             }
         }
-        else if constexpr (PERF_RUN_TYPE != PerfRunType::PACK_ISOLATE)
+        else if constexpr (PERF_RUN_TYPE != PerfRunType::PACK_ISOLATE) // UNPACK_ISOLATE, L1_TO_L1, L1_CONGESTION
         {
             for (int loop = 0; loop < params->LOOP_FACTOR; ++loop)
             {
                 for (int i = 0; i < params->TILE_CNT; ++i)
                 {
-                    _llk_unpack_A_<BroadcastType::NONE, is_fp32_dest_acc_en, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
+                    _llk_unpack_A_<BROADCAST_TYPE, is_fp32_dest_acc_en, reuse_dest_type, unpack_to_dest>(
                         PERF_ADDRESS(PERF_INPUT_A, /* tile_idx */ i), formats.unpack_src, formats.unpack_dst);
                 }
             }
@@ -78,11 +87,13 @@ void run_kernel(const volatile struct RuntimeParams* params)
 
 void run_kernel(const volatile struct RuntimeParams* params)
 {
+    const DataCopyType data_copy_type = DataCopyType::A2D;
+
     {
         ZONE_SCOPED("INIT")
 
-        _llk_math_eltwise_unary_datacopy_init_<DataCopyType::A2D, is_fp32_dest_acc_en>(params->num_faces, formats.math);
-        _llk_math_pack_sync_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+        _llk_math_eltwise_unary_datacopy_init_<data_copy_type, is_fp32_dest_acc_en>(params->num_faces, formats.math);
+        _llk_math_pack_sync_init_<DST_SYNC_MODE, is_fp32_dest_acc_en>();
         _llk_math_hw_configure_<is_fp32_dest_acc_en>(formats.math, formats.math);
 
         _llk_math_eltwise_unary_sfpu_init_<SFPU_UNARY_OPERATION>();
@@ -93,66 +104,63 @@ void run_kernel(const volatile struct RuntimeParams* params)
 
         if constexpr (PERF_RUN_TYPE == PerfRunType::UNPACK_ISOLATE)
         {
-            if constexpr (unpack_to_dest)
+            for (int loop = 0; loop < params->LOOP_FACTOR; ++loop)
             {
-                for (int loop = 0; loop < params->LOOP_FACTOR; ++loop)
+                for (int i = 0; i < params->TILE_CNT; ++i)
                 {
-                    for (int i = 0; i < params->TILE_CNT; ++i)
+                    // For unpack isolate scenario, math should only perform necessary synchronization and nothing else.
+                    if constexpr (unpack_to_dest)
                     {
-                        // Only perform synchronization with unpacker, it does not copy
-                        // the data when unpack_to_dest is true - as data is already in dest.
-                        _llk_math_eltwise_unary_datacopy_<DataCopyType::A2D, DstSync::SyncHalf, is_fp32_dest_acc_en, BroadcastType::NONE, unpack_to_dest>(
-                            i, formats.math, formats.math);
+                        // In this case, unpacker needs software synchronization from math - to acknowledge that destination register is
+                        // "consumed" and can be overwritten with new data.
+                        // Due to the fact that BROADCAST_TYPE is always NONE in the test and combination of unpack_to_dest and 32b data is always set,
+                        // this method will perform synchronization only and no actual data copy.
+                        _llk_math_eltwise_unary_datacopy_<data_copy_type, DST_SYNC_MODE, is_fp32_dest_acc_en, BROADCAST_TYPE, unpack_to_dest>(
+                            i % MAX_TILES_DEST, formats.math, formats.math);
+                    }
+                    else
+                    {
+                        // Perform only necessary hardware synchronization to indicate that source registers are consumed.
+                        _perf_math_loop_clear_valid<
+                            /* src A */ true,
+                            /* src B */ true>(
+                            /* iterations*/ params->num_faces);
                     }
                 }
-            }
-            else
-            {
-                // Clear valid for sources A and B
-                _perf_math_loop_clear_valid<
-                    /* src A */ true,
-                    /* src B */ true>(
-                    /* iterations*/ params->num_faces * params->TILE_CNT * params->LOOP_FACTOR);
             }
         }
         else if constexpr (PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
         {
-            if constexpr (unpack_to_dest)
+            for (int loop = 0; loop < params->LOOP_FACTOR; ++loop)
             {
-                for (int loop = 0; loop < params->LOOP_FACTOR; ++loop)
+                for (int block_start = 0; block_start < params->TILE_CNT; block_start += MAX_TILES_DEST)
                 {
-                    for (int block_start = 0; block_start < params->TILE_CNT; block_start += MAX_TILES_DEST)
+                    int block_tiles = std::min(params->TILE_CNT - block_start, MAX_TILES_DEST);
+
+                    _llk_math_wait_for_dest_available_<DST_SYNC_MODE>();
+
+                    for (int block_tile = 0; block_tile < block_tiles; ++block_tile)
                     {
-                        int block_tiles = std::min(params->TILE_CNT - block_start, MAX_TILES_DEST);
-                        for (int block_tile = 0; block_tile < block_tiles; ++block_tile)
+                        if constexpr (unpack_to_dest)
                         {
-                            _llk_math_eltwise_unary_datacopy_<DataCopyType::A2D, DstSync::SyncHalf, is_fp32_dest_acc_en, BroadcastType::NONE, unpack_to_dest>(
-                                block_start + block_tile, formats.math, formats.math);
+                            // In this case, unpacker needs software synchronization from math - to acknowledge that destination register is
+                            // "consumed" and can be overwritten with new data.
+                            // Due to the fact that BROADCAST_TYPE is always NONE in the test and combination of unpack_to_dest and 32b data is always set,
+                            // this method will perform synchronization only and no actual data copy.
+                            _llk_math_eltwise_unary_datacopy_<data_copy_type, DST_SYNC_MODE, is_fp32_dest_acc_en, BROADCAST_TYPE, unpack_to_dest>(
+                                block_tile, formats.math, formats.math);
                         }
-
-                        _llk_math_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
-                    }
-                }
-            }
-            else
-            {
-                for (int loop = 0; loop < params->LOOP_FACTOR; ++loop)
-                {
-                    for (int block_start = 0; block_start < params->TILE_CNT; block_start += MAX_TILES_DEST)
-                    {
-                        int block_tiles = std::min(params->TILE_CNT - block_start, MAX_TILES_DEST);
-
-                        for (int block_tile = 0; block_tile < block_tiles; ++block_tile)
+                        else
                         {
+                            // Perform only necessary hardware synchronization to indicate that source registers are consumed.
                             _perf_math_loop_clear_valid<
                                 /* src A */ true,
                                 /* src B */ true>(
                                 /* iterations*/ params->num_faces);
                         }
-
-                        _llk_math_wait_for_dest_available_<DstSync::SyncHalf>();
-                        _llk_math_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
                     }
+
+                    _llk_math_dest_section_done_<DST_SYNC_MODE, is_fp32_dest_acc_en>();
                 }
             }
         }
@@ -162,24 +170,27 @@ void run_kernel(const volatile struct RuntimeParams* params)
             {
                 for (int block_start = 0; block_start < params->TILE_CNT; block_start += MAX_TILES_DEST)
                 {
-                    if constexpr (!unpack_to_dest)
+                    int block_tiles = std::min(params->TILE_CNT - block_start, MAX_TILES_DEST);
+
+                    for (int block_tile = 0; block_tile < block_tiles; ++block_tile)
                     {
-                        int block_tiles = std::min(params->TILE_CNT - block_start, MAX_TILES_DEST);
-
-                        for (int block_tile = 0; block_tile < block_tiles; ++block_tile)
+                        // When data is not unpacked to dest, math needs to copy data from srcA to dest before starting SFPU operation.
+                        // Otherwise, data is immediately ready in destination register.
+                        if constexpr (!unpack_to_dest)
                         {
-                            _llk_math_eltwise_unary_datacopy_<DataCopyType::A2D, DstSync::SyncHalf, is_fp32_dest_acc_en, BroadcastType::NONE, unpack_to_dest>(
-                                block_start + block_tile, formats.math, formats.math);
+                            _llk_math_eltwise_unary_datacopy_<data_copy_type, DST_SYNC_MODE, is_fp32_dest_acc_en, BROADCAST_TYPE, unpack_to_dest>(
+                                block_tile, formats.math, formats.math);
                         }
-                    }
 
-                    _llk_math_eltwise_unary_sfpu_start_<DstSync::SyncHalf>(/* dst_index */ block_start);
-                    test_utils::call_sfpu_operation<APPROX_MODE, is_fp32_dest_acc_en, ITERATIONS, FAST_MODE, STABLE_SORT>(SFPU_UNARY_OPERATION, formats.math);
-                    _llk_math_eltwise_unary_sfpu_done_();
+                        _llk_math_eltwise_unary_sfpu_start_<DST_SYNC_MODE>(/* dst_index */ block_tile);
+                        test_utils::call_sfpu_operation<APPROX_MODE, is_fp32_dest_acc_en, ITERATIONS, FAST_MODE, STABLE_SORT>(
+                            SFPU_UNARY_OPERATION, formats.math);
+                        _llk_math_eltwise_unary_sfpu_done_();
+                    }
                 }
             }
         }
-        else if constexpr (PERF_RUN_TYPE != PerfRunType::PACK_ISOLATE)
+        else if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1)
         {
             for (int loop = 0; loop < params->LOOP_FACTOR; ++loop)
             {
@@ -187,22 +198,22 @@ void run_kernel(const volatile struct RuntimeParams* params)
                 {
                     int block_tiles = std::min(params->TILE_CNT - block_start, MAX_TILES_DEST);
 
-                    _llk_math_wait_for_dest_available_<DstSync::SyncHalf>();
+                    _llk_math_wait_for_dest_available_<DST_SYNC_MODE>();
 
                     // Copy from srcA to dest
                     for (int block_tile = 0; block_tile < block_tiles; ++block_tile)
                     {
-                        _llk_math_eltwise_unary_datacopy_<DataCopyType::A2D, DstSync::SyncHalf, is_fp32_dest_acc_en, BroadcastType::NONE, unpack_to_dest>(
-                            block_start + block_tile, formats.math, formats.math);
+                        _llk_math_eltwise_unary_datacopy_<data_copy_type, DST_SYNC_MODE, is_fp32_dest_acc_en, BROADCAST_TYPE, unpack_to_dest>(
+                            block_tile, formats.math, formats.math);
+
+                        // Start SFPU operation
+                        _llk_math_eltwise_unary_sfpu_start_<DST_SYNC_MODE>(/* dst_index */ block_tile);
+                        test_utils::call_sfpu_operation<APPROX_MODE, is_fp32_dest_acc_en, ITERATIONS, FAST_MODE, STABLE_SORT>(
+                            SFPU_UNARY_OPERATION, formats.math);
+                        _llk_math_eltwise_unary_sfpu_done_();
                     }
 
-                    // Start SFPU operation
-                    _llk_math_eltwise_unary_sfpu_start_<DstSync::SyncHalf>(/* dst_index */ block_start);
-
-                    test_utils::call_sfpu_operation<APPROX_MODE, is_fp32_dest_acc_en, ITERATIONS, FAST_MODE, STABLE_SORT>(SFPU_UNARY_OPERATION, formats.math);
-
-                    _llk_math_eltwise_unary_sfpu_done_();
-                    _llk_math_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+                    _llk_math_dest_section_done_<DST_SYNC_MODE, is_fp32_dest_acc_en>();
                 }
             }
         }
@@ -231,7 +242,7 @@ void run_kernel(const volatile struct RuntimeParams* params)
         _llk_pack_init_<false, false>(formats.pack_dst, FACE_R_DIM, params->num_faces);
 #endif
         // Initialize destination for packing
-        _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+        _llk_pack_dest_init_<DST_SYNC_MODE, is_fp32_dest_acc_en>();
 
         PROFILER_SYNC();
     }
@@ -248,8 +259,7 @@ void run_kernel(const volatile struct RuntimeParams* params)
 
                     for (int block_tile = 0; block_tile < block_tiles; ++block_tile)
                     {
-                        _llk_pack_<DstSync::SyncHalf, is_fp32_dest_acc_en, /* untilize */ false>(
-                            block_tile, PERF_ADDRESS(PERF_OUTPUT, block_start + block_tile));
+                        _llk_pack_<DST_SYNC_MODE, is_fp32_dest_acc_en, /* untilize */ false>(block_tile, PERF_ADDRESS(PERF_OUTPUT, block_start + block_tile));
                     }
                 }
             }
@@ -265,10 +275,9 @@ void run_kernel(const volatile struct RuntimeParams* params)
                     _llk_packer_wait_for_math_done_();
                     for (int block_tile = 0; block_tile < block_tiles; ++block_tile)
                     {
-                        _llk_pack_<DstSync::SyncHalf, is_fp32_dest_acc_en, /* untilize */ false>(
-                            block_tile, PERF_ADDRESS(PERF_OUTPUT, block_start + block_tile));
+                        _llk_pack_<DST_SYNC_MODE, is_fp32_dest_acc_en, /* untilize */ false>(block_tile, PERF_ADDRESS(PERF_OUTPUT, block_start + block_tile));
                     }
-                    _llk_pack_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+                    _llk_pack_dest_section_done_<DST_SYNC_MODE, is_fp32_dest_acc_en>();
                 }
             }
         }

--- a/tests/sources/eltwise_unary_sfpu_test.cpp
+++ b/tests/sources/eltwise_unary_sfpu_test.cpp
@@ -8,29 +8,35 @@
 #include <type_traits>
 
 #include "ckernel.h"
+#include "ckernel_defs.h"
 #include "llk_defs.h"
+#include "params.h"
 
 // Globals
-std::uint32_t unp_cfg_context          = 0;
-std::uint32_t pack_sync_tile_dst_ptr   = 0;
-std::uint32_t math_sync_tile_dst_index = 0;
+std::uint32_t unp_cfg_context              = 0;
+std::uint32_t pack_sync_tile_dst_ptr       = 0;
+std::uint32_t math_sync_tile_dst_index     = 0;
+static constexpr ckernel::DstSync DST_SYNC = ckernel::DstSync::SyncHalf;
 
 #ifdef LLK_TRISC_UNPACK
 
 #include "llk_unpack_A.h"
 #include "llk_unpack_common.h"
-#include "params.h"
 
 void run_kernel(const volatile struct RuntimeParams *params)
 {
-    _llk_unpack_A_init_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
-        0, 0, FACE_R_DIM, 4, formats.unpack_src, formats.unpack_dst);
+    const int MAX_TILES_DEST =
+        is_fp32_dest_acc_en ? (BIT32_DEST_REGISTER_HALF_SIZE / (TILE_NUM_FACES * FACE_R_DIM)) : (DEST_REGISTER_HALF_SIZE / (TILE_NUM_FACES * FACE_R_DIM));
+
     _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
-        formats.unpack_src, formats.unpack_src, formats.unpack_dst, formats.unpack_dst, FACE_R_DIM, FACE_R_DIM, 4 /* num_faces */, 4 /* num_faces */);
+        formats.unpack_src, formats.unpack_src, formats.unpack_dst, formats.unpack_dst, FACE_R_DIM, FACE_R_DIM, TILE_NUM_FACES, TILE_NUM_FACES);
+
+    _llk_unpack_A_init_<BroadcastType::NONE, false /* is_fp32_dest_acc_en - why true does not work? */, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
+        0 /* transpose_of_faces */, 0 /* within_face_16x16_transpose */, FACE_R_DIM, TILE_NUM_FACES, formats.unpack_src, formats.unpack_dst);
 
     for (int i = 0; i < params->TILE_CNT; ++i)
     {
-        _llk_unpack_A_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
+        _llk_unpack_A_<BroadcastType::NONE, false /* is_fp32_dest_acc_en - why true does not work? */, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
             L1_ADDRESS(buffer_A[i]), formats.unpack_src, formats.unpack_dst);
     }
 }
@@ -43,7 +49,6 @@ void run_kernel(const volatile struct RuntimeParams *params)
 #include "llk_math_common.h"
 #include "llk_math_eltwise_unary_datacopy.h"
 #include "llk_math_eltwise_unary_sfpu.h"
-#include "params.h"
 #include "sfpu_operations.h"
 
 using namespace ckernel;
@@ -53,32 +58,41 @@ const int iterations = 32;
 
 void run_kernel(const volatile struct RuntimeParams *params)
 {
+    const int MAX_TILES_DEST =
+        is_fp32_dest_acc_en ? (BIT32_DEST_REGISTER_HALF_SIZE / (TILE_NUM_FACES * FACE_R_DIM)) : (DEST_REGISTER_HALF_SIZE / (TILE_NUM_FACES * FACE_R_DIM));
+
 // copy srca to dest
 #ifdef ARCH_BLACKHOLE
-    _llk_math_eltwise_unary_datacopy_init_<DataCopyType::A2D, is_fp32_dest_acc_en, BroadcastType::NONE, false, false>(4, formats.math);
+    _llk_math_eltwise_unary_datacopy_init_<DataCopyType::A2D, is_fp32_dest_acc_en, BroadcastType::NONE, false, false>(TILE_NUM_FACES, formats.math);
 #else
-    _llk_math_eltwise_unary_datacopy_init_<DataCopyType::A2D, is_fp32_dest_acc_en, BroadcastType::NONE, false>(4, formats.math);
+    _llk_math_eltwise_unary_datacopy_init_<DataCopyType::A2D, is_fp32_dest_acc_en, BroadcastType::NONE, false>(TILE_NUM_FACES, formats.math);
 #endif
-    _llk_math_pack_sync_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
     _llk_math_hw_configure_<is_fp32_dest_acc_en>(formats.math, formats.math);
+    _llk_math_pack_sync_init_<DST_SYNC, is_fp32_dest_acc_en>();
 
-    for (int i = 0; i < params->TILE_CNT; ++i)
+    _llk_math_eltwise_unary_sfpu_init_<SFPU_UNARY_OPERATION>();
+
+    for (int block_start = 0; block_start < params->TILE_CNT; block_start += MAX_TILES_DEST)
     {
-        _llk_math_wait_for_dest_available_<DstSync::SyncHalf>();
-        _llk_math_eltwise_unary_datacopy_<DataCopyType::A2D, DstSync::SyncHalf, is_fp32_dest_acc_en, BroadcastType::NONE, unpack_to_dest>(
-            i, formats.math, formats.math);
+        int block_tiles = std::min(params->TILE_CNT - block_start, MAX_TILES_DEST);
 
-        // calculation of sfpu operation on dest
-        _llk_math_eltwise_unary_sfpu_init_<SFPU_UNARY_OPERATION>();
-        _llk_math_eltwise_unary_sfpu_start_<DstSync::SyncHalf>(i);
-        // calling sfpu function from ckernel
-        // this part is where parametrization of operation takes part
-        test_utils::call_sfpu_operation<APPROX_MODE, is_fp32_dest_acc_en, iterations, FAST_MODE>(SFPU_UNARY_OPERATION, formats.math);
+        _llk_math_wait_for_dest_available_<DST_SYNC>();
+        for (int block_tile = 0; block_tile < block_tiles; ++block_tile)
+        {
+            _llk_math_eltwise_unary_datacopy_<DataCopyType::A2D, DST_SYNC, is_fp32_dest_acc_en, BroadcastType::NONE, unpack_to_dest>(
+                block_tile, formats.math, formats.math);
 
-        _llk_math_eltwise_unary_sfpu_done_();
+            // calculation of sfpu operation on dest
+            _llk_math_eltwise_unary_sfpu_start_<DST_SYNC>(block_tile);
+            // calling sfpu function from ckernel
+            // this part is where parametrization of operation takes part
+            test_utils::call_sfpu_operation<APPROX_MODE, is_fp32_dest_acc_en, iterations>(SFPU_UNARY_OPERATION, formats.math);
+
+            _llk_math_eltwise_unary_sfpu_done_();
+        }
+
+        _llk_math_dest_section_done_<DST_SYNC, is_fp32_dest_acc_en>();
     }
-
-    _llk_math_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
 }
 
 #endif
@@ -87,30 +101,33 @@ void run_kernel(const volatile struct RuntimeParams *params)
 
 #include "llk_pack.h"
 #include "llk_pack_common.h"
-#include "params.h"
 
 void run_kernel(const volatile struct RuntimeParams *params)
 {
-#ifdef ARCH_BLACKHOLE
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, false, false>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
-#else
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, false>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
-#endif
-
-    _llk_pack_init_<false, false>(formats.pack_dst);
+    const int MAX_TILES_DEST =
+        is_fp32_dest_acc_en ? (BIT32_DEST_REGISTER_HALF_SIZE / (TILE_NUM_FACES * FACE_R_DIM)) : (DEST_REGISTER_HALF_SIZE / (TILE_NUM_FACES * FACE_R_DIM));
 
 #ifdef ARCH_BLACKHOLE
-    _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, false, false>(formats.pack_src, formats.pack_dst, FACE_R_DIM * FACE_C_DIM * TILE_NUM_FACES);
+    _llk_pack_init_<false, false>(formats.pack_dst, FACE_R_DIM, TILE_C_DIM, TILE_NUM_FACES);
+    _llk_pack_dest_init_<DST_SYNC, is_fp32_dest_acc_en>();
 #else
-    _llk_pack_dest_init_<DstSync::SyncHalf, false, false>();
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, false>(formats.pack_src, formats.pack_dst, FACE_R_DIM * FACE_C_DIM * TILE_NUM_FACES);
+    _llk_pack_init_<false, false>(formats.pack_dst, FACE_R_DIM, TILE_NUM_FACES);
+    _llk_pack_dest_init_<DST_SYNC, is_fp32_dest_acc_en, false>();
 #endif
 
-    _llk_packer_wait_for_math_done_();
-    for (int i = 0; i < params->TILE_CNT; ++i)
+    for (int block_start = 0; block_start < params->TILE_CNT; block_start += MAX_TILES_DEST)
     {
-        _llk_pack_<DstSync::SyncHalf, is_fp32_dest_acc_en, false>(i, L1_ADDRESS(buffer_Res[i]));
+        int block_tiles = std::min(params->TILE_CNT - block_start, MAX_TILES_DEST);
+
+        _llk_packer_wait_for_math_done_();
+        for (int block_tile = 0; block_tile < block_tiles; ++block_tile)
+        {
+            _llk_pack_<DST_SYNC, is_fp32_dest_acc_en, /* untilize */ false>(block_tile, L1_ADDRESS(buffer_Res[block_start + block_tile]));
+        }
+        _llk_pack_dest_section_done_<DST_SYNC, is_fp32_dest_acc_en>();
     }
-    _llk_pack_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
 }
 
 #endif

--- a/tests/sources/pack_untilize_perf.cpp
+++ b/tests/sources/pack_untilize_perf.cpp
@@ -109,13 +109,16 @@ void run_kernel(const volatile struct RuntimeParams* params)
                 return;
             }
 
-            // FIXME: Currently have no way to mock math for unpack to dest
             for (std::uint32_t loop = 0; loop < params->LOOP_FACTOR; loop++)
             {
                 for (std::uint32_t block = 0; block < params->TILE_CNT / BLOCK_CT_DIM; block++)
                 {
                     for (std::uint32_t block_tile = 0; block_tile < BLOCK_CT_DIM; block_tile++)
                     {
+                        // In this case, unpacker needs software synchronization from math - to acknowledge that destination register is
+                        // "consumed" and can be overwritten with new data.
+                        // Due to the fact that BROADCAST_TYPE is always NONE in the test and combination of unpack_to_dest and 32b data is always set,
+                        // this method will perform synchronization only and no actual data copy.
                         _llk_math_eltwise_unary_datacopy_<DataCopyType::A2D, DstSync::SyncHalf, is_fp32_dest_acc_en, BroadcastType::NONE, unpack_to_dest>(
                             block_tile, formats.math, formats.math);
                     }

--- a/tests/sources/unpack_tilize_perf.cpp
+++ b/tests/sources/unpack_tilize_perf.cpp
@@ -121,6 +121,10 @@ void run_kernel(const volatile struct RuntimeParams* params)
             {
                 for (std::uint32_t i = 0; i < params->TILE_CNT; i++)
                 {
+                    // In this case, unpacker needs software synchronization from math - to acknowledge that destination register is
+                    // "consumed" and can be overwritten with new data.
+                    // Due to the fact that BROADCAST_TYPE is always NONE in the test and combination of unpack_to_dest and 32b data is always set,
+                    // this method will perform synchronization only and no actual data copy.
                     _llk_math_eltwise_unary_datacopy_<DataCopyType::A2D, DstSync::SyncHalf, is_fp32_dest_acc_en, BroadcastType::NONE, unpack_to_dest>(
                         i, formats.math, formats.math);
                 }


### PR DESCRIPTION
### Ticket
#1133
#1146 

### Problem description
It was discovered that LLK is measuring better perf results than real results. The reason was that SFPU was invoked only for the 1st tile in the block, which is incorrect behavior.

### What's changed
This PR fixes a critical performance measurement bug where SFPU (Special Function Processing Unit) operations were only being invoked for the first tile in each block, leading to inaccurate performance results. The fix ensures SFPU operations are called for every tile.

Changes:
- Modified SFPU test kernels to call SFPU operations inside the tile loop instead of once per block
- Refactored to use relative tile indices (block_tile) instead of absolute indices (block_start + block_tile)
- Added Rsqrt operation to the Python test suite

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
