### PR TITLE
Fix agreement between UPK and MATH about SrcA dvalids in unary_bcast

### DIFF
--- a/tt_llk_blackhole/llk_lib/llk_math_eltwise_unary_datacopy.h
+++ b/tt_llk_blackhole/llk_lib/llk_math_eltwise_unary_datacopy.h
@@ -342,7 +342,7 @@ inline void eltwise_unary_configure_mop(uint rows_per_inst, uint total_rows, con
         if constexpr (bcast_type == BroadcastType::SCALAR)
         {
             ckernel_template tmp(outerloop, innerloop, TT_OP_MOVB2D(0, 0, addr_mod, broadcast_type, 0));
-            tmp.set_end_op(TT_OP_SETRWC(p_setrwc::CLR_AB, 0, 0, 0, 0, 0));
+            tmp.set_end_op(TT_OP_SETRWC(p_setrwc::CLR_B, 0, 0, 0, 0, 0));
             tmp.program();
         }
         else if constexpr (bcast_type == BroadcastType::COL)

--- a/tt_llk_blackhole/llk_lib/llk_unpack_A.h
+++ b/tt_llk_blackhole/llk_lib/llk_unpack_A.h
@@ -99,10 +99,7 @@ inline void _llk_unpack_A_mop_config_(
             constexpr uint32_t innerloop = 1;
             constexpr uint32_t outerloop = 1; // TODO: add support for num_faces
             ckernel_template tmp(outerloop, innerloop, unpack_srcb, srcb_set_z_2);
-            if (!(unpack_dst_format == (uint)DataFormat::UInt16))
-            {
-                tmp.set_start_op(unpack_srca_set_dvalid);
-            }
+            tmp.set_start_op(unpack_srca_set_dvalid);
             tmp.set_end_op(unpack_srcb);
             tmp.program();
         }

--- a/tt_llk_wormhole_b0/llk_lib/llk_unpack_A.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_unpack_A.h
@@ -99,10 +99,8 @@ inline void _llk_unpack_A_mop_config_(
         constexpr uint32_t innerloop = 1;
         constexpr uint32_t outerloop = 1; // TODO: add support for num_faces
         ckernel_template tmp(outerloop, innerloop, unpack_srcb, srcb_set_z_2);
-        if (!(unpack_dst_format == (uint)DataFormat::UInt16))
-        {
-            tmp.set_start_op(unpack_srca_zerosrc_set_dvalid);
-        }
+        // ELWADD used in datacopy for float16
+        tmp.set_start_op(unpack_srca_zerosrc_set_dvalid);
         tmp.set_end_op(unpack_srcb);
         tmp.program();
     }
@@ -124,11 +122,8 @@ inline void _llk_unpack_A_mop_config_(
         constexpr uint32_t outerloop = 1;
         constexpr uint32_t innerloop = 1;
         ckernel_template tmp(outerloop, innerloop, unpack_srcb_inc_z_0);
-        // ELWADD used in datacopy due to WH broadcast bug, use zerosrca regardless of acc_to_dest
-        if (!(unpack_dst_format == (uint)DataFormat::UInt16))
-        {
-            tmp.set_start_op(unpack_srca_zerosrc_set_dvalid);
-        }
+        // ELWADD used in datacopy for float16
+        tmp.set_start_op(unpack_srca_zerosrc_set_dvalid);
         tmp.program();
     }
     else


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/23354

also probably https://github.com/tenstorrent/tt-metal/issues/36142 (testing this now, will update this)

### Problem description
Broke the agreement between UPK and MATH for SCALAR/COL UInt16/Float16 about setting/unsetting the SrcA dvalid

### What's changed
SCALAR/COL UInt16/Float16 will always set and clear SrcA dvalid exactly once, irrespective of if I use ELWADD or MOVB2D to reduce code complexity 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
