### PR TITLE
Add tests for 16xN tiny tiles to fast tilize

### DIFF
--- a/tests/python_tests/helpers/stimuli_config.py
+++ b/tests/python_tests/helpers/stimuli_config.py
@@ -58,6 +58,7 @@ class StimuliConfig:
         sfpu=False,
         write_full_tiles: bool = False,
         use_dense_tile_dimensions: bool = False,
+        operand_res_tile_size: int = None,
     ):
 
         # Fields init
@@ -78,6 +79,7 @@ class StimuliConfig:
         self.sfpu = sfpu
         self.write_full_tiles = write_full_tiles
         self.use_dense_tile_dimensions = use_dense_tile_dimensions
+        self.operand_res_tile_size = operand_res_tile_size
 
         # Stimuli addresses calculation
         # Use actual tile size based on tile_dimensions for memory-efficient allocation
@@ -127,6 +129,8 @@ class StimuliConfig:
         buf_res_tile_size = calculate_tile_size_bytes(
             output_format, self.tile_dimensions, format_tile_sizes
         )
+        if self.operand_res_tile_size is not None:
+            buf_res_tile_size = self.operand_res_tile_size
 
         values = [
             self.buf_a_addr,
@@ -176,6 +180,8 @@ class StimuliConfig:
         buf_res_tile_size = calculate_tile_size_bytes(
             output_format, self.tile_dimensions, format_tile_sizes
         )
+        if self.operand_res_tile_size is not None:
+            buf_res_tile_size = self.operand_res_tile_size
 
         lines: list[str] = [
             f"constexpr Operand buffer_A({hex(self.buf_a_addr)}, {buf_a_tile_size});",

--- a/tests/python_tests/test_fast_tilize.py
+++ b/tests/python_tests/test_fast_tilize.py
@@ -63,7 +63,7 @@ def generate_input_dimensions(max_size: int) -> list[tuple[int, int]]:
 )
 def test_fast_tilize(formats, dest_acc, dimensions, workers_tensix_coordinates):
 
-    input_width, input_height = dimensions
+    input_height, input_width = dimensions
 
     if formats.input == DataFormat.Bfp8_b:
         pytest.skip("Bfp8_b input format is not supported for fast tilize")


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/37959

### Problem description
Need LLK infra tests for new tiny tiles 16xN fast tilize on WH

### What's changed
Add test_fast_tilize_tiny_tiles.py, and update test_fast_tilize.py

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
