### PR TITLE
ci: tag the latest image when workflow runs from main branch

### DIFF
--- a/.github/scripts/build-docker-images.sh
+++ b/.github/scripts/build-docker-images.sh
@@ -36,14 +36,13 @@ build_and_push() {
 
         # If we're on main, update the latest tag even if the image exists
         if [ "$on_main" = "true" ]; then
-            # Check if latest already points to this tag
-            latest_digest=$(docker manifest inspect $image_name:latest 2>/dev/null | jq -r '.config.digest' || echo "")
-            current_digest=$(docker manifest inspect $image_name:$DOCKER_TAG | jq -r '.config.digest')
+            # Check if latest already points to this tag (compare manifest digests)
+            latest_digest=$(docker buildx imagetools inspect "$image_name:latest" 2>/dev/null | awk '/^Digest: / {print $2; exit}' || echo "")
+            current_digest=$(docker buildx imagetools inspect "$image_name:$DOCKER_TAG" 2>/dev/null | awk '/^Digest: / {print $2; exit}')
 
             if [ "$latest_digest" != "$current_digest" ]; then
                 echo "Updating latest tag for $image_name"
-                docker manifest create $image_name:latest --amend $image_name:$DOCKER_TAG
-                docker manifest push $image_name:latest
+                docker buildx imagetools create -t $image_name:latest $image_name:$DOCKER_TAG
             else
                 echo "Latest tag already points to $DOCKER_TAG"
             fi


### PR DESCRIPTION
### Ticket
None

### Problem description
https://github.com/tenstorrent/tt-llk/pull/1211 introduced a regression in behavior. Although new images are a bit smaller and faster to unpack, we lost the existing behavior of tagging the latest image that simplifies IRD workflow.

### What's changed
This change should restore this behavior and tag the latest Docker image with latest tag.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Assert validation](docs/Introduction_to_asserts.md) Complied with assert doc (if applicable)
