### PR TITLE
Add tile_shape to fuser operands

### DIFF
--- a/tests/python_tests/helpers/fused_operand.py
+++ b/tests/python_tests/helpers/fused_operand.py
@@ -8,6 +8,7 @@ from typing import Optional, Tuple
 import torch
 from helpers.llk_params import DataFormat, format_dict
 from helpers.stimuli_generator import generate_random_face
+from helpers.tile_shape import TileShape, construct_tile_shape
 from helpers.tilize_untilize import tilize_block
 
 
@@ -16,6 +17,7 @@ class Operand:
     name: str
     dimensions: Optional[Tuple[int, int]] = None
     data_format: Optional[DataFormat] = None
+    tile_shape: Optional[TileShape] = None
     l1_address: Optional[int] = None
     is_output: bool = False
     sfpu: bool = True
@@ -30,6 +32,8 @@ class Operand:
             raise ValueError(
                 f"Input operand '{self.name}' must have dimensions and data_format"
             )
+        if self.tile_shape is None:
+            self.tile_shape = construct_tile_shape((32, 32))
 
     def is_input(self) -> bool:
         return not self.is_output
@@ -44,9 +48,11 @@ class Operand:
             )
 
         height, width = self.dimensions[0], self.dimensions[1]
-        tile_count = (height // 32) * (width // 32)
+        tile_rows = self.tile_shape.total_row_dim()
+        tile_cols = self.tile_shape.total_col_dim()
+        tile_count = (height // tile_rows) * (width // tile_cols)
 
-        faces_needed = tile_count * 4
+        faces_needed = tile_count * self.tile_shape.total_num_faces()
         faces_data = []
 
         for _ in range(faces_needed):
@@ -55,7 +61,7 @@ class Operand:
                 const_value=const_value,
                 const_face=const_value is not None,
                 sfpu=self.sfpu,
-                face_r_dim=16,
+                face_r_dim=self.tile_shape.face_r_dim,
                 negative_values=False,
             )
             faces_data.extend(face.tolist())
@@ -118,8 +124,10 @@ class Operand:
     def tile_count(self) -> Optional[int]:
         if self._tile_count is None:
             if self.dimensions is not None:
-                self._tile_count = (self.dimensions[0] // 32) * (
-                    self.dimensions[1] // 32
+                tile_rows = self.tile_shape.total_row_dim()
+                tile_cols = self.tile_shape.total_col_dim()
+                self._tile_count = (self.dimensions[0] // tile_rows) * (
+                    self.dimensions[1] // tile_cols
                 )
             elif self.is_input():
                 self.generate_data()
@@ -175,7 +183,10 @@ class OperandMapping:
 
     def get_output_tile_count(self, operand_registry: "OperandRegistry") -> int:
         dims = self.resolve_output_dimensions(operand_registry)
-        return (dims[0] // 32) * (dims[1] // 32)
+        output_op = operand_registry.get(self.output)
+        tile_rows = output_op.tile_shape.total_row_dim()
+        tile_cols = output_op.tile_shape.total_col_dim()
+        return (dims[0] // tile_rows) * (dims[1] // tile_cols)
 
 
 class OperandRegistry:
@@ -260,14 +271,18 @@ class OperandRegistry:
         else:
             existing = self.operands[src_a]
             if list(existing.dimensions) != list(src_a_dims):
-                existing.dimensions = list(src_a_dims)
+                raise ValueError(
+                    f"Operand '{src_a}' already exists with dimensions {existing.dimensions}, got {src_a_dims}"
+                )
 
         if src_b not in self.operands:
             self.add_input(src_b, dimensions=src_b_dims, data_format=input_format)
         else:
             existing = self.operands[src_b]
             if list(existing.dimensions) != list(src_b_dims):
-                existing.dimensions = list(src_b_dims)
+                raise ValueError(
+                    f"Operand '{src_b}' already exists with dimensions {existing.dimensions}, got {src_b_dims}"
+                )
 
         if src_a_tensor is not None:
             self.operands[src_a].set_data(src_a_tensor)

--- a/tests/python_tests/helpers/fused_operation.py
+++ b/tests/python_tests/helpers/fused_operation.py
@@ -39,15 +39,6 @@ class FusedOperation:
     partial_face_A: bool = False
     partial_face_B: bool = False
     partial_face: bool = False
-    num_faces: int = 4
-    num_faces_A: int = 4
-    num_faces_B: int = 4
-    in0_tile_r_dim: int = 32
-    in0_tile_c_dim: int = 32
-    in1_tile_r_dim: int = 32
-    in1_tile_c_dim: int = 32
-    face_r_dim: int = 16
-    face_c_dim: int = 16
     dest_sync: DestSync = DestSync.Half
     dst_index: int = 0
     srca_reuse_count: int = 4
@@ -60,6 +51,18 @@ class FusedOperation:
         src_a = registry.get(mapping.src_a)
         src_b = registry.get(mapping.src_b)
         output = registry.get(mapping.output)
+
+        self.in0_tile_r_dim = src_a.tile_shape.total_row_dim()
+        self.in0_tile_c_dim = src_a.tile_shape.total_col_dim()
+        self.num_faces_A = src_a.tile_shape.total_num_faces()
+
+        self.in1_tile_r_dim = src_b.tile_shape.total_row_dim()
+        self.in1_tile_c_dim = src_b.tile_shape.total_col_dim()
+        self.num_faces_B = src_b.tile_shape.total_num_faces()
+
+        self.face_r_dim = output.tile_shape.face_r_dim
+        self.face_c_dim = output.tile_shape.face_c_dim
+        self.num_faces = output.tile_shape.total_num_faces()
 
         TILE_SIZES = {
             DataFormat.Bfp8_b: 68,
@@ -88,8 +91,8 @@ class FusedOperation:
         self.buffer_B_tile_size = format_tile_sizes[self.src_b.data_format]
         self.buffer_Res_tile_size = format_tile_sizes[self.output.data_format]
 
-        num_rows = 32
-        num_cols = 32
+        num_rows = output.tile_shape.total_row_dim()
+        num_cols = output.tile_shape.total_col_dim()
 
         validate_tile_dimensions(self.src_a.dimensions[0], num_rows)
         validate_tile_dimensions(self.src_a.dimensions[1], num_cols)
@@ -188,4 +191,5 @@ class FusedOperation:
             f"  Output: {self.output}\n"
             f"  Math Fidelity: {self.math_fidelity}\n"
             f"  Batch Size: {self.batch_size}\n"
+            f"  Tile Shape: {self.output.tile_shape}\n"
         )


### PR DESCRIPTION
### Ticket
<!-- Link to Github Issue -->

### Problem description
<!-- Provide context for the problem. -->
Fuser uses hardcoded tile dimensions instead of `tile_shape`

### What's changed
<!-- Describe the approach used to solve the problem.
Summarize the changes made and its impact. -->
Fuser operands now have `tile_shape`, and operations use those values instead of hardcoded ones.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Assert validation](https://github.com/tenstorrent/tt-llk/blob/main/docs/Introduction_to_asserts.md) Complied with assert doc (if applicable)
