### PR TITLE
replaced hardcoded 0b011 values with named equivalent from `p_setadc`

### DIFF
--- a/tt_llk_blackhole/common/inc/cunpack_common.h
+++ b/tt_llk_blackhole/common/inc/cunpack_common.h
@@ -116,8 +116,8 @@ typedef union
 // Set unpacker offsets to 0, except for unpacker 0, channel 1, X, which is the tile X dimension
 inline void unpacker_addr_counter_init()
 {
-    TTI_SETADCXY(0b011, 0, 0, 0, 0, 0b1011);
-    TTI_SETADCZW(0b011, 0, 0, 0, 0, 0b1111);
+    TTI_SETADCXY(p_setadc::UNP_A | p_setadc::UNP_B, 0, 0, 0, 0, 0b1011);
+    TTI_SETADCZW(p_setadc::UNP_A | p_setadc::UNP_B, 0, 0, 0, 0, 0b1111);
 }
 
 inline void unpacker_iteration_cleanup(std::uint32_t &context)

--- a/tt_llk_wormhole_b0/common/inc/cunpack_common.h
+++ b/tt_llk_wormhole_b0/common/inc/cunpack_common.h
@@ -117,8 +117,8 @@ typedef union
 // Set unpacker offsets to 0, except for unpacker 0, channel 1, X, which is the tile X dimension
 inline void unpacker_addr_counter_init()
 {
-    TTI_SETADCXY(0b011, 0, 0, 0, 0, 0b1011);
-    TTI_SETADCZW(0b011, 0, 0, 0, 0, 0b1111);
+    TTI_SETADCXY(p_setadc::UNP_A | p_setadc::UNP_B, 0, 0, 0, 0, 0b1011);
+    TTI_SETADCZW(p_setadc::UNP_A | p_setadc::UNP_B, 0, 0, 0, 0, 0b1111);
 }
 
 inline void unpacker_iteration_cleanup(std::uint32_t &context)


### PR DESCRIPTION
### Ticket
na

### Problem description
similar to many existing places across the codebase ([example](https://github.com/tenstorrent/tt-llk/blob/410c555c71e07c4a5f06bd4d793e0e729a1ddf40/tt_llk_wormhole_b0/common/inc/cunpack_common.h#L437)) i propose to replace hardcoded raw values like 0b011 with a more descriptive named variable which make it significantly easier to understand what that particular values means / refers to

### What's changed
replaced hardcoded 0b011 values with named equivalent from `p_setadc`

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Assert validation](https://github.com/tenstorrent/tt-llk/blob/main/docs/Introduction_to_asserts.md) Complied with assert doc (if applicable)
