### PR TITLE
ci: add notify-dispatch step to metal-integration-tests workflow

### DIFF
--- a/.github/workflows/trigger-tt-metal-post-commit.yml
+++ b/.github/workflows/trigger-tt-metal-post-commit.yml
@@ -242,7 +242,7 @@ jobs:
           DISPATCHED_TESTS=""
 
           if [ "${{ needs.detect-changes.outputs.run-wormhole }}" = "true" ]; then
-            DISPATCHED_TESTS="${DISPATCHED_TESTS}- 🌀 **Wormhole post-commit tests**"$'\n'
+            DISPATCHED_TESTS="${DISPATCHED_TESTS}- 🌀 **All post-commit tests**"$'\n'
           fi
 
           if [ "${{ needs.detect-changes.outputs.run-blackhole }}" = "true" ]; then


### PR DESCRIPTION
### Ticket
None

### Problem description
Users pointed out that they weren't aware that their action (adding a label) triggered any GH action until the tests finished running which could be in several hours.

### What's changed
Added a notification steps, to inform the user which group of tests is being run for their PR, with the link to the running workflow(s).

<img width="904" height="396" alt="image" src="https://github.com/user-attachments/assets/04db5625-c859-4a3b-b896-d4138c4727a2" />

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
