### PR TITLE
Increase coverage of unpack reconfig

### DIFF
--- a/tt_llk_blackhole/llk_lib/llk_unpack_common.h
+++ b/tt_llk_blackhole/llk_lib/llk_unpack_common.h
@@ -103,17 +103,17 @@ inline void _llk_unpack_reconfig_data_format_srca_impl_(
 
     if constexpr (dim_stride_target == p_dim_stride_target::FACE_ROW_MAJOR)
     {
-        uint unpack_ch1_x_stride = (uint)(unpack_dst_format & 0x3) == (uint)DataFormat::Float32   ? 4
-                                   : (uint)(unpack_dst_format & 0x3) == (uint)DataFormat::Float16 ? 2
-                                                                                                  : 1;
+        std::uint32_t unpack_ch1_x_stride = (std::uint32_t)(unpack_dst_format & 0x3) == (std::uint32_t)DataFormat::Float32   ? 4
+                                            : (std::uint32_t)(unpack_dst_format & 0x3) == (std::uint32_t)DataFormat::Float16 ? 2
+                                                                                                                             : 1;
         // FACE_R_DIM constant is used here because data is not stored densely in src/dest registers
         // so we want to keep standard stride for one face
-        uint unpack_ch1_z_stride = FACE_C_DIM * FACE_R_DIM * unpack_ch1_x_stride;
+        std::uint32_t unpack_ch1_z_stride = FACE_C_DIM * FACE_R_DIM * unpack_ch1_x_stride;
         cfg_reg_rmw_tensix<UNP0_ADDR_CTRL_ZW_REG_1_Zstride_RMW>(unpack_ch1_z_stride);
 
         // Program unpacker0 per context x_dim (face size in l1)
         // Overrides value set by tile descriptor when thread override bit is set in unpack instruction
-        const uint face_dim = unpack_face_r_dim * FACE_C_DIM;
+        const std::uint32_t face_dim = unpack_face_r_dim * FACE_C_DIM;
         cfg_reg_rmw_tensix<THCON_SEC0_REG5_Tile_x_dim_cntx0_ADDR32, 0, 0xffffffff>(face_dim | (face_dim << 16));
 
         // Set Z-dim to number of faces
@@ -151,10 +151,10 @@ inline void _llk_unpack_reconfig_data_format_srcb_impl_(
 
     if constexpr (dim_stride_target == p_dim_stride_target::FACE_ROW_MAJOR)
     {
-        uint unpack_ch1_x_stride = (uint)(unpack_dst_format & 0x3) == (uint)DataFormat::Float32   ? 4
-                                   : (uint)(unpack_dst_format & 0x3) == (uint)DataFormat::Float16 ? 2
-                                                                                                  : 1;
-        uint unpack_ch1_z_stride = FACE_C_DIM * FACE_R_DIM * unpack_ch1_x_stride;
+        std::uint32_t unpack_ch1_x_stride = (std::uint32_t)(unpack_dst_format & 0x3) == (std::uint32_t)DataFormat::Float32   ? 4
+                                            : (std::uint32_t)(unpack_dst_format & 0x3) == (std::uint32_t)DataFormat::Float16 ? 2
+                                                                                                                             : 1;
+        std::uint32_t unpack_ch1_z_stride = FACE_C_DIM * FACE_R_DIM * unpack_ch1_x_stride;
         cfg_reg_rmw_tensix<UNP1_ADDR_CTRL_ZW_REG_1_Zstride_RMW>(unpack_ch1_z_stride);
 
         // Set X-dim to face_r_dim * FACE_C_DIM

--- a/tt_llk_wormhole_b0/llk_lib/llk_unpack_common.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_unpack_common.h
@@ -99,17 +99,17 @@ inline void _llk_unpack_reconfig_data_format_srca_impl_(
 
     if constexpr (dim_stride_target == p_dim_stride_target::FACE_ROW_MAJOR)
     {
-        uint unpack_ch1_x_stride = (uint)(unpack_dst_format & 0x3) == (uint)DataFormat::Float32   ? 4
-                                   : (uint)(unpack_dst_format & 0x3) == (uint)DataFormat::Float16 ? 2
-                                                                                                  : 1;
+        std::uint32_t unpack_ch1_x_stride = (std::uint32_t)(unpack_dst_format & 0x3) == (std::uint32_t)DataFormat::Float32   ? 4
+                                            : (std::uint32_t)(unpack_dst_format & 0x3) == (std::uint32_t)DataFormat::Float16 ? 2
+                                                                                                                             : 1;
         // FACE_R_DIM constant is used here because data is not stored densely in src/dest registers
         // so we want to keep standard stride for one face
-        uint unpack_ch1_z_stride = FACE_C_DIM * FACE_R_DIM * unpack_ch1_x_stride;
+        std::uint32_t unpack_ch1_z_stride = FACE_C_DIM * FACE_R_DIM * unpack_ch1_x_stride;
         cfg_reg_rmw_tensix<UNP0_ADDR_CTRL_ZW_REG_1_Zstride_RMW>(unpack_ch1_z_stride);
 
         // Program unpacker0 per context x_dim (face size in l1)
         // Overrides value set by tile descriptor when thread override bit is set in unpack instruction
-        const uint face_dim = unpack_face_r_dim * FACE_C_DIM;
+        const std::uint32_t face_dim = unpack_face_r_dim * FACE_C_DIM;
         cfg_reg_rmw_tensix<THCON_SEC0_REG5_Tile_x_dim_cntx0_ADDR32, 0, 0xffffffff>(face_dim | (face_dim << 16));
 
         // Set Z-dim to number of faces
@@ -142,10 +142,10 @@ inline void _llk_unpack_reconfig_data_format_srcb_impl_(
 
     if constexpr (dim_stride_target == p_dim_stride_target::FACE_ROW_MAJOR)
     {
-        uint unpack_ch1_x_stride = (uint)(unpack_dst_format & 0x3) == (uint)DataFormat::Float32   ? 4
-                                   : (uint)(unpack_dst_format & 0x3) == (uint)DataFormat::Float16 ? 2
-                                                                                                  : 1;
-        uint unpack_ch1_z_stride = FACE_C_DIM * FACE_R_DIM * unpack_ch1_x_stride;
+        std::uint32_t unpack_ch1_x_stride = (std::uint32_t)(unpack_dst_format & 0x3) == (std::uint32_t)DataFormat::Float32   ? 4
+                                            : (std::uint32_t)(unpack_dst_format & 0x3) == (std::uint32_t)DataFormat::Float16 ? 2
+                                                                                                                             : 1;
+        std::uint32_t unpack_ch1_z_stride = FACE_C_DIM * FACE_R_DIM * unpack_ch1_x_stride;
         cfg_reg_rmw_tensix<UNP1_ADDR_CTRL_ZW_REG_1_Zstride_RMW>(unpack_ch1_z_stride);
 
         // Set X-dim to face_r_dim * FACE_C_DIM


### PR DESCRIPTION
### Ticket
<!-- Link to Github Issue -->
[Link to Github Issue](https://github.com/tenstorrent/tt-llk/issues/1188)
[Also](https://github.com/tenstorrent/tt-metal/issues/36654)

### Problem description
<!-- Provide context for the problem. -->
Changing arguments to/from the defaults that are passed down through `llk_unpack_hw_configure` can change the values that fill certain registers, but not all of these are addressed properly in a reconfig call when these parameters could be different from before. When the reconfig does not reprogram these registers as expected, this can lead to incorrect behaviour.

### What's changed
<!-- Describe the approach used to solve the problem.
Summarize the changes made and its impact. -->
For `_llk_unpack_reconfig_data_format_srca_impl_` and `_llk_unpack_reconfig_data_format_srcb_impl_`
- Added `unpack_face_r_dim` and `unpack_num_faces` parameters and their default vals
- Addressed discrepancies between registers and counters that get set in the hw_config function which should be changeable in the reconfig function if the parameters change
### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
