### PR TITLE
fix: unpack workaround to use data format valid for Src reg

### DIFF
--- a/tt_llk_wormhole_b0/common/inc/cunpack_common.h
+++ b/tt_llk_wormhole_b0/common/inc/cunpack_common.h
@@ -437,6 +437,9 @@ inline void unpack_to_dest_tile_done(std::uint32_t &context_id)
     TTI_SETADCXX(p_setadc::UNP_A, FACE_C_DIM - 1, 0x0);
 
 #if TT_SIM
+
+    Compilation error
+    
     // See issue tt-llk#1398: Analyze UNPACR Wormhole behavior when using data format invalid for SrcA.
 
     // Need to make sure the data formats used are valid in SrcA.

--- a/tt_llk_wormhole_b0/common/inc/cunpack_common.h
+++ b/tt_llk_wormhole_b0/common/inc/cunpack_common.h
@@ -436,7 +436,7 @@ inline void unpack_to_dest_tile_done(std::uint32_t &context_id)
     // Due to a hardware bug (TEN-3868), we need to have one unpack-to-srcA instruction after the last unpack-to-dest instruction.
     TTI_SETADCXX(p_setadc::UNP_A, FACE_C_DIM - 1, 0x0);
 
-#if TT_SIM
+#ifdef TT_SIM
 
     Compilation error
     
@@ -453,7 +453,7 @@ inline void unpack_to_dest_tile_done(std::uint32_t &context_id)
 
     TT_UNPACR(SrcA, 0, 0, context_id, 0, 1 /* Set OvrdThreadId*/, 0 /*Set Dvalid*/, p_unpacr::RAREFYB_DISABLE, 1, 0, 0, 0, 1);
 
-#if TT_SIM
+#ifdef TT_SIM
     TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::STALL_UNPACK);
     TTI_WRCFG(p_gpr_unpack::TMP_HI, p_cfg::WRCFG_32b, THCON_SEC0_REG0_TileDescriptor_ADDR32);
     TTI_WRCFG(p_gpr_unpack::TMP_LO, p_cfg::WRCFG_32b, THCON_SEC0_REG2_Out_data_format_ADDR32);

--- a/tt_llk_wormhole_b0/common/inc/cunpack_common.h
+++ b/tt_llk_wormhole_b0/common/inc/cunpack_common.h
@@ -435,7 +435,27 @@ inline void unpack_to_dest_tile_done(std::uint32_t &context_id)
 
     // Due to a hardware bug (TEN-3868), we need to have one unpack-to-srcA instruction after the last unpack-to-dest instruction.
     TTI_SETADCXX(p_setadc::UNP_A, FACE_C_DIM - 1, 0x0);
+
+#if TT_SIM
+    // See issue tt-llk#1398: Analyze UNPACR Wormhole behavior when using data format invalid for SrcA.
+
+    // Need to make sure the data formats used are valid in SrcA.
+    // Temporarily change in/out formats to UInt16
+    TTI_RDCFG(p_gpr_unpack::TMP_LO, THCON_SEC0_REG2_Out_data_format_ADDR32);
+    TTI_RDCFG(p_gpr_unpack::TMP_HI, THCON_SEC0_REG0_TileDescriptor_ADDR32);
+    cfg_reg_rmw_tensix<THCON_SEC0_REG2_Out_data_format_RMW>(to_underlying(DataFormat::UInt16));
+    cfg_reg_rmw_tensix<THCON_SEC0_REG0_TileDescriptor_ADDR32, 0, 0xF>(to_underlying(DataFormat::UInt16));
+    TTI_STALLWAIT(p_stall::STALL_UNPACK, p_stall::STALL_CFG);
+#endif
+
     TT_UNPACR(SrcA, 0, 0, context_id, 0, 1 /* Set OvrdThreadId*/, 0 /*Set Dvalid*/, p_unpacr::RAREFYB_DISABLE, 1, 0, 0, 0, 1);
+
+#if TT_SIM
+    TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::STALL_UNPACK);
+    TTI_WRCFG(p_gpr_unpack::TMP_HI, p_cfg::WRCFG_32b, THCON_SEC0_REG0_TileDescriptor_ADDR32);
+    TTI_WRCFG(p_gpr_unpack::TMP_LO, p_cfg::WRCFG_32b, THCON_SEC0_REG2_Out_data_format_ADDR32);
+#endif
+
     TTI_SETADCXX(p_setadc::UNP_A, FACE_R_DIM * FACE_C_DIM - 1, 0x0);
 }
 


### PR DESCRIPTION
### Ticket
<!-- Link to Github Issue -->

### Problem description
<!-- Provide context for the problem. -->

### What's changed
<!-- Describe the approach used to solve the problem.
Summarize the changes made and its impact. -->

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Assert validation](https://github.com/tenstorrent/tt-llk/blob/main/docs/Introduction_to_asserts.md) Complied with assert doc (if applicable)
