### PR TITLE
Fix a typo in test infra

### DIFF
--- a/tests/python_tests/quasar/test_eltwise_binary_broadcast_quasar.py
+++ b/tests/python_tests/quasar/test_eltwise_binary_broadcast_quasar.py
@@ -140,7 +140,7 @@ def test_eltwise_binary_broadcast_quasar(
 
     assert len(res_from_L1) == len(
         golden_tensor
-    ), "Result tensor and golder tensor are not of the same length"
+    ), "Result tensor and golden tensor are not of the same length"
 
     torch_format = format_dict[formats.output_format]
     res_tensor = torch.tensor(res_from_L1, dtype=torch_format)

--- a/tests/python_tests/quasar/test_eltwise_binary_quasar.py
+++ b/tests/python_tests/quasar/test_eltwise_binary_quasar.py
@@ -158,7 +158,7 @@ def test_eltwise_binary(
     # Verify results match golden
     assert len(res_from_L1) == len(
         golden_tensor
-    ), "Result tensor and golder tensor are not of the same length"
+    ), "Result tensor and golden tensor are not of the same length"
 
     torch_format = format_dict[formats.output_format]
     res_tensor = torch.tensor(res_from_L1, dtype=torch_format)

--- a/tests/python_tests/quasar/test_eltwise_unary_datacopy_quasar.py
+++ b/tests/python_tests/quasar/test_eltwise_unary_datacopy_quasar.py
@@ -179,7 +179,7 @@ def test_eltwise_unary_datacopy_quasar(
 
     assert len(res_from_L1) == len(
         golden_tensor
-    ), "Result tensor and golder tensor are not of the same length"
+    ), "Result tensor and golden tensor are not of the same length"
 
     torch_format = format_dict[formats.output_format]
     res_tensor = torch.tensor(res_from_L1, dtype=torch_format)

--- a/tests/python_tests/quasar/test_matmul_quasar.py
+++ b/tests/python_tests/quasar/test_matmul_quasar.py
@@ -183,7 +183,7 @@ def test_matmul(
 
     assert len(res_from_L1) == len(
         golden_tensor
-    ), "Result tensor and golder tensor are not of the same length"
+    ), "Result tensor and golden tensor are not of the same length"
 
     res_tensor = torch.tensor(res_from_L1, dtype=torch_format)
 

--- a/tests/python_tests/quasar/test_pack_quasar.py
+++ b/tests/python_tests/quasar/test_pack_quasar.py
@@ -141,7 +141,7 @@ def test_pack_quasar(formats_dest_acc_input_dims, boot_mode=BootMode.DEFAULT):
 
     assert len(res_from_L1) == len(
         golden_tensor
-    ), "Result tensor and golder tensor are not of the same length"
+    ), "Result tensor and golden tensor are not of the same length"
 
     torch_format = format_dict[formats.output_format]
     res_tensor = torch.tensor(res_from_L1, dtype=torch_format)

--- a/tests/python_tests/quasar/test_pack_untilize_quasar.py
+++ b/tests/python_tests/quasar/test_pack_untilize_quasar.py
@@ -136,7 +136,7 @@ def test_pack_untilize_quasar(formats_dest_acc_dimensions):
 
     assert len(res_from_L1) == len(
         golden_tensor
-    ), "Result tensor and golder tensor are not of the same length"
+    ), "Result tensor and golden tensor are not of the same length"
 
     res_tensor = torch.tensor(res_from_L1, dtype=format_dict[formats.output_format])
 

--- a/tests/python_tests/quasar/test_reduce_quasar.py
+++ b/tests/python_tests/quasar/test_reduce_quasar.py
@@ -159,7 +159,7 @@ def test_reduce_quasar(
 
     assert len(res_from_L1) == len(
         golden_tensor
-    ), "Result tensor and golder tensor are not of the same length"
+    ), "Result tensor and golden tensor are not of the same length"
 
     res_tensor = torch.tensor(res_from_L1, dtype=format_dict[formats.output_format])
 

