### PR TITLE
Fix wrongly introduced changes to llk_math_commit

### DIFF
--- a/tt_llk_blackhole/llk_lib/llk_math_common.h
+++ b/tt_llk_blackhole/llk_lib/llk_math_common.h
@@ -39,9 +39,10 @@ inline void _llk_math_hw_configure_(const std::uint32_t srca_data_format, const 
     // Configure ZEROACC to auto-detect destination bank (non-legacy mode).
     cfg_reg_rmw_tensix<DEST_ACCESS_CFG_zeroacc_absolute_tile_mode_RMW>(0);
     TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::MATH);
-    std::uint32_t int8_math_enabled =
-        ((srca_data_format & 0xF) == ckernel::to_underlying(DataFormat::Int8)) || ((srcb_data_format & 0xF) == ckernel::to_underlying(DataFormat::Int8)) ||
-        (srca_data_format == ckernel::to_underlying(DataFormat::Int32)) || (srcb_data_format == ckernel::to_underlying(DataFormat::Int32));
+    std::uint32_t int8_math_enabled = (masked_data_format(srca_data_format) == ckernel::to_underlying(DataFormat::Int8)) ||
+                                      (masked_data_format(srcb_data_format) == ckernel::to_underlying(DataFormat::Int8)) ||
+                                      (srca_data_format == ckernel::to_underlying(DataFormat::Int32)) ||
+                                      (srcb_data_format == ckernel::to_underlying(DataFormat::Int32));
     cfg_reg_rmw_tensix<ALU_ACC_CTRL_INT8_math_enabled_RMW>(int8_math_enabled);
 
     cfg_reg_rmw_tensix<ALU_ACC_CTRL_Fp32_enabled_RMW>(is_fp32_dest_acc_en);
@@ -156,8 +157,8 @@ inline void _llk_math_reconfig_data_format_srca_(const std::uint32_t srca_data_f
     {
         static_assert(is_fp32_dest_acc_en, "Reconfiguring math to/from Int8 formats requires FP32 Dest mode enabled");
         TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::MATH);
-        std::uint32_t int8_math_enabled =
-            ((srca_data_format & 0xF) == ckernel::to_underlying(DataFormat::Int8)) || (srca_data_format == ckernel::to_underlying(DataFormat::Int32));
+        std::uint32_t int8_math_enabled = (masked_data_format(srca_data_format) == ckernel::to_underlying(DataFormat::Int8)) ||
+                                          (srca_data_format == ckernel::to_underlying(DataFormat::Int32));
         cfg_reg_rmw_tensix<ALU_ACC_CTRL_INT8_math_enabled_RMW>(int8_math_enabled);
     }
 }
@@ -169,8 +170,8 @@ inline void _llk_math_reconfig_data_format_srcb_(const std::uint32_t srcb_data_f
     {
         static_assert(is_fp32_dest_acc_en, "Reconfiguring math to/from Int8 formats requires FP32 Dest mode enabled");
         TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::MATH);
-        std::uint32_t int8_math_enabled =
-            ((srcb_data_format & 0xF) == ckernel::to_underlying(DataFormat::Int8)) || (srcb_data_format == ckernel::to_underlying(DataFormat::Int32));
+        std::uint32_t int8_math_enabled = (masked_data_format(srcb_data_format) == ckernel::to_underlying(DataFormat::Int8)) ||
+                                          (srcb_data_format == ckernel::to_underlying(DataFormat::Int32));
         cfg_reg_rmw_tensix<ALU_ACC_CTRL_INT8_math_enabled_RMW>(int8_math_enabled);
     }
 }
@@ -182,9 +183,10 @@ inline void _llk_math_reconfig_data_format_(const std::uint32_t srca_data_format
     {
         static_assert(is_fp32_dest_acc_en, "Reconfiguring math to/from Int8 formats requires FP32 Dest mode enabled");
         TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::MATH);
-        std::uint32_t int8_math_enabled =
-            ((srca_data_format & 0xF) == ckernel::to_underlying(DataFormat::Int8)) || ((srcb_data_format & 0xF) == ckernel::to_underlying(DataFormat::Int8)) ||
-            (srca_data_format == ckernel::to_underlying(DataFormat::Int32)) || (srcb_data_format == ckernel::to_underlying(DataFormat::Int32));
+        std::uint32_t int8_math_enabled = (masked_data_format(srca_data_format) == ckernel::to_underlying(DataFormat::Int8)) ||
+                                          (masked_data_format(srcb_data_format) == ckernel::to_underlying(DataFormat::Int8)) ||
+                                          (srca_data_format == ckernel::to_underlying(DataFormat::Int32)) ||
+                                          (srcb_data_format == ckernel::to_underlying(DataFormat::Int32));
         cfg_reg_rmw_tensix<ALU_ACC_CTRL_INT8_math_enabled_RMW>(int8_math_enabled);
     }
 }

--- a/tt_llk_wormhole_b0/llk_lib/llk_math_common.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_math_common.h
@@ -37,9 +37,9 @@ template <bool is_fp32_dest_acc_en = false>
 inline void _llk_math_hw_configure_(const std::uint32_t srca_data_format, const std::uint32_t srcb_data_format)
 {
     TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::MATH | p_stall::WAIT_SFPU);
