### PR TITLE
add fast mode to unary sfpu test sweep

### DIFF
--- a/tests/helpers/include/sfpu_operations.h
+++ b/tests/helpers/include/sfpu_operations.h
@@ -69,8 +69,21 @@ void call_sfpu_operation(SfpuType operation, uint32_t math_format = 0, float fil
             break;
         case SfpuType::exponential:
             _init_exponential_<APPROX_MODE, FAST_MODE, 0x3F800000 /* exp_base_scale_factor */>();
-            _calculate_exponential_<APPROX_MODE, false /* scale_en */, ITERATIONS, FAST_MODE, false /* skip_positive_check */>(
-                p_sfpu::kCONST_1_FP16B /* exp_base_scale_factor */);
+            if (FAST_MODE && APPROX_MODE)
+            {
+                for (int i = 0; i < 4; i++)
+                {
+                    _calculate_exponential_<APPROX_MODE, false /* scale_en */, ITERATIONS, FAST_MODE, false /* skip_positive_check */>(
+                        p_sfpu::kCONST_1_FP16B /* exp_base_scale_factor */);
+                    TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_D, 8, 0, 0, p_setrwc::SET_D);
+                    TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_D, 8, 0, 0, p_setrwc::SET_D);
+                }
+            }
+            else
+            {
+                _calculate_exponential_<APPROX_MODE, false /* scale_en */, ITERATIONS, FAST_MODE, false /* skip_positive_check */>(
+                    p_sfpu::kCONST_1_FP16B /* exp_base_scale_factor */);
+            }
             break;
         case SfpuType::fill:
             if (math_format == static_cast<std::underlying_type_t<DataFormat>>(DataFormat::Int32))

--- a/tests/python_tests/test_eltwise_unary_sfpu.py
+++ b/tests/python_tests/test_eltwise_unary_sfpu.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
+from itertools import chain, product
+
 import pytest
 import torch
 from helpers.chip_architecture import ChipArchitecture
@@ -10,6 +12,7 @@ from helpers.golden_generators import UnarySFPUGolden, get_golden_generator
 from helpers.llk_params import (
     ApproximationMode,
     DestAccumulation,
+    FastMode,
     MathOperation,
     format_dict,
 )
@@ -19,56 +22,92 @@ from helpers.stimuli_generator import generate_stimuli
 from helpers.test_config import TestConfig
 from helpers.test_variant_parameters import (
     APPROX_MODE,
+    FAST_MODE,
     INPUT_DIMENSIONS,
     MATH_OP,
     TILE_COUNT,
 )
 from helpers.utils import passed_test
 
+SUPPORTED_FAST_MODE_OPS = [
+    MathOperation.Log1p,
+    MathOperation.Exp,
+    MathOperation.Rsqrt,
+    MathOperation.Sqrt,
+]
 
