### PR TITLE
fix: add NUM_FACES to performance test runtimes

### DIFF
--- a/tests/python_tests/perf_fast_tilize.py
+++ b/tests/python_tests/perf_fast_tilize.py
@@ -11,6 +11,7 @@ from helpers.stimuli_config import StimuliConfig
 from helpers.test_variant_parameters import (
     INPUT_DIMENSIONS,
     LOOP_FACTOR,
+    NUM_FACES,
     TILE_COUNT,
 )
 
@@ -74,7 +75,7 @@ def test_fast_tilize_perf(
         formats,
         run_types=[PerfRunType.L1_TO_L1],
         templates=[INPUT_DIMENSIONS(input_dimensions, input_dimensions)],
-        runtimes=[TILE_COUNT(tile_count), LOOP_FACTOR(1024)],
+        runtimes=[TILE_COUNT(tile_count), LOOP_FACTOR(1024), NUM_FACES(4)],
         variant_stimuli=StimuliConfig(
             None,
             formats.input_format,


### PR DESCRIPTION
### Ticket
None

### Problem description
Change of `fast_tilize_test.cpp` in https://github.com/tenstorrent/tt-llk/commit/f7cf9292e1d80dc52cf39301c426e41f407bced8 broke perf fast tilize test, because we now fail to pass `num_faces` to the runtime structure and code doesn’t compile (since both perf and functional test use the same cpp file).

This made our pef nightlies to fail two times in a row and detect an issue with rerun of workflows that stopped the workflow before sending failure notification to Slack (but that’s another topic for another PR).

### What's changed
Added passing num_faces from the test into runtime params struct.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Assert validation](https://github.com/tenstorrent/tt-llk/blob/main/docs/Introduction_to_asserts.md) Complied with assert doc (if applicable)
