### PR TITLE
Remove iterations 8 from perf sfpu tests.

### DIFF
--- a/tests/python_tests/perf_eltwise_binary_sfpu.py
+++ b/tests/python_tests/perf_eltwise_binary_sfpu.py
@@ -59,7 +59,6 @@ from helpers.test_variant_parameters import (
         16,
     ],  # Number of iterations to run the test in order to minimize profiler overhead in measurement
     iterations=[
-        8,
         32,
     ],
     input_dimensions=[
@@ -149,7 +148,6 @@ def test_perf_eltwise_binary_sfpu_float(
         16,
     ],
     iterations=[
-        8,
         32,
     ],
     input_dimensions=[
@@ -240,7 +238,6 @@ def test_perf_eltwise_binary_sfpu_int(
         16,
     ],
     iterations=[
-        8,
         32,
     ],
     input_dimensions=[

--- a/tests/python_tests/perf_eltwise_unary_sfpu.py
+++ b/tests/python_tests/perf_eltwise_unary_sfpu.py
@@ -65,7 +65,6 @@ from helpers.test_variant_parameters import (
         16,
     ],  # Number of iterations to run the test in order to minimize profiler overhead in measurement
     iterations=[
-        8,
         32,
     ],  # Number of SFPU iterations
     fast_mode=[


### PR DESCRIPTION
### Ticket
#0

### Problem description
Currently, perf sfpu tests are having a choice for iterations which can either be 8 or 32. However, due to the fact on how these kernels are written, and that tiles with dimensions 32x32 per tile are used in the tests, there is no point in iterating 8 times (only first 8 rows instead of all 32 rows).

### What's changed
Removing iterations count 8 from sfpu perf tests. This will remove numeroous of combinations and speed up total duration of these tests.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Assert validation](docs/Introduction_to_asserts.md) Complied with assert doc (if applicable)
