### PR TITLE
Pull _configure_buf_desc_table_ out of _llk_unpack/pack_hw_configure_ 

### DIFF
--- a/tests/sources/quasar/eltwise_binary_broadcast_quasar_test.cpp
+++ b/tests/sources/quasar/eltwise_binary_broadcast_quasar_test.cpp
@@ -48,6 +48,8 @@ void run_kernel(const volatile struct RuntimeParams *params)
     td_val_B.buf_desc_id     = buf_desc_id_b;
     td_val_B.reg_data_format = static_cast<uint8_t>(formats.unpack_dst);
 
+    _configure_buf_desc_table_(td_val_A.buf_desc_id, td_val_A.buf_desc);
+    _configure_buf_desc_table_(td_val_B.buf_desc_id, td_val_B.buf_desc);
     _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(td_val_A, td_val_B);
     _llk_unpack_binary_broadcast_operands_init_<BROADCAST_TYPE>(buf_desc_id_a, buf_desc_id_b, num_tiles_per_unpack);
     _llk_unpack_binary_broadcast_operands_(0, 0);
@@ -108,6 +110,7 @@ void run_kernel(const volatile struct RuntimeParams *params)
     tdma_desc.buf_desc_id     = buf_desc_id;
     tdma_desc.reg_data_format = static_cast<uint8_t>(formats.pack_src);
 
+    _configure_buf_desc_table_(tdma_desc.buf_desc_id, tdma_desc.buf_desc);
     _llk_pack_hw_configure_<p_pacr::PACK0>(tdma_desc);
     _llk_pack_init_<p_pacr::PACK0>(buf_desc_id, num_tiles_per_pack);
     _llk_pack_<p_pacr::PACK0>(0, 0);

--- a/tests/sources/quasar/eltwise_binary_test.cpp
+++ b/tests/sources/quasar/eltwise_binary_test.cpp
@@ -54,6 +54,8 @@ void run_kernel(const volatile struct RuntimeParams *params)
     td_val_B.reg_data_format = static_cast<uint8_t>(formats.unpack_dst);
 
     // Configure hardware for binary operations
+    _configure_buf_desc_table_(td_val_A.buf_desc_id, td_val_A.buf_desc);
+    _configure_buf_desc_table_(td_val_B.buf_desc_id, td_val_B.buf_desc);
     _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(td_val_A, td_val_B);
 
     // Initialize binary operands unpacker - unpack 1 tile per MOP run
@@ -136,6 +138,7 @@ void run_kernel(const volatile struct RuntimeParams *params)
     tdma_desc.reg_data_format = static_cast<uint8_t>(formats.pack_src);
 
     // Configure and initialize pack hardware
+    _configure_buf_desc_table_(tdma_desc.buf_desc_id, tdma_desc.buf_desc);
     _llk_pack_hw_configure_<p_pacr::PACK0>(tdma_desc);
     _llk_pack_init_<p_pacr::PACK0>(buf_desc_id, 1);
 

--- a/tests/sources/quasar/eltwise_unary_datacopy_quasar_test.cpp
+++ b/tests/sources/quasar/eltwise_unary_datacopy_quasar_test.cpp
@@ -46,6 +46,7 @@ void run_kernel(const volatile struct RuntimeParams *params)
     td_val.buf_desc_id     = buf_desc_id;
     td_val.reg_data_format = static_cast<uint8_t>(formats.unpack_dst);
 