-    std::uint32_t int8_math_enabled = ((srca_data_format & 0xF) == to_underlying(DataFormat::Int8)) ||
-                                      ((srcb_data_format & 0xF) == to_underlying(DataFormat::Int8)) || (srca_data_format == to_underlying(DataFormat::Int32)) ||
-                                      (srcb_data_format == to_underlying(DataFormat::Int32));
+    std::uint32_t int8_math_enabled = (masked_data_format(srca_data_format) == to_underlying(DataFormat::Int8)) ||
+                                      (masked_data_format(srcb_data_format) == to_underlying(DataFormat::Int8)) ||
+                                      (srca_data_format == to_underlying(DataFormat::Int32)) || (srcb_data_format == to_underlying(DataFormat::Int32));
     std::uint32_t config_data = (srca_data_format << ALU_FORMAT_SPEC_REG0_SrcA_SHAMT) | (srcb_data_format << ALU_FORMAT_SPEC_REG1_SrcB_SHAMT) |
                                 (int8_math_enabled << ALU_ACC_CTRL_INT8_math_enabled_SHAMT);
     constexpr std::uint32_t config_mask = ALU_FORMAT_SPEC_REG0_SrcA_MASK | ALU_FORMAT_SPEC_REG1_SrcB_MASK | ALU_ACC_CTRL_INT8_math_enabled_MASK;
@@ -144,7 +144,7 @@ inline void _llk_math_reconfig_data_format_srca_(const std::uint32_t srca_data_f
         static_assert(is_fp32_dest_acc_en, "Reconfiguring math to/from Int8 formats requires FP32 Dest mode enabled");
         TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::MATH | p_stall::WAIT_SFPU);
         std::uint32_t int8_math_enabled =
-            ((srca_data_format & 0xF) == to_underlying(DataFormat::Int8)) || (srca_data_format == to_underlying(DataFormat::Int32));
+            (masked_data_format(srca_data_format) == to_underlying(DataFormat::Int8)) || (srca_data_format == to_underlying(DataFormat::Int32));
         std::uint32_t config_data = (srca_data_format << ALU_FORMAT_SPEC_REG0_SrcA_SHAMT) | (int8_math_enabled << ALU_ACC_CTRL_INT8_math_enabled_SHAMT);
         constexpr std::uint32_t config_mask = ALU_FORMAT_SPEC_REG0_SrcA_MASK | ALU_ACC_CTRL_INT8_math_enabled_MASK;
         cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG0_SrcA_ADDR32, 0, config_mask>(config_data);
@@ -164,7 +164,7 @@ inline void _llk_math_reconfig_data_format_srcb_(const std::uint32_t srcb_data_f
         static_assert(is_fp32_dest_acc_en, "Reconfiguring math to/from Int8 formats requires FP32 Dest mode enabled");
         TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::MATH | p_stall::WAIT_SFPU);
         std::uint32_t int8_math_enabled =
-            ((srcb_data_format & 0xF) == to_underlying(DataFormat::Int8)) || (srcb_data_format == to_underlying(DataFormat::Int32));
+            (masked_data_format(srcb_data_format) == to_underlying(DataFormat::Int8)) || (srcb_data_format == to_underlying(DataFormat::Int32));
         std::uint32_t config_data = (srcb_data_format << ALU_FORMAT_SPEC_REG1_SrcB_SHAMT) | (int8_math_enabled << ALU_ACC_CTRL_INT8_math_enabled_SHAMT);
         constexpr std::uint32_t config_mask = ALU_FORMAT_SPEC_REG1_SrcB_MASK | ALU_ACC_CTRL_INT8_math_enabled_MASK;
         cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG1_SrcB_ADDR32, 0, config_mask>(config_data);
@@ -183,8 +183,8 @@ inline void _llk_math_reconfig_data_format_(const std::uint32_t srca_data_format
     {
         static_assert(is_fp32_dest_acc_en, "Reconfiguring math to/from Int8 formats requires FP32 Dest mode enabled");
         TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::MATH | p_stall::WAIT_SFPU);
-        std::uint32_t int8_math_enabled = ((srca_data_format & 0xF) == to_underlying(DataFormat::Int8)) ||
-                                          ((srcb_data_format & 0xF) == to_underlying(DataFormat::Int8)) ||
+        std::uint32_t int8_math_enabled = (masked_data_format(srca_data_format) == to_underlying(DataFormat::Int8)) ||
+                                          (masked_data_format(srcb_data_format) == to_underlying(DataFormat::Int8)) ||
                                           (srca_data_format == to_underlying(DataFormat::Int32)) || (srcb_data_format == to_underlying(DataFormat::Int32));
         std::uint32_t config_data = (srca_data_format << ALU_FORMAT_SPEC_REG0_SrcA_SHAMT) | (srcb_data_format << ALU_FORMAT_SPEC_REG1_SrcB_SHAMT) |
                                     (int8_math_enabled << ALU_ACC_CTRL_INT8_math_enabled_SHAMT);


### PR DESCRIPTION
### Ticket
<!-- Link to Github Issue -->

### Problem description
In PR https://github.com/tenstorrent/tt-llk/pull/1415 there was introduced fixes for verifying correct configuration and refactoring around bit masking data formats. However, in llk_math_common.h the refactor was not correctly done and unnecessary mask was introduced causing wrong calculation of int8_math_enabled flag.

### What's changed
Fixed calculation of int8_math_enabled flag. Data format is masked only where needed - for checking on Int8 and removed on checking for Int32.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Assert validation](https://github.com/tenstorrent/tt-llk/blob/main/docs/Introduction_to_asserts.md) Complied with assert doc (if applicable)
