### PR TITLE
Removed the relu discrepancy issue print in test_pack

### DIFF
--- a/tests/python_tests/test_pack.py
+++ b/tests/python_tests/test_pack.py
@@ -256,25 +256,23 @@ def test_pack(
         golden_tensor, res_tensor, formats.output_format, print_erros=False
     )
 
-    if not test_passed and relu_type in [
-        PackerReluType.MinThresholdRelu,
-        PackerReluType.MaxThresholdRelu,
-    ]:
-        # When a datum is extremely close to the ReLU threshold, differences can arise due to
-        # floating point precision limitations and rounding during format conversions.
-        # We check if all mismatches are within a small tolerance of the threshold. If so, we consider the test as passed.
-        is_tolerance_issue = is_relu_threshold_tolerance_issue(
+    if (
+        not test_passed
+        and relu_type
+        in [
+            PackerReluType.MinThresholdRelu,
+            PackerReluType.MaxThresholdRelu,
+        ]
+        and is_relu_threshold_tolerance_issue(
             golden_tensor,
             res_tensor,
             relu_config,
             data_formats.pack_src,
         )
-
-        if is_tolerance_issue:
-            print(
-                "Detected a packer ReLU threshold precision difference between hardware and software "
-                "the discrepancy is within tolerance and is considered acceptable."
-            )
-            test_passed = True
+    ):
+        # When a datum is extremely close to the ReLU threshold, differences can arise due to
+        # floating point precision limitations and rounding during format conversions.
+        # We check if all mismatches are within a small tolerance of the threshold. If so, we consider the test as passed.
+        test_passed = True
 
     assert test_passed


### PR DESCRIPTION
### Problem description
When encountering relu hardware-software discrepancy issue, we were printing it.
When running all tests, the print confuses the user since it's not as important...


### What's changed
Removed the print entirely. 

### Type of change

The change is of purely aesthetic nature.