+    _configure_buf_desc_table_(td_val.buf_desc_id, td_val.buf_desc);
     if (is_fp32_dest_acc_en)
     {
         // If Dst fmt is 32b and operation is Mov2D, we need both SrcA/B fmts to be configured since Mov2D will be implemented via ELWADD
@@ -120,6 +121,7 @@ void run_kernel(const volatile struct RuntimeParams *params)
     tdma_desc.buf_desc_id     = buf_desc_id;
     tdma_desc.reg_data_format = static_cast<uint8_t>(formats.pack_src);
 
+    _configure_buf_desc_table_(tdma_desc.buf_desc_id, tdma_desc.buf_desc);
     _llk_pack_hw_configure_<p_pacr::PACK0>(tdma_desc);
     _llk_pack_init_<p_pacr::PACK0>(buf_desc_id, num_tiles_per_pack);
     _llk_pack_<p_pacr::PACK0>(params->DST_INDEX, 0);

--- a/tests/sources/quasar/matmul_quasar_test.cpp
+++ b/tests/sources/quasar/matmul_quasar_test.cpp
@@ -51,6 +51,8 @@ void run_kernel(const volatile struct RuntimeParams *params)
     tdma_desc_src_b.buf_desc_id             = buf_desc_id_src_b;
     tdma_desc_src_b.reg_data_format         = (uint)formats.unpack_dst;
 
+    _configure_buf_desc_table_(tdma_desc_src_a.buf_desc_id, tdma_desc_src_a.buf_desc);
+    _configure_buf_desc_table_(tdma_desc_src_b.buf_desc_id, tdma_desc_src_b.buf_desc);
     _llk_unpack_hw_configure_<ckernel::p_unpacr::UNP_B>(tdma_desc_src_a);
     _llk_unpack_hw_configure_<ckernel::p_unpacr::UNP_A>(tdma_desc_src_b);
 
@@ -109,6 +111,7 @@ void run_kernel(const volatile struct RuntimeParams *params)
     tdma_desc_dst.buf_desc_id             = buf_desc_id_dst;
     tdma_desc_dst.reg_data_format         = static_cast<uint8_t>(formats.pack_src);
 
+    _configure_buf_desc_table_(tdma_desc_dst.buf_desc_id, tdma_desc_dst.buf_desc);
     _llk_pack_hw_configure_<p_pacr::PACK0>(tdma_desc_dst);
     _llk_pack_matmul_init_<p_pacr::PACK0>(buf_desc_id_dst, RT_DIM, CT_DIM, 1); // Use destination buffer descriptor for packing output
 

--- a/tests/sources/quasar/pack_quasar_test.cpp
+++ b/tests/sources/quasar/pack_quasar_test.cpp
@@ -46,6 +46,7 @@ void run_kernel(const volatile struct RuntimeParams *params)
     td_val.buf_desc_id     = buf_desc_id;
     td_val.reg_data_format = static_cast<uint8_t>(formats.unpack_dst);
 
+    _configure_buf_desc_table_(td_val.buf_desc_id, td_val.buf_desc);
     if (is_fp32_dest_acc_en && !unpack_to_dest)
     {
         // If Dst fmt is 32b and operation is Mov2D, we need both SrcA/B fmts to be configured since Mov2D will be implemented via ELWADD
@@ -134,6 +135,7 @@ void run_kernel(const volatile struct RuntimeParams *params)
     tdma_desc.buf_desc_id     = buf_desc_id;
     tdma_desc.reg_data_format = static_cast<uint8_t>(formats.pack_src);
 
+    _configure_buf_desc_table_(tdma_desc.buf_desc_id, tdma_desc.buf_desc);
     _llk_pack_hw_configure_<p_pacr::PACK0>(tdma_desc);
     _llk_pack_init_<p_pacr::PACK0>(buf_desc_id, num_tiles_per_pack);
     _llk_pack_<p_pacr::PACK0>(0, 0);

--- a/tests/sources/quasar/pack_untilize_quasar_test.cpp
+++ b/tests/sources/quasar/pack_untilize_quasar_test.cpp
@@ -36,6 +36,7 @@ void run_kernel(const volatile struct RuntimeParams *params)
     td_val.buf_desc_id     = buf_desc_id;
     td_val.reg_data_format = static_cast<uint8_t>(formats.unpack_dst);
 
+    _configure_buf_desc_table_(td_val.buf_desc_id, td_val.buf_desc);
     _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(td_val, td_val);
     _llk_unpack_unary_operand_init_<UNPACKER_ENGINE_SEL, false /*transpose*/, is_fp32_dest_acc_en>(buf_desc_id, num_tiles_per_unpack);
     _llk_unpack_unary_operand_<UNPACKER_ENGINE_SEL>(0);
@@ -108,6 +109,7 @@ void run_kernel(const volatile struct RuntimeParams *params)
     constexpr uint32_t C_DIM_FACES = (tile_shape.narrow_tile ? 1 : 2);                    // Tile width in faces
     constexpr uint32_t R_DIM_FACES = (num_faces == 2 && !tile_shape.narrow_tile) ? 1 : 2; // Tile height in faces
 
+    _configure_buf_desc_table_(tdma_desc.buf_desc_id, tdma_desc.buf_desc);
     _llk_pack_hw_configure_<p_pacr::PACK0>(tdma_desc);
     _llk_pack_untilize_init_<FULL_CT_DIM, BLOCK_CT_DIM, C_DIM_FACES>(buf_desc_id, tile_shape);
 

--- a/tests/sources/quasar/reduce_quasar_test.cpp
+++ b/tests/sources/quasar/reduce_quasar_test.cpp
@@ -51,6 +51,8 @@ void run_kernel(const volatile struct RuntimeParams *params)
     TileShape tile_shape_A = {
         .num_faces = params->num_faces, .face_r_dim = params->TEST_FACE_R_DIM, .face_c_dim = params->TEST_FACE_C_DIM, .narrow_tile = false};
 
+    _configure_buf_desc_table_(td_val_A.buf_desc_id, td_val_A.buf_desc);
+    _configure_buf_desc_table_(td_val_B.buf_desc_id, td_val_B.buf_desc);
     _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(td_val_A, td_val_B);
     _llk_unpack_reduce_init_<REDUCE_DIM>(buf_desc_id_a, buf_desc_id_b, 1 /*num_tiles_per_pack*/, tile_shape_A);
     for (int i = 0; i < params->TILE_CNT; ++i)
@@ -115,6 +117,7 @@ void run_kernel(const volatile struct RuntimeParams *params)
     tdma_desc.buf_desc_id     = buf_desc_id;
     tdma_desc.reg_data_format = static_cast<uint8_t>(formats.pack_src);
 
+    _configure_buf_desc_table_(tdma_desc.buf_desc_id, tdma_desc.buf_desc);
     _llk_pack_hw_configure_<p_pacr::PACK0>(tdma_desc);
     _llk_pack_init_<p_pacr::PACK0>(buf_desc_id, 1 /*num_tiles_per_pack*/);
     _llk_pack_reduce_mask_config_<REDUCE_DIM>();

--- a/tests/sources/quasar/unpack_tilize_quasar_test.cpp
+++ b/tests/sources/quasar/unpack_tilize_quasar_test.cpp
@@ -49,6 +49,7 @@ void run_kernel(const volatile struct RuntimeParams*)
     constexpr uint32_t C_DIM_FACES = (tile_shape.narrow_tile ? 1 : 2);                    // Tile width in faces
     constexpr uint32_t R_DIM_FACES = (num_faces == 2 && !tile_shape.narrow_tile) ? 1 : 2; // Tile height in faces
 
+    _configure_buf_desc_table_(td_val.buf_desc_id, td_val.buf_desc);
     if (is_fp32_dest_acc_en)
     {
         // If Dst fmt is 32b and operation is Mov2D, we need both SrcA/B fmts to be configured since Mov2D will be implemented via ELWADD
@@ -130,6 +131,7 @@ void run_kernel(const volatile struct RuntimeParams*)
     tdma_desc.buf_desc_id     = buf_desc_id;
     tdma_desc.reg_data_format = static_cast<uint8_t>(formats.pack_src);
 
+    _configure_buf_desc_table_(tdma_desc.buf_desc_id, tdma_desc.buf_desc);
     _llk_pack_hw_configure_<p_pacr::PACK0>(tdma_desc);
     _llk_pack_init_<p_pacr::PACK0>(buf_desc_id, num_tiles_per_pack);
     _llk_pack_<p_pacr::PACK0>(0, 0);

--- a/tests/sources/quasar/unpack_unary_operand_quasar_test.cpp
+++ b/tests/sources/quasar/unpack_unary_operand_quasar_test.cpp
@@ -59,6 +59,7 @@ void run_kernel(const volatile struct RuntimeParams *params)
     td_val.buf_desc_id     = buf_desc_id;
     td_val.reg_data_format = static_cast<uint8_t>(formats.unpack_dst);
 
+    _configure_buf_desc_table_(td_val.buf_desc_id, td_val.buf_desc);
     if (is_fp32_dest_acc_en && !unpack_to_dest)
     {
         // If Dst fmt is 32b and operation is Mov2D, we need both SrcA/B fmts to be configured since Mov2D will be implemented via ELWADD
@@ -148,6 +149,7 @@ void run_kernel(const volatile struct RuntimeParams *params)
     tdma_desc.buf_desc_id     = buf_desc_id;
     tdma_desc.reg_data_format = static_cast<uint8_t>(formats.pack_src);
 
+    _configure_buf_desc_table_(tdma_desc.buf_desc_id, tdma_desc.buf_desc);
     _llk_pack_hw_configure_<p_pacr::PACK0>(tdma_desc);
     _llk_pack_init_<p_pacr::PACK0>(buf_desc_id, num_tiles_per_pack);
     _llk_pack_<p_pacr::PACK0>(0, 0);

--- a/tt_llk_quasar/llk_lib/llk_pack_common.h
+++ b/tt_llk_quasar/llk_lib/llk_pack_common.h
@@ -12,16 +12,13 @@ using namespace ckernel::trisc;
 /**
  * @brief Programs packer l1 info & math destination register format
  * @tparam PACK_SEL: Sets which packer to configure. values = p_pacr::PACK0/PACK1
- * @param tdma_desc: Contains L1 buffer descriptor information & destination register format
+ * @param tdma_desc: Contains destination register format
  */
 
 template <uint32_t PACK_SEL>
 inline void _llk_pack_hw_configure_(const tdma_descriptor_t& tdma_desc)
 {
     static_assert((PACK_SEL == p_pacr::PACK0) || (PACK_SEL == p_pacr::PACK1), "PACK_SEL can only be set to p_pacr::PACK0/PACK1");
-
-    // Populate the buffer descriptor table
-    _configure_buf_desc_table_(tdma_desc.buf_desc_id, tdma_desc.buf_desc);
 
     // RT: make defines to aggregate the packer input format address, to make the below a single function
     // Program math destination register format

--- a/tt_llk_quasar/llk_lib/llk_unpack_common.h
+++ b/tt_llk_quasar/llk_lib/llk_unpack_common.h
@@ -12,7 +12,7 @@ using namespace ckernel::trisc;
 /**
  * @brief Programs unpacker l1 info & source register format
  * @tparam UNP_SEL: Sets unpacker to configure. values = p_unpacr::UNP_A/UNP_B/UNP_S
- * @param tdma_desc_src: Contains L1 buffer descriptor information & source reg format for Src Reg
+ * @param tdma_desc_src: Contains source reg format
  */
 template <uint32_t UNP_SEL>
 inline void _llk_unpack_hw_configure_(const tdma_descriptor_t& tdma_desc_src)
@@ -20,9 +20,6 @@ inline void _llk_unpack_hw_configure_(const tdma_descriptor_t& tdma_desc_src)
     static_assert(
         (UNP_SEL == p_unpacr::UNP_A) || (UNP_SEL == p_unpacr::UNP_B) || (UNP_SEL == p_unpacr::UNP_S) || (UNP_SEL == p_unpacr::UNP_DEST),
         "UNP_SEL can only be set to p_unpacr::UNP_A/UNP_B/UNP_S/UNP_DEST");
-
-    // Populate the buffer descriptor table
-    _configure_buf_desc_table_(tdma_desc_src.buf_desc_id, tdma_desc_src.buf_desc);
 
     // RT: make defines to aggregate the source format address, to make the below a single function
     // Program src formats


### PR DESCRIPTION
### Ticket
<!-- Link to Github Issue -->

### Problem description
`_configure_buf_desc_table_` needs to be moved outside of the hw config functions so that in tt-metal, we can have a universal (not pack/unpack hw config specific) function that iterates over all 32 buff descs and configures them.

### What's changed
Buffer descriptors are being configured outside of hardware config functions.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