--- a/tests/python_tests/quasar/test_unpack_tilize_quasar.py
+++ b/tests/python_tests/quasar/test_unpack_tilize_quasar.py
@@ -163,7 +163,7 @@ def test_unpack_tilize_quasar(
 
     assert len(res_from_L1) == len(
         golden_tensor
-    ), "Result tensor and golder tensor are not of the same length"
+    ), "Result tensor and golden tensor are not of the same length"
 
     torch_format = format_dict[formats.output_format]
     res_tensor = torch.tensor(res_from_L1, dtype=torch_format)

--- a/tests/python_tests/quasar/test_unpack_unary_operand_quasar.py
+++ b/tests/python_tests/quasar/test_unpack_unary_operand_quasar.py
@@ -210,7 +210,7 @@ def test_unpack_unary_operand_quasar(
 
     assert len(res_from_L1) == len(
         golden_tensor
-    ), "Result tensor and golder tensor are not of the same length"
+    ), "Result tensor and golden tensor are not of the same length"
 
     torch_format = format_dict[formats.output_format]
     res_tensor = torch.tensor(res_from_L1, dtype=torch_format)

--- a/tests/python_tests/test_eltwise_binary.py
+++ b/tests/python_tests/test_eltwise_binary.py
@@ -160,7 +160,7 @@ def test_eltwise_binary(
 
     assert len(res_from_L1) == len(
         golden_tensor
-    ), "Result tensor and golder tensor are not of the same length"
+    ), "Result tensor and golden tensor are not of the same length"
 
     torch_format = format_dict[formats.output_format]
     res_tensor = torch.tensor(res_from_L1, dtype=torch_format)

--- a/tests/python_tests/test_eltwise_binary_transpose_bcast.py
+++ b/tests/python_tests/test_eltwise_binary_transpose_bcast.py
@@ -148,7 +148,7 @@ def test_eltwise_binary_transpose_bcast(
 
     assert len(res_from_L1) == len(
         golden_tensor
-    ), "Result tensor and golder tensor are not of the same length"
+    ), "Result tensor and golden tensor are not of the same length"
 
     torch_format = format_dict[formats.output_format]
     res_tensor = torch.tensor(res_from_L1, dtype=torch_format)

--- a/tests/python_tests/test_eltwise_unary_sfpu.py
+++ b/tests/python_tests/test_eltwise_unary_sfpu.py
@@ -272,7 +272,7 @@ def eltwise_unary_sfpu(
     # golden_tensor = golden_tensor[:1024]
     assert len(res_from_L1) == len(
         golden_tensor
-    ), "Result tensor and golder tensor are not of the same length"
+    ), "Result tensor and golden tensor are not of the same length"
 
     torch_format = format_dict[formats.output_format]
     res_tensor = torch.tensor(res_from_L1, dtype=torch_format)

--- a/tests/python_tests/test_math_matmul.py
+++ b/tests/python_tests/test_math_matmul.py
@@ -211,7 +211,7 @@ def test_math_matmul(
 
     assert len(res_from_L1) == len(
         golden_tensor
-    ), "Result tensor and golder tensor are not of the same length"
+    ), "Result tensor and golden tensor are not of the same length"
 
     res_tensor = torch.tensor(res_from_L1, dtype=torch_format)
     if num_faces < 4:

--- a/tests/python_tests/test_matmul.py
+++ b/tests/python_tests/test_matmul.py
@@ -157,7 +157,7 @@ def test_matmul(
 
     assert len(res_from_L1) == len(
         golden_tensor
-    ), "Result tensor and golder tensor are not of the same length"
+    ), "Result tensor and golden tensor are not of the same length"
 
     res_tensor = torch.tensor(res_from_L1, dtype=torch_format)
 

--- a/tests/python_tests/test_matmul_pack_untilize.py
+++ b/tests/python_tests/test_matmul_pack_untilize.py
@@ -85,7 +85,7 @@ def test_matmul_pack_untilize(
     res_from_L1 = configuration.run(workers_tensix_coordinates)
     assert len(res_from_L1) == len(
         golden_tensor
-    ), "Result tensor and golder tensor are not of the same length"
+    ), "Result tensor and golden tensor are not of the same length"
 
     res_tensor = torch.tensor(res_from_L1, dtype=(torch_format))
 

