### PR TITLE
ci: enable automatic uplift to metal if quasar LLKs change

### DIFF
--- a/.github/workflows/trigger-tt-metal-bump.yml
+++ b/.github/workflows/trigger-tt-metal-bump.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - 'tt_llk_blackhole/**'
+      - 'tt_llk_quasar/**'
       - 'tt_llk_wormhole_b0/**'
 
 permissions:


### PR DESCRIPTION

### Ticket
None

### Problem description
Thus far, we have been ignoring changes in Quasar LLKs when determining whether to start the metal uplift process. This was historically OK, but now that metal is starting to bring up Quasar this assumption no longer stands.

### What's changed
Updated the uplift workflow to monitor Quasar changes, too.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Assert validation](https://github.com/tenstorrent/tt-llk/blob/main/docs/Introduction_to_asserts.md) Complied with assert doc (if applicable)
