### PR TITLE
using `_llk_unpack_configure_single_address_` for unpacker0 l1 address configuration

### DIFF
--- a/tt_llk_blackhole/llk_lib/experimental/llk_unpack_A_custom.h
+++ b/tt_llk_blackhole/llk_lib/experimental/llk_unpack_A_custom.h
@@ -37,8 +37,7 @@ inline void _llk_unpack_A_custom_(const std::uint32_t address, const std::uint32
     // Wait for free context
     wait_for_next_context(2);
 
-    const std::uint32_t upk0_reg = (unp_cfg_context == 0) ? THCON_SEC0_REG3_Base_address_ADDR32 : THCON_SEC0_REG3_Base_cntx1_address_ADDR32;
-    cfg[upk0_reg]                = address;
+    _llk_unpack_configure_single_address_<p_setadc::UNP_A>(address, cfg);
 
     // Trisc::SEMPOST for context acquire
     semaphore_post(semaphore::UNPACK_SYNC);

--- a/tt_llk_blackhole/llk_lib/llk_unpack_A.h
+++ b/tt_llk_blackhole/llk_lib/llk_unpack_A.h
@@ -259,12 +259,11 @@ inline void _llk_unpack_A_(const std::uint32_t address, const std::uint32_t unpa
     // Set upk0/1 L1 read addr
     if constexpr (((BType == BroadcastType::NONE) && (!acc_to_dest)) || binary_reuse_dest == EltwiseBinaryReuseDestType::DEST_TO_SRCB || unpack_to_dest)
     {
-        _llk_unpack_configure_single_address_(address, cfg);
+        _llk_unpack_configure_single_address_<p_setadc::UNP_A>(address, cfg);
     }
     else
     {
-        const std::uint32_t upk1_reg = (unp_cfg_context == 0) ? THCON_SEC1_REG3_Base_address_ADDR32 : THCON_SEC1_REG3_Base_cntx1_address_ADDR32;
-        cfg[upk1_reg]                = address;
+        _llk_unpack_configure_single_address_<p_setadc::UNP_B>(address, cfg);
     }
 
     // Trisc::SEMPOST for context acquire

--- a/tt_llk_blackhole/llk_lib/llk_unpack_A.h
+++ b/tt_llk_blackhole/llk_lib/llk_unpack_A.h
@@ -259,8 +259,7 @@ inline void _llk_unpack_A_(const std::uint32_t address, const std::uint32_t unpa
     // Set upk0/1 L1 read addr
     if constexpr (((BType == BroadcastType::NONE) && (!acc_to_dest)) || binary_reuse_dest == EltwiseBinaryReuseDestType::DEST_TO_SRCB || unpack_to_dest)
     {
-        const std::uint32_t upk0_reg = (unp_cfg_context == 0) ? THCON_SEC0_REG3_Base_address_ADDR32 : THCON_SEC0_REG3_Base_cntx1_address_ADDR32;
-        cfg[upk0_reg]                = address;
+        _llk_unpack_configure_single_address_(address, cfg);
     }
     else
     {

--- a/tt_llk_blackhole/llk_lib/llk_unpack_common.h
+++ b/tt_llk_blackhole/llk_lib/llk_unpack_common.h
@@ -213,21 +213,30 @@ inline void _llk_unpack_configure_addresses_(const std::uint32_t address_a, cons
  * @brief Validates L1 address and configures unpack base address for a single unpacker
  *
  * This helper function validates that the address is within the valid L1 memory region,
- * then configures the appropriate THCON_SEC0 base address register based on the unpack configuration context.
+ * then configures the appropriate THCON_SEC0 or THCON_SEC1 base address register based on the unpack configuration context.
  *
- * @param address Address for unpacker A (THCON_SEC0)
+ * @tparam UNP_SEL: Selects which unpacker resource to use,
+ * values = p_setadc::UNP_A/p_setadc::UNP_B
+ *
+ * @param address Address for unpacker A (THCON_SEC0) or unpacker B (THCON_SEC1)
  * @param cfg Pointer to configuration registers
  */
+template <std::uint32_t UNP_SEL>
 inline void _llk_unpack_configure_single_address_(const std::uint32_t address, volatile std::uint32_t tt_reg_ptr *cfg)
 {
+    static_assert(UNP_SEL == p_setadc::UNP_A || UNP_SEL == p_setadc::UNP_B, "UNP_SEL must be either p_setadc::UNP_A or p_setadc::UNP_B");
     LLK_ASSERT(is_valid_L1_address(address), "L1 base_address must be in valid L1 memory region");
+
+    constexpr std::uint32_t base_address = (UNP_SEL == p_setadc::UNP_A) ? THCON_SEC0_REG3_Base_address_ADDR32 : THCON_SEC1_REG3_Base_address_ADDR32;
+    constexpr std::uint32_t base_cntx1_address =
+        (UNP_SEL == p_setadc::UNP_A) ? THCON_SEC0_REG3_Base_cntx1_address_ADDR32 : THCON_SEC1_REG3_Base_cntx1_address_ADDR32;
 
     if (0 == unp_cfg_context)
     {
-        cfg[THCON_SEC0_REG3_Base_address_ADDR32] = address;
+        cfg[base_address] = address;
     }
     else
     {
-        cfg[THCON_SEC0_REG3_Base_cntx1_address_ADDR32] = address;
+        cfg[base_cntx1_address] = address;
     }
 }

--- a/tt_llk_blackhole/llk_lib/llk_unpack_reduce.h
+++ b/tt_llk_blackhole/llk_lib/llk_unpack_reduce.h
@@ -73,7 +73,7 @@ inline void _llk_unpack_reduce_(const std::uint32_t address)
     wait_for_next_context(2);
 
     // Validate and configure address
-    _llk_unpack_configure_single_address_(address, cfg);
+    _llk_unpack_configure_single_address_<p_setadc::UNP0>(address, cfg);
 
     // Trisc::SEMPOST for context acquire
     semaphore_post(semaphore::UNPACK_SYNC);

--- a/tt_llk_blackhole/llk_lib/llk_unpack_tilize.h
+++ b/tt_llk_blackhole/llk_lib/llk_unpack_tilize.h
@@ -126,14 +126,7 @@ inline void _llk_unpack_tilize_(
     wait_for_next_context(2);
 
     // Get tile address
-    if (0 == unp_cfg_context)
-    {
-        cfg[THCON_SEC0_REG3_Base_address_ADDR32] = address;
-    }
-    else
-    {
-        cfg[THCON_SEC0_REG3_Base_cntx1_address_ADDR32] = address;
-    }
+    _llk_unpack_configure_single_address_<p_setadc::UNP_A>(address, cfg);
 
     // Trisc::SEMPOST for context acquire
     semaphore_post(semaphore::UNPACK_SYNC);

--- a/tt_llk_blackhole/llk_lib/llk_unpack_untilize.h
+++ b/tt_llk_blackhole/llk_lib/llk_unpack_untilize.h
@@ -147,7 +147,7 @@ inline void _llk_unpack_untilize_pass_(const std::uint32_t base_address, const s
     wait_for_next_context(2);
 
     // Validate and configure address
-    _llk_unpack_configure_single_address_(base_address, cfg);
+    _llk_unpack_configure_single_address_<p_setadc::UNP0>(base_address, cfg);
 
     // Trisc::SEMPOST for context acquire
     semaphore_post(semaphore::UNPACK_SYNC);

--- a/tt_llk_wormhole_b0/llk_lib/llk_unpack_A.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_unpack_A.h
@@ -251,8 +251,7 @@ inline void _llk_unpack_A_(const std::uint32_t address, const std::uint32_t unpa
     // Set upk0/1 L1 read addr
     if constexpr (((BType == BroadcastType::NONE) && (!acc_to_dest)) || binary_reuse_dest == EltwiseBinaryReuseDestType::DEST_TO_SRCB || unpack_to_dest)
     {
-        const std::uint32_t upk0_reg = (unp_cfg_context == 0) ? THCON_SEC0_REG3_Base_address_ADDR32 : THCON_SEC0_REG3_Base_cntx1_address_ADDR32;
-        cfg[upk0_reg]                = address;
+        _llk_unpack_configure_single_address_(address, cfg);
     }
     else
     {

--- a/tt_llk_wormhole_b0/llk_lib/llk_unpack_A.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_unpack_A.h
@@ -251,12 +251,11 @@ inline void _llk_unpack_A_(const std::uint32_t address, const std::uint32_t unpa
     // Set upk0/1 L1 read addr
     if constexpr (((BType == BroadcastType::NONE) && (!acc_to_dest)) || binary_reuse_dest == EltwiseBinaryReuseDestType::DEST_TO_SRCB || unpack_to_dest)
     {
-        _llk_unpack_configure_single_address_(address, cfg);
+        _llk_unpack_configure_single_address_<p_setadc::UNP_A>(address, cfg);
     }
     else
     {
-        const std::uint32_t upk1_reg = (unp_cfg_context == 0) ? THCON_SEC1_REG3_Base_address_ADDR32 : THCON_SEC1_REG3_Base_cntx1_address_ADDR32;
-        cfg[upk1_reg]                = address;
+        _llk_unpack_configure_single_address_<p_setadc::UNP_B>(address, cfg);
     }
 
     if constexpr (unpack_to_dest)

--- a/tt_llk_wormhole_b0/llk_lib/llk_unpack_common.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_unpack_common.h
@@ -209,22 +209,30 @@ inline void _llk_unpack_configure_addresses_(const std::uint32_t address_a, cons
  * @brief Validates L1 address and configures unpack base address for a single unpacker
  *
  * This helper function validates that the address is within the valid L1 memory region,
- * then configures the appropriate THCON_SEC0 base address register based on the unpack configuration context.
+ * then configures the appropriate THCON_SEC0 or THCON_SEC1 base address register based on the unpack configuration context.
  *
- * @param address Address for unpacker A (THCON_SEC0)
+ * @tparam UNP_SEL: Selects which unpacker resource to use,
+ * values = p_setadc::UNP_A/p_setadc::UNP_B
+ * 
+ * @param address Address for either unpacker A (THCON_SEC0) or unpacker B (THCON_SEC1)
  * @param cfg Pointer to configuration registers
  */
+template <std::uint32_t UNP_SEL>
 inline void _llk_unpack_configure_single_address_(const std::uint32_t address, volatile std::uint32_t tt_reg_ptr *cfg)
 {
+    static_assert(UNP_SEL == p_setadc::UNP_A || UNP_SEL == p_setadc::UNP_B, "UNP_SEL must be either p_setadc::UNP_A or p_setadc::UNP_B");
     LLK_ASSERT(is_valid_L1_address(address), "L1 base_address must be in valid L1 memory region");
 
-    // Program srcA base address
+    constexpr std::uint32_t base_address = (UNP_SEL == p_setadc::UNP_A) ? THCON_SEC0_REG3_Base_address_ADDR32 : THCON_SEC1_REG3_Base_address_ADDR32;
+    constexpr std::uint32_t base_cntx1_address =
+        (UNP_SEL == p_setadc::UNP_A) ? THCON_SEC0_REG3_Base_cntx1_address_ADDR32 : THCON_SEC1_REG3_Base_cntx1_address_ADDR32;
+
     if (0 == unp_cfg_context)
     {
-        cfg[THCON_SEC0_REG3_Base_address_ADDR32] = address;
+        cfg[base_address] = address;
     }
     else
     {
-        cfg[THCON_SEC0_REG3_Base_cntx1_address_ADDR32] = address;
+        cfg[base_cntx1_address] = address;
     }
 }

--- a/tt_llk_wormhole_b0/llk_lib/llk_unpack_reduce.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_unpack_reduce.h
@@ -75,7 +75,7 @@ inline void _llk_unpack_reduce_(const std::uint32_t address)
     wait_for_next_context(2);
 
     // Validate and configure address
-    _llk_unpack_configure_single_address_(address, cfg);
+    _llk_unpack_configure_single_address_<p_setadc::UNP0>(address, cfg);
 
     // Trisc::SEMPOST for context acquire
     semaphore_post(semaphore::UNPACK_SYNC);

--- a/tt_llk_wormhole_b0/llk_lib/llk_unpack_tilize.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_unpack_tilize.h
@@ -95,7 +95,7 @@ inline void unpack_tilize_impl(
         wait_for_next_context(2);
 
         // Validate and configure address
-        _llk_unpack_configure_single_address_(address, cfg);
+        _llk_unpack_configure_single_address_<p_setadc::UNP_A>(address, cfg);
 
         // Trisc::SEMPOST for context acquire
         semaphore_post(semaphore::UNPACK_SYNC);

--- a/tt_llk_wormhole_b0/llk_lib/llk_unpack_untilize.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_unpack_untilize.h
@@ -108,7 +108,7 @@ inline void _llk_unpack_untilize_pass_(const std::uint32_t base_address, const s
     wait_for_next_context(2);
 
     // Validate and configure address
-    _llk_unpack_configure_single_address_(base_address, cfg);
+    _llk_unpack_configure_single_address_<p_setadc::UNP0>(base_address, cfg);
 
     // Trisc::SEMPOST for context acquire
     semaphore_post(semaphore::UNPACK_SYNC);


### PR DESCRIPTION
### Ticket
na

### Problem description
1. the existing code for the unpacker0 L1 address configuration duplicates the functionality of [_llk_unpack_configure_single_address_](https://github.com/tenstorrent/tt-llk/blob/410c555c71e07c4a5f06bd4d793e0e729a1ddf40/tt_llk_blackhole/llk_lib/llk_unpack_common.h#L221). i propose we use that function directly instead of duplicating its logic

2. shall the same refactoring also apply to unpacker1? this would require minor changes to `_llk_unpack_configure_single_address_`

### What's changed
replaced duplicated functionality with direct usage of `_llk_unpack_configure_single_address_` function

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Assert validation](https://github.com/tenstorrent/tt-llk/blob/main/docs/Introduction_to_asserts.md) Complied with assert doc (if applicable)
