### PR TITLE
Add 16x32 support for fast tilize

### DIFF
--- a/tests/python_tests/helpers/golden_generators.py
+++ b/tests/python_tests/helpers/golden_generators.py
@@ -2068,7 +2068,7 @@ class TilizeGolden:
             raise ValueError(f"`num_faces` must be between 1 and 4, got {num_faces}")
 
         # Always do full tilization first
-        result = tilize_block(operand, dimensions, data_format)
+        result = tilize_block(operand, dimensions, data_format, num_faces)
         torch_format = format_dict[data_format]
 
         # Then select the appropriate number of faces from the tilized result

--- a/tests/python_tests/helpers/stimuli_config.py
+++ b/tests/python_tests/helpers/stimuli_config.py
@@ -173,7 +173,7 @@ class StimuliConfig:
         )
 
         for ind in range(tile_count):
-            start_idx = FULL_TILE_ELEMENTS * ind
+            start_idx = tile_elements * ind
             tile_data = buffer[start_idx : start_idx + tile_elements]
             packed_data = pack_function_lambda(tile_data)
             addresses.append(base_address + ind * tile_size)

--- a/tests/python_tests/helpers/stimuli_generator.py
+++ b/tests/python_tests/helpers/stimuli_generator.py
@@ -105,6 +105,56 @@ def _generate_mxfp8_face(stimuli_format, size, const_face, const_value, sfpu):
     return face_data
 
 
