### PR TITLE
Fix build break caused by adding LLK_ASSERT in ckernel_structs.h

### DIFF
--- a/tt_llk_blackhole/common/inc/ckernel_structs.h
+++ b/tt_llk_blackhole/common/inc/ckernel_structs.h
@@ -28,7 +28,6 @@ struct semaphore
 
     constexpr static std::uint16_t t6_sem(const std::uint8_t sem_index)
     {
-        LLK_ASSERT(sem_index < NUM_SEMAPHORES, "Semaphore index out of bounds.");
         return (1 << sem_index);
     }
 };

--- a/tt_llk_wormhole_b0/common/inc/ckernel_structs.h
+++ b/tt_llk_wormhole_b0/common/inc/ckernel_structs.h
@@ -28,7 +28,6 @@ struct semaphore
 
     constexpr static std::uint16_t t6_sem(const std::uint8_t sem_index)
     {
-        LLK_ASSERT(sem_index < NUM_SEMAPHORES, "Semaphore index out of bounds");
         return (1 << sem_index);
     }
 };


### PR DESCRIPTION
### Ticket
#0

### Problem description
https://github.com/tenstorrent/tt-llk/pull/1401 PR introduced some new LLK_ASSERT-s but the asserts added in ckernel_structs.h are causing build breaks when uplifting LLK to Metal.

### What's changed
Fixing build breaks by erasing the asserts.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Assert validation](https://github.com/tenstorrent/tt-llk/blob/main/docs/Introduction_to_asserts.md) Complied with assert doc (if applicable)
