### PR TITLE
[Quasar] Replace SFPMUL with SFPMOV to save 1 cycle in sigmoid

### DIFF
--- a/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_sigmoid.h
+++ b/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_sigmoid.h
@@ -21,10 +21,10 @@ inline void _calculate_sigmoid_regs_(const std::uint32_t src_reg, const std::uin
 {
     // ALthough SFPMUL/SFPADD are 2 cycle instructions, we don't need a TTI_NOP
     // because the hardware implicitly stalls if the next instruction depends on results
-    TTI_SFPMUL(src_reg, p_sfpu::LCONST_neg1, p_sfpu::LCONST_0, work_reg, 0); // Multiply src_reg * -1, store result in work_reg, takes 2 cycles
-    TTI_SFPNONLINEAR(work_reg, dest_reg, p_sfpnonlinear::EXP_MODE);          // Read value from work_reg, take exponential, load back into dest_reg
-    TTI_SFPADD(p_sfpu::LCONST_1, dest_reg, p_sfpu::LCONST_1, work_reg, 0);   // Add 1 to dest_reg, store in work_reg, takes 2 cycles
-    TTI_SFPNONLINEAR(work_reg, dest_reg, p_sfpnonlinear::RECIP_MODE);        // Read value from work_reg, approximate recip, load back into dest_reg
+    TTI_SFPMOV(src_reg, work_reg, 1);                                      // Copy src_reg to work_reg and invert sign bit (take negative of input)
+    TTI_SFPNONLINEAR(work_reg, dest_reg, p_sfpnonlinear::EXP_MODE);        // Read value from work_reg, take exponential, load back into dest_reg
+    TTI_SFPADD(p_sfpu::LCONST_1, dest_reg, p_sfpu::LCONST_1, work_reg, 0); // Add 1 to dest_reg, store in work_reg, takes 2 cycles
+    TTI_SFPNONLINEAR(work_reg, dest_reg, p_sfpnonlinear::RECIP_MODE);      // Read value from work_reg, approximate recip, load back into dest_reg
 }
 
 // Calculates SIGMOID for number of rows of output SFPU ops (Quasar = 2 rows)


### PR DESCRIPTION
### Ticket
<!-- Link to Github Issue -->
n/a
### Problem description
<!-- Provide context for the problem. -->
SFPMUL takes 2 cycles to execute, we can save time by replacing a "multiply by -1" with SFPMOV "copy value and invert sign bit"
### What's changed
<!-- Describe the approach used to solve the problem.
Summarize the changes made and its impact. -->
Replaces call to SFPMUL in sigmoid with SFPMOV

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Assert validation](https://github.com/tenstorrent/tt-llk/blob/main/docs/Introduction_to_asserts.md) Complied with assert doc (if applicable)
