### PR TITLE
fix: replace L1 base address increment instructions with CFGSHIFTMASK for performance

### DIFF
--- a/tt_llk_blackhole/llk_lib/llk_unpack_AB_matmul.h
+++ b/tt_llk_blackhole/llk_lib/llk_unpack_AB_matmul.h
@@ -26,7 +26,7 @@ inline void _llk_unpack_AB_matmul_mop_config_(
     // in1/inB - loaded to SrcA
 
     const bool reuse_a                      = ct_dim >= rt_dim;
-    const std::uint32_t replay_buf_prog_len = (reuse_a && unpA_partial_face) ? 12 : ((!reuse_a && unpB_partial_face) ? 12 : 6);
+    const std::uint32_t replay_buf_prog_len = (reuse_a && unpA_partial_face) ? 13 : ((!reuse_a && unpB_partial_face) ? 13 : 7);
     const std::uint32_t replay_buf_run_len  = replay_buf_prog_len / 2;
 
     if (reuse_a)
@@ -54,6 +54,7 @@ inline void _llk_unpack_AB_matmul_mop_config_(
                 if constexpr (kernel_broadcast_b == 1)
                 {
                     TTI_NOP;
+                    TTI_NOP;
                 }
                 else
                 {
@@ -78,6 +79,7 @@ inline void _llk_unpack_AB_matmul_mop_config_(
                 }
                 if constexpr (kernel_broadcast_b == 1)
                 {
+                    TTI_NOP;
                     TTI_NOP;
                 }
                 else
@@ -114,6 +116,7 @@ inline void _llk_unpack_AB_matmul_mop_config_(
                 if constexpr (kernel_broadcast_a == 1)
                 {
                     TTI_NOP;
+                    TTI_NOP;
                 }
                 else
                 {
@@ -138,6 +141,7 @@ inline void _llk_unpack_AB_matmul_mop_config_(
                 }
                 if constexpr (kernel_broadcast_a == 1)
                 {
+                    TTI_NOP;
                     TTI_NOP;
                 }
                 else

--- a/tt_llk_blackhole/llk_lib/llk_unpack_AB_matmul.h
+++ b/tt_llk_blackhole/llk_lib/llk_unpack_AB_matmul.h
@@ -179,6 +179,8 @@ __attribute__((always_inline)) inline void _llk_unpack_AB_matmul_init_(
 {
     LLK_ASSERT(unpA_num_faces == 1 || unpA_num_faces == 2 || unpA_num_faces == 4, "unpA_num_faces must be 1, 2, or 4");
     LLK_ASSERT(unpB_num_faces == 1 || unpB_num_faces == 2 || unpB_num_faces == 4, "unpB_num_faces must be 1, 2, or 4");
+
+    const bool reuse_a = ct_dim >= rt_dim;
     // also turn on within_face_16x16_transpose if it was turned off by datacopy at runtime
     // on WH, the unpacker performs both transpose of faces as well as transpose each face.
     // the former is configured in mop, the latter is configured in cfg register in hw_configure

--- a/tt_llk_blackhole/llk_lib/llk_unpack_AB_matmul.h
+++ b/tt_llk_blackhole/llk_lib/llk_unpack_AB_matmul.h
@@ -26,7 +26,7 @@ inline void _llk_unpack_AB_matmul_mop_config_(
     // in1/inB - loaded to SrcA
 
     const bool reuse_a                      = ct_dim >= rt_dim;
-    const std::uint32_t replay_buf_prog_len = (reuse_a && unpA_partial_face) ? 18 : ((!reuse_a && unpB_partial_face) ? 18 : 12);
+    const std::uint32_t replay_buf_prog_len = (reuse_a && unpA_partial_face) ? 12 : ((!reuse_a && unpB_partial_face) ? 12 : 6);
     const std::uint32_t replay_buf_run_len  = replay_buf_prog_len / 2;
 
     if (reuse_a)
@@ -54,16 +54,11 @@ inline void _llk_unpack_AB_matmul_mop_config_(
                 if constexpr (kernel_broadcast_b == 1)
                 {
                     TTI_NOP;
-                    TTI_NOP;
-                    TTI_NOP;
-                    TTI_NOP;
                 }
                 else
                 {
-                    TTI_RDCFG(p_gpr_unpack::TMP0, THCON_SEC0_REG3_Base_address_ADDR32);
-                    TTI_ADDDMAREG(0, p_gpr_unpack::TMP0, p_gpr_unpack::TMP0, p_gpr_unpack::TILE_SIZE_A);
-                    TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::THCON);
-                    TTI_WRCFG(p_gpr_unpack::TMP0, 0, THCON_SEC0_REG3_Base_address_ADDR32);
+                    // THCON_SEC0_REG3_Base_address_ADDR32 =  THCON_SEC0_REG3_Base_address_ADDR32 +  SCRATCH_SEC0_val_ADDR32
+                    TTI_CFGSHIFTMASK(1, 0b011, 32 - 1, 0, 0b11, THCON_SEC0_REG3_Base_address_ADDR32);
                 }
                 // Added to ensure WRCFG instruction has finished, since it takes 2 cycles.
                 TTI_NOP;
@@ -84,16 +79,11 @@ inline void _llk_unpack_AB_matmul_mop_config_(
                 if constexpr (kernel_broadcast_b == 1)
                 {
                     TTI_NOP;
-                    TTI_NOP;
-                    TTI_NOP;
-                    TTI_NOP;
                 }
                 else
                 {
-                    TTI_RDCFG(p_gpr_unpack::TMP0, THCON_SEC0_REG3_Base_cntx1_address_ADDR32);
-                    TTI_ADDDMAREG(0, p_gpr_unpack::TMP0, p_gpr_unpack::TMP0, p_gpr_unpack::TILE_SIZE_A);
-                    TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::THCON);
-                    TTI_WRCFG(p_gpr_unpack::TMP0, 0, THCON_SEC0_REG3_Base_cntx1_address_ADDR32);
+                    // THCON_SEC0_REG3_Base_cntx1_address_ADDR32 =  THCON_SEC0_REG3_Base_cntx1_address_ADDR32 +  SCRATCH_SEC0_val_ADDR32
+                    TTI_CFGSHIFTMASK(1, 0b011, 32 - 1, 0, 0b11, THCON_SEC0_REG3_Base_cntx1_address_ADDR32);
                 }
                 // Added to ensure WRCFG instruction has finished, since it takes 2 cycles.
                 TTI_NOP;
@@ -124,16 +114,11 @@ inline void _llk_unpack_AB_matmul_mop_config_(
                 if constexpr (kernel_broadcast_a == 1)
                 {
                     TTI_NOP;
-                    TTI_NOP;
-                    TTI_NOP;
-                    TTI_NOP;
                 }
                 else
                 {
-                    TTI_RDCFG(p_gpr_unpack::TMP0, THCON_SEC1_REG3_Base_address_ADDR32);
-                    TTI_ADDDMAREG(0, p_gpr_unpack::TMP0, p_gpr_unpack::TMP0, p_gpr_unpack::TMP_LO);
-                    TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::THCON);
-                    TTI_WRCFG(p_gpr_unpack::TMP0, 0, THCON_SEC1_REG3_Base_address_ADDR32);
+                    // THCON_SEC1_REG3_Base_address_ADDR32 =  THCON_SEC1_REG3_Base_address_ADDR32 +  SCRATCH_SEC0_val_ADDR32
+                    TTI_CFGSHIFTMASK(1, 0b011, 32 - 1, 0, 0b11, THCON_SEC1_REG3_Base_address_ADDR32);
                 }
                 // Added to ensure WRCFG instruction has finished, since it takes 2 cycles.
                 TTI_NOP;
@@ -154,16 +139,11 @@ inline void _llk_unpack_AB_matmul_mop_config_(
                 if constexpr (kernel_broadcast_a == 1)
                 {
                     TTI_NOP;
-                    TTI_NOP;
-                    TTI_NOP;
-                    TTI_NOP;
                 }
                 else
                 {
-                    TTI_RDCFG(p_gpr_unpack::TMP0, THCON_SEC1_REG3_Base_cntx1_address_ADDR32);
-                    TTI_ADDDMAREG(0, p_gpr_unpack::TMP0, p_gpr_unpack::TMP0, p_gpr_unpack::TMP_LO);
-                    TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::THCON);
-                    TTI_WRCFG(p_gpr_unpack::TMP0, 0, THCON_SEC1_REG3_Base_cntx1_address_ADDR32);
+                    // THCON_SEC1_REG3_Base_cntx1_address_ADDR32 =  THCON_SEC1_REG3_Base_cntx1_address_ADDR32 +  SCRATCH_SEC0_val_ADDR32
+                    TTI_CFGSHIFTMASK(1, 0b011, 32 - 1, 0, 0b11, THCON_SEC1_REG3_Base_cntx1_address_ADDR32);
                 }
                 // Added to ensure WRCFG instruction has finished, since it takes 2 cycles.
                 TTI_NOP;
@@ -235,6 +215,19 @@ __attribute__((always_inline)) inline void _llk_unpack_AB_matmul_init_(
 
     TT_SETDMAREG(0, LOWER_HALFWORD(kt_dim), 0, LO_16(p_gpr_unpack::KT_DIM)); // store kt_dim to gpr for scaling tile size
 
+    // Write to scratch cfg register L1 address increment
+    if (reuse_a)
+    {
+        TTI_WRCFG(p_gpr_unpack::TILE_SIZE_A, 0, SCRATCH_SEC0_val_ADDR32);
+    }
+    else
+    {
+        TTI_MULDMAREG(0, p_gpr_unpack::TMP_LO, p_gpr_unpack::TILE_SIZE_B, p_gpr_unpack::KT_DIM);
+        TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::THCON);
+        TTI_WRCFG(p_gpr_unpack::TMP_LO, 0, SCRATCH_SEC0_val_ADDR32);
+    }
+    TTI_NOP;
+
     _llk_unpack_AB_matmul_mop_config_<kernel_broadcast_a, kernel_broadcast_b>(ct_dim, rt_dim, unpA_partial_face, unpB_partial_face);
 }
 
@@ -266,11 +259,6 @@ inline void _llk_unpack_AB_matmul_(
 
     const bool reuse_a        = ct_dim >= rt_dim;
     const std::uint32_t t_dim = reuse_a ? rt_dim : ct_dim;
-
-    if (!reuse_a)
-    {
-        TTI_MULDMAREG(0, p_gpr_unpack::TMP_LO, p_gpr_unpack::TILE_SIZE_B, p_gpr_unpack::KT_DIM);
-    }
 
     for (uint t = 0; t < t_dim; t++)
     {


### PR DESCRIPTION
### Ticket
#55 

### Problem description
This is a revamp of @atatuzunerTT's [PR](https://github.com/tenstorrent/tt-llk-bh/pull/71) he made last year while LLKs lived in a separate repo.

### What's changed
Using CFGSHIFTMASK to increment L1 base address instead of cfg read/writes and tdma reg operations in the matmul unpack llk. This saves 6 instructions in the mop replay buffer and is a possible performance improvement.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
