### PR TITLE
[Quasar] Include llk_defs.h in ckernel.h to make MathFidelity enum visible

### DIFF
--- a/tt_llk_quasar/common/inc/ckernel.h
+++ b/tt_llk_quasar/common/inc/ckernel.h
@@ -13,6 +13,7 @@
 #include "ckernel_include.h"
 #include "ckernel_ops.h"
 // #include "fw_debug.h"
+#include "llk_defs.h"
 #include "t6_debug_map.h"
 #include "tensix.h"
 


### PR DESCRIPTION
### Ticket
<!-- Link to Github Issue -->

### Problem description
Include llk_defs.h in ckernel.h to make MathFidelity enum visible in tt-metal.

### What's changed
<!-- Describe the approach used to solve the problem.
Summarize the changes made and its impact. -->

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Assert validation](https://github.com/tenstorrent/tt-llk/blob/main/docs/Introduction_to_asserts.md) Complied with assert doc (if applicable)
