### PR TITLE
Add fp32_dest setter for packer

### DIFF
--- a/tt_llk_blackhole/llk_lib/llk_pack.h
+++ b/tt_llk_blackhole/llk_lib/llk_pack.h
@@ -336,6 +336,12 @@ inline void _llk_pack_reconfig_data_format_(
     }
 }
 
+inline void _llk_pack_set_fp32_dest_acc_(bool enable)
+{
+    TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::PACK);
+    cfg_reg_rmw_tensix<PCK_DEST_RD_CTRL_Read_32b_data_RMW>(enable);
+}
+
 template <bool is_fp32_dest_acc_en, bool untilize = false, bool tilize = false>
 inline void _llk_pack_hw_configure_(
     const std::uint32_t pack_src_format,

--- a/tt_llk_wormhole_b0/llk_lib/llk_pack.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_pack.h
@@ -122,6 +122,12 @@ inline void _llk_pack_reconfig_data_format_(
     }
 }
 
+inline void _llk_pack_set_fp32_dest_acc_(bool enable)
+{
+    TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::PACK);
+    cfg_reg_rmw_tensix<PCK_DEST_RD_CTRL_Read_32b_data_RMW>(enable);
+}
+
 template <bool is_fp32_dest_acc_en, bool untilize = false>
 inline void _llk_pack_hw_configure_(
     const std::uint32_t pack_src_format,


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/38923

### Problem description
To support the Deepseek effort, we need to implement API that allows the users to enable/disable float32 individually and add proper LLK support.

### What's changed
While the https://github.com/tenstorrent/tt-llk/pull/1386 added support for the MATH thread, this PR does the same for the PACK thread - introduces LLK functions to configure `fp32_dest_acc` on for packer. 

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Assert validation](https://github.com/tenstorrent/tt-llk/blob/main/docs/Introduction_to_asserts.md) Complied with assert doc (if applicable)
