### PR TITLE
Update LLK_ASSERT definition when asserts are disabled

### DIFF
--- a/tt_llk_blackhole/llk_lib/llk_assert.h
+++ b/tt_llk_blackhole/llk_lib/llk_assert.h
@@ -31,6 +31,8 @@
 
 #else
 
-#define LLK_ASSERT(condition, message) ((void)(condition), (void)(message))
+// sizeof creates an unevaluated context: the condition is fully compiled
+// (type-checked, name-resolved) but never executed at runtime.
+#define LLK_ASSERT(condition, message) ((void)sizeof((condition)))
 
 #endif // ENABLE_LLK_ASSERT

--- a/tt_llk_wormhole_b0/llk_lib/llk_assert.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_assert.h
@@ -31,6 +31,8 @@
 
 #else
 
-#define LLK_ASSERT(condition, message) ((void)(condition), (void)(message))
+// sizeof creates an unevaluated context: the condition is fully compiled
+// (type-checked, name-resolved) but never executed at runtime.
+#define LLK_ASSERT(condition, message) ((void)sizeof((condition)))
 
 #endif // ENABLE_LLK_ASSERT


### PR DESCRIPTION
### Ticket
#1313

### Problem description
Previous definition of LLK_ASSERT macro, when LLK_ASSERT-s are disabled still required runtime calculation of condition which introduces overhead in both runtime performances and DRAM code size in some tests:
#define LLK_ASSERT(condition, message) ((void)(condition), (void)(message))


### What's changed
Updated this definition to:
#define LLK_ASSERT(condition, message) ((void)sizeof((condition)))
Because the idea is to preserve syntax check of condition in compile time, but to have 0 runtime overhead when LLK_ASSERT-s are disabled.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [x] [Assert validation](https://github.com/tenstorrent/tt-llk/blob/main/docs/Introduction_to_asserts.md) Complied with assert doc (if applicable)
