### PR TITLE
Fix hitting asserts for matmul perf and unpack tilize perf tests 

### DIFF
--- a/tests/sources/matmul_perf.cpp
+++ b/tests/sources/matmul_perf.cpp
@@ -70,8 +70,8 @@ void run_kernel(const volatile struct RuntimeParams* params)
                 for (std::uint32_t j = 0; j < params->KT_DIM; j++)
                 {
                     _llk_unpack_AB_matmul_<>(
-                        L1_ADDRESS(buffer_A[0]),
-                        L1_ADDRESS(buffer_B[0]),
+                        PERF_ADDRESS(PERF_INPUT_A, j),
+                        PERF_ADDRESS(PERF_INPUT_B, j),
                         j,
                         j * params->CT_DIM,
                         TILE_SIZE_UNPACK_A,
@@ -181,7 +181,8 @@ void run_kernel(const volatile struct RuntimeParams* params)
             {
                 for (std::uint32_t tile = 0; tile < params->CT_DIM * params->RT_DIM; tile++)
                 {
-                    _llk_pack_<DstSync::SyncHalf, is_fp32_dest_acc_en>(tile, PERF_ADDRESS(PERF_OUTPUT, tile));
+                    const std::uint32_t tile_index = tile % MAX_TILES_DEST;
+                    _llk_pack_<DstSync::SyncHalf, is_fp32_dest_acc_en>(tile_index, PERF_ADDRESS(PERF_OUTPUT, tile_index));
                 }
             }
         }
@@ -192,7 +193,8 @@ void run_kernel(const volatile struct RuntimeParams* params)
                 _llk_packer_wait_for_math_done_();
                 for (std::uint32_t tile = 0; tile < params->CT_DIM * params->RT_DIM; tile++)
                 {
-                    _llk_pack_<DstSync::SyncHalf, is_fp32_dest_acc_en>(tile, PERF_ADDRESS(PERF_OUTPUT, tile));
+                    const std::uint32_t tile_index = tile % MAX_TILES_DEST;
+                    _llk_pack_<DstSync::SyncHalf, is_fp32_dest_acc_en>(tile_index, PERF_ADDRESS(PERF_OUTPUT, tile_index));
                 }
                 _llk_pack_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
             }

--- a/tests/sources/unpack_tilize_perf.cpp
+++ b/tests/sources/unpack_tilize_perf.cpp
@@ -57,7 +57,7 @@ void run_kernel(const volatile struct RuntimeParams* params)
                 const std::uint32_t tile_row_addr = L1_ADDRESS(src + (i % 8) * 0x1000); // TODO SS<-LP use PERF_ADDRESS here
                 for (std::uint32_t j = 0; j < BLOCK_CT_DIM; j++)
                 {
-                    _llk_unpack_tilize_(tile_row_addr, j, formats.unpack_src, 0, FACE_R_DIM, 4, false);
+                    _llk_unpack_tilize_(tile_row_addr, j, formats.unpack_src, formats.unpack_dst, 0, FACE_R_DIM, 4, false);
                 }
             }
         }


### PR DESCRIPTION
### Ticket
#0

### Problem description
There are perf tests which hit asserts, when asserts are enabled and tests ran.
1. matmul_perf hits asserts on L1_ADDRESS verification
2. unpack_tilize_perf hit asserts on num_faces verification.
 
### What's changed
Fixed these 2 tests.
1. matmul perf is fixed by updating addresses which are passed to _llk_unpack_AB_matmul_. Also, fixed tile indexes passed to _llk_pack_.
2. unpack_tilize_perf fixed by adding format.unpack_dst as parameter to _llk_unpack_tilize_

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [x] [Assert validation](docs/Introduction_to_asserts.md) Complied with assert doc (if applicable)
