### PR TITLE
fix: unpack workaround to use data format valid for Src reg

### DIFF
--- a/tt_llk_wormhole_b0/common/inc/cunpack_common.h
+++ b/tt_llk_wormhole_b0/common/inc/cunpack_common.h
@@ -435,7 +435,17 @@ inline void unpack_to_dest_tile_done(std::uint32_t &context_id)
 
     // Due to a hardware bug (TEN-3868), we need to have one unpack-to-srcA instruction after the last unpack-to-dest instruction.
     TTI_SETADCXX(p_setadc::UNP_A, FACE_C_DIM - 1, 0x0);
+    // Need to make sure the data formats used are valid in Src
+    // Temporarily change in/out formats to UInt16
+    TTI_RDCFG(p_gpr_unpack::TMP_LO, THCON_SEC0_REG2_Out_data_format_ADDR32);
+    TTI_RDCFG(p_gpr_unpack::TMP_HI, THCON_SEC0_REG0_TileDescriptor_ADDR32);
+    cfg_reg_rmw_tensix<THCON_SEC0_REG2_Out_data_format_RMW>(to_underlying(DataFormat::UInt16));
+    cfg_reg_rmw_tensix<THCON_SEC0_REG0_TileDescriptor_ADDR32, 0, 0xF>(to_underlying(DataFormat::UInt16));
+
     TT_UNPACR(SrcA, 0, 0, context_id, 0, 1 /* Set OvrdThreadId*/, 0 /*Set Dvalid*/, p_unpacr::RAREFYB_DISABLE, 1, 0, 0, 0, 1);
+
+    TTI_WRCFG(p_gpr_unpack::TMP_HI, p_cfg::WRCFG_32b, THCON_SEC0_REG0_TileDescriptor_ADDR32);
+    TTI_WRCFG(p_gpr_unpack::TMP_LO, p_cfg::WRCFG_32b, THCON_SEC0_REG2_Out_data_format_ADDR32);
     TTI_SETADCXX(p_setadc::UNP_A, FACE_R_DIM * FACE_C_DIM - 1, 0x0);
 }
 


### PR DESCRIPTION
### Ticket
[#38246](https://github.com/tenstorrent/tt-metal/issues/38246)

### Problem description
Wormhole's `unpack_to_dest_tile_done()` implements a workaround for a hardware bug, by issuing an additional unpack-to-srcA instruction after the last unpack-to-dest TT_UNPACR instruction.
There was a problem in the workaround. The additional TT_UNPACR was implicitly using the same in/out data formats as the previous unpack-to-dest instructions. Since the test in the issue was unpacking INT32 data, this lead to an undefined behavior when unpacking to src, because it does not support the 32bit integer format.

### What's changed
The workaround code is changed to use UINT16 data format in the additional TT_UNPACR. This is OK, because the actual data values being stored into the srcA aren't used.

### Type of change

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Assert validation](https://github.com/tenstorrent/tt-llk/blob/main/docs/Introduction_to_asserts.md) Complied with assert doc (if applicable)
