### PR TITLE
[Test Infra] Disable format outliers check for Quasar

### DIFF
--- a/tests/python_tests/helpers/test_config.py
+++ b/tests/python_tests/helpers/test_config.py
@@ -603,8 +603,11 @@ class TestConfig:
 
         # Check if this is an outlier format combination that requires dest_acc to be enabled
         # Automatically enable dest_acc for outlier combinations
-        if is_format_combination_outlier(
-            self.formats.input_format, self.formats.output_format, self.dest_acc
+        if (
+            is_format_combination_outlier(
+                self.formats.input_format, self.formats.output_format, self.dest_acc
+            )
+            and TestConfig.CHIP_ARCH != ChipArchitecture.QUASAR
         ):
             dest_acc = DestAccumulation.Yes
 


### PR DESCRIPTION
### Ticket
<!-- Link to Github Issue -->

### Problem description
This PR fixes a previously fixed bug which reappeared in the process of refactoring.
Forcing 32bit mode dest in the case of a format outlier (8bit exp to
5bit exp) should not be done on Quasar, as Quasar packer can perform
these conversions.

### What's changed
- Do format outliers check only for WH, BH.
- Added Qsr data inference comments and error raise for unsupported
Fp16/16_b -> Fp32 packer conversion.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Assert validation](https://github.com/tenstorrent/tt-llk/blob/main/docs/Introduction_to_asserts.md) Complied with assert doc (if applicable)
