### PR TITLE
Add stallwaits to uninits and reconfigs

### DIFF
--- a/tt_llk_blackhole/common/inc/cpack_common.h
+++ b/tt_llk_blackhole/common/inc/cpack_common.h
@@ -572,7 +572,8 @@ inline void reconfigure_packer_l1_acc(const std::uint32_t pack_l1_acc)
     // TTI_STALLWAIT(p_stall::STALL_PACK, p_stall::TRISC_CFG);
 
     const std::uint32_t pack_l1_acc_disable_pack_zero_flag = pack_l1_acc ? (0b11) : (0b00);
-
+    // Stall cfg_reg_rmw_tensix done by CFG until PACK is done
+    TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::PACK);
     cfg_reg_rmw_tensix<
         THCON_SEC0_REG1_Pack_L1_Acc_ADDR32,
         THCON_SEC0_REG1_Pack_L1_Acc_SHAMT,

--- a/tt_llk_blackhole/llk_lib/llk_pack_rows.h
+++ b/tt_llk_blackhole/llk_lib/llk_pack_rows.h
@@ -158,6 +158,8 @@ inline void _llk_pack_rows_(const std::uint32_t tile_index, const std::uint32_t 
  */
 inline void _llk_pack_rows_uninit_()
 {
+    // Stalling SETADCXX done by THCON until PACK finishes
+    TTI_STALLWAIT(p_stall::STALL_THCON, p_stall::PACK);
     // Restore X counter to default
     TTI_SETADCXX(p_setadc::PAC, FACE_R_DIM * FACE_C_DIM - 1, 0x0);
 }

--- a/tt_llk_blackhole/llk_lib/llk_unpack_A.h
+++ b/tt_llk_blackhole/llk_lib/llk_unpack_A.h
@@ -232,6 +232,8 @@ inline void _llk_unpack_A_uninit_(const std::uint32_t face_r_dim)
 {
     // Unpack A is used for all single unpacker operations, except bcast, since bcast HW feature is only available on unpacker B
     constexpr std::uint32_t UNP_SEL = (BType == BroadcastType::NONE) ? p_setadc::UNP_A : p_setadc::UNP_B;
+    // Stalling SETADCXX done by THCON until UNPACK finished
+    TTI_STALLWAIT(p_stall::STALL_THCON, (UNP_SEL == p_setadc::UNP_A) ? p_stall::UNPACK0 : p_stall::UNPACK1);
     // TODO NC: Issue tt-llk#1036 will make this transient
     TT_SETADCXX(UNP_SEL, face_r_dim * FACE_C_DIM - 1, 0x0);
 }

--- a/tt_llk_blackhole/llk_lib/llk_unpack_AB_matmul.h
+++ b/tt_llk_blackhole/llk_lib/llk_unpack_AB_matmul.h
@@ -240,6 +240,8 @@ __attribute__((always_inline)) inline void _llk_unpack_AB_matmul_init_(
 
 inline void _llk_unpack_AB_matmul_uninit_(const std::uint32_t unpA_face_r_dim, const std::uint32_t unpB_face_r_dim)
 {
+    // Stalling SETADCXX done by THCON until UNPACK finished
+    TTI_STALLWAIT(p_stall::STALL_THCON, p_stall::UNPACK);
     // TODO NC: Issue tt-llk#1036 will make this transient
     TT_SETADCXX(p_setadc::UNP_A, unpA_face_r_dim * FACE_C_DIM - 1, 0x0);
     TT_SETADCXX(p_setadc::UNP_B, unpB_face_r_dim * FACE_C_DIM - 1, 0x0);

--- a/tt_llk_wormhole_b0/common/inc/cpack_common.h
+++ b/tt_llk_wormhole_b0/common/inc/cpack_common.h
@@ -725,7 +725,8 @@ inline void reconfigure_packer_l1_acc(const std::uint32_t pack_l1_acc)
     // TTI_STALLWAIT(p_stall::STALL_PACK, p_stall::TRISC_CFG);
 
     const std::uint32_t pack_l1_acc_disable_pack_zero_flag = pack_l1_acc ? (0b11) : (0b00);
-
+    // Stall cfg_reg_rmw_tensix done by CFG until PACK is done
+    TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::PACK);
     cfg_reg_rmw_tensix<
         THCON_SEC0_REG1_Pack_L1_Acc_ADDR32,
         THCON_SEC0_REG1_Pack_L1_Acc_SHAMT,

--- a/tt_llk_wormhole_b0/llk_lib/llk_math_matmul.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_math_matmul.h
@@ -719,6 +719,8 @@ inline void _llk_math_matmul_init_(
 
 inline void _llk_math_matmul_uninit_()
 {
+    // Stall SETC16 done by CFG until MATH/SFPU are done
+    TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::MATH | p_stall::WAIT_SFPU);
     TTI_SETC16(CLR_DVALID_SrcA_Disable_ADDR32, 0);
     TTI_SETC16(CLR_DVALID_SrcB_Disable_ADDR32, 0);
 }

--- a/tt_llk_wormhole_b0/llk_lib/llk_pack.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_pack.h
@@ -178,6 +178,8 @@ inline void _llk_pack_init_(
 
 inline void _llk_pack_uninit_(const std::uint32_t face_r_dim)
 {
+    // Stall SETADCXX done by THCON until PACK finished
+    TTI_STALLWAIT(p_stall::STALL_THCON, p_stall::PACK);
     TT_SETADCXX(p_setadc::PAC, face_r_dim * FACE_C_DIM - 1, 0x0);
 }
 

--- a/tt_llk_wormhole_b0/llk_lib/llk_pack_rows.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_pack_rows.h
@@ -139,5 +139,7 @@ inline void _llk_pack_rows_(const std::uint32_t tile_index, const std::uint32_t 
  */
 inline void _llk_pack_rows_uninit_()
 {
+    // Stalling SETADCXX done by THCON until PACK finishes
+    TTI_STALLWAIT(p_stall::STALL_THCON, p_stall::PACK);
     TTI_SETADCXX(p_setadc::PAC, FACE_R_DIM * FACE_C_DIM - 1, 0x0);
 }

--- a/tt_llk_wormhole_b0/llk_lib/llk_pack_untilize.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_pack_untilize.h
@@ -162,6 +162,8 @@ inline void _llk_pack_untilize_init_(const std::uint32_t pack_dst_format, const 
 
 inline void _llk_pack_untilize_uninit_(const std::uint32_t face_r_dim)
 {
+    // Stalling SETADCXX done by THCON until PACK finishes
+    TTI_STALLWAIT(p_stall::STALL_THCON, p_stall::PACK);
     TT_SETADCXX(p_setadc::PAC, face_r_dim * FACE_C_DIM - 1, 0x0);
 }
 

--- a/tt_llk_wormhole_b0/llk_lib/llk_unpack_A.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_unpack_A.h
@@ -294,5 +294,7 @@ template <BroadcastType BType = BroadcastType::NONE>
 inline void _llk_unpack_A_uninit_(const std::uint32_t face_r_dim)
 {
     constexpr std::uint32_t UNP_SEL = (BType == BroadcastType::NONE) ? p_setadc::UNP_A : p_setadc::UNP_B;
+    // Stalling SETADCXX done by THCON until UNPACK finished
+    TTI_STALLWAIT(p_stall::STALL_THCON, (UNP_SEL == p_setadc::UNP_A) ? p_stall::UNPACK0 : p_stall::UNPACK1);
     TT_SETADCXX(UNP_SEL, face_r_dim * FACE_C_DIM - 1, 0x0);
 }

--- a/tt_llk_wormhole_b0/llk_lib/llk_unpack_AB.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_unpack_AB.h
@@ -135,6 +135,8 @@ inline void _llk_unpack_AB_reduce_init_(
 
 inline void _llk_unpack_AB_uninit_(const std::uint32_t face_r_dim = FACE_R_DIM)
 {
+    // Stalling SETADCXX done by THCON until UNPACK finished
+    TTI_STALLWAIT(p_stall::STALL_THCON, p_stall::UNPACK);
     TT_SETADCXX(p_setadc::UNP_AB, face_r_dim * FACE_C_DIM - 1, 0x0);
 }
 
@@ -265,6 +267,8 @@ inline void _llk_unpack_bcastA_B_init_()
 
 inline void _llk_unpack_bcastA_B_uninit_(const std::uint32_t y_stride = FACE_R_DIM * 2, const std::uint32_t face_r_dim = FACE_R_DIM)
 {
+    // Stalling cfg_reg_rmw_tensix done by CFG until UNPACK finished
+    TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::UNPACK);
     // Revisit default stride value in tt-llk#1015
     cfg_reg_rmw_tensix<UNP0_ADDR_CTRL_XY_REG_1_Ystride_RMW>(y_stride);
     TT_SETADCXX(p_setadc::UNP_AB, face_r_dim * FACE_C_DIM - 1, 0x0);

--- a/tt_llk_wormhole_b0/llk_lib/llk_unpack_AB_matmul.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_unpack_AB_matmul.h
@@ -208,6 +208,8 @@ __attribute__((always_inline)) inline void _llk_unpack_AB_matmul_init_(
 
 inline void _llk_unpack_AB_matmul_uninit_(const std::uint32_t face_r_dim)
 {
+    // Stalling SETADCXX done by THCON until UNPACK finished
+    TTI_STALLWAIT(p_stall::STALL_THCON, p_stall::UNPACK);
     TT_SETADCXX(p_setadc::UNP_AB, face_r_dim * FACE_C_DIM - 1, 0x0);
 }
 


### PR DESCRIPTION
### Ticket
<!-- Link to Github Issue -->
[Link to Github Issue](https://github.com/tenstorrent/tt-llk/issues/747)
### Problem description
<!-- Provide context for the problem. -->
Some uninits and reconfigs are missing stallwaits that should be in place for safety.

### What's changed
<!-- Describe the approach used to solve the problem.
Summarize the changes made and its impact. -->
Added stallwaits as needed before tensix instructions. Combines changes from previous pr that kinda got messed up and cant rebase [1](https://github.com/tenstorrent/tt-llk/pull/1107) [2](https://github.com/tenstorrent/tt-llk/pull/1112)
(hoping that the checks work out this time)

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Assert validation](https://github.com/tenstorrent/tt-llk/blob/main/docs/Introduction_to_asserts.md) Complied with assert doc (if applicable)
