### PR TITLE
Fix race condition due to same register accessed by unpacker and pack…

### DIFF
--- a/tt_llk_blackhole/common/inc/cpack_common.h
+++ b/tt_llk_blackhole/common/inc/cpack_common.h
@@ -201,7 +201,11 @@ inline void set_packer_strides(const std::uint32_t pack_src_format, const std::u
 inline void reconfigure_packer_l1_acc(const std::uint32_t pack_l1_acc)
 {
     cfg_reg_rmw_tensix<THCON_SEC0_REG1_Disable_pack_zero_flags_RMW>(pack_l1_acc);
+
+    // Encompassing word shared by unpacker thread
+    t6_mutex_acquire(mutex::REG_RMW);
     cfg_reg_rmw_tensix<THCON_SEC0_REG1_Pack_L1_Acc_RMW>(pack_l1_acc);
+    t6_mutex_release(mutex::REG_RMW);
 }
 
 template <bool is_fp32_dest_acc_en>
@@ -245,7 +249,11 @@ inline void set_packer_config(
         constexpr std::uint32_t exp_threshold_rmw_mask = THCON_SEC0_REG1_Exp_threshold_en_MASK | THCON_SEC0_REG1_Exp_threshold_MASK;
         std::uint32_t exp_threshold_rmw_data =
             (exp_threshold_val << THCON_SEC0_REG1_Exp_threshold_SHAMT) | (exp_threshold_en << THCON_SEC0_REG1_Exp_threshold_en_SHAMT);
-        cfg_reg_rmw_tensix<THCON_SEC0_REG1_Row_start_section_size_ADDR32 + 3, 0, exp_threshold_rmw_mask>(exp_threshold_rmw_data);
+
+        // Encompassing word shared by unpacker thread
+        t6_mutex_acquire(mutex::REG_RMW);
+        cfg_reg_rmw_tensix<THCON_SEC0_REG1_Exp_threshold_en_ADDR32, 0, exp_threshold_rmw_mask>(exp_threshold_rmw_data);
+        t6_mutex_release(mutex::REG_RMW);
     }
 
     // Program:
@@ -390,7 +398,11 @@ inline void reconfig_packer_data_format(
         constexpr std::uint32_t exp_threshold_rmw_mask = THCON_SEC0_REG1_Exp_threshold_en_MASK | THCON_SEC0_REG1_Exp_threshold_MASK;
         std::uint32_t exp_threshold_rmw_data =
             (exp_threshold_val << THCON_SEC0_REG1_Exp_threshold_SHAMT) | (exp_threshold_en << THCON_SEC0_REG1_Exp_threshold_en_SHAMT);
-        cfg_reg_rmw_tensix<THCON_SEC0_REG1_Row_start_section_size_ADDR32 + 3, 0, exp_threshold_rmw_mask>(exp_threshold_rmw_data);
+
+        // Encompassing word shared by unpacker thread
+        t6_mutex_acquire(mutex::REG_RMW);
+        cfg_reg_rmw_tensix<THCON_SEC0_REG1_Exp_threshold_en_ADDR32, 0, exp_threshold_rmw_mask>(exp_threshold_rmw_data);
+        t6_mutex_release(mutex::REG_RMW);
     }
 
     cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG2_Dstacc_RMW>(pack_output_src_format);

--- a/tt_llk_blackhole/llk_lib/llk_unpack_common.h
+++ b/tt_llk_blackhole/llk_lib/llk_unpack_common.h
@@ -86,6 +86,12 @@ inline void _llk_unpack_reconfig_data_format_srca_impl_(
 {
     LLK_ASSERT(unpack_num_faces == 1 || unpack_num_faces == 2 || unpack_num_faces == 4, "unpack_num_faces must be 1, 2, or 4");
     TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::UNPACK0);
+
+    // Encompassing word shared by packer thread
+    t6_mutex_acquire(mutex::REG_RMW);
+    cfg_reg_rmw_tensix<THCON_SEC0_REG1_Unp_LF8_4b_exp_RMW>(((unpack_src_format & 0x1F) == (std::uint32_t)DataFormat::Fp8_e4m3) ? 1 : 0);
+    t6_mutex_release(mutex::REG_RMW);
+
     if constexpr (to_from_int8)
     {
         static_assert(is_fp32_dest_acc_en, "Reconfiguring unpack to/from Int8 formats requires FP32 Dest mode enabled");
@@ -93,10 +99,6 @@ inline void _llk_unpack_reconfig_data_format_srca_impl_(
     }
 
     cfg_reg_rmw_tensix<THCON_SEC0_REG0_TileDescriptor_ADDR32, 0, 0x0f>(unpack_src_format);
-
-    // TO DO: Enable support for this data format, without causing a race #1254
-    // Set FP8 E4M3 mode, bit is accessible by unpacker/packer
-    // cfg_reg_rmw_tensix<THCON_SEC0_REG1_Unp_LF8_4b_exp_RMW>(((unpack_src_format & 0x1F) == (uint)DataFormat::Fp8_e4m3) ? 1 : 0);
 
     cfg_reg_rmw_tensix<THCON_SEC0_REG2_Out_data_format_RMW>(unpack_dst_format);
     TT_SETDMAREG(0, LOWER_HALFWORD(tile_size), 0, LO_16(p_gpr_unpack::TILE_SIZE_A)); // update gpr which holds tile size A
@@ -134,6 +136,12 @@ inline void _llk_unpack_reconfig_data_format_srcb_impl_(
 {
     LLK_ASSERT(unpack_num_faces == 1 || unpack_num_faces == 2 || unpack_num_faces == 4, "unpack_num_faces must be 1, 2, or 4");
     TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::UNPACK1);
+
+    // Encompassing word shared by packer thread
+    t6_mutex_acquire(mutex::REG_RMW);
+    cfg_reg_rmw_tensix<THCON_SEC1_REG1_Unp_LF8_4b_exp_RMW>(((unpack_src_format & 0x1F) == (std::uint32_t)DataFormat::Fp8_e4m3) ? 1 : 0);
+    t6_mutex_release(mutex::REG_RMW);
+
     if constexpr (to_from_int8)
     {
         static_assert(is_fp32_dest_acc_en, "Reconfiguring unpack to/from Int8 formats requires FP32 Dest mode enabled");
@@ -141,10 +149,6 @@ inline void _llk_unpack_reconfig_data_format_srcb_impl_(
     }
 
     cfg_reg_rmw_tensix<THCON_SEC1_REG0_TileDescriptor_ADDR32, 0, 0x0f>(unpack_src_format);
-
-    // TO DO: Enable support for this data format, without causing a race #1254
-    // Set FP8 E4M3 mode, bit is accessible by unpacker/packer
-    // cfg_reg_rmw_tensix<THCON_SEC1_REG1_Unp_LF8_4b_exp_RMW>(((unpack_src_format & 0x1F) == (uint)DataFormat::Fp8_e4m3) ? 1 : 0);
 
     cfg_reg_rmw_tensix<THCON_SEC1_REG2_Out_data_format_RMW>(unpack_dst_format);
     TT_SETDMAREG(0, LOWER_HALFWORD(tile_size), 0, LO_16(p_gpr_unpack::TILE_SIZE_B)); // update gpr which holds tile size B


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-llk/issues/1254

### Problem description
Some of the non-thread duplicated registers are accessed by multiple threads. This one is specific to blackhole as the LF8 format was introduced and packer/unpackers registers were allocated within the same word. 

### What's changed
Made sure tensix mutex is acquired whenever the shared register word is accessed. 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Assert validation](https://github.com/tenstorrent/tt-llk/blob/main/docs/Introduction_to_asserts.md) Complied with assert doc (if applicable)
