### PR TITLE
Add functions which verify whether unpacker is configured correctly

### DIFF
--- a/tt_llk_blackhole/common/inc/cpack_common.h
+++ b/tt_llk_blackhole/common/inc/cpack_common.h
@@ -688,6 +688,7 @@ inline bool are_packers_configured_correctly(
     const std::uint32_t pack_src_format, const std::uint32_t pack_dst_format, const std::uint32_t face_r_dim = FACE_R_DIM, const std::uint32_t nop_count = 10)
 {
     // Ensure configuration writes complete before subsequent operations
+    tensix_sync();
     for (std::uint32_t i = 0; i < nop_count; i++)
     {
         asm volatile("nop");

--- a/tt_llk_blackhole/common/inc/cunpack_common.h
+++ b/tt_llk_blackhole/common/inc/cunpack_common.h
@@ -557,6 +557,7 @@ inline bool is_unpacker_A_configured_correctly(
     const std::uint32_t nop_count       = 10)
 {
     // Ensure configuration writes complete before subsequent operations
+    tensix_sync();
     for (std::uint32_t i = 0; i < nop_count; i++)
     {
         asm volatile("nop");
@@ -614,6 +615,7 @@ inline bool are_unpacker_AB_configured_correctly(
     const std::uint32_t nop_count       = 10)
 {
     // Ensure configuration writes complete before subsequent operations
+    tensix_sync();
     for (std::uint32_t i = 0; i < nop_count; i++)
     {
         asm volatile("nop");

--- a/tt_llk_wormhole_b0/common/inc/cpack_common.h
+++ b/tt_llk_wormhole_b0/common/inc/cpack_common.h
@@ -862,6 +862,7 @@ inline bool are_packers_configured_correctly(
     const std::uint32_t pack_src_format, const std::uint32_t pack_dst_format, const std::uint32_t face_r_dim = FACE_R_DIM, const std::uint32_t nop_count = 10)
 {
     // Ensure configuration writes complete before subsequent operations
+    tensix_sync();
     for (std::uint32_t i = 0; i < nop_count; i++)
     {
         asm volatile("nop");

--- a/tt_llk_wormhole_b0/common/inc/cunpack_common.h
+++ b/tt_llk_wormhole_b0/common/inc/cunpack_common.h
@@ -547,6 +547,7 @@ inline bool is_unpacker_A_configured_correctly(
     const std::uint32_t nop_count       = 10)
 {
     // Ensure configuration writes complete before subsequent operations
+    tensix_sync();
     for (std::uint32_t i = 0; i < nop_count; i++)
     {
         asm volatile("nop");
@@ -604,6 +605,7 @@ inline bool are_unpacker_AB_configured_correctly(
     const std::uint32_t nop_count       = 10)
 {
     // Ensure configuration writes complete before subsequent operations
+    tensix_sync();
     for (std::uint32_t i = 0; i < nop_count; i++)
     {
         asm volatile("nop");


### PR DESCRIPTION
### Ticket
#1227

### Problem description
We want to be able to assert whether unpacker configurations are set the way it is expected when executing OP.
There are 2 main steps which are important for this PR for UNPACKER:
- hardware configuration
- execution

Before executing OP, we want to check whether last hardware configure is still valid for the OP. The newly added function is_unpacker_configured_correctly will be used from compute API in metal repo in runtime assert.

### What's changed
There is a new function is_unpacker_configured_correctly implemented for blackhole and wormhole which offers a way to verify whether UNPACKER is configured in the expected way.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [x] [Assert validation](docs/Introduction_to_asserts.md) Complied with assert doc (if applicable)
