### PR TITLE
Add name to 0th semaphore, for fpu-sfpu sync

### DIFF
--- a/tt_llk_blackhole/common/inc/ckernel_structs.h
+++ b/tt_llk_blackhole/common/inc/ckernel_structs.h
@@ -10,6 +10,7 @@ namespace ckernel
 // Semaphores mapping and trisc space -> tensix space conversion
 struct semaphore
 {
+    constexpr static uint32_t FPU_SFPU            = 0; // fpu <-> sfpu sync
     constexpr static uint32_t MATH_PACK           = 1; // math <-> pack sync on dest register
     constexpr static uint32_t UNPACK_TO_DEST      = 2; // unpack <-> math sync on unpack to dest
     constexpr static uint32_t UNPACK_OPERAND_SYNC = 3; // unpack <-> pack, math sync on operand get/release

--- a/tt_llk_wormhole_b0/common/inc/ckernel_structs.h
+++ b/tt_llk_wormhole_b0/common/inc/ckernel_structs.h
@@ -10,6 +10,7 @@ namespace ckernel
 // Semaphores mapping and trisc space -> tensix space conversion
 struct semaphore
 {
+    constexpr static uint32_t FPU_SFPU            = 0; // fpu <-> sfpu sync
     constexpr static uint32_t MATH_PACK           = 1; // math <-> pack sync on dest register
     constexpr static uint32_t UNPACK_TO_DEST      = 2; // unpack <-> math sync on unpack to dest
     constexpr static uint32_t UNPACK_OPERAND_SYNC = 3; // unpack <-> pack, math sync on operand get/release


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/36242 

### Problem description
Need to add synchronization between fpu and sfpu running on separate threads for WH/BH

### What's changed
Gave a name to an existing semaphore, nobody was using. 

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