--- a/tests/python_tests/test_matmul_unpack_tilize.py
+++ b/tests/python_tests/test_matmul_unpack_tilize.py
@@ -88,7 +88,7 @@ def test_matmul_unpack_tilize(
 
     assert len(res_from_L1) == len(
         golden_tensor
-    ), "Result tensor and golder tensor are not of the same length"
+    ), "Result tensor and golden tensor are not of the same length"
 
     res_tensor = torch.tensor(res_from_L1, dtype=torch_format)
 

--- a/tests/python_tests/test_multiple_tiles_eltwise.py
+++ b/tests/python_tests/test_multiple_tiles_eltwise.py
@@ -92,7 +92,7 @@ def test_multiple_tiles(
 
     assert len(res_from_L1) == len(
         golden_tensor
-    ), "Result tensor and golder tensor are not of the same length"
+    ), "Result tensor and golden tensor are not of the same length"
 
     torch_format = format_dict[formats.output_format]
     res_tensor = torch.tensor(res_from_L1, dtype=torch_format)

--- a/tests/python_tests/test_pack.py
+++ b/tests/python_tests/test_pack.py
@@ -247,7 +247,7 @@ def test_pack(
 
     assert len(res_from_L1) == len(
         golden_tensor
-    ), "Result tensor and golder tensor are not of the same length"
+    ), "Result tensor and golden tensor are not of the same length"
 
     torch_format = format_dict[formats.output_format]
     res_tensor = torch.tensor(res_from_L1, dtype=torch_format)

--- a/tests/python_tests/test_pack_untilize.py
+++ b/tests/python_tests/test_pack_untilize.py
@@ -128,7 +128,7 @@ def test_pack_untilize(
 
     assert len(res_from_L1) == len(
         golden_tensor
-    ), "Result tensor and golder tensor are not of the same length"
+    ), "Result tensor and golden tensor are not of the same length"
 
     res_tensor = torch.tensor(res_from_L1, dtype=format_dict[formats.output_format])
 

--- a/tests/python_tests/test_reduce.py
+++ b/tests/python_tests/test_reduce.py
@@ -84,7 +84,7 @@ def test_reduce(formats, dest_acc, reduce_dim, pool_type, workers_tensix_coordin
 
     assert len(res_from_L1) == len(
         golden_tensor
-    ), "Result tensor and golder tensor are not of the same length"
+    ), "Result tensor and golden tensor are not of the same length"
 
     res_tensor = torch.tensor(res_from_L1, dtype=format_dict[formats.output_format])
 

--- a/tests/python_tests/test_risc_compute.py
+++ b/tests/python_tests/test_risc_compute.py
@@ -50,7 +50,7 @@ def test_risc_compute(workers_tensix_coordinates):
 
     assert len(res_from_L1) == len(
         golden_tensor
-    ), "Result tensor and golder tensor are not of the same length"
+    ), "Result tensor and golden tensor are not of the same length"
 
     torch_format = format_dict[formats.output_format]
     res_tensor = torch.tensor(res_from_L1, dtype=torch_format)

