### PR TITLE
setadcxx in pack reconfig

### DIFF
--- a/tt_llk_blackhole/common/inc/cpack_common.h
+++ b/tt_llk_blackhole/common/inc/cpack_common.h
@@ -388,6 +388,10 @@ inline void reconfig_packer_data_format(
 
     // Set packer strides
     set_packer_strides(pack_output_src_format, tile_c_dim);
+
+    // TO DO: Enable support for this data format, without causing a race #1254
+    // Set Fp8 E4M3 mode for packer
+    // cfg_reg_rmw_tensix<THCON_SEC0_REG1_Pac_LF8_4b_exp_RMW>((pack_dst_format & 0x1F) == static_cast<DataFormatType>(DataFormat::Fp8_e4m3) ? 1 : 0);
 }
 
 template <bool is_fp32_dest_acc_en, bool untilize = false, bool tilize = false>

--- a/tt_llk_wormhole_b0/common/inc/cpack_common.h
+++ b/tt_llk_wormhole_b0/common/inc/cpack_common.h
@@ -511,6 +511,14 @@ inline void reconfig_packer_data_format(
 
     // Set packer strides
     set_packer_strides(pack_src_format);
+
+    const std::uint32_t face_dim = face_r_dim * FACE_C_DIM;
+
+    // To untilize narrow tile (32x16) we just pack 2 faces back to back
+    // Number of datums to pack per row
+    const std::uint32_t pack_x_dim = (narrow_tile) ? face_dim : FACE_R_DIM;
+
+    TT_SETADCXX(p_setadc::PAC, pack_x_dim - 1, 0x0);
 }
 
 template <bool is_fp32_dest_acc_en, bool untilize>

--- a/tt_llk_wormhole_b0/common/inc/cpack_common.h
+++ b/tt_llk_wormhole_b0/common/inc/cpack_common.h
@@ -386,7 +386,8 @@ inline void reconfig_packer_data_format(
     const std::uint32_t tile_size  = 0,
     const std::uint32_t face_r_dim = FACE_R_DIM,
     const std::uint32_t num_faces  = 4,
-    const bool partial_face        = false)
+    const bool partial_face        = false,
+    const bool narrow_tile         = false)
 {
     LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be 1, 2, or 4");
     // Configure packers

--- a/tt_llk_wormhole_b0/common/inc/cpack_common.h
+++ b/tt_llk_wormhole_b0/common/inc/cpack_common.h
@@ -517,7 +517,7 @@ inline void reconfig_packer_data_format(
 
     // To untilize narrow tile (32x16) we just pack 2 faces back to back
     // Number of datums to pack per row
-    const std::uint32_t pack_x_dim = (narrow_tile) ? face_dim : FACE_R_DIM;
+    const std::uint32_t pack_x_dim = (narrow_tile) ? face_dim : FACE_C_DIM;
 
     TT_SETADCXX(p_setadc::PAC, pack_x_dim - 1, 0x0);
 }

--- a/tt_llk_wormhole_b0/llk_lib/llk_pack.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_pack.h
@@ -103,7 +103,7 @@ inline void _llk_pack_mop_config_(
     }
 }
 
-template <bool is_fp32_dest_acc_en, bool is_tile_dim_reconfig_en = false>
+template <bool is_fp32_dest_acc_en, bool is_tile_dim_reconfig_en = false, bool untilize = false>
 inline void _llk_pack_reconfig_data_format_(
     const std::uint32_t pack_src_format,
     const std::uint32_t pack_dst_format,
@@ -114,7 +114,7 @@ inline void _llk_pack_reconfig_data_format_(
     const bool narrow_tile         = false)
 {
     LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be 1, 2, or 4");
-    reconfig_packer_data_format<is_fp32_dest_acc_en>(pack_src_format, pack_dst_format, tile_size, face_r_dim, num_faces, partial_face);
+    reconfig_packer_data_format<is_fp32_dest_acc_en, untilize>(pack_src_format, pack_dst_format, tile_size, face_r_dim, num_faces, partial_face);
 
     if constexpr (is_tile_dim_reconfig_en)
     {

--- a/tt_llk_wormhole_b0/llk_lib/llk_pack.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_pack.h
@@ -114,7 +114,7 @@ inline void _llk_pack_reconfig_data_format_(
     const bool narrow_tile         = false)
 {
     LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be 1, 2, or 4");
-    reconfig_packer_data_format<is_fp32_dest_acc_en>(pack_src_format, pack_dst_format, tile_size, face_r_dim, num_faces, partial_face);
+    reconfig_packer_data_format<is_fp32_dest_acc_en>(pack_src_format, pack_dst_format, tile_size, face_r_dim, num_faces, partial_face, narrow_tile);
 
     if constexpr (is_tile_dim_reconfig_en)
     {

--- a/tt_llk_wormhole_b0/llk_lib/llk_pack.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_pack.h
@@ -103,7 +103,7 @@ inline void _llk_pack_mop_config_(
     }
 }
 
-template <bool is_fp32_dest_acc_en, bool is_tile_dim_reconfig_en = false, bool untilize = false>
+template <bool is_fp32_dest_acc_en, bool is_tile_dim_reconfig_en = false>
 inline void _llk_pack_reconfig_data_format_(
     const std::uint32_t pack_src_format,
     const std::uint32_t pack_dst_format,
@@ -114,7 +114,7 @@ inline void _llk_pack_reconfig_data_format_(
     const bool narrow_tile         = false)
 {
     LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be 1, 2, or 4");
-    reconfig_packer_data_format<is_fp32_dest_acc_en, untilize>(pack_src_format, pack_dst_format, tile_size, face_r_dim, num_faces, partial_face);
+    reconfig_packer_data_format<is_fp32_dest_acc_en>(pack_src_format, pack_dst_format, tile_size, face_r_dim, num_faces, partial_face);
 
     if constexpr (is_tile_dim_reconfig_en)
     {


### PR DESCRIPTION
### Ticket
<!-- Link to Github Issue -->
[Link to Github Issue](https://github.com/tenstorrent/tt-llk/issues/1243)

### Problem description
<!-- Provide context for the problem. -->
pack reconfig is missing a counter set for switching between narrow tile and not narrow tile that is done in hw_configure.

### What's changed
<!-- Describe the approach used to solve the problem.
Summarize the changes made and its impact. -->
Added call to SETADCXX, also added to-do note regarding support for another data format

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Assert validation](https://github.com/tenstorrent/tt-llk/blob/main/docs/Introduction_to_asserts.md) Complied with assert doc (if applicable)
