### PR TITLE
POC: Add vconst verifier

### DIFF
--- a/common/inc/vconst_verifier.h
+++ b/common/inc/vconst_verifier.h
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <type_traits>
+
+namespace vconst_verifier
+{
+
+struct disable
+{
+    // This is used as a default to mark that verification is not enabled for given function. Allows to be backward compatible and not break when some path has
+    // not yet enabled verification.
+};
+
+struct unhandled
+{
+    // This is used to mark paths that are not yet handling verification. This allows to detect incorrect init/compute configuration (e.g. init went unhandled
+    // path when compute expected initialization).
+};
+
+struct no_used_regs
+{
+    // This is default, when no vConst register are yet used.
+};
+
+template <typename B = no_used_regs>
+struct use_vconst0 : public B
+{
+    // Mark that vConst0 is set in the init function.
+    static void vconst0();
+};
+
+template <typename B = no_used_regs>
+struct use_vconst1 : public B
+{
+    // Mark that vConst1 is set in the init function.
+    static void vconst1();
+};
+
+template <typename B = no_used_regs>
+struct use_vconst2 : public B
+{
+    // Mark that vConst2 is set in the init function.
+    static void vconst2();
+};
+
+template <typename verifier>
+constexpr bool is_unhandled_path()
+{
+    return std::is_same_v<verifier, unhandled> || std::is_base_of_v<unhandled, verifier>;
+}
+
+template <typename verifier>
+inline void assert_vconst_0()
+{
+    static_assert(!is_unhandled_path<verifier>(), "vconst verifier unhandled path used");
+    if constexpr (!std::is_same_v<verifier, disable>)
+    {
+        static_assert(std::is_void<decltype(verifier::vconst0())>::value, "vConst0 not marked as set.");
+    }
+}
+
+template <typename verifier>
+inline void assert_vconst_1()
+{
+    static_assert(!is_unhandled_path<verifier>(), "vconst verifier unhandled path used");
+    if constexpr (!std::is_same_v<verifier, disable>)
+    {
+        static_assert(std::is_void<decltype(verifier::vconst1())>::value, "vConst1 not marked as set.");
+    }
+}
+
+template <typename verifier>
+inline void assert_vconst_2()
+{
+    static_assert(!is_unhandled_path<verifier>(), "vconst verifier unhandled path used");
+    if constexpr (!std::is_same_v<verifier, disable>)
+    {
+        static_assert(std::is_void<decltype(verifier::vconst2())>::value, "vConst2 not marked as set.");
+    }
+}
+} // namespace vconst_verifier

--- a/tests/python_tests/helpers/test_config.py
+++ b/tests/python_tests/helpers/test_config.py
@@ -258,6 +258,7 @@ class TestConfig:
             f"-I../{TestConfig.ARCH_LLK_ROOT}/llk_lib",
             f"-I../{TestConfig.ARCH_LLK_ROOT}/common/inc",
             f"-I../{TestConfig.ARCH_LLK_ROOT}/common/inc/sfpu",
+            "-I../common/inc",
             f"-I{TestConfig.HEADER_DIR}",
             f"-Ihw_specific/{TestConfig.ARCH.value}",
             f"-Ihw_specific/{TestConfig.ARCH.value}/metal_sfpu",


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/37896

### Problem description
Kernels initialization can be pretty complex, with multiple layers and parametrization. This may lead to accidental miss of vConst setting, as there is no verification in this matter. As difference in const may cause small enough difference in result, UTs may not be able to catch this. Same for models - with luck this may go unnoticed.


### What's changed
Added compile time mechanism to mark which consts are being set in initialization, and then, in compute part, check whether required const register was initialized.
All sets and checks are done in compile time plus compiler having empty base class optimization and unused result heuristics, which results in 0 run time overhead of this checks (assuming -O1 or higher).

POC done for silu. Tested on WH. Requires 
complementary tt-metal change for testing https://github.com/tenstorrent/tt-metal/pull/37921.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Assert validation](https://github.com/tenstorrent/tt-llk/blob/main/docs/Introduction_to_asserts.md) Complied with assert doc (if applicable)
