### PR TITLE
Reduce SFPU LaneConfig init from 3 instructions to 1

### DIFF
--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_load_config.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_load_config.h
@@ -34,7 +34,7 @@ inline void _sfpu_load_config32_(const uint dest, const uint upper16, const uint
 
 inline void _init_sfpu_config_reg()
 {
-    _sfpu_load_config32_(0xF, 0x0, 0x0);
+    TTI_SFPCONFIG(0, 0xF, 1);
 }
 
 } // namespace sfpu

--- a/tt_llk_quasar/common/inc/cmath_common.h
+++ b/tt_llk_quasar/common/inc/cmath_common.h
@@ -116,7 +116,7 @@ inline void _sfpu_load_config32_(const uint dest, const uint upper16, const uint
  */
 inline void _init_sfpu_config_reg_()
 {
-    _sfpu_load_config32_(0xF, 0x0, 0x0);
+    TTI_SFPCONFIG(0, 0xF, 1);
 }
 
 /**

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_load_config.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_load_config.h
@@ -34,7 +34,7 @@ inline void _sfpu_load_config32_(const uint dest, const uint upper16, const uint
 
 inline void _init_sfpu_config_reg()
 {
-    _sfpu_load_config32_(0xF, 0x0, 0x0);
+    TTI_SFPCONFIG(0, 0xF, 1);
 }
 
 } // namespace sfpu


### PR DESCRIPTION
### Ticket
/

### Problem description
Common init code for all SFPU kernels was using an inefficient instruction sequence.

### What's changed
Instead of using 2 SFPLOADIs to L0 and 1 SFPCONFIG from L0 to initialize LaneConfig to zero, use the immediate form instead.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
