### PR TITLE
Handle DST bit 11

### DIFF
--- a/tt_llk_blackhole/llk_lib/llk_math_common.h
+++ b/tt_llk_blackhole/llk_lib/llk_math_common.h
@@ -15,14 +15,14 @@ using namespace ckernel::math;
 
 inline void _llk_math_dbg_feature_disable_()
 {
-    // reg_write(RISCV_DEBUG_REG_DBG_FEATURE_DISABLE, 1 << 11); // Set debug feature disable bit 11
+    reg_write(RISCV_DEBUG_REG_DBG_FEATURE_DISABLE, 1 << 11); // Set debug feature disable bit 11
                                                              // workaround for bug tenstorrent/budabackend#1372
 }
 
 inline void _llk_math_dbg_feature_enable_()
 {
-    // tensix_sync();
-    // reg_write(RISCV_DEBUG_REG_DBG_FEATURE_DISABLE, 0); // Clear debug feature disable bit 11
+    tensix_sync();
+    reg_write(RISCV_DEBUG_REG_DBG_FEATURE_DISABLE, 0); // Clear debug feature disable bit 11
                                                        // workaround for bug tenstorrent/budabackend#1372
 }
 
@@ -40,11 +40,6 @@ inline void _llk_math_hw_configure_(const std::uint32_t srca_data_format, const 
     cfg_reg_rmw_tensix<ALU_ACC_CTRL_Fp32_enabled_RMW>(fp32_dest_acc_en);
     cfg_reg_rmw_tensix<ALU_ACC_CTRL_SFPU_Fp32_enabled_RMW>(fp32_dest_acc_en);
 
-    // Workaround for HW bugs:
-    // budabackend#1948: int32 dest and movd2a/b with int8 srcA/B
-    // budabackend#1948: fp32 dest and movd2a/b with UInt16 srcA/B
-    bool uint16_with_fp32_dest =
-        is_fp32_dest_acc_en && (((uint)srca_data_format == (uint)DataFormat::UInt16) || ((uint)srcb_data_format == (uint)DataFormat::UInt16));
 }
 
 inline void _llk_math_reconfig_remap_(const bool remap_enable)

--- a/tt_llk_blackhole/llk_lib/llk_math_common.h
+++ b/tt_llk_blackhole/llk_lib/llk_math_common.h
@@ -45,11 +45,6 @@ inline void _llk_math_hw_configure_(const std::uint32_t srca_data_format, const 
     // budabackend#1948: fp32 dest and movd2a/b with UInt16 srcA/B
     bool uint16_with_fp32_dest =
         is_fp32_dest_acc_en && (((uint)srca_data_format == (uint)DataFormat::UInt16) || ((uint)srcb_data_format == (uint)DataFormat::UInt16));
-
-    if (int8_math_enabled || uint16_with_fp32_dest)
-    {
-        _llk_math_dbg_feature_disable_();
-    }
 }
 
 inline void _llk_math_reconfig_remap_(const bool remap_enable)

--- a/tt_llk_blackhole/llk_lib/llk_math_common.h
+++ b/tt_llk_blackhole/llk_lib/llk_math_common.h
@@ -15,14 +15,14 @@ using namespace ckernel::math;
 
 inline void _llk_math_dbg_feature_disable_()
 {
-    reg_write(RISCV_DEBUG_REG_DBG_FEATURE_DISABLE, 1 << 11); // Set debug feature disable bit 11
+    // reg_write(RISCV_DEBUG_REG_DBG_FEATURE_DISABLE, 1 << 11); // Set debug feature disable bit 11
                                                              // workaround for bug tenstorrent/budabackend#1372
 }
 
 inline void _llk_math_dbg_feature_enable_()
 {
-    tensix_sync();
-    reg_write(RISCV_DEBUG_REG_DBG_FEATURE_DISABLE, 0); // Clear debug feature disable bit 11
+    // tensix_sync();
+    // reg_write(RISCV_DEBUG_REG_DBG_FEATURE_DISABLE, 0); // Clear debug feature disable bit 11
                                                        // workaround for bug tenstorrent/budabackend#1372
 }
 

--- a/tt_llk_blackhole/llk_lib/llk_math_eltwise_unary_datacopy.h
+++ b/tt_llk_blackhole/llk_lib/llk_math_eltwise_unary_datacopy.h
@@ -375,11 +375,16 @@ inline void eltwise_unary_configure_mop(uint rows_per_inst, uint total_rows, con
     }
 }
 
