### PR TITLE
Add DISABLE_SFPLOADMACRO path to 'where' kernels

### DIFF
--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_where.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_where.h
@@ -28,6 +28,23 @@ inline void _calculate_where_(
 
     constexpr std::uint32_t mod0 = data_format == DataFormat::Float16_b ? InstrModLoadStore::LO16 : InstrModLoadStore::INT32;
 
+#ifdef DISABLE_SFPLOADMACRO
+    int offset3 = (dst_index_out * 32) << 1;
+
+    lltt::record(0, 6);
+    TT_SFPLOAD(p_sfpu::LREG0, mod0, ADDR_MOD_7, offset0);
+    TT_SFPLOAD(p_sfpu::LREG1, mod0, ADDR_MOD_7, offset1);
+    TTI_SFPSETCC(0, p_sfpu::LREG0, 0, sfpi::SFPSETCC_MOD1_LREG_EQ0);
+    TT_SFPLOAD(p_sfpu::LREG1, mod0, ADDR_MOD_7, offset2);
+    TTI_SFPENCC(0, 0, 0, sfpi::SFPENCC_MOD1_EU_R1);
+    TT_SFPSTORE(p_sfpu::LREG1, mod0, ADDR_MOD_6, offset3);
+
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++)
+    {
+        lltt::replay(0, 6);
+    }
+#else
     if (dst_index_out == dst_index_in0)
     {
         // We use macros 0 and 2 to schedule the following, which achieves 3 cycles per input row of 32 values:
@@ -84,11 +101,13 @@ inline void _calculate_where_(
             lltt::replay(0, 4);
         }
     }
+#endif
 }
 
 template <bool APPROXIMATION_MODE>
 inline void _init_where_()
 {
+#ifndef DISABLE_SFPLOADMACRO
     // InstructionTemplate[0]
     TTI_SFPSETCC(0, 0, 12, 6); // SFPSETCC_MOD1_LREG_EQ0
 
@@ -125,6 +144,7 @@ inline void _init_where_()
 
     // Misc: {UsesLoadMod0ForStore=1, WaitForElapsedInstructions=1} for all macros.
     TTI_SFPCONFIG(0x770, 8, 1);
+#endif
 }
 
 } // namespace ckernel::sfpu

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_where.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_where.h
@@ -28,6 +28,23 @@ inline void _calculate_where_(
 
     constexpr std::uint32_t mod0 = data_format == DataFormat::Float16_b ? InstrModLoadStore::LO16 : InstrModLoadStore::INT32;
 
+#ifdef DISABLE_SFPLOADMACRO
+    int offset3 = (dst_index_out * 32) << 1;
+
+    lltt::record(0, 6);
+    TT_SFPLOAD(p_sfpu::LREG0, mod0, ADDR_MOD_3, offset0);
+    TT_SFPLOAD(p_sfpu::LREG1, mod0, ADDR_MOD_3, offset1);
+    TTI_SFPSETCC(0, p_sfpu::LREG0, 0, sfpi::SFPSETCC_MOD1_LREG_EQ0);
+    TT_SFPLOAD(p_sfpu::LREG1, mod0, ADDR_MOD_3, offset2);
+    TTI_SFPENCC(0, 0, 0, sfpi::SFPENCC_MOD1_EU_R1);
+    TT_SFPSTORE(p_sfpu::LREG1, mod0, ADDR_MOD_2, offset3);
+
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++)
+    {
+        lltt::replay(0, 6);
+    }
+#else
     if (dst_index_out == dst_index_in0)
     {
         // We use macros 0 and 2 to schedule the following, which achieves 3 cycles per input row of 32 values:
@@ -74,11 +91,13 @@ inline void _calculate_where_(
             lltt::replay(0, 4);
         }
     }
+#endif
 }
 
 template <bool APPROXIMATION_MODE>
 inline void _init_where_()
 {
+#ifndef DISABLE_SFPLOADMACRO
     // InstructionTemplate[0]
     TTI_SFPSETCC(0, 0, 12, 6); // SFPSETCC_MOD1_LREG_EQ0
 
@@ -115,6 +134,7 @@ inline void _init_where_()
 
     // Misc: {UsesLoadMod0ForStore=1, WaitForElapsedInstructions=1} for all macros.
     TTI_SFPCONFIG(0x770, 8, 1);
+#endif
 }
 
 } // namespace ckernel::sfpu


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-llk/issues/1241

### Problem description
Need non-SFPLOADMACRO path for 'where'.

### What's changed
Simple instruction-for-instruction-equivalent code path, using the exact same algorithm as the SFPLOADMACRO path.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Assert validation](docs/Introduction_to_asserts.md) Complied with assert doc (if applicable)
