### PR TITLE
Call _configure_buf_desc_table_ in sfpu rsqrt Quasar test

### DIFF
--- a/tests/sources/quasar/sfpu_rsqrt_quasar_test.cpp
+++ b/tests/sources/quasar/sfpu_rsqrt_quasar_test.cpp
@@ -42,6 +42,7 @@ void run_kernel(const volatile struct RuntimeParams *params)
     td_val.buf_desc_id     = buf_desc_id;
     td_val.reg_data_format = static_cast<uint8_t>(formats.unpack_dst);
 
+    _configure_buf_desc_table_(td_val.buf_desc_id, td_val.buf_desc);
     if (is_fp32_dest_acc_en && !unpack_to_dest)
     {
         // If Dst fmt is 32b and operation is Mov2D, we need both SrcA/B fmts to be configured since Mov2D will be implemented via ELWADD
@@ -164,6 +165,7 @@ void run_kernel(const volatile struct RuntimeParams *params)
     tdma_desc.buf_desc_id     = buf_desc_id;
     tdma_desc.reg_data_format = static_cast<uint8_t>(formats.pack_src);
 
+    _configure_buf_desc_table_(tdma_desc.buf_desc_id, tdma_desc.buf_desc);
     _llk_pack_hw_configure_<p_pacr::PACK0>(tdma_desc);
     _llk_pack_init_<p_pacr::PACK0>(buf_desc_id, num_tiles_per_pack);
     _llk_pack_<p_pacr::PACK0>(params->DST_INDEX, 0);


### PR DESCRIPTION
### Ticket
<!-- Link to Github Issue -->

### Problem description
PR #1138 missed to add the call to `_configure_buf_desc_table_` in the Quasar sfpu rsqrt test. 

### What's changed
`_configure_buf_desc_table_` call added to the Quasar sfpu rsqrt test. 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
