### PR TITLE
Reinstate fix for dst32b datatypes for BH ZEROACC workaround

### DIFF
--- a/tt_llk_blackhole/llk_lib/llk_math_eltwise_unary_datacopy.h
+++ b/tt_llk_blackhole/llk_lib/llk_math_eltwise_unary_datacopy.h
@@ -40,7 +40,8 @@ inline void _llk_math_eltwise_unary_datacopy_(
         // To mitigate that, we issue additional zero flag clear instruction immediately after unpack tile to dest is done.
         // RISC-to-dest event is not currently used.
 
-        const int clear_fp32          = static_cast<int>(dst_format == (uint)DataFormat::Float32);
+        const int clear_fp32 =
+            static_cast<int>(dst_format == (uint)DataFormat::Float32 || dst_format == (uint)DataFormat::Int32 || dst_format == (uint)DataFormat::UInt32);
         const uint32_t tiles_per_bank = clear_fp32 ? 4 : 8;
         const uint32_t local_tile     = dst_index & (tiles_per_bank - 1);
 #pragma GCC unroll 0


### PR DESCRIPTION
### Ticket
/

### Problem description
ZEROACC workaround was checking for FP32, but not for INT32 types, which could cause the wrong rows' zero flags to be set. This change was already merged but appears to have been lost in a merge.

### What's changed
Check for both Int32 and UInt32 in addition to Float32.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Assert validation](docs/Introduction_to_asserts.md) Complied with assert doc (if applicable)
