### PR TITLE
Fill in missing dst32b datatypes for BH ZEROACC workaround

### DIFF
--- a/tt_llk_blackhole/llk_lib/llk_math_eltwise_unary_datacopy.h
+++ b/tt_llk_blackhole/llk_lib/llk_math_eltwise_unary_datacopy.h
@@ -47,7 +47,7 @@ inline void _llk_math_eltwise_unary_datacopy_(
             // Clears zero flags in DEST for one face.
             TT_ZEROACC(
                 p_zeroacc::CLR_16,
-                static_cast<int>(dst_format == (uint)DataFormat::Float32),
+                static_cast<int>(dst_format == (uint)DataFormat::Float32 || dst_format == (uint)DataFormat::Int32 || dst_format == (uint)DataFormat::UInt32),
                 1 /*clear zero flags*/,
                 ADDR_MOD_3,
                 dest_base_offset_in_faces + dst_index_in_faces + i);


### PR DESCRIPTION
### Ticket
/

### Problem description
ZEROACC workaround was checking for FP32, but not for INT32 types, which could cause the wrong rows' zero flags to be set.

### What's changed
Check for both Int32 and UInt32 in addition to Float32.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
