### PR TITLE
Increase coverage of math reconfig

### DIFF
--- a/tt_llk_blackhole/llk_lib/llk_math_common.h
+++ b/tt_llk_blackhole/llk_lib/llk_math_common.h
@@ -152,6 +152,9 @@ inline void _llk_math_reconfig_data_format_srca_(const std::uint32_t srca_data_f
         uint int8_math_enabled = ((uint)(srca_data_format & 0xF) == (uint)DataFormat::Int8) || ((uint)srca_data_format == (uint)DataFormat::Int32);
         cfg_reg_rmw_tensix<ALU_ACC_CTRL_INT8_math_enabled_RMW>(int8_math_enabled);
     }
+    uint32_t fp32_dest_acc_en = is_fp32_dest_acc_en ? 1 : 0;
+    cfg_reg_rmw_tensix<ALU_ACC_CTRL_Fp32_enabled_RMW>(fp32_dest_acc_en);
+    cfg_reg_rmw_tensix<ALU_ACC_CTRL_SFPU_Fp32_enabled_RMW>(fp32_dest_acc_en);
 }
 
 template <bool is_fp32_dest_acc_en, bool to_from_int8 = false>
@@ -164,6 +167,9 @@ inline void _llk_math_reconfig_data_format_srcb_(const std::uint32_t srcb_data_f
         uint int8_math_enabled = ((uint)(srcb_data_format & 0xF) == (uint)DataFormat::Int8) || ((uint)srcb_data_format == (uint)DataFormat::Int32);
         cfg_reg_rmw_tensix<ALU_ACC_CTRL_INT8_math_enabled_RMW>(int8_math_enabled);
     }
+    uint32_t fp32_dest_acc_en = is_fp32_dest_acc_en ? 1 : 0;
+    cfg_reg_rmw_tensix<ALU_ACC_CTRL_Fp32_enabled_RMW>(fp32_dest_acc_en);
+    cfg_reg_rmw_tensix<ALU_ACC_CTRL_SFPU_Fp32_enabled_RMW>(fp32_dest_acc_en);
 }
 
 template <bool is_fp32_dest_acc_en, bool to_from_int8 = false>
@@ -177,6 +183,9 @@ inline void _llk_math_reconfig_data_format_(const std::uint32_t srca_data_format
                                  ((uint)srca_data_format == (uint)DataFormat::Int32) || ((uint)srcb_data_format == (uint)DataFormat::Int32);
         cfg_reg_rmw_tensix<ALU_ACC_CTRL_INT8_math_enabled_RMW>(int8_math_enabled);
     }
+    uint32_t fp32_dest_acc_en = is_fp32_dest_acc_en ? 1 : 0;
+    cfg_reg_rmw_tensix<ALU_ACC_CTRL_Fp32_enabled_RMW>(fp32_dest_acc_en);
+    cfg_reg_rmw_tensix<ALU_ACC_CTRL_SFPU_Fp32_enabled_RMW>(fp32_dest_acc_en);
 }
 
 inline std::uint32_t _llk_math_get_compute_special_value_flags_()

--- a/tt_llk_wormhole_b0/llk_lib/llk_math_common.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_math_common.h
@@ -146,6 +146,9 @@ inline void _llk_math_reconfig_data_format_srca_(const std::uint32_t srca_data_f
         TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::MATH | p_stall::WAIT_SFPU);
         cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG0_SrcA_RMW>(srca_data_format);
     }
+    uint32_t fp32_dest_acc_en = is_fp32_dest_acc_en ? 1 : 0;
+    cfg_reg_rmw_tensix<ALU_ACC_CTRL_Fp32_enabled_RMW>(fp32_dest_acc_en);
+    cfg_reg_rmw_tensix<ALU_ACC_CTRL_SFPU_Fp32_enabled_RMW>(fp32_dest_acc_en);
 }
 
 template <bool is_fp32_dest_acc_en, bool to_from_int8 = false>
@@ -165,6 +168,9 @@ inline void _llk_math_reconfig_data_format_srcb_(const std::uint32_t srcb_data_f
         TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::MATH | p_stall::WAIT_SFPU);
         cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG1_SrcB_RMW>(srcb_data_format);
     }
+    uint32_t fp32_dest_acc_en = is_fp32_dest_acc_en ? 1 : 0;
+    cfg_reg_rmw_tensix<ALU_ACC_CTRL_Fp32_enabled_RMW>(fp32_dest_acc_en);
+    cfg_reg_rmw_tensix<ALU_ACC_CTRL_SFPU_Fp32_enabled_RMW>(fp32_dest_acc_en);
 }
 
 template <bool is_fp32_dest_acc_en, bool to_from_int8 = false>
@@ -188,6 +194,9 @@ inline void _llk_math_reconfig_data_format_(const std::uint32_t srca_data_format
         constexpr uint config_mask = ALU_FORMAT_SPEC_REG0_SrcA_MASK | ALU_FORMAT_SPEC_REG1_SrcB_MASK;
         cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG0_SrcA_ADDR32, 0, config_mask>(config_data);
     }
+    uint32_t fp32_dest_acc_en = is_fp32_dest_acc_en ? 1 : 0;
+    cfg_reg_rmw_tensix<ALU_ACC_CTRL_Fp32_enabled_RMW>(fp32_dest_acc_en);
+    cfg_reg_rmw_tensix<ALU_ACC_CTRL_SFPU_Fp32_enabled_RMW>(fp32_dest_acc_en);
 }
 
 inline std::uint32_t _llk_math_get_compute_special_value_flags_()


### PR DESCRIPTION
### Ticket
<!-- Link to Github Issue -->
[Link to Github Issue](https://github.com/tenstorrent/tt-llk/issues/1221)
### Problem description
<!-- Provide context for the problem. -->
Reconfig doesn't handle the case where template parameter `is_fp32_dest_acc_en` differs from its initial value in `_llk_math_hw_configure_`, which can cause ALU registers to not be reprogrammed as expected

### What's changed
<!-- Describe the approach used to solve the problem.
Summarize the changes made and its impact. -->
Fix has been made to modify registers the same way as in the hw_configure for WH and BH

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
