### PR TITLE
feat: provide two parameter overload for _llk_math_eltwise_binary_sfpu_params_

### DIFF
--- a/tt_llk_blackhole/llk_lib/llk_defs.h
+++ b/tt_llk_blackhole/llk_lib/llk_defs.h
@@ -9,7 +9,7 @@
 namespace ckernel
 {
 
-enum VectorMode
+enum class VectorMode : uint8_t
 {
     None      = 0,
     R         = 1,

--- a/tt_llk_blackhole/llk_lib/llk_math_eltwise_binary_sfpu_params.h
+++ b/tt_llk_blackhole/llk_lib/llk_math_eltwise_binary_sfpu_params.h
@@ -10,11 +10,9 @@
 
 // Internal implementation - takes a nullary callable that wraps the actual sfpu invocation
 template <typename InvokeFunc>
-inline void _llk_math_eltwise_binary_sfpu_params_impl_(InvokeFunc&& invoke, int vector_mode)
+inline void _llk_math_eltwise_binary_sfpu_params_impl_(InvokeFunc&& invoke, VectorMode mode)
 {
     _llk_math_eltwise_binary_sfpu_start_<DST_SYNC_MODE>(0);
-
-    VectorMode mode = static_cast<VectorMode>(vector_mode);
 
     if (mode == VectorMode::R)
     {
@@ -67,14 +65,14 @@ inline void _llk_math_eltwise_binary_sfpu_params_impl_(InvokeFunc&& invoke, int 
 // Overload for callables that take (dst_index_in0, dst_index_in1, dst_index_out, args...)
 template <bool APPROXIMATE, typename Callable, typename... Args>
 inline void _llk_math_eltwise_binary_sfpu_params_(
-    Callable&& sfpu_func, uint dst_index_in0, uint dst_index_in1, uint dst_index_out, int vector_mode = static_cast<int>(VectorMode::RC), Args&&... args)
+    Callable&& sfpu_func, uint dst_index_in0, uint dst_index_in1, uint dst_index_out, VectorMode vector_mode = VectorMode::RC, Args&&... args)
 {
     _llk_math_eltwise_binary_sfpu_params_impl_([&]() { sfpu_func(dst_index_in0, dst_index_in1, dst_index_out, std::forward<Args>(args)...); }, vector_mode);
 }
 
 // Overload for callables that take (dst_index_in0, dst_index_in1, args...) - no dst_index_out
 template <bool APPROXIMATE, typename Callable, typename... Args>
-inline void _llk_math_eltwise_binary_sfpu_params_(Callable&& sfpu_func, uint dst_index_in0, uint dst_index_in1, int vector_mode, Args&&... args)
+inline void _llk_math_eltwise_binary_sfpu_params_(Callable&& sfpu_func, uint dst_index_in0, uint dst_index_in1, VectorMode vector_mode, Args&&... args)
 {
     _llk_math_eltwise_binary_sfpu_params_impl_([&]() { sfpu_func(dst_index_in0, dst_index_in1, std::forward<Args>(args)...); }, vector_mode);
 }
@@ -83,5 +81,5 @@ inline void _llk_math_eltwise_binary_sfpu_params_(Callable&& sfpu_func, uint dst
 template <bool APPROXIMATE, typename Callable>
 inline void _llk_math_eltwise_binary_sfpu_params_(Callable&& sfpu_func, uint dst_index_in0, uint dst_index_in1)
 {
-    _llk_math_eltwise_binary_sfpu_params_impl_([&]() { sfpu_func(dst_index_in0, dst_index_in1); }, static_cast<int>(VectorMode::RC));
+    _llk_math_eltwise_binary_sfpu_params_impl_([&]() { sfpu_func(dst_index_in0, dst_index_in1); }, VectorMode::RC);
 }

--- a/tt_llk_wormhole_b0/llk_lib/llk_defs.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_defs.h
@@ -9,7 +9,7 @@
 namespace ckernel
 {
 
-enum VectorMode
+enum class VectorMode : uint8_t
 {
     None      = 0,
     R         = 1,

--- a/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_binary_sfpu_params.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_binary_sfpu_params.h
@@ -10,11 +10,9 @@
 
 // Internal implementation - takes a nullary callable that wraps the actual sfpu invocation
 template <typename InvokeFunc>
-inline void _llk_math_eltwise_binary_sfpu_params_impl_(InvokeFunc&& invoke, int vector_mode)
+inline void _llk_math_eltwise_binary_sfpu_params_impl_(InvokeFunc&& invoke, VectorMode mode)
 {
     _llk_math_eltwise_binary_sfpu_start_<DST_SYNC_MODE>(0);
-
-    VectorMode mode = static_cast<VectorMode>(vector_mode);
 
     if (mode == VectorMode::R)
     {
@@ -67,14 +65,14 @@ inline void _llk_math_eltwise_binary_sfpu_params_impl_(InvokeFunc&& invoke, int 
 // Overload for callables that take (dst_index_in0, dst_index_in1, dst_index_out, args...)
 template <bool APPROXIMATE, typename Callable, typename... Args>
 inline void _llk_math_eltwise_binary_sfpu_params_(
-    Callable&& sfpu_func, uint dst_index_in0, uint dst_index_in1, uint dst_index_out, int vector_mode = static_cast<int>(VectorMode::RC), Args&&... args)
+    Callable&& sfpu_func, uint dst_index_in0, uint dst_index_in1, uint dst_index_out, VectorMode vector_mode = VectorMode::RC, Args&&... args)
 {
     _llk_math_eltwise_binary_sfpu_params_impl_([&]() { sfpu_func(dst_index_in0, dst_index_in1, dst_index_out, std::forward<Args>(args)...); }, vector_mode);
 }
 
 // Overload for callables that take (dst_index_in0, dst_index_in1, args...) - no dst_index_out
 template <bool APPROXIMATE, typename Callable, typename... Args>
-inline void _llk_math_eltwise_binary_sfpu_params_(Callable&& sfpu_func, uint dst_index_in0, uint dst_index_in1, int vector_mode, Args&&... args)
+inline void _llk_math_eltwise_binary_sfpu_params_(Callable&& sfpu_func, uint dst_index_in0, uint dst_index_in1, VectorMode vector_mode, Args&&... args)
 {
     _llk_math_eltwise_binary_sfpu_params_impl_([&]() { sfpu_func(dst_index_in0, dst_index_in1, std::forward<Args>(args)...); }, vector_mode);
 }
@@ -83,5 +81,5 @@ inline void _llk_math_eltwise_binary_sfpu_params_(Callable&& sfpu_func, uint dst
 template <bool APPROXIMATE, typename Callable>
 inline void _llk_math_eltwise_binary_sfpu_params_(Callable&& sfpu_func, uint dst_index_in0, uint dst_index_in1)
 {
-    _llk_math_eltwise_binary_sfpu_params_impl_([&]() { sfpu_func(dst_index_in0, dst_index_in1); }, static_cast<int>(VectorMode::RC));
+    _llk_math_eltwise_binary_sfpu_params_impl_([&]() { sfpu_func(dst_index_in0, dst_index_in1); }, VectorMode::RC);
 }


### PR DESCRIPTION
### Ticket
None

### Problem description
Based on comment from @ncvetkovicTT [here](https://github.com/tenstorrent/tt-metal/pull/35216/files#r2712698243)
It seems like our implementation of `_llk_math_eltwise_binary_sfpu_params_` forces user to provide third, out parameter, even when it is unused. This leads to ugly APIs.

### What's changed
Provided a two parameter overloads that hide away dst_out parameter if one isn't needed.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update