### PR TITLE
[skip uplift] Add uint16 support for fill op

### DIFF
--- a/tests/helpers/include/sfpu_operations.h
+++ b/tests/helpers/include/sfpu_operations.h
@@ -100,7 +100,15 @@ void call_sfpu_operation(SfpuType operation, std::uint32_t math_format = 0, floa
         case SfpuType::fill:
             if (math_format == ckernel::to_underlying(DataFormat::Int32))
             {
-                _calculate_fill_int_<APPROX_MODE, ITERATIONS>(fill_const_value);
+                _calculate_fill_int_<APPROX_MODE, ckernel::InstrModLoadStore::INT32, ITERATIONS>(static_cast<std::uint32_t>(fill_const_value));
+            }
+            else if (math_format == ckernel::to_underlying(DataFormat::UInt16))
+            {
+                _calculate_fill_int_<APPROX_MODE, ckernel::InstrModLoadStore::LO16, ITERATIONS>(static_cast<std::uint32_t>(fill_const_value));
+            }
+            else if (math_format == ckernel::to_underlying(DataFormat::UInt32))
+            {
+                _calculate_fill_int_<APPROX_MODE, ckernel::InstrModLoadStore::INT32, ITERATIONS>(static_cast<std::uint32_t>(fill_const_value));
             }
             else
             {

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_fill.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_fill.h
@@ -26,15 +26,25 @@ inline void _calculate_fill_(const float value)
     }
 }
 
-template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_fill_int_(const int value)
+template <bool APPROXIMATION_MODE, InstrModLoadStore INSTRUCTION_MODE, int ITERATIONS>
+inline void _calculate_fill_int_(const std::uint32_t value)
 {
     // SFPU microcode
-    sfpi::vInt fill_val = value;
-
+    if constexpr (INSTRUCTION_MODE == InstrModLoadStore::INT32)
+    {
+        _sfpu_load_imm32_(p_sfpu::LREG1, value);
+    }
+    else if constexpr (INSTRUCTION_MODE == InstrModLoadStore::LO16)
+    {
+        _sfpu_load_imm16_(p_sfpu::LREG1, value);
+    }
+    else
+    {
+        static_assert(false, "INSTRUCTION_MODE must be one of: INT32, LO16.");
+    }
     for (int d = 0; d < ITERATIONS; d++)
     {
-        sfpi::dst_reg[0] = fill_val;
+        TTI_SFPSTORE(p_sfpu::LREG1, INSTRUCTION_MODE, ADDR_MOD_3, 0);
         sfpi::dst_reg++;
     }
 }

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_fill.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_fill.h
@@ -26,15 +26,25 @@ inline void _calculate_fill_(const float value)
     }
 }
 
-template <bool APPROXIMATION_MODE, int ITERATIONS>
+template <bool APPROXIMATION_MODE, InstrModLoadStore INSTRUCTION_MODE, int ITERATIONS>
 inline void _calculate_fill_int_(const std::uint32_t value)
 {
     // SFPU microcode
-    _sfpu_load_imm32_(p_sfpu::LREG1, value);
-
+    if constexpr (INSTRUCTION_MODE == InstrModLoadStore::INT32)
+    {
+        _sfpu_load_imm32_(p_sfpu::LREG1, value);
+    }
+    else if constexpr (INSTRUCTION_MODE == InstrModLoadStore::LO16)
+    {
+        _sfpu_load_imm16_(p_sfpu::LREG1, value);
+    }
+    else
+    {
+        static_assert(false, "INSTRUCTION_MODE must be one of: INT32, LO16.");
+    }
     for (int d = 0; d < ITERATIONS; d++)
     {
-        TTI_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::INT32, ADDR_MOD_3, 0);
+        TTI_SFPSTORE(p_sfpu::LREG1, INSTRUCTION_MODE, ADDR_MOD_3, 0);
         sfpi::dst_reg++;
     }
 }


### PR DESCRIPTION
### Ticket
 Link to Github Issue https://github.com/tenstorrent/tt-metal/issues/36917


### What's changed
Added uint16 support for fill op

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
