### PR TITLE
ci: refactor nightly performance tests workflow

### DIFF
--- a/.github/workflows/nightly-perf-tests.yml
+++ b/.github/workflows/nightly-perf-tests.yml
@@ -24,7 +24,7 @@ jobs:
     if: always()
     needs: nightly-performance-tests
     steps:
-     - name: Checkout repository
+      - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 1


### PR DESCRIPTION
### Ticket
None

### Problem description
Recently added rerun failed job step was causing issues because it would always fail as it cannot rerun a running job, since it is a part of the job it is trying to rerun. This caused the next step (Slack reporting) to not run at all due to rerun failure that terminates the workflow. Due to this issue, we didn’t get the last two reports from our nightly runs that failed.
We will have to figure out rerunning mechanism in another way.

### What's changed
Removed rerun-failed-jobs step and simplified report-status conditions.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Assert validation](https://github.com/tenstorrent/tt-llk/blob/main/docs/Introduction_to_asserts.md) Complied with assert doc (if applicable)