-template <DataCopyType type, bool is_fp32_dest_acc_en, BroadcastType src_b_bcast_type = BroadcastType::NONE, bool tilize = false, bool is_int_fpu_en = false>
+template <DataCopyType type, bool is_fp32_dest_acc_en, BroadcastType src_b_bcast_type = BroadcastType::NONE, bool tilize = false, bool is_int_fpu_en = false, bool unpack_to_dest = false>
 inline void _llk_math_eltwise_unary_datacopy_init_(const std::uint32_t num_faces = 4, const std::uint32_t dst_format = 255)
 {
     LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be 1, 2, or 4");
     eltwise_unary_configure_addrmod<type, src_b_bcast_type>(dst_format);
+
+    if constexpr (src_b_bcast_type != BroadcastType::NONE)
+    {
+        _llk_math_dbg_feature_disable_();
+    }
 
     if constexpr (type == A2D && src_b_bcast_type == BroadcastType::NONE)
     {

--- a/tt_llk_blackhole/llk_lib/llk_math_eltwise_unary_datacopy.h
+++ b/tt_llk_blackhole/llk_lib/llk_math_eltwise_unary_datacopy.h
@@ -376,12 +376,12 @@ inline void eltwise_unary_configure_mop(uint rows_per_inst, uint total_rows, con
 }
 
 template <DataCopyType type, bool is_fp32_dest_acc_en, BroadcastType src_b_bcast_type = BroadcastType::NONE, bool tilize = false, bool is_int_fpu_en = false, bool unpack_to_dest = false>
-inline void _llk_math_eltwise_unary_datacopy_init_(const std::uint32_t num_faces = 4, const std::uint32_t dst_format = 255)
+inline void _llk_math_eltwise_unary_datacopy_init_(const std::uint32_t num_faces = 4, const std::uint32_t dst_format = 255, const bool is_32bit_input = false)
 {
     LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be 1, 2, or 4");
     eltwise_unary_configure_addrmod<type, src_b_bcast_type>(dst_format);
 
-    if constexpr (src_b_bcast_type != BroadcastType::NONE)
+    if (unpack_to_dest && (src_b_bcast_type != BroadcastType::NONE || is_32bit_input))
     {
         _llk_math_dbg_feature_disable_();
     }
@@ -411,10 +411,10 @@ inline void _llk_math_eltwise_unary_datacopy_init_(const std::uint32_t num_faces
 }
 
 template <BroadcastType src_b_bcast_type = BroadcastType::NONE, bool unpack_to_dest = false>
-inline void _llk_math_eltwise_unary_datacopy_uninit_()
+inline void _llk_math_eltwise_unary_datacopy_uninit_(const bool is_32bit_input = false)
 {
     // clear debug feature disable
-    if constexpr (src_b_bcast_type != BroadcastType::NONE && unpack_to_dest)
+    if (unpack_to_dest && (src_b_bcast_type != BroadcastType::NONE || is_32bit_input))
     {
         _llk_math_dbg_feature_enable_();
     }

--- a/tt_llk_blackhole/llk_lib/llk_math_reduce.h
+++ b/tt_llk_blackhole/llk_lib/llk_math_reduce.h
@@ -465,6 +465,7 @@ inline void _llk_math_reduce_init_()
     if constexpr (enforce_fp32_accumulation)
     {
         static_assert(is_fp32_dest_acc_en, "FP32 Dest must be enabled for FP32 accumulation");
+        __llk_math_dbg_feature_disable_();
     }
     TTI_SETC16(CLR_DVALID_SrcA_Disable_ADDR32, 0);
 

--- a/tt_llk_blackhole/llk_lib/llk_math_transpose_dest.h
+++ b/tt_llk_blackhole/llk_lib/llk_math_transpose_dest.h
@@ -247,10 +247,19 @@ inline void _llk_math_transpose_dest_init_()
     transpose_dest_configure_addrmod<is_32bit>();
     transpose_dest_configure_mop<transpose_of_faces, is_32bit>();
 
+    if constexpr (is_32bit)
+    {
+        _llk_math_dbg_feature_disable_();
+    }
+
     TTI_SETC16(CLR_DVALID_SrcA_Disable_ADDR32, 0);
 }
 
+template <bool is_32bit = false>
 inline void _llk_math_transpose_dest_uninit_()
 {
-    // No state to restore - all states are transient or default
+    if constexpr (is_32bit)
+    {
+        _llk_math_dbg_feature_enable_();
+    }
 }

--- a/tt_llk_blackhole/llk_lib/llk_pack_common.h
+++ b/tt_llk_blackhole/llk_lib/llk_pack_common.h
@@ -17,17 +17,6 @@
 using namespace ckernel;
 using namespace ckernel::packer;
 
-inline void _llk_pack_dbg_feature_disable_()
-{
-    // reg_write(RISCV_DEBUG_REG_DBG_FEATURE_DISABLE, 1 << 11); // Set debug feature disable bit 11
-}
-
-inline void _llk_pack_dbg_feature_enable_()
-{
-    // tensix_sync();
-    // reg_write(RISCV_DEBUG_REG_DBG_FEATURE_DISABLE, 0); // Clear debug feature disable bit 11
-}
-
 // wait until math is done and has produced something to pack
 inline void _llk_packer_wait_for_math_done_()
 {
@@ -147,11 +136,6 @@ inline void _llk_pack_reconfig_l1_acc_(const std::uint32_t enable)
 template <bool untilize = false, ReduceDim dim, bool enforce_fp32_accumulation = false>
 inline void _llk_pack_reduce_mask_config_()
 {
-    if constexpr (enforce_fp32_accumulation)
-    {
-        _llk_pack_dbg_feature_disable_();
-    }
-
     ckernel::packer::pck_edge_offset_u pack_edge_offset = {.val = 0};
 
     // We initialize PCK_EDGE_OFFSET_SEC0 mask to clear out all the datums in the row

--- a/tt_llk_blackhole/llk_lib/llk_pack_common.h
+++ b/tt_llk_blackhole/llk_lib/llk_pack_common.h
@@ -17,6 +17,17 @@
 using namespace ckernel;
 using namespace ckernel::packer;
 
+inline void _llk_pack_dbg_feature_disable_()
+{
+    reg_write(RISCV_DEBUG_REG_DBG_FEATURE_DISABLE, 1 << 11); // Set debug feature disable bit 11
+}
+
+inline void _llk_pack_dbg_feature_enable_()
+{
+    tensix_sync();
+    reg_write(RISCV_DEBUG_REG_DBG_FEATURE_DISABLE, 0); // Clear debug feature disable bit 11
+}
+
 // wait until math is done and has produced something to pack
 inline void _llk_packer_wait_for_math_done_()
 {
@@ -133,9 +144,14 @@ inline void _llk_pack_reconfig_l1_acc_(const std::uint32_t enable)
     reconfigure_packer_l1_acc(enable);
 }
 
-template <bool untilize = false, ReduceDim dim>
+template <bool untilize = false, ReduceDim dim, bool enforce_fp32_accumulation = false>
 inline void _llk_pack_reduce_mask_config_()
 {
+    if constexpr (enforce_fp32_accumulation)
+    {
+        _llk_pack_dbg_feature_disable_();
+    }
+
     ckernel::packer::pck_edge_offset_u pack_edge_offset = {.val = 0};
 
     // We initialize PCK_EDGE_OFFSET_SEC0 mask to clear out all the datums in the row
@@ -217,8 +233,14 @@ inline void _llk_pack_reduce_mask_config_()
     TTI_NOP;
 }
 
+template <bool enforce_fp32_accumulation = false>
 inline void _llk_pack_reduce_mask_clear_()
 {
+    if constexpr (enforce_fp32_accumulation)
+    {
+        _llk_pack_dbg_feature_enable_();
+    }
+
     // By default, all packers are set to use TILE_ROW_SET_MAPPING_0 and
     // mask is configured to pass through all the datums
     pck_edge_offset_u pack_edge_offset = {.val = 0};

--- a/tt_llk_blackhole/llk_lib/llk_pack_common.h
+++ b/tt_llk_blackhole/llk_lib/llk_pack_common.h
@@ -19,13 +19,13 @@ using namespace ckernel::packer;
 
 inline void _llk_pack_dbg_feature_disable_()
 {
-    reg_write(RISCV_DEBUG_REG_DBG_FEATURE_DISABLE, 1 << 11); // Set debug feature disable bit 11
+    // reg_write(RISCV_DEBUG_REG_DBG_FEATURE_DISABLE, 1 << 11); // Set debug feature disable bit 11
 }
 
 inline void _llk_pack_dbg_feature_enable_()
 {
-    tensix_sync();
-    reg_write(RISCV_DEBUG_REG_DBG_FEATURE_DISABLE, 0); // Clear debug feature disable bit 11
+    // tensix_sync();
+    // reg_write(RISCV_DEBUG_REG_DBG_FEATURE_DISABLE, 0); // Clear debug feature disable bit 11
 }
 
 // wait until math is done and has produced something to pack

--- a/tt_llk_blackhole/llk_lib/llk_unpack_A.h
+++ b/tt_llk_blackhole/llk_lib/llk_unpack_A.h
@@ -219,11 +219,11 @@ inline void _llk_unpack_A_init_(
         config_unpacker_x_end<UNP_SEL>(face_r_dim);
     }
 
-    // TODO NC: Move to TRISC1 tt-metal#36411
-    if constexpr (BType != BroadcastType::NONE && unpack_to_dest)
-    {
-        _llk_unpack_dbg_feature_disable_();
-    }
+    // // TODO NC: Move to TRISC1 tt-metal#36411
+    // if constexpr (BType != BroadcastType::NONE && unpack_to_dest)
+    // {
+    //     _llk_unpack_dbg_feature_disable_();
+    // }
     _llk_unpack_A_mop_config_<BType, acc_to_dest, binary_reuse_dest, unpack_to_dest>(transpose_of_faces > 0, num_faces, unpack_src_format, unpack_dst_format);
 }
 

--- a/tt_llk_blackhole/llk_lib/llk_unpack_A.h
+++ b/tt_llk_blackhole/llk_lib/llk_unpack_A.h
@@ -219,11 +219,6 @@ inline void _llk_unpack_A_init_(
         config_unpacker_x_end<UNP_SEL>(face_r_dim);
     }
 
-    // // TODO NC: Move to TRISC1 tt-metal#36411
-    // if constexpr (BType != BroadcastType::NONE && unpack_to_dest)
-    // {
-    //     _llk_unpack_dbg_feature_disable_();
-    // }
     _llk_unpack_A_mop_config_<BType, acc_to_dest, binary_reuse_dest, unpack_to_dest>(transpose_of_faces > 0, num_faces, unpack_src_format, unpack_dst_format);
 }
 

--- a/tt_llk_blackhole/llk_lib/llk_unpack_common.h
+++ b/tt_llk_blackhole/llk_lib/llk_unpack_common.h
@@ -99,13 +99,6 @@ inline void _llk_unpack_reconfig_data_format_srcb_impl_(
     TT_SETDMAREG(0, LOWER_HALFWORD(tile_size), 0, LO_16(p_gpr_unpack::TILE_SIZE_B)); // update gpr which holds tile size B
 }
 
-// TODO NC: Remove as a part of tt-metal#36411
-inline void _llk_unpack_dbg_feature_disable_()
-{
-    reg_write(RISCV_DEBUG_REG_DBG_FEATURE_DISABLE, 1 << 11); // Set debug feature disable bit 11
-                                                             // workaround for bug tenstorrent/budabackend#1372
-}
-
 inline void _llk_enable_int8_fpu_math_()
 {
     enable_int8_fpu_math();

--- a/tt_llk_wormhole_b0/llk_lib/llk_math_common.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_math_common.h
@@ -36,21 +36,12 @@ inline void _llk_math_hw_configure_(const std::uint32_t srca_data_format, const 
                        (int8_math_enabled << ALU_ACC_CTRL_INT8_math_enabled_SHAMT);
     constexpr uint config_mask = ALU_FORMAT_SPEC_REG0_SrcA_MASK | ALU_FORMAT_SPEC_REG1_SrcB_MASK | ALU_ACC_CTRL_INT8_math_enabled_MASK;
     cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG0_SrcA_ADDR32, 0, config_mask>(config_data);
-
-    uint32_t fp32_dest_acc_en = is_fp32_dest_acc_en ? 1 : 0;
-    cfg_reg_rmw_tensix<ALU_ACC_CTRL_Fp32_enabled_RMW>(fp32_dest_acc_en);
-    cfg_reg_rmw_tensix<ALU_ACC_CTRL_SFPU_Fp32_enabled_RMW>(fp32_dest_acc_en);
+    cfg_reg_rmw_tensix<ALU_ACC_CTRL_Fp32_enabled_RMW>(is_fp32_dest_acc_en);
+    cfg_reg_rmw_tensix<ALU_ACC_CTRL_SFPU_Fp32_enabled_RMW>(is_fp32_dest_acc_en);
 
     // Workaround for HW bugs:
     // budabackend#1948: int32 dest and movd2a/b with int8 srcA/B
     // budabackend#1948: fp32 dest and movd2a/b with UInt16 srcA/B
-    bool uint16_with_fp32_dest =
-        is_fp32_dest_acc_en && (((uint)srca_data_format == (uint)DataFormat::UInt16) || ((uint)srcb_data_format == (uint)DataFormat::UInt16));
-
-    if (int8_math_enabled || uint16_with_fp32_dest)
-    {
-        _llk_math_dbg_feature_disable_();
-    }
 }
 
 template <DstSync Dst>

--- a/tt_llk_wormhole_b0/llk_lib/llk_math_common.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_math_common.h
@@ -15,14 +15,14 @@ using namespace ckernel::math;
 
 inline void _llk_math_dbg_feature_disable_()
 {
-    // reg_write(RISCV_DEBUG_REG_DBG_FEATURE_DISABLE, 1 << 11); // Set debug feature disable bit 11
+    reg_write(RISCV_DEBUG_REG_DBG_FEATURE_DISABLE, 1 << 11); // Set debug feature disable bit 11
                                                              // workaround for bug tenstorrent/budabackend#1372
 }
 
 inline void _llk_math_dbg_feature_enable_()
 {
-    // tensix_sync();
-    // reg_write(RISCV_DEBUG_REG_DBG_FEATURE_DISABLE, 0); // Clear debug feature disable bit 11
+    tensix_sync();
+    reg_write(RISCV_DEBUG_REG_DBG_FEATURE_DISABLE, 0); // Clear debug feature disable bit 11
                                                        // workaround for bug tenstorrent/budabackend#1372
 }
 

--- a/tt_llk_wormhole_b0/llk_lib/llk_math_common.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_math_common.h
@@ -15,14 +15,14 @@ using namespace ckernel::math;
 
 inline void _llk_math_dbg_feature_disable_()
 {
-    reg_write(RISCV_DEBUG_REG_DBG_FEATURE_DISABLE, 1 << 11); // Set debug feature disable bit 11
+    // reg_write(RISCV_DEBUG_REG_DBG_FEATURE_DISABLE, 1 << 11); // Set debug feature disable bit 11
                                                              // workaround for bug tenstorrent/budabackend#1372
 }
 
 inline void _llk_math_dbg_feature_enable_()
 {
-    tensix_sync();
-    reg_write(RISCV_DEBUG_REG_DBG_FEATURE_DISABLE, 0); // Clear debug feature disable bit 11
+    // tensix_sync();
+    // reg_write(RISCV_DEBUG_REG_DBG_FEATURE_DISABLE, 0); // Clear debug feature disable bit 11
                                                        // workaround for bug tenstorrent/budabackend#1372
 }
 

--- a/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_unary_datacopy.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_unary_datacopy.h
@@ -362,12 +362,12 @@ inline void eltwise_unary_configure_mop(uint rows_per_inst, uint total_rows, con
 }
 
 template <DataCopyType type, bool is_fp32_dest_acc_en, BroadcastType src_b_bcast_type = BroadcastType::NONE, bool is_int_fpu_en = false, bool unpack_to_dest = false>
-inline void _llk_math_eltwise_unary_datacopy_init_(const std::uint32_t num_faces = 4, const std::uint32_t dst_format = 255)
+inline void _llk_math_eltwise_unary_datacopy_init_(const std::uint32_t num_faces = 4, const std::uint32_t dst_format = 255, const bool is_32bit_input = false)
 {
     LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be 1, 2, or 4");
     eltwise_unary_configure_addrmod<type, src_b_bcast_type>(dst_format);
 
-    if (src_b_bcast_type != BroadcastType::NONE && unpack_to_dest)
+    if (unpack_to_dest && (src_b_bcast_type != BroadcastType::NONE || is_32bit_input))
     {
         _llk_math_dbg_feature_disable_();
     }
@@ -387,10 +387,10 @@ inline void _llk_math_eltwise_unary_datacopy_init_(const std::uint32_t num_faces
 }
 
 template <BroadcastType src_b_bcast_type = BroadcastType::NONE, bool unpack_to_dest = false>
-inline void _llk_math_eltwise_unary_datacopy_uninit_()
+inline void _llk_math_eltwise_unary_datacopy_uninit_(const bool is_32bit_input)
 {
     // clear debug feature disable
-    if constexpr (src_b_bcast_type != BroadcastType::NONE && unpack_to_dest)
+    if (unpack_to_dest && (src_b_bcast_type != BroadcastType::NONE || is_32bit_input))
     {
         _llk_math_dbg_feature_enable_();
     }

--- a/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_unary_datacopy.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_unary_datacopy.h
@@ -263,7 +263,7 @@ inline void eltwise_unary_configure_mop(uint rows_per_inst, uint total_rows, con
         uint innerloop = (rows_per_inst == p_mova2d::MOV_1_ROW) ? total_rows : (total_rows >> 3);
         uint outerloop = num_faces;
 
-        if(unpack_to_dest && is_fp32_dest_acc_en && !is_32bit_input(dst_format, dst_format) && !(dst_format == (uint)DataFormat::UInt16)){
+        if(unpack_to_dest && is_fp32_dest_acc_en && !is_32bit_input(dst_format, dst_format) && dst_format != (uint)DataFormat::UInt16){
             ckernel_template tmp(outerloop, innerloop, TT_OP_ELWADD(0, 0, p_elwise::SRCB_NO_BCAST, ADDR_MOD_2, 0));
             tmp.set_end_op(TT_OP_SETRWC(p_setrwc::CLR_AB, 0, 0, 0, 0, p_setrwc::SET_AB));
             tmp.program();
@@ -360,7 +360,7 @@ inline void _llk_math_eltwise_unary_datacopy_init_(const std::uint32_t num_faces
 {
     LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be 1, 2, or 4");
     eltwise_unary_configure_addrmod<type, src_b_bcast_type>(dst_format);
-    if (is_fp32_dest_acc_en)
+    if (is_fp32_dest_acc_en || unpack_to_dest)
     {
         _llk_math_dbg_feature_disable_();
     }

--- a/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_unary_datacopy.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_unary_datacopy.h
@@ -34,6 +34,9 @@ inline void _llk_math_eltwise_unary_datacopy_(const std::uint32_t dst_index, con
             cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(1); // Do not 0 out ints
             TTI_SETDVALID(0b10);
 
+            cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG_SrcA_override_RMW>(1);
+            cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG_SrcA_val_RMW>(static_cast<std::uint32_t>(DataFormat::Tf32));
+
             // move back to B and broadcast in 2 parts, first hi16 bits then lo16 bits
             constexpr int dest_32b_hi = 0;
             constexpr int dest_32b_lo = 1;
@@ -52,9 +55,14 @@ inline void _llk_math_eltwise_unary_datacopy_(const std::uint32_t dst_index, con
             TTI_MOVB2D(dest_32b_hi, p_movb2d::SRC_ROW16_OFFSET, ADDR_MOD_3, p_movb2d::MOV_8_ROW_BRCST, 48);
             TTI_MOVB2D(dest_32b_hi, p_movb2d::SRC_ROW16_OFFSET, ADDR_MOD_3, p_movb2d::MOV_8_ROW_BRCST, 56);
 
+            cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG_SrcA_val_RMW>(static_cast<std::uint32_t>(DataFormat::Float16));
+
             // move lo bits D2B
             TTI_MOVD2B(dest_32b_lo, p_movd2b::SRC_ZERO_OFFSET, ADDR_MOD_3, p_movd2b::MOV_1_ROW, 0);
             TTI_MOVD2B(dest_32b_lo, p_movd2b::SRC_ROW16_OFFSET, ADDR_MOD_3, p_movd2b::MOV_1_ROW, 16);
+
+            cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG_SrcA_override_RMW>(0);
+            cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG_SrcA_val_RMW>(static_cast<std::uint32_t>(DataFormat::Float32));
 
             // broadcast lo bits B2D
             TTI_MOVB2D(dest_32b_lo, p_movb2d::SRC_ZERO_OFFSET, ADDR_MOD_3, p_movb2d::MOV_8_ROW_BRCST, 0);
@@ -67,7 +75,7 @@ inline void _llk_math_eltwise_unary_datacopy_(const std::uint32_t dst_index, con
             TTI_MOVB2D(dest_32b_lo, p_movb2d::SRC_ROW16_OFFSET, ADDR_MOD_3, p_movb2d::MOV_8_ROW_BRCST, 56);
 
             // restore fp32 mode
-            cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(0);
+            // cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(0);
             TTI_CLEARDVALID(0b10, 0);
         }
         else if constexpr (src_b_bcast_type == BroadcastType::SCALAR)
@@ -75,6 +83,9 @@ inline void _llk_math_eltwise_unary_datacopy_(const std::uint32_t dst_index, con
             // workarounds for hi/lo D2B/B2D on BH (Issue #449)
             cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(1); // Do not 0 out ints
             TTI_SETDVALID(0b10);
+
+            cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG_SrcA_override_RMW>(1);
+            cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG_SrcA_val_RMW>(static_cast<std::uint32_t>(DataFormat::Tf32));
 
             // move back to B and broadcast in 2 parts, first hi16 bits then lo16 bits
             constexpr int dest_32b_hi = 0;
@@ -93,8 +104,13 @@ inline void _llk_math_eltwise_unary_datacopy_(const std::uint32_t dst_index, con
             TTI_MOVB2D(dest_32b_hi, p_movb2d::SRC_ZERO_OFFSET, ADDR_MOD_3, p_movb2d::MOV_8_ROW_BRCST_D0_BRCST, 48);
             TTI_MOVB2D(dest_32b_hi, p_movb2d::SRC_ZERO_OFFSET, ADDR_MOD_3, p_movb2d::MOV_8_ROW_BRCST_D0_BRCST, 56);
 
+            cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG_SrcA_val_RMW>(static_cast<std::uint32_t>(DataFormat::Float16));
+
             // move lo bits D2B
             TTI_MOVD2B(dest_32b_lo, p_movd2b::SRC_ZERO_OFFSET, ADDR_MOD_3, p_movd2b::MOV_1_ROW, 0);
+
+            cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG_SrcA_override_RMW>(0);
+            cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG_SrcA_val_RMW>(static_cast<std::uint32_t>(DataFormat::Float32));
 
             // broadcast lo bits B2D
             TTI_MOVB2D(dest_32b_lo, p_movb2d::SRC_ZERO_OFFSET, ADDR_MOD_3, p_movb2d::MOV_8_ROW_BRCST_D0_BRCST, 0);
@@ -116,9 +132,12 @@ inline void _llk_math_eltwise_unary_datacopy_(const std::uint32_t dst_index, con
             cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(1); // Do not 0 out ints
             TTI_SETDVALID(0b10);
 
+
 #pragma GCC unroll 2
             for (int offset = 0; offset < 2; ++offset)
             {
+            cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG_SrcA_override_RMW>(1);
+            cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG_SrcA_val_RMW>(static_cast<std::uint32_t>(DataFormat::Tf32));
 #pragma GCC unroll 2
                 for (int dst_32b_hi_lo_idx = 0; dst_32b_hi_lo_idx < 2; ++dst_32b_hi_lo_idx)
                 {
@@ -128,6 +147,10 @@ inline void _llk_math_eltwise_unary_datacopy_(const std::uint32_t dst_index, con
                     TTI_MOVD2B(dst_32b_hi_lo_idx, p_movd2b::SRC_ROW16_OFFSET + 8, ADDR_MOD_3, p_movd2b::MOV_4_ROWS, offset * 32 + 8);
                     TTI_MOVD2B(dst_32b_hi_lo_idx, p_movd2b::SRC_ROW16_OFFSET + 12, ADDR_MOD_3, p_movd2b::MOV_4_ROWS, offset * 32 + 12);
 
+                    if(dst_32b_hi_lo_idx == 1){
+                        cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG_SrcA_val_RMW>(static_cast<std::uint32_t>(DataFormat::Float32));
+                    }
+
                     TTI_MOVB2D(dst_32b_hi_lo_idx, p_movb2d::SRC_ROW16_OFFSET, ADDR_MOD_3, p_movb2d::MOV_4_ROWS_D0_BRCST, offset * 32 + 0);
                     TTI_MOVB2D(dst_32b_hi_lo_idx, p_movb2d::SRC_ROW16_OFFSET + 4, ADDR_MOD_3, p_movb2d::MOV_4_ROWS_D0_BRCST, offset * 32 + 4);
                     TTI_MOVB2D(dst_32b_hi_lo_idx, p_movb2d::SRC_ROW16_OFFSET + 8, ADDR_MOD_3, p_movb2d::MOV_4_ROWS_D0_BRCST, offset * 32 + 8);
@@ -136,11 +159,14 @@ inline void _llk_math_eltwise_unary_datacopy_(const std::uint32_t dst_index, con
                     TTI_MOVB2D(dst_32b_hi_lo_idx, p_movb2d::SRC_ROW16_OFFSET + 4, ADDR_MOD_3, p_movb2d::MOV_4_ROWS_D0_BRCST, offset * 32 + 20);
                     TTI_MOVB2D(dst_32b_hi_lo_idx, p_movb2d::SRC_ROW16_OFFSET + 8, ADDR_MOD_3, p_movb2d::MOV_4_ROWS_D0_BRCST, offset * 32 + 24);
                     TTI_MOVB2D(dst_32b_hi_lo_idx, p_movb2d::SRC_ROW16_OFFSET + 12, ADDR_MOD_3, p_movb2d::MOV_4_ROWS_D0_BRCST, offset * 32 + 28);
+
+                    if(dst_32b_hi_lo_idx == 0){
+                        cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG_SrcA_val_RMW>(static_cast<std::uint32_t>(DataFormat::Float16));
+                    }
                 }
             }
 
             // restore fp32 mode
-
             cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(0);
             TTI_CLEARDVALID(0b10, 0);
         }

--- a/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_unary_datacopy.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_unary_datacopy.h
@@ -263,7 +263,7 @@ inline void eltwise_unary_configure_mop(uint rows_per_inst, uint total_rows, con
         uint innerloop = (rows_per_inst == p_mova2d::MOV_1_ROW) ? total_rows : (total_rows >> 3);
         uint outerloop = num_faces;
 
-        if(unpack_to_dest && is_fp32_dest_acc_en && !is_32bit_input(dst_format, dst_format)){
+        if(unpack_to_dest && is_fp32_dest_acc_en && !is_32bit_input(dst_format, dst_format) && !(dst_format == (uint)DataFormat::UInt16)){
             ckernel_template tmp(outerloop, innerloop, TT_OP_ELWADD(0, 0, p_elwise::SRCB_NO_BCAST, ADDR_MOD_2, 0));
             tmp.set_end_op(TT_OP_SETRWC(p_setrwc::CLR_AB, 0, 0, 0, 0, p_setrwc::SET_AB));
             tmp.program();

--- a/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_unary_datacopy.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_unary_datacopy.h
@@ -22,12 +22,12 @@ inline void eltwise_unary_configure_addrmod(const uint dst_format);
 template <DataCopyType type, DstSync Dst, bool is_fp32_dest_acc_en, BroadcastType src_b_bcast_type = BroadcastType::NONE, bool unpack_to_dest = false>
 inline void _llk_math_eltwise_unary_datacopy_(const std::uint32_t dst_index, const std::uint32_t src_format, const std::uint32_t dst_format)
 {
+
     if (unpack_to_dest && is_32bit_input(src_format, dst_format))
     {
         math_unpack_to_dest_math_ready();
         math::set_dst_write_addr<DstTileShape::Tile32x32, UnpackDestination::DestReg>(dst_index);
         math::math_unpack_to_dest_tile_ready();
-
         if constexpr (src_b_bcast_type == BroadcastType::ROW)
         {
             // workarounds for hi/lo D2B/B2D on BH (Issue #449)
@@ -393,7 +393,7 @@ inline void _llk_math_eltwise_unary_datacopy_init_(const std::uint32_t num_faces
     LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be 1, 2, or 4");
     eltwise_unary_configure_addrmod<type, src_b_bcast_type>(dst_format);
 
-    if (unpack_to_dest && (src_b_bcast_type != BroadcastType::NONE || is_32bit_input))
+    if (src_b_bcast_type != BroadcastType::NONE || is_32bit_input)
     {
         _llk_math_dbg_feature_disable_();
     }
@@ -416,7 +416,7 @@ template <BroadcastType src_b_bcast_type = BroadcastType::NONE, bool unpack_to_d
 inline void _llk_math_eltwise_unary_datacopy_uninit_(const bool is_32bit_input)
 {
     // clear debug feature disable
-    if (unpack_to_dest && (src_b_bcast_type != BroadcastType::NONE || is_32bit_input))
+    if (src_b_bcast_type != BroadcastType::NONE || is_32bit_input)
     {
         _llk_math_dbg_feature_enable_();
     }

--- a/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_unary_datacopy.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_unary_datacopy.h
@@ -360,7 +360,7 @@ inline void _llk_math_eltwise_unary_datacopy_init_(const std::uint32_t num_faces
 {
     LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be 1, 2, or 4");
     eltwise_unary_configure_addrmod<type, src_b_bcast_type>(dst_format);
-    if (is_fp32_dest_acc_en || unpack_to_dest)
+    if (is_fp32_dest_acc_en || (unpack_to_dest && is_32bit_input))
     {
         _llk_math_dbg_feature_disable_();
     }

--- a/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_unary_datacopy.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_unary_datacopy.h
@@ -361,11 +361,17 @@ inline void eltwise_unary_configure_mop(uint rows_per_inst, uint total_rows, con
     }
 }
 
-template <DataCopyType type, bool is_fp32_dest_acc_en, BroadcastType src_b_bcast_type = BroadcastType::NONE, bool is_int_fpu_en = false>
+template <DataCopyType type, bool is_fp32_dest_acc_en, BroadcastType src_b_bcast_type = BroadcastType::NONE, bool is_int_fpu_en = false, bool unpack_to_dest = false>
 inline void _llk_math_eltwise_unary_datacopy_init_(const std::uint32_t num_faces = 4, const std::uint32_t dst_format = 255)
 {
     LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be 1, 2, or 4");
     eltwise_unary_configure_addrmod<type, src_b_bcast_type>(dst_format);
+
+    if (src_b_bcast_type != BroadcastType::NONE && unpack_to_dest)
+    {
+        _llk_math_dbg_feature_disable_();
+    }
+    _llk_math_dbg_feature_disable_();
 
     if constexpr (type == A2D && src_b_bcast_type == BroadcastType::NONE)
     {

--- a/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_unary_datacopy.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_unary_datacopy.h
@@ -371,7 +371,6 @@ inline void _llk_math_eltwise_unary_datacopy_init_(const std::uint32_t num_faces
     {
         _llk_math_dbg_feature_disable_();
     }
-    _llk_math_dbg_feature_disable_();
 
     if constexpr (type == A2D && src_b_bcast_type == BroadcastType::NONE)
     {

--- a/tt_llk_wormhole_b0/llk_lib/llk_math_reduce.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_math_reduce.h
@@ -68,6 +68,18 @@ inline void _llk_math_reduce_(const uint dst_index, bool narrow_tile = false, co
 
         if constexpr (enforce_fp32_accumulation)
         {
+            // Equivalent to cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG_SrcA_override_RMW>(1);
+            TTI_RMWCIB0(
+                ALU_FORMAT_SPEC_REG_SrcA_override_MASK,
+                ALU_FORMAT_SPEC_REG_SrcA_override_MASK,
+                ALU_FORMAT_SPEC_REG_SrcA_override_ADDR32);
+
+            // Equivalent to cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG_SrcA_val_RMW>(static_cast<std::uint32_t>(DataFormat::Tf32));
+            TTI_RMWCIB0(
+                ALU_FORMAT_SPEC_REG_SrcA_val_MASK,
+                static_cast<std::uint32_t>(DataFormat::Tf32),
+                ALU_FORMAT_SPEC_REG_SrcA_val_ADDR32);
+
             // Move back to B and transpose in 2 parts, first hi16 bits then lo16 bits
             constexpr int dest_32b_hi = 0;
             constexpr int dest_32b_lo = 1;
@@ -86,6 +98,12 @@ inline void _llk_math_reduce_(const uint dst_index, bool narrow_tile = false, co
             TTI_MOVB2D(dest_32b_hi, p_movb2d::SRC_ROW16_OFFSET + 8, ADDR_MOD_0, p_movb2d::MOV_4_ROWS, 8);
             TTI_MOVB2D(dest_32b_hi, p_movb2d::SRC_ROW16_OFFSET + 12, ADDR_MOD_0, p_movb2d::MOV_4_ROWS, 12);
 
+            // Equivalent to cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG_SrcA_val_RMW>(static_cast<std::uint32_t>(DataFormat::Float16));
+            TTI_RMWCIB0(
+                ALU_FORMAT_SPEC_REG_SrcA_val_MASK,
+                static_cast<std::uint32_t>(DataFormat::Float16),
+                ALU_FORMAT_SPEC_REG_SrcA_val_ADDR32);
+
             // move lo16 bits D2B
             TTI_MOVD2B(dest_32b_lo, p_movd2b::SRC_ROW16_OFFSET, ADDR_MOD_0, p_movd2b::MOV_1_ROW, 0);
             // transpose face
@@ -93,13 +111,26 @@ inline void _llk_math_reduce_(const uint dst_index, bool narrow_tile = false, co
             // move row again for cases of reducing multiple tiles
             TTI_MOVD2B(dest_32b_lo, p_movd2b::SRC_ROW16_OFFSET, ADDR_MOD_0, p_movd2b::MOV_1_ROW, 0);
 
+            // Equivalent to cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG_SrcA_override_RMW>(0);
+            TTI_RMWCIB0(
+                ALU_FORMAT_SPEC_REG_SrcA_override_MASK,
+                0,
+                ALU_FORMAT_SPEC_REG_SrcA_override_ADDR32);
+
+            // Equivalent to cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG_SrcA_val_RMW>(static_cast<std::uint32_t>(DataFormat::Float32));
+            TTI_RMWCIB0(
+                ALU_FORMAT_SPEC_REG_SrcA_val_MASK,
+                static_cast<std::uint32_t>(DataFormat::Float32),
+                ALU_FORMAT_SPEC_REG_SrcA_val_ADDR32);
+
             // move lo16 bits B2D
             TTI_MOVB2D(dest_32b_lo, p_movb2d::SRC_ROW16_OFFSET, ADDR_MOD_0, p_movb2d::MOV_4_ROWS, 0);
             TTI_MOVB2D(dest_32b_lo, p_movb2d::SRC_ROW16_OFFSET + 4, ADDR_MOD_0, p_movb2d::MOV_4_ROWS, 4);
             TTI_MOVB2D(dest_32b_lo, p_movb2d::SRC_ROW16_OFFSET + 8, ADDR_MOD_0, p_movb2d::MOV_4_ROWS, 8);
             TTI_MOVB2D(dest_32b_lo, p_movb2d::SRC_ROW16_OFFSET + 12, ADDR_MOD_0, p_movb2d::MOV_4_ROWS, 12);
+
         }
-        else
+       else
         {
             // Datums stored in int32 dest cannot be moved to SrcB which is configured for int8 inputs
             // Cast int32 datums to int8 using SFPU instructions (load int32, store int8) before moving data to srcB
@@ -194,6 +225,18 @@ inline void _llk_math_reduce_(const uint dst_index, bool narrow_tile = false, co
 
             if constexpr (enforce_fp32_accumulation)
             {
+                // Equivalent to cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG_SrcA_override_RMW>(1);
+                TTI_RMWCIB0(
+                    ALU_FORMAT_SPEC_REG_SrcA_override_MASK,
+                    ALU_FORMAT_SPEC_REG_SrcA_override_MASK,
+                    ALU_FORMAT_SPEC_REG_SrcA_override_ADDR32);
+
+                // Equivalent to cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG_SrcA_val_RMW>(static_cast<std::uint32_t>(DataFormat::Tf32));
+                TTI_RMWCIB0(
+                    ALU_FORMAT_SPEC_REG_SrcA_val_MASK,
+                    static_cast<std::uint32_t>(DataFormat::Tf32),
+                    ALU_FORMAT_SPEC_REG_SrcA_val_ADDR32);
+
                 // Move back to B and transpose in 2 parts, first hi16 bits then lo16 bits
                 constexpr int dest_32b_hi = 0;
                 constexpr int dest_32b_lo = 1;
@@ -212,12 +255,26 @@ inline void _llk_math_reduce_(const uint dst_index, bool narrow_tile = false, co
                 TTI_MOVB2D(dest_32b_hi, p_movb2d::SRC_ROW16_OFFSET + 8, ADDR_MOD_0, p_movb2d::MOV_4_ROWS, 8);
                 TTI_MOVB2D(dest_32b_hi, p_movb2d::SRC_ROW16_OFFSET + 12, ADDR_MOD_0, p_movb2d::MOV_4_ROWS, 12);
 
+                TTI_RMWCIB0(
+                    ALU_FORMAT_SPEC_REG_SrcA_val_MASK,
+                    static_cast<std::uint32_t>(DataFormat::Float16),
+                    ALU_FORMAT_SPEC_REG_SrcA_val_ADDR32);
+
                 // move lo16 bits D2B
                 TTI_MOVD2B(dest_32b_lo, p_movd2b::SRC_ROW16_OFFSET, ADDR_MOD_0, p_movd2b::MOV_1_ROW, 0);
                 // transpose face
                 TTI_TRNSPSRCB;
                 // move row again for cases of reducing multiple tiles
                 TTI_MOVD2B(dest_32b_lo, p_movd2b::SRC_ROW16_OFFSET, ADDR_MOD_0, p_movd2b::MOV_1_ROW, 0);
+
+                TTI_RMWCIB0(
+                    ALU_FORMAT_SPEC_REG_SrcA_override_MASK,
+                    0,
+                    ALU_FORMAT_SPEC_REG_SrcA_override_ADDR32);
+                TTI_RMWCIB0(
+                    ALU_FORMAT_SPEC_REG_SrcA_val_MASK,
+                    static_cast<std::uint32_t>(DataFormat::Float32),
+                    ALU_FORMAT_SPEC_REG_SrcA_val_ADDR32);
 
                 // move lo16 bits B2D
                 TTI_MOVB2D(dest_32b_lo, p_movb2d::SRC_ROW16_OFFSET, ADDR_MOD_0, p_movb2d::MOV_4_ROWS, 0);

--- a/tt_llk_wormhole_b0/llk_lib/llk_math_reduce.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_math_reduce.h
@@ -462,6 +462,7 @@ inline void _llk_math_reduce_init_()
         // MOVB2D/D2B depends on SrcA ALU Format - Hi/Lo16 does not work with Tf32 (only on WH)
         // This is needed because FP32 data from L1 that is unpacked to Src registers is reduced to Tf32
         cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG0_SrcA_RMW>((uint)DataFormat::Float32);
+        _llk_math_dbg_feature_disable_();
     }
     TTI_SETC16(CLR_DVALID_SrcA_Disable_ADDR32, 0);
 

--- a/tt_llk_wormhole_b0/llk_lib/llk_math_reduce_custom.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_math_reduce_custom.h
@@ -123,7 +123,6 @@ inline void _llk_math_reduce_block_max_row_mop_config_()
         // Move low 16 bits to SrcB rows 16 - 31 and transpose
         TTI_MOVD2B(dest_32b_lo, p_movd2b::SRC_ROW16_OFFSET, ADDR_MOD_0, p_movd2b::MOV_1_ROW, 0);
         TTI_TRNSPSRCB;
-
         // Move low 16 bits from SrcB rows 16 - 31 to DEST rows 0, 4, 8, 12
         // ADDR_MOD_2 increments CR_D and Dest counter val by 4, so that's why DEST location is '0', not '0, 4, 8, 12'.
         TTI_MOVB2D(dest_32b_lo, p_movb2d::SRC_ROW16_OFFSET, ADDR_MOD_2, p_movb2d::MOV_4_ROWS, 0);
@@ -241,13 +240,32 @@ inline void _llk_math_reduce_block_max_row_(const uint dst_index)
     {
         // Run the MOP, performing a column reduce across all 4 faces
         ckernel::ckernel_template::run();
+
         // needs to be disabled for MOVD2B/B2D on BH (Issue ##449)
         cfg_reg_rmw_tensix<ALU_ACC_CTRL_Fp32_enabled_RMW>(0);
-        // Replay the 12 instructions to transpose the reduced F0&F1 results
-        lltt::replay(2, 12);
+    #pragma GCC unroll 2
+        for(std::uint32_t face = 0; face < 2; ++face){
+            cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG_SrcA_override_RMW>(1);
+            cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG_SrcA_val_RMW>(static_cast<std::uint32_t>(DataFormat::Tf32));
+
+            // Run for F0 and F1 lower 16 bits
+            lltt::replay(2, 6);
+
+            cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG_SrcA_val_RMW>(static_cast<std::uint32_t>(DataFormat::Float16));
+
+            lltt::replay(8, 2);
+
+            cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG_SrcA_override_RMW>(0);
+            cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG_SrcA_val_RMW>(static_cast<std::uint32_t>(DataFormat::Float32));
+
+            lltt::replay(10, 4);
+        }
+
         // Replay the 13 instructions to transpose the reduced F2&F3 results
         // 13th instruction clears B valid bit to release SrcB bank and clears all address counters
-        lltt::replay(2, 13);
+        lltt::replay(14, 1);
+
+
         cfg_reg_rmw_tensix<ALU_ACC_CTRL_Fp32_enabled_RMW>(1);
     }
     else

--- a/tt_llk_wormhole_b0/llk_lib/llk_math_reduce_custom.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_math_reduce_custom.h
@@ -211,9 +211,14 @@ inline void _llk_math_reduce_block_max_row_init_()
     _llk_math_reduce_block_max_row_mop_config_<block_ct_dim, is_fp32_dest_acc_en>();
 }
 
+template <bool is_fp32_dest_acc_en = false>
 inline void _llk_math_reduce_block_max_row_uninit_()
 {
     // No state to restore - all states are transient or default
+    if constexpr (is_fp32_dest_acc_en)
+    {
+        _llk_math_dbg_feature_enable_();
+    }
 }
 
 /**

--- a/tt_llk_wormhole_b0/llk_lib/llk_math_transpose_dest.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_math_transpose_dest.h
@@ -54,6 +54,7 @@ inline void _llk_math_transpose_dest_(const std::uint32_t dst_index)
         if constexpr (transpose_of_faces)
         {
             // 4x 32b face transpositions followed by 8x middle-face row swaps.
+            // This is done over SFPU
             ckernel_unpack_template::run(12, 0xff0);
         }
         else
@@ -267,10 +268,20 @@ inline void _llk_math_transpose_dest_init_()
     transpose_dest_configure_addrmod<is_32bit>();
     transpose_dest_configure_mop<transpose_of_faces, is_32bit>();
 
+    if constexpr (is_32bit)
+    {
+        _llk_math_dbg_feature_disable_();
+    }
+
     TTI_SETC16(CLR_DVALID_SrcA_Disable_ADDR32, 0);
 }
 
+template <bool is_32bit = false>
 inline void _llk_math_transpose_dest_uninit_()
 {
+    if constexpr (is_32bit)
+    {
+        _llk_math_dbg_feature_enable_();
+    }
     // No state to restore - all states are transient or default
 }

--- a/tt_llk_wormhole_b0/llk_lib/llk_math_transpose_dest.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_math_transpose_dest.h
@@ -58,9 +58,14 @@ inline void _llk_math_transpose_dest_(const std::uint32_t dst_index)
         }
         else
         {
+            // reg_write(RISCV_DEBUG_REG_DBG_FEATURE_DISABLE, 1 << 11);
             // 4x 32b face transpositions.
+
             ckernel_unpack_template::run(4, 0);
+            // tensix_sync();
+            // reg_write(RISCV_DEBUG_REG_DBG_FEATURE_DISABLE, 0);
         }
+
 
         cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(0);
     }
@@ -109,7 +114,17 @@ inline void transpose_dest_configure_mop()
 {
     if (is_32bit)
     {
-        lltt::record(16, 16);
+        lltt::record(16, 21);
+
+        // Enable override and use Tf32 for hi16 transpose.
+        TTI_RMWCIB0(
+            ALU_FORMAT_SPEC_REG_SrcA_override_MASK,
+            ALU_FORMAT_SPEC_REG_SrcA_override_MASK,
+            ALU_FORMAT_SPEC_REG_SrcA_override_ADDR32);
+        TTI_RMWCIB0(
+            ALU_FORMAT_SPEC_REG_SrcA_val_MASK,
+            static_cast<std::uint32_t>(DataFormat::Tf32),
+            ALU_FORMAT_SPEC_REG_SrcA_val_ADDR32);
 
 #pragma GCC unroll 2
         for (int dest_32b_lo = 0; dest_32b_lo < 2; ++dest_32b_lo)
@@ -118,10 +133,33 @@ inline void transpose_dest_configure_mop()
             TTI_MOVD2B(dest_32b_lo, 20, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 4);
             TTI_MOVD2B(dest_32b_lo, 24, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 8);
             TTI_MOVD2B(dest_32b_lo, 28, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 12);
+
+            if (dest_32b_lo == 1)
+            {
+                // Disable override and restore Float32 for lo16 B2D.
+                TTI_RMWCIB0(
+                    ALU_FORMAT_SPEC_REG_SrcA_override_MASK,
+                    0,
+                    ALU_FORMAT_SPEC_REG_SrcA_override_ADDR32);
+                TTI_RMWCIB0(
+                    ALU_FORMAT_SPEC_REG_SrcA_val_MASK,
+                    static_cast<std::uint32_t>(DataFormat::Float32),
+                    ALU_FORMAT_SPEC_REG_SrcA_val_ADDR32);
+            }
+
             TTI_MOVB2D(dest_32b_lo, 16, ADDR_MOD_1, p_movb2d::MOV_4_ROWS, 0);
             TTI_MOVB2D(dest_32b_lo, 20, ADDR_MOD_1, p_movb2d::MOV_4_ROWS, 4);
             TTI_MOVB2D(dest_32b_lo, 24, ADDR_MOD_1, p_movb2d::MOV_4_ROWS, 8);
             TTI_MOVB2D(dest_32b_lo, 28, dest_32b_lo == 1 ? ADDR_MOD_0 : ADDR_MOD_1, p_movb2d::MOV_4_ROWS, 12);
+
+            if (dest_32b_lo == 0)
+            {
+                // switch to Float16 for lo16 transpose
+                TTI_RMWCIB0(
+                    ALU_FORMAT_SPEC_REG_SrcA_val_MASK,
+                    static_cast<std::uint32_t>(DataFormat::Float16),
+                    ALU_FORMAT_SPEC_REG_SrcA_val_ADDR32);
+            }
         }
 
         uint macro0 = TT_OP_SFPNOP;
@@ -165,9 +203,9 @@ inline void transpose_dest_configure_mop()
         }
 
         // A 32b face transpose consists of: (movd2b_hi, transpose, movb2d_hi_d2b_lo, transpose, movb2d_lo).
-        uint movd2b_hi        = lltt::replay_insn(16, 4);
-        uint movb2d_hi_d2b_lo = lltt::replay_insn(20, 8);
-        uint movb2d_lo        = lltt::replay_insn(28, 4);
+        uint movd2b_hi        = lltt::replay_insn(16, 6);
+        uint movb2d_hi_d2b_lo = lltt::replay_insn(22, 9);
+        uint movb2d_lo        = lltt::replay_insn(31, 6);
         uint transpose        = TT_OP_TRNSPSRCB;
 
         // MOP config:

--- a/tt_llk_wormhole_b0/llk_lib/llk_pack_common.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_pack_common.h
@@ -20,11 +20,11 @@ inline void _llk_pack_dbg_feature_disable_()
     reg_write(RISCV_DEBUG_REG_DBG_FEATURE_DISABLE, 1 << 11); // Set debug feature disable bit 11
 }
 
-inline void _llk_pack_dbg_feature_enable_()
-{
-    tensix_sync();
-    reg_write(RISCV_DEBUG_REG_DBG_FEATURE_DISABLE, 0); // Clear debug feature disable bit 11
-}
+// inline void _llk_pack_dbg_feature_enable_()
+// {
+//     // tensix_sync();
+//     // reg_write(RISCV_DEBUG_REG_DBG_FEATURE_DISABLE, 0); // Clear debug feature disable bit 11
+// }
 
 // wait until math is done and has produced something to pack
 inline void _llk_packer_wait_for_math_done_()
@@ -273,10 +273,10 @@ inline void _llk_pack_reduce_mask_config_()
 template <bool enforce_fp32_accumulation = false>
 inline void _llk_pack_reduce_mask_clear_()
 {
-    if constexpr (enforce_fp32_accumulation)
-    {
-        _llk_pack_dbg_feature_enable_();
-    }
+    // if constexpr (enforce_fp32_accumulation)
+    // {
+    //     _llk_pack_dbg_feature_enable_();
+    // }
 
     // By default, all packers are set to use TILE_ROW_SET_MAPPING_0 and
     // mask is configured to pass through all the datums

--- a/tt_llk_wormhole_b0/llk_lib/llk_pack_common.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_pack_common.h
@@ -15,17 +15,6 @@
 using namespace ckernel;
 using namespace ckernel::packer;
 
-inline void _llk_pack_dbg_feature_disable_()
-{
-    // reg_write(RISCV_DEBUG_REG_DBG_FEATURE_DISABLE, 1 << 11); // Set debug feature disable bit 11
-}
-
-// inline void _llk_pack_dbg_feature_enable_()
-// {
-//     tensix_sync();
-//     reg_write(RISCV_DEBUG_REG_DBG_FEATURE_DISABLE, 0); // Clear debug feature disable bit 11
-// }
-
 // wait until math is done and has produced something to pack
 inline void _llk_packer_wait_for_math_done_()
 {
@@ -184,11 +173,6 @@ inline void _llk_pack_reconfig_l1_acc_(const std::uint32_t enable)
 template <bool untilize = false, ReduceDim dim, bool enforce_fp32_accumulation = false>
 inline void _llk_pack_reduce_mask_config_()
 {
-    if constexpr (enforce_fp32_accumulation)
-    {
-        _llk_pack_dbg_feature_disable_();
-    }
-
     ckernel::packer::pck_edge_offset_u pack_edge_offset = {.val = 0};
 
     // We initialize PCK_EDGE_OFFSET_SEC0 mask to clear out all the datums in the row

--- a/tt_llk_wormhole_b0/llk_lib/llk_pack_common.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_pack_common.h
@@ -17,13 +17,13 @@ using namespace ckernel::packer;
 
 inline void _llk_pack_dbg_feature_disable_()
 {
-    reg_write(RISCV_DEBUG_REG_DBG_FEATURE_DISABLE, 1 << 11); // Set debug feature disable bit 11
+    // reg_write(RISCV_DEBUG_REG_DBG_FEATURE_DISABLE, 1 << 11); // Set debug feature disable bit 11
 }
 
 // inline void _llk_pack_dbg_feature_enable_()
 // {
-//     // tensix_sync();
-//     // reg_write(RISCV_DEBUG_REG_DBG_FEATURE_DISABLE, 0); // Clear debug feature disable bit 11
+//     tensix_sync();
+//     reg_write(RISCV_DEBUG_REG_DBG_FEATURE_DISABLE, 0); // Clear debug feature disable bit 11
 // }
 
 // wait until math is done and has produced something to pack

--- a/tt_llk_wormhole_b0/llk_lib/llk_pack_common.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_pack_common.h
@@ -15,6 +15,17 @@
 using namespace ckernel;
 using namespace ckernel::packer;
 
+inline void _llk_pack_dbg_feature_disable_()
+{
+    reg_write(RISCV_DEBUG_REG_DBG_FEATURE_DISABLE, 1 << 11); // Set debug feature disable bit 11
+}
+
+inline void _llk_pack_dbg_feature_enable_()
+{
+    tensix_sync();
+    reg_write(RISCV_DEBUG_REG_DBG_FEATURE_DISABLE, 0); // Clear debug feature disable bit 11
+}
+
 // wait until math is done and has produced something to pack
 inline void _llk_packer_wait_for_math_done_()
 {
@@ -170,9 +181,14 @@ inline void _llk_pack_reconfig_l1_acc_(const std::uint32_t enable)
     reconfigure_packer_l1_acc(enable);
 }
 
-template <bool untilize = false, ReduceDim dim>
+template <bool untilize = false, ReduceDim dim, bool enforce_fp32_accumulation = false>
 inline void _llk_pack_reduce_mask_config_()
 {
+    if constexpr (enforce_fp32_accumulation)
+    {
+        _llk_pack_dbg_feature_disable_();
+    }
+
     ckernel::packer::pck_edge_offset_u pack_edge_offset = {.val = 0};
 
     // We initialize PCK_EDGE_OFFSET_SEC0 mask to clear out all the datums in the row
@@ -254,8 +270,14 @@ inline void _llk_pack_reduce_mask_config_()
     TTI_NOP;
 }
 
+template <bool enforce_fp32_accumulation = false>
 inline void _llk_pack_reduce_mask_clear_()
 {
+    if constexpr (enforce_fp32_accumulation)
+    {
+        _llk_pack_dbg_feature_enable_();
+    }
+
     // By default, all packers are set to use TILE_ROW_SET_MAPPING_0 and
     // mask is configured to pass through all the datums
     pck_edge_offset_u pack_edge_offset = {.val = 0};

--- a/tt_llk_wormhole_b0/llk_lib/llk_unpack_A.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_unpack_A.h
@@ -219,10 +219,10 @@ inline void _llk_unpack_A_init_(
     }
 
     // TODO NC: Move to TRISC1 tt-metal#36411
-    if constexpr (BType != BroadcastType::NONE && unpack_to_dest)
-    {
-        _llk_unpack_dbg_feature_disable_();
-    }
+    // if constexpr (BType != BroadcastType::NONE && unpack_to_dest)
+    // {
+    //     _llk_unpack_dbg_feature_disable_();
+    // }
     _llk_unpack_A_mop_config_<BType, acc_to_dest, binary_reuse_dest, unpack_to_dest>(transpose_of_faces > 0, num_faces, unpack_src_format, unpack_dst_format);
 }
 

--- a/tt_llk_wormhole_b0/llk_lib/llk_unpack_A.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_unpack_A.h
@@ -218,11 +218,6 @@ inline void _llk_unpack_A_init_(
         config_unpacker_x_end<UNP_SEL>(face_r_dim);
     }
 
-    // TODO NC: Move to TRISC1 tt-metal#36411
-    // if constexpr (BType != BroadcastType::NONE && unpack_to_dest)
-    // {
-    //     _llk_unpack_dbg_feature_disable_();
-    // }
     _llk_unpack_A_mop_config_<BType, acc_to_dest, binary_reuse_dest, unpack_to_dest>(transpose_of_faces > 0, num_faces, unpack_src_format, unpack_dst_format);
 }
 

--- a/tt_llk_wormhole_b0/llk_lib/llk_unpack_common.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_unpack_common.h
@@ -100,13 +100,6 @@ inline void _llk_unpack_reconfig_data_format_srcb_impl_(
     TT_SETDMAREG(0, LOWER_HALFWORD(tile_size), 0, LO_16(p_gpr_unpack::TILE_SIZE_B)); // update gpr which holds tile size B
 }
 
-// TODO NC: Remove as a part of tt-metal#36411
-inline void _llk_unpack_dbg_feature_disable_()
-{
-    reg_write(RISCV_DEBUG_REG_DBG_FEATURE_DISABLE, 1 << 11); // Set debug feature disable bit 11
-                                                             // workaround for bug tenstorrent/budabackend#1372
-}
-
 inline void _llk_enable_int8_fpu_math_()
 {
     enable_int8_fpu_math();


### PR DESCRIPTION
### Ticket
<!-- Link to Github Issue -->

### Problem description
<!-- Provide context for the problem. -->
[tt-metal issue #36411](https://github.com/tenstorrent/tt-metal/issues/36411)
[Parent tt-metal PR](https://github.com/tenstorrent/tt-metal/pull/36461)

### What's changed
<!-- Describe the approach used to solve the problem.
Summarize the changes made and its impact. -->

Status: 
- [x] Remove unpack debug feature function handlers and anything related to them
- [x] Make necessary calls to debug feature handlers on Math side
       - Addition to this (We also need handling on `TRISC2 (Pack)` since it reads Lo16 Hi16 bits from `dst` and it depends on it
- [ ] Clean up
  - [ ] Remove redundant commented code
  - [ ] Finish Blackhole part implementaion
  - [ ] Run pre-commit for clean-up
- [ ] Decide what to do with issue that existed with current main code but it was never hit

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
