### PR TITLE
replaced /bin/bash with /usr/bin/env bash to improve portability

### DIFF
--- a/tests/sfpi-info.sh
+++ b/tests/sfpi-info.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/usr/bin/env bash
 
 # Compute SFPI release version information.
 # Emit as evaluable shell assignments or CMAKE script


### PR DESCRIPTION
### Ticket
na

### Problem description
when building [tt-llk tests](https://github.com/tenstorrent/tt-llk/tree/main/tests) on nixos it might need to execute sfpi-info.sh from [setup_testing_env.sh](https://github.com/tenstorrent/tt-llk/blob/c10e7fc74ab40d0bc24ff73fbad4ee91bb9cc187/tests/setup_testing_env.sh#L206) (also [this](https://github.com/tenstorrent/tt-llk/blob/c10e7fc74ab40d0bc24ff73fbad4ee91bb9cc187/tests/setup_testing_env.sh#L179)). this will fail on nixos (and other non-fhs systems) because `/bin/bash` doesn't exist. on nixos for example it is installed at `/nix/store/<hash>-bash-<version>/bin/bash`

most of shell scripts in tt-llk tests already use `/usr/bin/env bash`, so this pull request is a proposal to make `sfpi-info.sh` more portable as well ☺️

### What's changed
na

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Assert validation](https://github.com/tenstorrent/tt-llk/blob/main/docs/Introduction_to_asserts.md) Complied with assert doc (if applicable)
