### PR TITLE
Add static and runtime asserts for configure_unpacker_x_end.

### DIFF
--- a/tt_llk_blackhole/common/inc/cunpack_common.h
+++ b/tt_llk_blackhole/common/inc/cunpack_common.h
@@ -394,6 +394,10 @@ inline void configure_unpack_AB(
 template <std::uint32_t UNP_SEL = p_setadc::UNP_AB>
 inline void config_unpacker_x_end(const std::uint32_t face_r_dim)
 {
+    static_assert(UNP_SEL == p_setadc::UNP_A || UNP_SEL == p_setadc::UNP_B || UNP_SEL == p_setadc::UNP_AB, "UNP_SEL must be UNP_A, UNP_B, or UNP_AB");
+    LLK_ASSERT(
+        face_r_dim == 1 || face_r_dim == 2 || face_r_dim == 4 || face_r_dim == 8 || face_r_dim == FACE_R_DIM, "face_r_dim must be 1, 2, 4, 8, or FACE_R_DIM");
+
     switch (face_r_dim)
     {
         case 1:

--- a/tt_llk_wormhole_b0/common/inc/cunpack_common.h
+++ b/tt_llk_wormhole_b0/common/inc/cunpack_common.h
@@ -379,6 +379,10 @@ inline void configure_unpack_AB(
 template <std::uint32_t UNP_SEL = p_setadc::UNP_AB>
 inline void config_unpacker_x_end(const std::uint32_t face_r_dim)
 {
+    static_assert(UNP_SEL == p_setadc::UNP_A || UNP_SEL == p_setadc::UNP_B || UNP_SEL == p_setadc::UNP_AB, "UNP_SEL must be UNP_A, UNP_B, or UNP_AB");
+    LLK_ASSERT(
+        face_r_dim == 1 || face_r_dim == 2 || face_r_dim == 4 || face_r_dim == 8 || face_r_dim == FACE_R_DIM, "face_r_dim must be 1, 2, 4, 8, or FACE_R_DIM");
+
     switch (face_r_dim)
     {
         case 1:


### PR DESCRIPTION
### Ticket
#0

### Problem description
There are no asserts guarding config_unpacker_x_end and there are some std::uint32_t template and runtime parameters that are not limited to certain allowed values.

### What's changed
Add asserts in config_unpacker_x_end in order to limit the allowed list of values for both template and runtime parameters.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [x] [Assert validation](docs/Introduction_to_asserts.md) Complied with assert doc (if applicable)