--- a/tests/python_tests/test_sfpu_binary.py
+++ b/tests/python_tests/test_sfpu_binary.py
@@ -144,7 +144,7 @@ def test_sfpu_binary_add_top_row(formats, dest_acc, mathop, workers_tensix_coord
 
     assert len(res_tensor) == len(
         golden_tensor
-    ), "Result tensor and golder tensor are not of the same length"
+    ), "Result tensor and golden tensor are not of the same length"
 
     assert passed_test(
         golden_tensor, res_tensor, formats.output_format
@@ -214,7 +214,7 @@ def sfpu_binary(formats, dest_acc, mathop, workers_tensix_coordinates):
 
     assert len(res_tensor) == len(
         golden_tensor
-    ), "Result tensor and golder tensor are not of the same length"
+    ), "Result tensor and golden tensor are not of the same length"
 
     assert passed_test(
         golden_tensor, res_tensor, formats.output_format

--- a/tests/python_tests/test_transpose_dest.py
+++ b/tests/python_tests/test_transpose_dest.py
@@ -217,7 +217,7 @@ def transpose_dest(
 
     assert len(res_from_L1) == len(
         golden_tensor
-    ), "Result tensor and golder tensor are not of the same length"
+    ), "Result tensor and golden tensor are not of the same length"
 
     torch_format = format_dict[formats.output_format]
     res_tensor = torch.tensor(res_from_L1, dtype=torch_format)

--- a/tests/python_tests/test_ttnn_where.py
+++ b/tests/python_tests/test_ttnn_where.py
@@ -107,7 +107,7 @@ def test_ttnn_where(formats, dest_acc, mathop, test_case, workers_tensix_coordin
     res_from_L1 = res_from_L1[:1024]
     assert len(res_from_L1) == len(
         golden
-    ), "Result tensor and golder tensor are not of the same length"
+    ), "Result tensor and golden tensor are not of the same length"
 
     golden_tensor = torch.tensor(
         golden,
@@ -218,5 +218,5 @@ def test_ttnn_where_mcw(
 
     assert len(res_tensor) == len(
         golden_tensor
-    ), "Result tensor and golder tensor are not of the same length"
+    ), "Result tensor and golden tensor are not of the same length"
     assert torch_equal_nan(golden_tensor, res_tensor), "Assert against golden failed"

--- a/tests/python_tests/test_unpack_A.py
+++ b/tests/python_tests/test_unpack_A.py
@@ -489,7 +489,7 @@ def test_unpack_comprehensive(
 
     assert len(res_from_L1) == len(
         golden_tensor
-    ), "Result tensor and golder tensor are not of the same length"
+    ), "Result tensor and golden tensor are not of the same length"
 
     res_tensor = torch.tensor(res_from_L1, dtype=format_dict[formats.output_format])
     assert passed_test(

--- a/tests/python_tests/test_unpack_a_bcast_eltwise.py
+++ b/tests/python_tests/test_unpack_a_bcast_eltwise.py
@@ -152,7 +152,7 @@ def test_unp_bcast_sub_sdpa(
 
     assert len(res_from_L1) == len(
         golden_tensor
-    ), "Result tensor and golder tensor are not of the same length"
+    ), "Result tensor and golden tensor are not of the same length"
 
     torch_format = format_dict[formats.output_format]
     res_tensor = torch.tensor(res_from_L1, dtype=torch_format)

--- a/tests/python_tests/test_unpack_matmul.py
+++ b/tests/python_tests/test_unpack_matmul.py
@@ -195,7 +195,7 @@ def test_unpack_matmul(math_fidelity, matmul_config, workers_tensix_coordinates)
 
     assert len(res_from_L1) == len(
         golden_tensor
-    ), "Result tensor and golder tensor are not of the same length"
+    ), "Result tensor and golden tensor are not of the same length"
 
     # Only compare the active faces in each tile since that's what the hardware processes
     num_elements_per_tile = num_faces * 256  # Each face is 16x16 = 256 elements

--- a/tests/python_tests/test_unpack_tilize.py
+++ b/tests/python_tests/test_unpack_tilize.py
@@ -74,7 +74,7 @@ def unpack_tilize(formats, workers_tensix_coordinates):
 
     assert len(res_from_L1) == len(
         golden_tensor
-    ), "Result tensor and golder tensor are not of the same length"
+    ), "Result tensor and golden tensor are not of the same length"
 
     res_tensor = torch.tensor(res_from_L1, dtype=format_dict[formats.output_format])
 

--- a/tests/python_tests/test_unpack_tilize_sweep.py
+++ b/tests/python_tests/test_unpack_tilize_sweep.py
@@ -159,7 +159,7 @@ def test_unpack_tilize_comprehensive(
 
     assert len(res_from_L1) == len(
         golden_tensor
-    ), "Result tensor and golder tensor are not of the same length"
+    ), "Result tensor and golden tensor are not of the same length"
 
     res_tensor = torch.tensor(res_from_L1, dtype=torch_format)
     assert passed_test(

--- a/tests/python_tests/test_unpack_untilize.py
+++ b/tests/python_tests/test_unpack_untilize.py
@@ -78,7 +78,7 @@ def test_unpack_untilize(formats, workers_tensix_coordinates):
 
     assert len(res_from_L1) == len(
         golden_tensor
-    ), "Result tensor and golder tensor are not of the same length"
+    ), "Result tensor and golden tensor are not of the same length"
 
     res_tensor = torch.tensor(res_from_L1, dtype=format_dict[formats.output_format])
 


### PR DESCRIPTION
### Ticket
/

### Problem description
In python tests, word `golden` was misspelled. 

### What's changed
Fixed a typo. 

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
