### PR TITLE
fixup :pencil2:: make load/store blocking accept template

### DIFF
--- a/tt_llk_blackhole/common/inc/ckernel.h
+++ b/tt_llk_blackhole/common/inc/ckernel.h
@@ -98,7 +98,7 @@ namespace internal
  * @param ptr address to read from
  * @return value read from the address
  */
-template <typename T, typename = std::enable_if_t<std::is_trivially_copyable<T>::value>>
+template <typename T, typename = std::enable_if_t<std::is_trivially_copyable_v<T>>>
 inline T load_blocking(volatile T *ptr)
 {
     static_assert(sizeof(T) == sizeof(std::uint32_t), "load_blocking: operand must be 32-bit");
@@ -135,7 +135,7 @@ inline T load_blocking(volatile T *ptr)
  * @param ptr address to write to
  * @param val value to write
  */
-template <typename T, typename U, typename = std::enable_if_t<std::is_trivially_copyable<T>::value && std::is_trivially_assignable<T &, U>::value>>
+template <typename T, typename U, typename = std::enable_if_t<std::is_trivially_copyable_v<T> && std::is_trivially_assignable_v<T &, U>>>
 inline void store_blocking(volatile T *ptr, U &&val)
 {
     static_assert(sizeof(T) == sizeof(std::uint32_t), "store_blocking: operand must be 32-bit");

--- a/tt_llk_wormhole_b0/common/inc/ckernel.h
+++ b/tt_llk_wormhole_b0/common/inc/ckernel.h
@@ -89,7 +89,7 @@ namespace internal
  * @param ptr address to read from
  * @return value read from the address
  */
-template <typename T, typename = std::enable_if_t<std::is_trivially_copyable<T>::value>>
+template <typename T, typename = std::enable_if_t<std::is_trivially_copyable_v<T>>>
 inline T load_blocking(volatile T *ptr)
 {
     static_assert(sizeof(T) == sizeof(std::uint32_t), "load_blocking: operand must be 32-bit");
@@ -128,7 +128,7 @@ inline T load_blocking(volatile T *ptr)
  * @param ptr address to write to
  * @param val value to write
  */
-template <typename T, typename U, typename = std::enable_if_t<std::is_trivially_copyable<T>::value && std::is_trivially_assignable<T &, U>::value>>
+template <typename T, typename U, typename = std::enable_if_t<std::is_trivially_copyable_v<T> && std::is_trivially_assignable_v<T &, U>>>
 inline void store_blocking(volatile T *ptr, U &&val)
 {
     static_assert(sizeof(T) == sizeof(std::uint32_t), "store_blocking: operand must be 32-bit");


### PR DESCRIPTION
### Ticket
<!-- Link to Github Issue -->

### Problem description
<!-- Provide context for the problem. -->
Expands the `load_blocking` and `store_blocking` APIs to accept templates to make use cases with enum classes more ergonomic, as well as mixing integral types.

### What's changed
<!-- Describe the approach used to solve the problem.
Summarize the changes made and its impact. -->

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Assert validation](https://github.com/tenstorrent/tt-llk/blob/main/docs/Introduction_to_asserts.md) Complied with assert doc (if applicable)
