### PR TITLE
fix: change default value of CLAMP_NEGATIVE to false

### DIFF
--- a/tests/helpers/include/sfpu_operations.h
+++ b/tests/helpers/include/sfpu_operations.h
@@ -35,7 +35,7 @@ using namespace ckernel::sfpu;
  * @param operation The SFPU operation type to execute
  * @param math_format Optional math format for operations that need format-specific behavior
  */
-template <bool APPROX_MODE, bool is_fp32_dest_acc_en, int ITERATIONS, bool FAST_MODE = false, bool STABLE_SORT = false, bool CLAMP_NEGATIVE = true>
+template <bool APPROX_MODE, bool is_fp32_dest_acc_en, int ITERATIONS, bool FAST_MODE = false, bool STABLE_SORT = false, bool CLAMP_NEGATIVE = false>
 void call_sfpu_operation(SfpuType operation, std::uint32_t math_format = 0, float fill_const_value = 5.0f)
 {
     switch (operation)


### PR DESCRIPTION
### Ticket
None

### Problem description
This code got merged as part of the 7e7cf4fcfbb9f66d6a812242b48141f78ceb3d94 commit. But the default parameter should have been false from the start, since it causes perf tests to follow different path and fail due to static assert.

### What's changed
Clamping shouldn't be true by default, especially not in this code.
Dedicated test that got added in 7e7cf4fcfbb9f66d6a812242b48141f78ceb3d94 will still exercise both values of this parameter (true and false), so this change won't be affecting it.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Assert validation](docs/Introduction_to_asserts.md) Complied with assert doc (if applicable)
