### PR TITLE
Fix _llk_math_mul_reduce_scalar_move_dest_to_src_ to work correctly in half dest mode

### DIFF
--- a/tt_llk_blackhole/llk_lib/experimental/llk_math_mul_reduce_scalar.h
+++ b/tt_llk_blackhole/llk_lib/experimental/llk_math_mul_reduce_scalar.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "ckernel_globals.h"
 #include "ckernel_include.h"
 #include "ckernel_ops.h"
@@ -81,13 +83,13 @@ inline void execute_high_fidelity_gapool()
  * @param idst Destination tile index (0-7)
  */
 template <EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE>
-inline void _llk_math_mul_reduce_scalar_move_dest_to_src_(uint32_t idst = 0)
+inline void _llk_math_mul_reduce_scalar_move_dest_to_src_(std::uint32_t idst = 0)
 {
     if constexpr (binary_reuse_dest == EltwiseBinaryReuseDestType::DEST_TO_SRCA)
     {
         if (idst == 0)
         {
-            TTI_SETC16(DEST_TARGET_REG_CFG_MATH_Offset_ADDR32, 0);
+            TT_SETC16(DEST_TARGET_REG_CFG_MATH_Offset_ADDR32, get_dest_buffer_base());
             TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_D);
         }
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/37535

### Problem description
`_llk_math_mul_reduce_scalar_move_dest_to_src_` was hardcoded to set the dest offset to 0. This isn't correct in half dest mode, where we switch between different halves of dest.

### What's changed
Change from 0 to use `get_dest_buffer_base()`

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Assert validation](docs/Introduction_to_asserts.md) Complied with assert doc (if applicable)