-@parametrize(
-    formats=input_output_formats(
-        [
-            DataFormat.Float32,
-            DataFormat.Float16,
-            DataFormat.Float16_b,
-            DataFormat.Bfp8_b,
-        ]
-    ),
-    approx_mode=[ApproximationMode.No, ApproximationMode.Yes],
-    mathop=[
-        MathOperation.Abs,
-        MathOperation.Atanh,
-        MathOperation.Asinh,
-        MathOperation.Acosh,
-        MathOperation.Cos,
-        MathOperation.Log,
-        MathOperation.Log1p,
-        MathOperation.Reciprocal,
-        MathOperation.Sin,
-        MathOperation.Sqrt,
-        MathOperation.Rsqrt,
-        MathOperation.Square,
-        MathOperation.Tanh,
-        MathOperation.Celu,
-        MathOperation.Silu,
-        MathOperation.Gelu,
-        MathOperation.Neg,
-        MathOperation.Fill,
-        MathOperation.Elu,
-        MathOperation.Exp,
-        MathOperation.Exp2,
-        MathOperation.Hardsigmoid,
-        MathOperation.Threshold,
-        MathOperation.ReluMax,
-        MathOperation.ReluMin,
-    ],
-    dest_acc=[DestAccumulation.No, DestAccumulation.Yes],
+ALL_MATHOPS = [
+    MathOperation.Abs,
+    MathOperation.Atanh,
+    MathOperation.Asinh,
+    MathOperation.Acosh,
+    MathOperation.Cos,
+    MathOperation.Log,
+    MathOperation.Log1p,
+    MathOperation.Reciprocal,
+    MathOperation.Sin,
+    MathOperation.Sqrt,
+    MathOperation.Rsqrt,
+    MathOperation.Square,
+    MathOperation.Tanh,
+    MathOperation.Celu,
+    MathOperation.Silu,
+    MathOperation.Gelu,
+    MathOperation.Neg,
+    MathOperation.Fill,
+    MathOperation.Elu,
+    MathOperation.Exp,
+    MathOperation.Exp2,
+    MathOperation.Hardsigmoid,
+    MathOperation.Threshold,
+    MathOperation.ReluMax,
+    MathOperation.ReluMin,
+]
+
+FORMATS = input_output_formats(
+    [
+        DataFormat.Float32,
+        DataFormat.Float16,
+        DataFormat.Float16_b,
+        DataFormat.Bfp8_b,
+    ]
+)
+
+FLOAT_TEST_PARAMS = list(
+    chain(
+        (
+            (fmt, approx, mathop, fast, dest)
+            for fmt, approx, mathop, fast, dest in product(
+                FORMATS,
+                [ApproximationMode.No, ApproximationMode.Yes],
+                SUPPORTED_FAST_MODE_OPS,
+                [FastMode.No, FastMode.Yes],
+                [DestAccumulation.No, DestAccumulation.Yes],
+            )
+        ),
+        (
+            (fmt, approx, mathop, FastMode.No, dest)
+            for fmt, approx, mathop, dest in product(
+                FORMATS,
+                [ApproximationMode.No, ApproximationMode.Yes],
+                [op for op in ALL_MATHOPS if op not in SUPPORTED_FAST_MODE_OPS],
+                [DestAccumulation.No, DestAccumulation.Yes],
+            )
+        ),
+    )
+)
+
+
+@pytest.mark.nightly
+@pytest.mark.parametrize(
+    "formats,approx_mode,mathop,fast_mode,dest_acc",
+    FLOAT_TEST_PARAMS,
 )
 def test_eltwise_unary_sfpu_float(
     formats: list[InputOutputFormat],
     approx_mode: ApproximationMode,
     mathop: MathOperation,
+    fast_mode: FastMode,
     dest_acc: DestAccumulation,
     workers_tensix_coordinates: str,
 ):
@@ -133,6 +172,7 @@ def test_eltwise_unary_sfpu_float(
         dest_acc,
         approx_mode,
         mathop,
+        fast_mode,
         workers_tensix_coordinates,
     )
 
@@ -144,12 +184,14 @@ def test_eltwise_unary_sfpu_float(
         MathOperation.Neg,
         MathOperation.Fill,
     ],
+    fast_mode=[FastMode.No, FastMode.Yes],
     dest_acc=[DestAccumulation.Yes],
 )
 def test_eltwise_unary_sfpu_int(
     formats: list[InputOutputFormat],
     approx_mode: ApproximationMode,
     mathop: MathOperation,
+    fast_mode: FastMode,
     dest_acc: DestAccumulation,
     workers_tensix_coordinates: str,
 ):
@@ -162,6 +204,7 @@ def test_eltwise_unary_sfpu_int(
         dest_acc,
         approx_mode,
         mathop,
+        fast_mode,
         workers_tensix_coordinates,
     )
 
@@ -172,6 +215,7 @@ def eltwise_unary_sfpu(
     dest_acc,
     approx_mode,
     mathop,
+    fast_mode: FastMode,
     workers_tensix_coordinates,
 ):
     torch.manual_seed(0)
@@ -201,6 +245,7 @@ def eltwise_unary_sfpu(
         templates=[
             INPUT_DIMENSIONS(input_dimensions, input_dimensions),
             APPROX_MODE(approx_mode),
+            FAST_MODE(fast_mode),
             MATH_OP(mathop=mathop),
         ],
         runtimes=[TILE_COUNT(tile_cnt_A)],

--- a/tests/sources/eltwise_unary_sfpu_test.cpp
+++ b/tests/sources/eltwise_unary_sfpu_test.cpp
@@ -73,7 +73,7 @@ void run_kernel(const volatile struct RuntimeParams *params)
         _llk_math_eltwise_unary_sfpu_start_<DstSync::SyncHalf>(i);
         // calling sfpu function from ckernel
         // this part is where parametrization of operation takes part
-        test_utils::call_sfpu_operation<APPROX_MODE, is_fp32_dest_acc_en, iterations>(SFPU_UNARY_OPERATION, formats.math);
+        test_utils::call_sfpu_operation<APPROX_MODE, is_fp32_dest_acc_en, iterations, FAST_MODE>(SFPU_UNARY_OPERATION, formats.math);
 
         _llk_math_eltwise_unary_sfpu_done_();
     }


### PR DESCRIPTION
### Ticket
<!-- Link to Github Issue -->

### Problem description
<!-- Provide context for the problem. -->
We don't have `FAST_MODE` in the SFPU test sweep.

### What's changed
<!-- Describe the approach used to solve the problem.
Summarize the changes made and its impact. -->
Added `FAST_MODE` parameter to `test_eltwise_unary_sfpu.h`

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
