### PR TITLE
[Quasar] Rename REDUCE_DIM to REDUCE_DIMENSION

### DIFF
--- a/tt_llk_quasar/llk_lib/llk_math_reduce.h
+++ b/tt_llk_quasar/llk_lib/llk_math_reduce.h
@@ -288,26 +288,27 @@ inline void _llk_math_reduce_scalar_mop_config_(const TileShape& tile_shape)
 
 /**
  * @brief Sets up addrmods for reduce operations
- * @tparam REDUCE_DIM: Sets the reduce dimension, values = [REDUCE_ROW, REDUCE_COL, REDUCE_SCALAR]
+ * @tparam REDUCE_DIMENSION: Sets the reduce dimension, values = [REDUCE_ROW, REDUCE_COL, REDUCE_SCALAR]
  * @tparam MATH_FIDELITY_TYPE: Only works for AVG/SUM pool types, shows how many loops
  * to use full precision with of Source register datums with multiplies, values = [LoFi, HiFi2, HiFi3, HiFi4]
  */
-template <ReduceDim REDUCE_DIM, ckernel::MathFidelity MATH_FIDELITY_TYPE>
+template <ReduceDim REDUCE_DIMENSION, ckernel::MathFidelity MATH_FIDELITY_TYPE>
 inline void _llk_math_reduce_addrmod_()
 {
     constexpr bool high_fidelity               = MATH_FIDELITY_TYPE != ckernel::MathFidelity::LoFi;
     constexpr std::uint32_t fidelity_increment = high_fidelity ? 1 : 0;
 
-    addr_mod_t {.srca = {.incr = 0}, .srcb = {.incr = 0}, .dest = {.incr = ((REDUCE_DIM == ReduceDim::REDUCE_COL) ? 16 : 0)}, .fidelity = {.incr = 0, .clr = 1}}
+    addr_mod_t {
+        .srca = {.incr = 0}, .srcb = {.incr = 0}, .dest = {.incr = ((REDUCE_DIMENSION == ReduceDim::REDUCE_COL) ? 16 : 0)}, .fidelity = {.incr = 0, .clr = 1}}
         .set(ADDR_MOD_0);
 
     addr_mod_t {.srca = {.incr = 0}, .srcb = {.incr = 0}, .dest = {.incr = 0}, .fidelity = {.incr = fidelity_increment}}.set(ADDR_MOD_2);
 
-    if constexpr (REDUCE_DIM == ReduceDim::REDUCE_COL)
+    if constexpr (REDUCE_DIMENSION == ReduceDim::REDUCE_COL)
     {
         addr_mod_t {.srca = {.incr = 0}, .srcb = {.incr = 0}, .dest = {.incr = 0, .clr = 1}, .fidelity = {.incr = 0, .clr = 1}}.set(ADDR_MOD_1);
     }
-    else if constexpr (REDUCE_DIM == ReduceDim::REDUCE_ROW)
+    else if constexpr (REDUCE_DIMENSION == ReduceDim::REDUCE_ROW)
     {
         addr_mod_t {
             .srca = {.incr = 0},
@@ -321,25 +322,25 @@ inline void _llk_math_reduce_addrmod_()
 /**
  * @brief Sets up mop config for reduce operations
  * @tparam POOL_TYPE: Type of reduce pool op, values = [MAX, SUM, AVG]
- * @tparam REDUCE_DIM: Sets the reduce dimension, values = [REDUCE_ROW, REDUCE_COL, REDUCE_SCALAR]
+ * @tparam REDUCE_DIMENSION: Sets the reduce dimension, values = [REDUCE_ROW, REDUCE_COL, REDUCE_SCALAR]
  * @tparam MATH_FIDELITY_TYPE: Only works for AVG/SUM pool types, shows how many loops
  * to use full precision with of Source register datums with multiplies, values = [LoFi, HiFi2, HiFi3, HiFi4]
  * @param tile_shape: Contains all the information of the tile shape: num faces, face row/col dim, etc
  */
-template <PoolType POOL_TYPE, ReduceDim REDUCE_DIM, ckernel::MathFidelity MATH_FIDELITY_TYPE>
+template <PoolType POOL_TYPE, ReduceDim REDUCE_DIMENSION, ckernel::MathFidelity MATH_FIDELITY_TYPE>
 inline void _llk_math_reduce_init_(const TileShape& tile_shape)
 {
-    _llk_math_reduce_addrmod_<REDUCE_DIM, MATH_FIDELITY_TYPE>();
+    _llk_math_reduce_addrmod_<REDUCE_DIMENSION, MATH_FIDELITY_TYPE>();
 
-    if constexpr (REDUCE_DIM == ReduceDim::REDUCE_COL)
+    if constexpr (REDUCE_DIMENSION == ReduceDim::REDUCE_COL)
     {
         _llk_math_reduce_col_mop_config_<POOL_TYPE, MATH_FIDELITY_TYPE>(tile_shape);
     }
-    else if constexpr (REDUCE_DIM == ReduceDim::REDUCE_ROW)
+    else if constexpr (REDUCE_DIMENSION == ReduceDim::REDUCE_ROW)
     {
         _llk_math_reduce_row_mop_config_<POOL_TYPE, MATH_FIDELITY_TYPE>(tile_shape);
     }
-    else if constexpr (REDUCE_DIM == ReduceDim::REDUCE_SCALAR)
+    else if constexpr (REDUCE_DIMENSION == ReduceDim::REDUCE_SCALAR)
     {
         _llk_math_reduce_scalar_mop_config_<POOL_TYPE, MATH_FIDELITY_TYPE>(tile_shape);
     }

--- a/tt_llk_quasar/llk_lib/llk_pack_common.h
+++ b/tt_llk_quasar/llk_lib/llk_pack_common.h
@@ -65,9 +65,9 @@ inline void _llk_pack_dest_dvalid_section_done_()
 
 /**
  * @brief Configure packer edge mask programming for packer 0 with reduce operations
- * @tparam REDUCE_DIM: The reduce op dimension, values = [REDUCE_ROW, REDUCE_COL, REDUCE_SCALAR]
+ * @tparam REDUCE_DIMENSION: The reduce op dimension, values = [REDUCE_ROW, REDUCE_COL, REDUCE_SCALAR]
  **/
-template <ReduceDim REDUCE_DIM>
+template <ReduceDim REDUCE_DIMENSION>
 inline void _llk_pack_reduce_mask_config_()
 {
     // Wait for packer to finish to avoid breaking its current configuration
@@ -79,7 +79,7 @@ inline void _llk_pack_reduce_mask_config_()
 
     // TODO: (RT) Clean this up using pack edge struct to match addresses
     //  Make it unified
-    if constexpr (REDUCE_DIM == ReduceDim::REDUCE_ROW)
+    if constexpr (REDUCE_DIMENSION == ReduceDim::REDUCE_ROW)
     {
         // This register specifies which datums will not have the mask applied
         // The register is 16 bits, each bit corresponds to a datum in the 1x16 row in dest
@@ -92,7 +92,7 @@ inline void _llk_pack_reduce_mask_config_()
         cfg_rmw(THCON_PACKER0_REG2_EDGE_MASK_SELECT_FACE0_RMW, 0x55555555);
         cfg_rmw(THCON_PACKER0_REG2_EDGE_MASK_SELECT_FACE2_RMW, 0x55555555);
     }
-    else if constexpr (REDUCE_DIM == ReduceDim::REDUCE_COL)
+    else if constexpr (REDUCE_DIMENSION == ReduceDim::REDUCE_COL)
     {
         // The below mask mean all datums in a row preserve their value
         cfg_rmw(THCON_PACKER0_REG1_EDGE_MASK1_RMW, 0x0000);

--- a/tt_llk_quasar/llk_lib/llk_unpack_reduce.h
+++ b/tt_llk_quasar/llk_lib/llk_unpack_reduce.h
@@ -14,7 +14,7 @@ using namespace ckernel;
  * @brief MOP configuration for unpack reduce operations
  * @details Sets up MOP for unpacking for reduce operations, which unpacks
  * tile for SrcA, and a single face for SrcB
- * @tparam REDUCE_DIM: Sets the reduce dimension, values = [REDUCE_ROW, REDUCE_COL, REDUCE_SCALAR]
+ * @tparam REDUCE_DIMENSION: Sets the reduce dimension, values = [REDUCE_ROW, REDUCE_COL, REDUCE_SCALAR]
  * buf_desc_id_0 will be used for UNPACKER0 -> SRCA
  * buf_desc_id_1 will be used for UNPACKER1 -> SRCB
  * @param buf_desc_id_0/1: The buffer descriptor ID where the buffer information is
@@ -22,7 +22,7 @@ using namespace ckernel;
  * @param tile_shape: Contains all the information of the tile shape: num faces, face row/col dim, etc
  * @param num_tiles: number of tiles to unpack at a time for SrcA, SrcB will only have first face unpacked
  */
-template <ReduceDim REDUCE_DIM>
+template <ReduceDim REDUCE_DIMENSION>
 inline void _llk_unpack_reduce_mop_config_(
     const std::uint32_t buf_desc_id_0, const std::uint32_t buf_desc_id_1, const TileShape& tile_shape, const std::uint32_t num_tiles)
 {
@@ -34,7 +34,7 @@ inline void _llk_unpack_reduce_mop_config_(
 
     ckernel_template temp(MOP_OUTER_LOOP, MOP_INNER_LOOP, unpack_srcA_face);
 
-    if constexpr (REDUCE_DIM == ReduceDim::REDUCE_SCALAR)
+    if constexpr (REDUCE_DIMENSION == ReduceDim::REDUCE_SCALAR)
     {
         // Need to zero out srcA first, because math will do some copying over to SrcA later
         constexpr static std::uint32_t unpack_zero_srcA =
@@ -50,7 +50,7 @@ inline void _llk_unpack_reduce_mop_config_(
  * @brief MOP configuration for unpack reduce operations
  * @details Sets up MOP for unpacking for reduce operations, which unpacks
  * tile for SrcA, and a single face for SrcB
- * @tparam REDUCE_DIM: Sets the reduce dimension, values = [REDUCE_ROW, REDUCE_COL, REDUCE_SCALAR]
+ * @tparam REDUCE_DIMENSION: Sets the reduce dimension, values = [REDUCE_ROW, REDUCE_COL, REDUCE_SCALAR]
  * buf_desc_id_0 will be used for UNPACKER0 -> SRCA
  * buf_desc_id_1 will be used for UNPACKER1 -> SRCB
  * @param buf_desc_id_0/1: The buffer descriptor ID where the buffer information is
@@ -58,13 +58,13 @@ inline void _llk_unpack_reduce_mop_config_(
  * @param tile_shape: Contains all the information of the tile shape: num faces, face row/col dim, etc
  * @param num_tiles: number of tiles to unpack at a time for SrcA, SrcB will only have first face unpacked
  */
-template <ReduceDim REDUCE_DIM>
+template <ReduceDim REDUCE_DIMENSION>
 inline void _llk_unpack_reduce_init_(
     const std::uint32_t buf_desc_id_0, const std::uint32_t buf_desc_id_1, const TileShape& tile_shape, const std::uint32_t num_tiles = NUM_TILES)
 {
-    cfg_rmw(THCON_UNPACKER0_REG0_TRANSPOSE_RMW, (REDUCE_DIM == ReduceDim::REDUCE_ROW));
+    cfg_rmw(THCON_UNPACKER0_REG0_TRANSPOSE_RMW, (REDUCE_DIMENSION == ReduceDim::REDUCE_ROW));
 
-    _llk_unpack_reduce_mop_config_<REDUCE_DIM>(buf_desc_id_0, buf_desc_id_1, tile_shape, num_tiles);
+    _llk_unpack_reduce_mop_config_<REDUCE_DIMENSION>(buf_desc_id_0, buf_desc_id_1, tile_shape, num_tiles);
 }
 
 /**


### PR DESCRIPTION
### Ticket
<!-- Link to Github Issue -->

### Problem description
The define for reduce dimension in tt-metal is named REDUCE_DIM. Because the template argument and the define have the same name, the template argument ReduceDim REDUCE_DIM expands to e.g. ReduceDim ReduceDim::REDUCE_ROW, which does not compile. 

### What's changed
Rename REDUCE_DIM template argument to REDUCE_DIMENSION.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Assert validation](https://github.com/tenstorrent/tt-llk/blob/main/docs/Introduction_to_asserts.md) Complied with assert doc (if applicable)