+def generate_identity_face(
+    stimuli_format: DataFormat, rows: int, cols: int
+) -> torch.Tensor:
+    assert rows % 16 == 0 and cols % 16 == 0, "Matrix size must be divisible by 16"
+
+    num_faces_row = rows // 16
+    num_faces_col = cols // 16
+    face_height, face_width = 16, 16
+
+    # Create output array in float32
+    matrix = torch.zeros((rows, cols), dtype=torch.float32)
+
+    # Fill each face with identity matrix
+    for face_r in range(num_faces_row):
+        for face_c in range(num_faces_col):
+            r_start = face_r * face_height
+            c_start = face_c * face_width
+
+            # Set diagonal elements within the face
+            for i in range(face_height):
+                matrix[r_start + i, c_start + i] = 1
+
+    return matrix.to(dtype=format_dict[stimuli_format])
+
+
+def generate_incrementing_face(
+    stimuli_format: DataFormat, rows: int, cols: int
+) -> torch.Tensor:
+    assert rows % 16 == 0 and cols % 16 == 0, "Matrix size must be divisible by 16"
+
+    num_faces_row = rows // 16
+    num_faces_col = cols // 16
+    face_height, face_width = 16, 16
+
+    # Create output array in float32
+    matrix = torch.zeros((rows, cols), dtype=torch.float32)
+
+    # Fill each face with its index
+    for face_r in range(num_faces_row):
+        for face_c in range(num_faces_col):
+            face_val = float(face_r * num_faces_col + face_c + 1)
+            r_start = face_r * face_height
+            c_start = face_c * face_width
+            matrix[r_start : r_start + face_height, c_start : c_start + face_width] = (
+                face_val
+            )
+
+    return matrix.to(dtype=format_dict[stimuli_format])
+
+
 def generate_face_matmul_data(
     num_faces: int,
     stimuli_format: DataFormat,

--- a/tests/python_tests/helpers/test_variant_parameters.py
+++ b/tests/python_tests/helpers/test_variant_parameters.py
@@ -289,7 +289,7 @@ class INPUT_DIMENSIONS(TemplateParameter):
     block_rt_dim: Optional[int] = None
 
     def covert_to_cpp(self) -> str:
-        num_rows, num_cols = 32, 32
+        num_rows, num_cols = 16, 32
         validate_tile_dimensions(self.srcA[0], num_rows)
         validate_tile_dimensions(self.srcA[1], num_cols)
         validate_tile_dimensions(self.srcB[0], num_rows)

--- a/tests/python_tests/helpers/utils.py
+++ b/tests/python_tests/helpers/utils.py
@@ -153,6 +153,7 @@ def passed_test(
     L1_to_L1_iterations: int = 1,
     print_erros: bool = True,
     print_pcc: bool = False,
+    tile_size=1024,
 ):
     Tolerance = namedtuple("Tolerance", ["atol", "rtol"])
 
@@ -228,14 +229,14 @@ def passed_test(
 
                 for tile_no in range(num_tiles):
                     result_tile = res_tensor[
-                        tile_no * 1024 : (tile_no + 1) * 1024
+                        tile_no * tile_size : (tile_no + 1) * tile_size
                     ].view(tile_shape)
                     golden_tile = golden_tensor[
-                        tile_no * 1024 : (tile_no + 1) * 1024
+                        tile_no * tile_size : (tile_no + 1) * tile_size
                     ].view(tile_shape)
-                    error_tile = ~is_valid[tile_no * 1024 : (tile_no + 1) * 1024].view(
-                        tile_shape
-                    )
+                    error_tile = ~is_valid[
+                        tile_no * tile_size : (tile_no + 1) * tile_size
+                    ].view(tile_shape)
 
                     lines = format_tile(result_tile, error_tile, tile_no)
                     if not lines:

--- a/tests/python_tests/test_fast_tilize.py
+++ b/tests/python_tests/test_fast_tilize.py
@@ -14,6 +14,7 @@ from helpers.test_config import TestConfig
 from helpers.test_variant_parameters import (
     INPUT_DIMENSIONS,
     LOOP_FACTOR,
+    NUM_FACES,
     TILE_COUNT,
 )
 from helpers.utils import passed_test
@@ -83,7 +84,7 @@ def test_fast_tilize(formats, dest_acc, dimensions, workers_tensix_coordinates):
         "sources/fast_tilize_test.cpp",
         formats,
         templates=[INPUT_DIMENSIONS(input_dimensions, input_dimensions)],
-        runtimes=[TILE_COUNT(tile_cnt_A), LOOP_FACTOR(1)],
+        runtimes=[TILE_COUNT(tile_cnt_A), LOOP_FACTOR(1), NUM_FACES(4)],
         variant_stimuli=StimuliConfig(
             src_A,
             formats.input_format,

--- a/tests/python_tests/test_fast_tilize_tiny_tiles.py
+++ b/tests/python_tests/test_fast_tilize_tiny_tiles.py
@@ -1,0 +1,99 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+
+import pytest
+import torch
+from conftest import skip_for_blackhole
+from helpers.format_config import DataFormat
+from helpers.llk_params import DestAccumulation, format_dict
+from helpers.param_config import input_output_formats, parametrize
+from helpers.stimuli_config import StimuliConfig
+from helpers.test_config import TestConfig
+from helpers.test_variant_parameters import (
+    INPUT_DIMENSIONS,
+    LOOP_FACTOR,
+    NUM_FACES,
+    TILE_COUNT,
+)
+from helpers.tilize_untilize import tilize_block
+from helpers.utils import passed_test
+
+# Width in tiles (16x32); height fixed at 1 row of tiles
+WIDTHS = [
+    2,
+    10,
+    18,
+    56,
+    224,
+]  # base case, two banks, three banks, and Deepseek model sizes
+
+
+@skip_for_blackhole
+@parametrize(
+    formats=input_output_formats([DataFormat.Float16_b]),
+    dest_acc=[DestAccumulation.No],
+    dimensions=[(w, 1) for w in WIDTHS],
+)
+def test_fast_tilize_tiny_tiles(
+    formats, dest_acc, dimensions, workers_tensix_coordinates
+):
+    input_width, input_height = dimensions
+
+    if formats.input == DataFormat.Bfp8_b:
+        pytest.skip("Bfp8_b input format is not supported for fast tilize")
+
+    # Tiny tiles: 16 rows x 32 cols per tile (2 faces instead of 4)
+    input_dimensions = [input_height * 16, input_width * 32]
+
+    # For tiny tiles, tile count is calculated differently:
+    # Each tile is 16 rows x 32 cols = 512 elements (2 faces of 16x16)
+    tile_cnt_A = input_height * input_width
+    tile_cnt_B = tile_cnt_A
+
+    # Generate stimuli directly (generate_stimuli assumes 32x32 tiles)
+    num_elements = input_dimensions[0] * input_dimensions[1]
+    src_A = torch.arange(num_elements, dtype=format_dict[formats.input_format])
+    src_B = src_A
+
+    # Use tilize_block directly for tiny tiles (TilizeGolden has a bug with num_faces < 4)
+    golden_tensor = tilize_block(
+        src_A, input_dimensions, formats.output, num_faces=2
+    ).flatten()
+
+    # For fast tilize, input is row-major (untilized), written contiguously.
+    # Calculate how many "full tile equivalents" (1024 elements each) we need to write.
+    # For Float16_b, 1024 elements = 2048 bytes = one full tile spacing, so this writes contiguously.
+    write_tile_count = (num_elements + 1023) // 1024  # Ceiling division
+
+    configuration = TestConfig(
+        "sources/fast_tilize_test.cpp",
+        formats,
+        templates=[INPUT_DIMENSIONS(input_dimensions, input_dimensions)],
+        runtimes=[TILE_COUNT(tile_cnt_A), LOOP_FACTOR(1), NUM_FACES(2)],
+        variant_stimuli=StimuliConfig(
+            src_A,
+            formats.input_format,
+            src_B,
+            formats.input_format,
+            formats.output_format,
+            tile_count_A=write_tile_count,  # Write all input data contiguously
+            tile_count_B=write_tile_count,
+            tile_count_res=tile_cnt_A,
+            num_faces=2,
+            write_full_tiles=True,
+        ),
+        dest_acc=dest_acc,
+    )
+
+    res_from_L1 = configuration.run(workers_tensix_coordinates)
+    # Force full tensor print even when very large (no truncation)
+    # torch.set_printoptions(threshold=sys.maxsize)
+    # print(res_from_L1)
+    # torch.set_printoptions(threshold=1000)  # restore default
+
+    assert len(res_from_L1) == len(golden_tensor)
+
+    res_tensor = torch.tensor(res_from_L1, dtype=format_dict[formats.output])
+
+    assert passed_test(golden_tensor, res_tensor, formats.output_format, tile_size=512)

--- a/tests/sources/fast_tilize_test.cpp
+++ b/tests/sources/fast_tilize_test.cpp
@@ -61,13 +61,20 @@ void run_kernel(const volatile struct RuntimeParams *params)
     {
         ZONE_SCOPED("INIT")
         _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
-            formats.unpack_src, formats.unpack_src, formats.unpack_dst, formats.unpack_dst, FACE_R_DIM, FACE_R_DIM, 4 /* num_faces */, 4 /* num_faces */);
+            formats.unpack_src,
+            formats.unpack_src,
+            formats.unpack_dst,
+            formats.unpack_dst,
+            FACE_R_DIM,
+            FACE_R_DIM,
+            params->num_faces,
+            params->num_faces /* num_faces */);
         _llk_unpack_fast_tilize_init_(formats.unpack_dst, BLOCK_CT_DIM);
         PROFILER_SYNC();
     }
     {
         ZONE_SCOPED("TILE_LOOP")
-        for (std::uint32_t loop = 0; loop < params->LOOP_FACTOR; loop++)
+        for (std::uint32_t loop = 0; loop < static_cast<std::uint32_t>(params->LOOP_FACTOR); loop++)
         {
             for (std::uint32_t i = 0; i < BLOCK_RT_DIM; i++)
             {
@@ -75,7 +82,8 @@ void run_kernel(const volatile struct RuntimeParams *params)
 
                 std::uint32_t packed_tiles    = 0;
                 std::uint32_t remaining_tiles = BLOCK_CT_DIM;
-                std::uint32_t dest_size       = is_fp32_dest_acc_en ? 4 : 8;
+                std::uint32_t bank_density    = params->num_faces == 2 ? 2 : 1; // 16x32 tiny tiles can fit twice as many tiles in a single dest bank
+                std::uint32_t dest_size       = is_fp32_dest_acc_en ? 4 * bank_density : 8 * bank_density;
                 std::uint32_t unit_dim        = BLOCK_CT_DIM == 1 ? 1 : 2;
                 std::uint32_t num_units       = dest_size / unit_dim;
 
@@ -84,7 +92,8 @@ void run_kernel(const volatile struct RuntimeParams *params)
                     std::uint32_t tile_index = read_offset + packed_tiles;
                     if (remaining_tiles > 2 * dest_size)
                     {
-                        _llk_unpack_fast_tilize_block_(L1_ADDRESS(buffer_A[0]), tile_index, formats.unpack_src, unit_dim, num_units, BLOCK_CT_DIM);
+                        _llk_unpack_fast_tilize_block_(
+                            L1_ADDRESS(buffer_A[0]), tile_index, formats.unpack_src, unit_dim, num_units, BLOCK_CT_DIM, params->num_faces);
                         packed_tiles += dest_size;
                         remaining_tiles -= dest_size;
                     }
@@ -92,7 +101,8 @@ void run_kernel(const volatile struct RuntimeParams *params)
                     {
                         std::uint32_t even_remainder = remaining_tiles / 2 + ((remaining_tiles / 2) % 2);
                         num_units                    = even_remainder / unit_dim;
-                        _llk_unpack_fast_tilize_block_(L1_ADDRESS(buffer_A[0]), tile_index, formats.unpack_src, unit_dim, num_units, BLOCK_CT_DIM);
+                        _llk_unpack_fast_tilize_block_(
+                            L1_ADDRESS(buffer_A[0]), tile_index, formats.unpack_src, unit_dim, num_units, BLOCK_CT_DIM, params->num_faces);
                         packed_tiles += even_remainder;
                         remaining_tiles -= even_remainder;
                     }
@@ -101,17 +111,20 @@ void run_kernel(const volatile struct RuntimeParams *params)
                         if (remaining_tiles % 2 == 0 || unit_dim == 1)
                         {
                             num_units = remaining_tiles / unit_dim;
-                            _llk_unpack_fast_tilize_block_(L1_ADDRESS(buffer_A[0]), tile_index, formats.unpack_src, unit_dim, num_units, BLOCK_CT_DIM);
+                            _llk_unpack_fast_tilize_block_(
+                                L1_ADDRESS(buffer_A[0]), tile_index, formats.unpack_src, unit_dim, num_units, BLOCK_CT_DIM, params->num_faces);
                         }
                         else if (remaining_tiles == 3)
                         {
-                            _llk_unpack_fast_tilize_block_(L1_ADDRESS(buffer_A[0]), tile_index, formats.unpack_src, 3, 1, BLOCK_CT_DIM);
+                            _llk_unpack_fast_tilize_block_(L1_ADDRESS(buffer_A[0]), tile_index, formats.unpack_src, 3, 1, BLOCK_CT_DIM, params->num_faces);
                         }
                         else
                         {
                             num_units = (remaining_tiles - 3) / unit_dim;
-                            _llk_unpack_fast_tilize_block_(L1_ADDRESS(buffer_A[0]), tile_index, formats.unpack_src, unit_dim, num_units, BLOCK_CT_DIM);
-                            _llk_unpack_fast_tilize_block_(L1_ADDRESS(buffer_A[0]), tile_index + remaining_tiles - 3, formats.unpack_src, 3, 1, BLOCK_CT_DIM);
+                            _llk_unpack_fast_tilize_block_(
+                                L1_ADDRESS(buffer_A[0]), tile_index, formats.unpack_src, unit_dim, num_units, BLOCK_CT_DIM, params->num_faces);
+                            _llk_unpack_fast_tilize_block_(
+                                L1_ADDRESS(buffer_A[0]), tile_index + remaining_tiles - 3, formats.unpack_src, 3, 1, BLOCK_CT_DIM, params->num_faces);
                         }
                         packed_tiles += remaining_tiles;
                         remaining_tiles = 0;
@@ -143,13 +156,14 @@ void run_kernel(const volatile struct RuntimeParams *params)
     }
     {
         ZONE_SCOPED("TILE_LOOP")
-        for (std::uint32_t loop = 0; loop < params->LOOP_FACTOR; loop++)
+        for (std::uint32_t loop = 0; loop < static_cast<std::uint32_t>(params->LOOP_FACTOR); loop++)
         {
             for (std::uint32_t i = 0; i < BLOCK_RT_DIM; i++)
             {
                 std::uint32_t packed_tiles    = 0;
                 std::uint32_t remaining_tiles = BLOCK_CT_DIM;
-                std::uint32_t dest_size       = is_fp32_dest_acc_en ? 4 : 8;
+                std::uint32_t bank_density    = params->num_faces == 2 ? 2 : 1; // 16x32 tiny tiles can fit twice as many tiles in a single dest bank
+                std::uint32_t dest_size       = is_fp32_dest_acc_en ? 4 * bank_density : 8 * bank_density;
                 std::uint32_t unit_dim        = BLOCK_CT_DIM == 1 ? 1 : 2;
                 std::uint32_t num_units       = dest_size / unit_dim;
 
@@ -159,7 +173,7 @@ void run_kernel(const volatile struct RuntimeParams *params)
 
                     if (remaining_tiles > 2 * dest_size)
                     {
-                        _llk_math_fast_tilize_block_(0, formats.math, unit_dim, num_units);
+                        _llk_math_fast_tilize_block_(0, formats.math, unit_dim, num_units, params->num_faces);
                         packed_tiles += dest_size;
                         remaining_tiles -= dest_size;
                     }
@@ -167,7 +181,7 @@ void run_kernel(const volatile struct RuntimeParams *params)
                     {
                         std::uint32_t even_remainder = remaining_tiles / 2 + ((remaining_tiles / 2) % 2);
                         num_units                    = even_remainder / unit_dim;
-                        _llk_math_fast_tilize_block_(0, formats.math, unit_dim, num_units);
+                        _llk_math_fast_tilize_block_(0, formats.math, unit_dim, num_units, params->num_faces);
                         packed_tiles += even_remainder;
                         remaining_tiles -= even_remainder;
                     }
@@ -176,17 +190,17 @@ void run_kernel(const volatile struct RuntimeParams *params)
                         if (remaining_tiles % 2 == 0 || unit_dim == 1)
                         {
                             num_units = remaining_tiles / unit_dim;
-                            _llk_math_fast_tilize_block_(0, formats.math, unit_dim, num_units);
+                            _llk_math_fast_tilize_block_(0, formats.math, unit_dim, num_units, params->num_faces);
                         }
                         else if (remaining_tiles == 3)
                         {
-                            _llk_math_fast_tilize_block_(0, formats.math, 3, 1);
+                            _llk_math_fast_tilize_block_(0, formats.math, 3, 1, params->num_faces);
                         }
                         else
                         {
                             num_units = (remaining_tiles - 3) / unit_dim;
-                            _llk_math_fast_tilize_block_(0, formats.math, unit_dim, num_units);
-                            _llk_math_fast_tilize_block_(remaining_tiles - 3, formats.math, 3, 1);
+                            _llk_math_fast_tilize_block_(0, formats.math, unit_dim, num_units, params->num_faces);
+                            _llk_math_fast_tilize_block_(remaining_tiles - 3, formats.math, 3, 1, params->num_faces);
                         }
                         packed_tiles += remaining_tiles;
                         remaining_tiles = 0;
@@ -216,12 +230,12 @@ void run_kernel(const volatile struct RuntimeParams *params)
         ZONE_SCOPED("INIT")
         _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en, false>();
         _llk_pack_hw_configure_<is_fp32_dest_acc_en>(formats.pack_src, formats.pack_dst, SCALE_DATUM_SIZE(formats.pack_dst, TILE_C_DIM * TILE_R_DIM));
-        _llk_pack_fast_tilize_init_<DstSync::SyncHalf>(use_32bit_dest, formats.pack_dst, BLOCK_CT_DIM == 1 ? 1 : 2);
+        _llk_pack_fast_tilize_init_<DstSync::SyncHalf>(use_32bit_dest, formats.pack_dst, BLOCK_CT_DIM == 1 ? 1 : 2, params->num_faces);
         PROFILER_SYNC();
     }
     {
         ZONE_SCOPED("TILE_LOOP")
-        for (std::uint32_t loop = 0; loop < params->LOOP_FACTOR; loop++)
+        for (std::uint32_t loop = 0; loop < static_cast<std::uint32_t>(params->LOOP_FACTOR); loop++)
         {
             for (std::uint32_t i = 0; i < BLOCK_RT_DIM; i++)
             {
@@ -229,7 +243,8 @@ void run_kernel(const volatile struct RuntimeParams *params)
 
                 std::uint32_t packed_tiles    = 0;
                 std::uint32_t remaining_tiles = BLOCK_CT_DIM;
-                std::uint32_t dest_size       = is_fp32_dest_acc_en ? 4 : 8;
+                std::uint32_t bank_density    = params->num_faces == 2 ? 2 : 1; // 16x32 tiny tiles can fit twice as many tiles in a single dest bank
+                std::uint32_t dest_size       = is_fp32_dest_acc_en ? 4 * bank_density : 8 * bank_density;
                 std::uint32_t unit_dim        = BLOCK_CT_DIM == 1 ? 1 : 2;
                 std::uint32_t num_units       = dest_size / unit_dim;
 
@@ -237,10 +252,10 @@ void run_kernel(const volatile struct RuntimeParams *params)
                 {
                     _llk_packer_wait_for_math_done_();
 
-                    std::uint32_t tile_index = write_offset + packed_tiles;
+                    std::uint32_t tile_index = write_offset + packed_tiles / bank_density;
                     if (remaining_tiles > 2 * dest_size)
                     {
-                        _llk_pack_fast_tilize_block_(0, L1_ADDRESS(buffer_Res[tile_index]), unit_dim, num_units);
+                        _llk_pack_fast_tilize_block_(0, L1_ADDRESS(buffer_Res[tile_index]), unit_dim, num_units, params->num_faces);
                         packed_tiles += dest_size;
                         remaining_tiles -= dest_size;
                     }
@@ -248,7 +263,7 @@ void run_kernel(const volatile struct RuntimeParams *params)
                     {
                         std::uint32_t even_remainder = remaining_tiles / 2 + ((remaining_tiles / 2) % 2);
                         num_units                    = even_remainder / unit_dim;
-                        _llk_pack_fast_tilize_block_(0, L1_ADDRESS(buffer_Res[tile_index]), unit_dim, num_units);
+                        _llk_pack_fast_tilize_block_(0, L1_ADDRESS(buffer_Res[tile_index]), unit_dim, num_units, params->num_faces);
                         packed_tiles += even_remainder;
                         remaining_tiles -= even_remainder;
                     }
@@ -257,17 +272,18 @@ void run_kernel(const volatile struct RuntimeParams *params)
                         if (remaining_tiles % 2 == 0 || unit_dim == 1)
                         {
                             num_units = remaining_tiles / unit_dim;
-                            _llk_pack_fast_tilize_block_(0, L1_ADDRESS(buffer_Res[tile_index]), unit_dim, num_units);
+                            _llk_pack_fast_tilize_block_(0, L1_ADDRESS(buffer_Res[tile_index]), unit_dim, num_units, params->num_faces);
                         }
                         else if (remaining_tiles == 3)
                         {
-                            _llk_pack_fast_tilize_block_(0, L1_ADDRESS(buffer_Res[tile_index]), 3, 1);
+                            _llk_pack_fast_tilize_block_(0, L1_ADDRESS(buffer_Res[tile_index]), 3, 1, params->num_faces);
                         }
                         else
                         {
                             num_units = (remaining_tiles - 3) / unit_dim;
-                            _llk_pack_fast_tilize_block_(0, L1_ADDRESS(buffer_Res[tile_index]), unit_dim, num_units);
-                            _llk_pack_fast_tilize_block_(remaining_tiles - 3, L1_ADDRESS(buffer_Res[tile_index + remaining_tiles - 3]), 3, 1);
+                            _llk_pack_fast_tilize_block_(0, L1_ADDRESS(buffer_Res[tile_index]), unit_dim, num_units, params->num_faces);
+                            _llk_pack_fast_tilize_block_(
+                                remaining_tiles - 3, L1_ADDRESS(buffer_Res[tile_index + remaining_tiles - 3]), 3, 1, params->num_faces);
                         }
                         packed_tiles += remaining_tiles;
                         remaining_tiles = 0;
@@ -280,7 +296,7 @@ void run_kernel(const volatile struct RuntimeParams *params)
         PROFILER_SYNC();
     }
 
-    _llk_pack_fast_tilize_uninit_<DstSync::SyncHalf, is_fp32_dest_acc_en>(formats.pack_dst);
+    _llk_pack_fast_tilize_uninit_<DstSync::SyncHalf, is_fp32_dest_acc_en>(formats.pack_dst, params->num_faces);
 }
 
 #endif

--- a/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_unary_datacopy.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_unary_datacopy.h
@@ -363,7 +363,7 @@ inline void eltwise_unary_configure_mop(std::uint32_t rows_per_inst, std::uint32
 }
 
 template <DataCopyType type, bool is_fp32_dest_acc_en, BroadcastType src_b_bcast_type = BroadcastType::NONE, bool is_int_fpu_en = false>
-inline void _llk_math_eltwise_unary_datacopy_init_(const std::uint32_t num_faces = 4, const std::uint32_t dst_format = 255)
+inline void _llk_math_eltwise_unary_datacopy_init_(const std::uint32_t num_faces = 2, const std::uint32_t dst_format = 255)
 {
     LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be 1, 2, or 4");
     eltwise_unary_configure_addrmod<type, src_b_bcast_type>(dst_format);
@@ -522,7 +522,11 @@ inline void _llk_math_fast_tilize_uninit_(const std::uint32_t unpack_dst_format)
 }
 
 inline void _llk_math_fast_tilize_block_(
-    const std::uint32_t dst_index, const std::uint32_t unpack_dst_format, const std::uint32_t unit_dim, const std::uint32_t num_units)
+    const std::uint32_t dst_index,
+    const std::uint32_t unpack_dst_format,
+    const std::uint32_t unit_dim,
+    const std::uint32_t num_units,
+    const std::uint32_t num_faces = 4)
 {
     // split dest and write the top faces in the first half and the bottom faces in the second half (or more precisely quarter, since dest sync half)
     // make life easier by lying to set_dst_write_addr that tile shape is 32x16 so correct stride is obtained for dst_index
@@ -553,7 +557,7 @@ inline void _llk_math_fast_tilize_block_(
             // clear just srcA dvalid since it's the only one set by the unpacker for unit_dim 1 and src RWCs
             TTI_SETRWC(p_setrwc::CLR_A, 0, 0, 0, 0, p_setrwc::SET_AB);
         }
-        else if (unit_dim == 2)
+        else if (unit_dim == 2 && num_faces == 4)
         {
             // srcA has the top faces (4 of them), copy them
             // inside mop:
@@ -574,6 +578,25 @@ inline void _llk_math_fast_tilize_block_(
             // finish with the bottom faces and jump back to the offset for the next tile
             TTI_MOVB2D(p_mov::DEST_NORM, 0, ADDR_MOD_0, p_movb2d::MOV_4_ROWS, 0);
             // clear both dvalids and src RWCs
+            TTI_SETRWC(p_setrwc::CLR_AB, 0, 0, 0, 0, p_setrwc::SET_AB);
+        }
+        else if (unit_dim == 2 && num_faces == 2)
+        {
+            // srcA has the top 8 rows
+            // inside mop:
+            // for (uint j = 0; j < 4; j++)
+            // {
+            //     TTI_MOVA2D(p_mov::DEST_NORM, 0, ADDR_MOD_2, p_mova2d::MOV_8_ROWS, 0);
+            // }
+            TTI_MOP(p_mop::MASK_LOOP, 4 - 1, 0x0);
+            // srcB has the bottom 8 rows
+            // inside mop:
+            // for (uint j = 0; j < 8; j++)
+            // {
+            //     TTI_MOVB2D(p_mov::DEST_NORM, 0, ADDR_MOD_1, p_movb2d::MOV_4_ROWS, 0);
+            // }
+            TTI_MOP(p_mop::MASK_LOOP, 8 - 1, 0xFFFF);
+            // done with this set of two tiles, clear dvalids and src RWCs
             TTI_SETRWC(p_setrwc::CLR_AB, 0, 0, 0, 0, p_setrwc::SET_AB);
         }
         else if (unit_dim == 3)

--- a/tt_llk_wormhole_b0/llk_lib/llk_pack.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_pack.h
@@ -268,8 +268,16 @@ inline void _llk_pack_fast_tilize_mop_config_([[maybe_unused]] const std::uint32
 }
 
 template <DstSync Dst>
-inline void _llk_pack_fast_tilize_init_(const std::uint32_t use_32bit_dest, const std::uint32_t pack_dst_format, const std::uint32_t unit_dim)
+inline void _llk_pack_fast_tilize_init_(
+    const std::uint32_t use_32bit_dest,
+    const std::uint32_t pack_dst_format,
+    const std::uint32_t unit_dim,
+    const std::uint32_t num_faces        = 4,
+    const std::uint32_t l1_tile_elements = TILE_C_DIM * TILE_R_DIM)
 {
+    LLK_ASSERT(
+        pack_dst_format == to_underlying(DataFormat::Float16_b) || pack_dst_format == to_underlying(DataFormat::Float32) || num_faces == 4,
+        "16x32 tiny tiles are only supported with float16_b or float32 output formats");
     // instead of using the actual is_fp32_dest_acc_en flag dest 32 bit mode is enabled if unpack_dst_format is TF32
     // this is due to a hw quirk with MOVA2D and MOVB2D
     // so clear PCK_DEST_RD_CTRL_Read_32b_data unless unpack_src_format is TF32
@@ -280,7 +288,7 @@ inline void _llk_pack_fast_tilize_init_(const std::uint32_t use_32bit_dest, cons
     }
 
     // set the address offset to the size of the tile in 16B words
-    std::uint32_t tile_size = SCALE_DATUM_SIZE(pack_dst_format, TILE_C_DIM * TILE_R_DIM);
+    std::uint32_t tile_size = SCALE_DATUM_SIZE(pack_dst_format, l1_tile_elements);
     // Not sure why BFP formats are not included SCALE_DATUM_SIZE but too scared to change that.
     if (pack_dst_format == to_underlying(DataFormat::Bfp4) || pack_dst_format == to_underlying(DataFormat::Bfp4_b))
     {
@@ -292,7 +300,7 @@ inline void _llk_pack_fast_tilize_init_(const std::uint32_t use_32bit_dest, cons
     }
     if (IS_BFP_FORMAT(pack_dst_format))
     {
-        tile_size += (TILE_C_DIM * TILE_R_DIM) / 16; // one exp byte per 16 datums
+        tile_size += l1_tile_elements / 16; // one exp byte per 16 datums
     }
     tile_size = tile_size >> 4; // convert to 16B words
     TT_SETDMAREG(p_setdmareg::PAYLOAD_IMMEDIATE, tile_size, p_setdmareg::MODE_IMMEDIATE, LO_16(p_gpr_pack::OUTPUT_ADDR_OFFSET));
@@ -301,27 +309,58 @@ inline void _llk_pack_fast_tilize_init_(const std::uint32_t use_32bit_dest, cons
     // difference between 16 bit dest and 32 bit dest is where the half of the active bank is (256 rows vs 128 rows)
     // stallwait and select_packer_dest_registers just replicate what _llk_init_packer_dest_offset_registers_ does
     TTI_STALLWAIT(p_stall::STALL_TDMA | p_stall::STALL_THCON, p_stall::PACK);
+
+    // TTI_SETDMAREG requires compile-time immediate operands; branch on num_faces and use literals.
     if (!use_32bit_dest)
     {
-        TTI_SETDMAREG(p_setdmareg::PAYLOAD_IMMEDIATE, 0x000 + 0x000, p_setdmareg::MODE_IMMEDIATE, LO_16(p_gpr_pack::DEST_OFFSET_LO + 0));
-        TTI_SETDMAREG(p_setdmareg::PAYLOAD_IMMEDIATE, 0x000 + 0x001, p_setdmareg::MODE_IMMEDIATE, LO_16(p_gpr_pack::DEST_OFFSET_LO + 1));
-        TTI_SETDMAREG(p_setdmareg::PAYLOAD_IMMEDIATE, 0x000 + 0x100, p_setdmareg::MODE_IMMEDIATE, LO_16(p_gpr_pack::DEST_OFFSET_LO + 2));
-        TTI_SETDMAREG(p_setdmareg::PAYLOAD_IMMEDIATE, 0x000 + 0x101, p_setdmareg::MODE_IMMEDIATE, LO_16(p_gpr_pack::DEST_OFFSET_LO + 3));
-        TTI_SETDMAREG(p_setdmareg::PAYLOAD_IMMEDIATE, DEST_REGISTER_HALF_SIZE + 0x000, p_setdmareg::MODE_IMMEDIATE, LO_16(p_gpr_pack::DEST_OFFSET_HI + 0));
-        TTI_SETDMAREG(p_setdmareg::PAYLOAD_IMMEDIATE, DEST_REGISTER_HALF_SIZE + 0x001, p_setdmareg::MODE_IMMEDIATE, LO_16(p_gpr_pack::DEST_OFFSET_HI + 1));
-        TTI_SETDMAREG(p_setdmareg::PAYLOAD_IMMEDIATE, DEST_REGISTER_HALF_SIZE + 0x100, p_setdmareg::MODE_IMMEDIATE, LO_16(p_gpr_pack::DEST_OFFSET_HI + 2));
-        TTI_SETDMAREG(p_setdmareg::PAYLOAD_IMMEDIATE, DEST_REGISTER_HALF_SIZE + 0x101, p_setdmareg::MODE_IMMEDIATE, LO_16(p_gpr_pack::DEST_OFFSET_HI + 3));
+        if (num_faces == 2)
+        {
+            // tiny tiles will use a similar packer scheme as unit_dim 2, but treats second tile as bottom 2 faces of the first tile
+            TTI_SETDMAREG(p_setdmareg::PAYLOAD_IMMEDIATE, 0x000 + 0x000, p_setdmareg::MODE_IMMEDIATE, LO_16(p_gpr_pack::DEST_OFFSET_LO + 0));
+            TTI_SETDMAREG(p_setdmareg::PAYLOAD_IMMEDIATE, 0x000 + 0x001, p_setdmareg::MODE_IMMEDIATE, LO_16(p_gpr_pack::DEST_OFFSET_LO + 1));
+            TTI_SETDMAREG(p_setdmareg::PAYLOAD_IMMEDIATE, 0x000 + 0x002, p_setdmareg::MODE_IMMEDIATE, LO_16(p_gpr_pack::DEST_OFFSET_LO + 2));
+            TTI_SETDMAREG(p_setdmareg::PAYLOAD_IMMEDIATE, 0x000 + 0x003, p_setdmareg::MODE_IMMEDIATE, LO_16(p_gpr_pack::DEST_OFFSET_LO + 3));
+            TTI_SETDMAREG(p_setdmareg::PAYLOAD_IMMEDIATE, DEST_REGISTER_HALF_SIZE + 0x000, p_setdmareg::MODE_IMMEDIATE, LO_16(p_gpr_pack::DEST_OFFSET_HI + 0));
+            TTI_SETDMAREG(p_setdmareg::PAYLOAD_IMMEDIATE, DEST_REGISTER_HALF_SIZE + 0x001, p_setdmareg::MODE_IMMEDIATE, LO_16(p_gpr_pack::DEST_OFFSET_HI + 1));
+            TTI_SETDMAREG(p_setdmareg::PAYLOAD_IMMEDIATE, DEST_REGISTER_HALF_SIZE + 0x002, p_setdmareg::MODE_IMMEDIATE, LO_16(p_gpr_pack::DEST_OFFSET_HI + 2));
+            TTI_SETDMAREG(p_setdmareg::PAYLOAD_IMMEDIATE, DEST_REGISTER_HALF_SIZE + 0x003, p_setdmareg::MODE_IMMEDIATE, LO_16(p_gpr_pack::DEST_OFFSET_HI + 3));
+        }
+        else
+        {
+            TTI_SETDMAREG(p_setdmareg::PAYLOAD_IMMEDIATE, 0x000 + 0x000, p_setdmareg::MODE_IMMEDIATE, LO_16(p_gpr_pack::DEST_OFFSET_LO + 0));
+            TTI_SETDMAREG(p_setdmareg::PAYLOAD_IMMEDIATE, 0x000 + 0x001, p_setdmareg::MODE_IMMEDIATE, LO_16(p_gpr_pack::DEST_OFFSET_LO + 1));
+            TTI_SETDMAREG(p_setdmareg::PAYLOAD_IMMEDIATE, 0x000 + 0x100, p_setdmareg::MODE_IMMEDIATE, LO_16(p_gpr_pack::DEST_OFFSET_LO + 2));
+            TTI_SETDMAREG(p_setdmareg::PAYLOAD_IMMEDIATE, 0x000 + 0x101, p_setdmareg::MODE_IMMEDIATE, LO_16(p_gpr_pack::DEST_OFFSET_LO + 3));
+            TTI_SETDMAREG(p_setdmareg::PAYLOAD_IMMEDIATE, DEST_REGISTER_HALF_SIZE + 0x000, p_setdmareg::MODE_IMMEDIATE, LO_16(p_gpr_pack::DEST_OFFSET_HI + 0));
+            TTI_SETDMAREG(p_setdmareg::PAYLOAD_IMMEDIATE, DEST_REGISTER_HALF_SIZE + 0x001, p_setdmareg::MODE_IMMEDIATE, LO_16(p_gpr_pack::DEST_OFFSET_HI + 1));
+            TTI_SETDMAREG(p_setdmareg::PAYLOAD_IMMEDIATE, DEST_REGISTER_HALF_SIZE + 0x100, p_setdmareg::MODE_IMMEDIATE, LO_16(p_gpr_pack::DEST_OFFSET_HI + 2));
+            TTI_SETDMAREG(p_setdmareg::PAYLOAD_IMMEDIATE, DEST_REGISTER_HALF_SIZE + 0x101, p_setdmareg::MODE_IMMEDIATE, LO_16(p_gpr_pack::DEST_OFFSET_HI + 3));
+        }
     }
     else
     {
-        TTI_SETDMAREG(p_setdmareg::PAYLOAD_IMMEDIATE, 0x000 + 0x000, p_setdmareg::MODE_IMMEDIATE, LO_16(p_gpr_pack::DEST_OFFSET_LO + 0));
-        TTI_SETDMAREG(p_setdmareg::PAYLOAD_IMMEDIATE, 0x000 + 0x001, p_setdmareg::MODE_IMMEDIATE, LO_16(p_gpr_pack::DEST_OFFSET_LO + 1));
-        TTI_SETDMAREG(p_setdmareg::PAYLOAD_IMMEDIATE, 0x000 + 0x080, p_setdmareg::MODE_IMMEDIATE, LO_16(p_gpr_pack::DEST_OFFSET_LO + 2));
-        TTI_SETDMAREG(p_setdmareg::PAYLOAD_IMMEDIATE, 0x000 + 0x081, p_setdmareg::MODE_IMMEDIATE, LO_16(p_gpr_pack::DEST_OFFSET_LO + 3));
-        TTI_SETDMAREG(p_setdmareg::PAYLOAD_IMMEDIATE, DEST_REGISTER_HALF_SIZE + 0x000, p_setdmareg::MODE_IMMEDIATE, LO_16(p_gpr_pack::DEST_OFFSET_HI + 0));
-        TTI_SETDMAREG(p_setdmareg::PAYLOAD_IMMEDIATE, DEST_REGISTER_HALF_SIZE + 0x001, p_setdmareg::MODE_IMMEDIATE, LO_16(p_gpr_pack::DEST_OFFSET_HI + 1));
-        TTI_SETDMAREG(p_setdmareg::PAYLOAD_IMMEDIATE, DEST_REGISTER_HALF_SIZE + 0x080, p_setdmareg::MODE_IMMEDIATE, LO_16(p_gpr_pack::DEST_OFFSET_HI + 2));
-        TTI_SETDMAREG(p_setdmareg::PAYLOAD_IMMEDIATE, DEST_REGISTER_HALF_SIZE + 0x081, p_setdmareg::MODE_IMMEDIATE, LO_16(p_gpr_pack::DEST_OFFSET_HI + 3));
+        if (num_faces == 2)
+        {
+            TTI_SETDMAREG(p_setdmareg::PAYLOAD_IMMEDIATE, 0x000 + 0x000, p_setdmareg::MODE_IMMEDIATE, LO_16(p_gpr_pack::DEST_OFFSET_LO + 0));
+            TTI_SETDMAREG(p_setdmareg::PAYLOAD_IMMEDIATE, 0x000 + 0x001, p_setdmareg::MODE_IMMEDIATE, LO_16(p_gpr_pack::DEST_OFFSET_LO + 1));
+            TTI_SETDMAREG(p_setdmareg::PAYLOAD_IMMEDIATE, 0x000 + 0x002, p_setdmareg::MODE_IMMEDIATE, LO_16(p_gpr_pack::DEST_OFFSET_LO + 2));
+            TTI_SETDMAREG(p_setdmareg::PAYLOAD_IMMEDIATE, 0x000 + 0x003, p_setdmareg::MODE_IMMEDIATE, LO_16(p_gpr_pack::DEST_OFFSET_LO + 3));
+            TTI_SETDMAREG(p_setdmareg::PAYLOAD_IMMEDIATE, DEST_REGISTER_HALF_SIZE + 0x000, p_setdmareg::MODE_IMMEDIATE, LO_16(p_gpr_pack::DEST_OFFSET_HI + 0));
+            TTI_SETDMAREG(p_setdmareg::PAYLOAD_IMMEDIATE, DEST_REGISTER_HALF_SIZE + 0x001, p_setdmareg::MODE_IMMEDIATE, LO_16(p_gpr_pack::DEST_OFFSET_HI + 1));
+            TTI_SETDMAREG(p_setdmareg::PAYLOAD_IMMEDIATE, DEST_REGISTER_HALF_SIZE + 0x002, p_setdmareg::MODE_IMMEDIATE, LO_16(p_gpr_pack::DEST_OFFSET_HI + 2));
+            TTI_SETDMAREG(p_setdmareg::PAYLOAD_IMMEDIATE, DEST_REGISTER_HALF_SIZE + 0x003, p_setdmareg::MODE_IMMEDIATE, LO_16(p_gpr_pack::DEST_OFFSET_HI + 3));
+        }
+        else
+        {
+            TTI_SETDMAREG(p_setdmareg::PAYLOAD_IMMEDIATE, 0x000 + 0x000, p_setdmareg::MODE_IMMEDIATE, LO_16(p_gpr_pack::DEST_OFFSET_LO + 0));
+            TTI_SETDMAREG(p_setdmareg::PAYLOAD_IMMEDIATE, 0x000 + 0x001, p_setdmareg::MODE_IMMEDIATE, LO_16(p_gpr_pack::DEST_OFFSET_LO + 1));
+            TTI_SETDMAREG(p_setdmareg::PAYLOAD_IMMEDIATE, 0x000 + 0x080, p_setdmareg::MODE_IMMEDIATE, LO_16(p_gpr_pack::DEST_OFFSET_LO + 2));
+            TTI_SETDMAREG(p_setdmareg::PAYLOAD_IMMEDIATE, 0x000 + 0x081, p_setdmareg::MODE_IMMEDIATE, LO_16(p_gpr_pack::DEST_OFFSET_LO + 3));
+            TTI_SETDMAREG(p_setdmareg::PAYLOAD_IMMEDIATE, DEST_REGISTER_HALF_SIZE + 0x000, p_setdmareg::MODE_IMMEDIATE, LO_16(p_gpr_pack::DEST_OFFSET_HI + 0));
+            TTI_SETDMAREG(p_setdmareg::PAYLOAD_IMMEDIATE, DEST_REGISTER_HALF_SIZE + 0x001, p_setdmareg::MODE_IMMEDIATE, LO_16(p_gpr_pack::DEST_OFFSET_HI + 1));
+            TTI_SETDMAREG(p_setdmareg::PAYLOAD_IMMEDIATE, DEST_REGISTER_HALF_SIZE + 0x080, p_setdmareg::MODE_IMMEDIATE, LO_16(p_gpr_pack::DEST_OFFSET_HI + 2));
+            TTI_SETDMAREG(p_setdmareg::PAYLOAD_IMMEDIATE, DEST_REGISTER_HALF_SIZE + 0x081, p_setdmareg::MODE_IMMEDIATE, LO_16(p_gpr_pack::DEST_OFFSET_HI + 3));
+        }
     }
     select_packer_dest_registers<Dst>();
 
@@ -361,7 +400,7 @@ inline void _llk_pack_fast_tilize_uninit_(
 }
 
 inline void _llk_pack_fast_tilize_block_(
-    const std::uint32_t tile_index, const std::uint32_t address, const std::uint32_t unit_dim, const std::uint32_t num_units)
+    const std::uint32_t tile_index, const std::uint32_t address, const std::uint32_t unit_dim, const std::uint32_t num_units, const std::uint32_t num_faces = 4)
 {
     // use false here so that the 31st bit of the address remains set as the offset addresses for the other packers continue to be used
     // while the address for the first packer is manipulated using ADDDMAREG and REG2FLOP
@@ -408,19 +447,23 @@ inline void _llk_pack_fast_tilize_block_(
             TTI_MOP(p_mop::MASK_LOOP, (FACE_R_DIM - 1) - 1, 0x0);
             TTI_PACR_COMMON(ADDR_MOD_0, p_pacr::P_ZERO_OUTPUT_DISABLED, PACK_SEL(NUM_PACKERS), 0, 1);
             // move to the next tile in L1
-            TTI_ADDDMAREG(p_adddmareg::REG_PLUS_REG, p_gpr_pack::OUTPUT_ADDR, p_gpr_pack::OUTPUT_ADDR, p_gpr_pack::OUTPUT_ADDR_OFFSET);
-            TTI_REG2FLOP_COMMON(p_reg2flop::WRITE_4B, REG2FLOP_FLOP_INDEX(THCON_SEC0_REG1_L1_Dest_addr_ADDR32), p_gpr_pack::OUTPUT_ADDR);
-            // same notes for the flush bit as above
-            // address mod here moves to the next tile in the same unit
-            TTI_PACR_COMMON(ADDR_MOD_1, p_pacr::P_ZERO_OUTPUT_DISABLED, PACK_SEL(NUM_PACKERS), 1, 0);
-            // pack a single tile
-            // inside mop:
-            // for (uint j = 0; j < 15; j++)
-            // {
-            //     TTI_PACR_COMMON(ADDR_MOD_0, p_pacr::P_ZERO_OUTPUT_DISABLED, PACK_SEL(NUM_PACKERS), 0, 0);
-            // }
-            TTI_MOP(p_mop::MASK_LOOP, (FACE_R_DIM - 1) - 1, 0x0);
-            TTI_PACR_COMMON(ADDR_MOD_0, p_pacr::P_ZERO_OUTPUT_DISABLED, PACK_SEL(NUM_PACKERS), 0, 1);
+            // don't do this for tiny tiles, since we pack 2 tiny tiles as 1 full sized tile
+            if (num_faces == 4)
+            {
+                TTI_ADDDMAREG(p_adddmareg::REG_PLUS_REG, p_gpr_pack::OUTPUT_ADDR, p_gpr_pack::OUTPUT_ADDR, p_gpr_pack::OUTPUT_ADDR_OFFSET);
+                TTI_REG2FLOP_COMMON(p_reg2flop::WRITE_4B, REG2FLOP_FLOP_INDEX(THCON_SEC0_REG1_L1_Dest_addr_ADDR32), p_gpr_pack::OUTPUT_ADDR);
+                // same notes for the flush bit as above
+                // address mod here moves to the next tile in the same unit
+                TTI_PACR_COMMON(ADDR_MOD_1, p_pacr::P_ZERO_OUTPUT_DISABLED, PACK_SEL(NUM_PACKERS), 1, 0);
+                // pack a single tile
+                // inside mop:
+                // for (uint j = 0; j < 15; j++)
+                // {
+                //     TTI_PACR_COMMON(ADDR_MOD_0, p_pacr::P_ZERO_OUTPUT_DISABLED, PACK_SEL(NUM_PACKERS), 0, 0);
+                // }
+                TTI_MOP(p_mop::MASK_LOOP, (FACE_R_DIM - 1) - 1, 0x0);
+                TTI_PACR_COMMON(ADDR_MOD_0, p_pacr::P_ZERO_OUTPUT_DISABLED, PACK_SEL(NUM_PACKERS), 0, 1);
+            }
             // move to the next unit in dest (2 * 2 faces, same thing as tile_index)
             TTI_INCADCZW(p_setadc::PAC, 0, 0, 0, 4); // CH0Z += 4
             // move to the next tile in L1

--- a/tt_llk_wormhole_b0/llk_lib/llk_unpack_tilize.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_unpack_tilize.h
@@ -220,7 +220,7 @@ inline void _llk_unpack_tilize_(
  *************************************************************************/
 
 template <bool neginf_srcA = false, std::uint32_t reload_srcB = false, bool zero_srcA = false, bool zero_srcA_reduce = false>
-inline void _llk_unpack_tilizeA_B_mop_config_(const bool narrow_tile = false, const std::uint32_t num_faces = 4)
+inline void _llk_unpack_tilizeA_B_mop_config_(const bool narrow_tile = false, const std::uint32_t num_faces = 2)
 {
     LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be 1, 2, or 4");
     static constexpr std::uint32_t unpack_srca =
@@ -322,7 +322,7 @@ inline void _llk_unpack_tilizeA_B_(
     std::uint32_t tile_index_a,
     std::uint32_t tile_index_b,
     std::uint32_t block_ct_dim,
-    std::uint32_t num_faces = 4)
+    std::uint32_t num_faces = 2)
 {
     LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be 1, 2, or 4");
     std::uint32_t top_face_offset_address = SCALE_DATUM_SIZE(unpA_src_format, tile_index_a) << (narrow_tile ? 0 : 1);
@@ -565,14 +565,19 @@ inline void _llk_unpack_fast_tilize_block_(
     const std::uint32_t unpack_src_format,
     const std::uint32_t unit_dim,
     const std::uint32_t num_units,
-    const std::uint32_t full_dim)
+    const std::uint32_t full_dim,
+    const std::uint32_t num_faces = 4)
 {
+    LLK_ASSERT(num_faces == 2 || num_faces == 4, "num_faces must be 2 or 4");
+    LLK_ASSERT(
+        (unit_dim == 2 && num_faces == 2) || num_faces == 4, "16x32 tiny tiles are only supported for tensors with even-sized tile widths for fast_tilize");
     volatile std::uint32_t tt_reg_ptr* cfg = get_cfg_pointer();
 
     std::uint32_t address = base_address + (SCALE_DATUM_SIZE(unpack_src_format, tile_index * TILE_C_DIM) >> 4); // move by tile width in 16B words
     // for unit_dim 2 UNPA reads top faces and UNPB reads bottom faces
     // for unit_dim 3 UNPA reads top 8 rows of top then bottom faces, UNPB reads bottom 8 rows of top then bottom faces
-    std::uint32_t unpB_row_offset = unit_dim == 2 ? FACE_R_DIM : (FACE_R_DIM / 2);
+    // tiny tiles will use same UPKB scheme as unit_dim 3, but only does top faces
+    std::uint32_t unpB_row_offset = unit_dim == 2 && num_faces == 4 ? FACE_R_DIM : (FACE_R_DIM / 2);
     std::uint32_t unpB_address    = address + (SCALE_DATUM_SIZE(unpack_src_format, full_dim * TILE_C_DIM * unpB_row_offset) >> 4);
 
     // reset all counters since X start and end are set after this
@@ -622,7 +627,7 @@ inline void _llk_unpack_fast_tilize_block_(
             TTI_UNPACR_COMMON(SrcA, ADDRMOD_CH1Y_0_CH1Z_0_CH0Y_0_CH0Z_0, 1);
             TTI_INCADCZW(p_setadc::UNP_A, 0, 0, 2, 0);
         }
-        else if (unit_dim == 2)
+        else if (unit_dim == 2 && num_faces == 4)
         {
             // read top(A)/bottom(B) faces of two tiles in a row (4 faces each), switch bank,
             // then move to the next two tiles (CH0Y += 2) and back to the top of a tile (CH01Z = 0)
@@ -633,6 +638,21 @@ inline void _llk_unpack_fast_tilize_block_(
             //     TTI_UNPACR_COMMON(SrcB, ADDRMOD_CH1Y_0_CH1Z_2_CH0Y_0_CH0Z_1, 0);
             // }
             TTI_MOP(p_mop::MASK_LOOP, (FACE_R_DIM - 1) - 1, 0x0);
+            TTI_UNPACR_COMMON(SrcA, ADDRMOD_CH1Y_0_CH1Z_0_CH0Y_2_CH0Z_0, 1);
+            TTI_UNPACR_COMMON(SrcB, ADDRMOD_CH1Y_0_CH1Z_0_CH0Y_2_CH0Z_0, 1);
+            TTI_SETADCZW(p_setadc::UNP_AB, 0, 0, 0, 0, SETADC_CH01(p_setadc::ZW));
+        }
+        else if (unit_dim == 2 && num_faces == 2)
+        {
+            // read top 8(A)/bottom 8(B) rows of top faces of two tiles in a row (4 halves of a face each),
+            // then move to the next two tiles (CH0Y += 2) and back to the top of a tile (CH01Z = 0)
+            // inside mop:
+            // for (std::uint32_t j = 0; j < FACE_R_DIM / 2 - 1; j++)
+            // {
+            //     TTI_UNPACR_COMMON(SrcA, ADDRMOD_CH1Y_0_CH1Z_2_CH0Y_0_CH0Z_1, 0);
+            //     TTI_UNPACR_COMMON(SrcB, ADDRMOD_CH1Y_0_CH1Z_2_CH0Y_0_CH0Z_1, 0);
+            // }
+            TTI_MOP(p_mop::MASK_LOOP, (FACE_R_DIM / 2 - 1) - 1, 0x0);
             TTI_UNPACR_COMMON(SrcA, ADDRMOD_CH1Y_0_CH1Z_0_CH0Y_2_CH0Z_0, 1);
             TTI_UNPACR_COMMON(SrcB, ADDRMOD_CH1Y_0_CH1Z_0_CH0Y_2_CH0Z_0, 1);
             TTI_SETADCZW(p_setadc::UNP_AB, 0, 0, 0, 0, SETADC_CH01(p_setadc::ZW));


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/35770

### Problem description
Need to be able to use tiny tiles for Deepseek use cases - 16x1792 and 16x7168 for float16_b

### What's changed
Added implementation of fast tilize to enable using 16x32 tiny tiles for flat tensors. Input tensor sizes which work are 1xN tiles where N is an even number

This implementation may work with Float32 but not tested. It doesn't support block float output

Added changes to test infra to enable densely packing L1 for input/output

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Assert validation](docs/Introduction_to_asserts.md) Complied with assert doc (if applicable)
