### PR TITLE
[MATMUL] Skip HiFi2 for HiFi3 bf16 x bfp4

### DIFF
--- a/tt_llk_blackhole/llk_lib/experimental/llk_math_matmul_custom_no_mop.h
+++ b/tt_llk_blackhole/llk_lib/experimental/llk_math_matmul_custom_no_mop.h
@@ -45,7 +45,7 @@ inline void set_matmul_no_mop_addrmod_5(const std::uint32_t fidelity_increment)
             set_matmul_no_mop_addrmod_5<2>();
             break;
         default:
-            LLK_ASSERT(false && "Unsupported runtime fidelity increment");
+            LLK_ASSERT(false, "Unsupported runtime fidelity increment");
             break;
     }
 }

--- a/tt_llk_blackhole/llk_lib/experimental/llk_math_matmul_custom_no_mop.h
+++ b/tt_llk_blackhole/llk_lib/experimental/llk_math_matmul_custom_no_mop.h
@@ -19,6 +19,37 @@ using namespace ckernel;
 static std::uint32_t matmul_no_mop_runtime_fidelity_phase_count = 1;
 static std::uint32_t matmul_no_mop_runtime_fidelity_increment   = 0;
 
+template <std::uint32_t fidelity_increment>
+inline void set_matmul_no_mop_addrmod_5()
+{
+    addr_mod_t {
+        .srca     = {.incr = 0, .clr = 1, .cr = 1},
+        .srcb     = {.incr = 0, .clr = 1, .cr = 1},
+        .dest     = {.incr = 0, .clr = 1, .cr = 1},
+        .fidelity = {.incr = fidelity_increment, .clr = 0},
+    }
+        .set(ADDR_MOD_5);
+}
+
+inline void set_matmul_no_mop_addrmod_5(const std::uint32_t fidelity_increment)
+{
+    switch (fidelity_increment)
+    {
+        case 0:
+            set_matmul_no_mop_addrmod_5<0>();
+            break;
+        case 1:
+            set_matmul_no_mop_addrmod_5<1>();
+            break;
+        case 2:
+            set_matmul_no_mop_addrmod_5<2>();
+            break;
+        default:
+            LLK_ASSERT(false && "Unsupported runtime fidelity increment");
+            break;
+    }
+}
+
 template <MathFidelity math_fidelity, int THROTTLE_LEVEL>
 inline void matmul_configure_addrmod_no_mop(
     const bool transpose,
@@ -46,13 +77,7 @@ inline void matmul_configure_addrmod_no_mop(
         .set(ADDR_MOD_0);
 
     // reset all, increment fidelity if we have more fidelity phases
-    addr_mod_t {
-        .srca     = {.incr = 0, .clr = 1, .cr = 1},
-        .srcb     = {.incr = 0, .clr = 1, .cr = 1},
-        .dest     = {.incr = 0, .clr = 1, .cr = 1},
-        .fidelity = {.incr = fidelity_increment, .clr = 0},
-    }
-        .set(ADDR_MOD_5);
+    set_matmul_no_mop_addrmod_5(fidelity_increment);
 
     if constexpr (THROTTLE_LEVEL)
     {
@@ -132,13 +157,7 @@ template <MathFidelity math_fidelity = MathFidelity::LoFi, int throttle_level = 
 inline void matmul_configure_addrmod_reinit_after_sub()
 {
     static_assert(throttle_level == 0, "matmul_configure_addrmod_reinit_after_sub only supports THROTTLE_LEVEL == 0");
-    addr_mod_t {
-        .srca     = {.incr = 0, .clr = 1, .cr = 1},
-        .srcb     = {.incr = 0, .clr = 1, .cr = 1},
-        .dest     = {.incr = 0, .clr = 1, .cr = 1},
-        .fidelity = {.incr = matmul_no_mop_runtime_fidelity_increment, .clr = 0},
-    }
-        .set(ADDR_MOD_5);
+    set_matmul_no_mop_addrmod_5(matmul_no_mop_runtime_fidelity_increment);
 }
 
 template <MathFidelity math_fidelity>

--- a/tt_llk_blackhole/llk_lib/experimental/llk_math_matmul_custom_no_mop.h
+++ b/tt_llk_blackhole/llk_lib/experimental/llk_math_matmul_custom_no_mop.h
@@ -12,16 +12,12 @@
 #include "cmath_common.h"
 #include "llk_assert.h"
 #include "llk_math_common.h"
+#include "llk_math_matmul_fidelity.h"
 
 using namespace ckernel;
 
-// Helper functions for math fidelity
-constexpr int get_math_num_fidelity_phases(const MathFidelity math_fidelity)
-{
-    // LoFi = 0 has 0 fidelity phases
-    // HiFi2 = 1 has 1 phase, HiFi3 = 2 has 2 phases, HiFi4 = 3 has 3 phases
-    return ckernel::to_underlying(math_fidelity);
-}
+static std::uint32_t matmul_no_mop_runtime_fidelity_phase_count = 1;
+static std::uint32_t matmul_no_mop_runtime_fidelity_increment   = 0;
 
 template <MathFidelity math_fidelity, int THROTTLE_LEVEL>
 inline void matmul_configure_addrmod_no_mop(
@@ -30,11 +26,11 @@ inline void matmul_configure_addrmod_no_mop(
     const std::uint32_t in0_tile_c_dim = TILE_C_DIM,
     const std::uint32_t in1_tile_r_dim = TILE_R_DIM,
     const std::uint32_t in1_tile_c_dim = TILE_C_DIM,
-    const bool partial_face            = false)
+    const bool partial_face            = false,
+    const std::uint32_t fidelity_increment =
+        (math_fidelity != MathFidelity::LoFi) ? 1 : 0)
 {
     static_assert(THROTTLE_LEVEL >= 0 && THROTTLE_LEVEL <= 5, "THROTTLE_LEVEL must be in range [0, 5]");
-    constexpr bool high_fidelity     = math_fidelity != MathFidelity::LoFi;
-    constexpr int fidelity_increment = high_fidelity ? 1 : 0;
 
     // MVMUL does D = B*A
 
@@ -126,7 +122,14 @@ inline void matmul_configure_addrmod_reinit(const bool transpose = false)
 {
     // Reinit must restore the full matmul address-modifier contract used by replay.
     // In particular, transpose affects ADDR_MOD_1/4 and fidelity/throttle use ADDR_MOD_5/6.
-    matmul_configure_addrmod_no_mop<math_fidelity, THROTTLE_LEVEL>(transpose);
+    matmul_configure_addrmod_no_mop<math_fidelity, THROTTLE_LEVEL>(
+        transpose,
+        TILE_R_DIM,
+        TILE_C_DIM,
+        TILE_R_DIM,
+        TILE_C_DIM,
+        false,
+        matmul_no_mop_runtime_fidelity_increment);
 }
 
 // After sub_exp custom (which only clobbers ADDR_MOD 5,6,7), matmul only needs
@@ -136,12 +139,11 @@ template <MathFidelity math_fidelity = MathFidelity::LoFi, int throttle_level = 
 inline void matmul_configure_addrmod_reinit_after_sub()
 {
     static_assert(throttle_level == 0, "matmul_configure_addrmod_reinit_after_sub only supports THROTTLE_LEVEL == 0");
-    constexpr int fidelity_increment = (math_fidelity != MathFidelity::LoFi) ? 1 : 0;
     addr_mod_t {
         .srca     = {.incr = 0, .clr = 1, .cr = 1},
         .srcb     = {.incr = 0, .clr = 1, .cr = 1},
         .dest     = {.incr = 0, .clr = 1, .cr = 1},
-        .fidelity = {.incr = fidelity_increment, .clr = 0},
+        .fidelity = {.incr = matmul_no_mop_runtime_fidelity_increment, .clr = 0},
     }
         .set(ADDR_MOD_5);
 }
@@ -164,7 +166,6 @@ inline void matmul_configure_mop_custom(
     // Col major layout in dest only impacts destination address increment
     // if col major layout faces are ordered as f0,f2,f1,f3
 
-    constexpr int num_fidelity_phases = get_math_num_fidelity_phases(math_fidelity);
     constexpr bool high_fidelity      = math_fidelity != MathFidelity::LoFi;
 
     const bool reuse_a        = ct_dim >= rt_dim;
@@ -332,7 +333,6 @@ inline void matmul_configure_mop_throttled_no_mop(
     // Col major layout in dest only impacts destination address increment
     // if col major layout faces are ordered as f0,f2,f1,f3
 
-    constexpr int num_fidelity_phases = get_math_num_fidelity_phases(math_fidelity);
     constexpr bool high_fidelity      = math_fidelity != MathFidelity::LoFi;
     static_assert((THROTTLE_LEVEL > 0) && (THROTTLE_LEVEL <= 5), "MM throttling only enabled for THROTTLE_LEVEL={1,2,3,4,5}");
     LLK_ASSERT(
@@ -358,20 +358,47 @@ inline void _llk_math_matmul_init_no_mop_(
     const std::uint32_t in0_tile_c_dim = TILE_C_DIM,
     const std::uint32_t in1_tile_r_dim = TILE_R_DIM,
     const std::uint32_t in1_tile_c_dim = TILE_C_DIM,
+    const std::uint32_t in0_dst_format = static_cast<std::uint32_t>(DataFormat::Float16_b),
+    const std::uint32_t in1_dst_format = static_cast<std::uint32_t>(DataFormat::Float16_b),
     const bool partial_face            = false,
     const std::uint32_t transpose      = 0,
     const std::uint32_t ct_dim         = 1,
     const std::uint32_t rt_dim         = 1)
 {
-    matmul_configure_addrmod_no_mop<math_fidelity, THROTTLE_LEVEL>(transpose, in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face);
+    matmul_no_mop_runtime_fidelity_phase_count =
+        get_matmul_fidelity_phase_count(math_fidelity, in0_dst_format, in1_dst_format);
+    matmul_no_mop_runtime_fidelity_increment =
+        get_matmul_fidelity_increment(math_fidelity, in0_dst_format, in1_dst_format);
+
+    matmul_configure_addrmod_no_mop<math_fidelity, THROTTLE_LEVEL>(
+        transpose,
+        in0_tile_r_dim,
+        in0_tile_c_dim,
+        in1_tile_r_dim,
+        in1_tile_c_dim,
+        partial_face,
+        matmul_no_mop_runtime_fidelity_increment);
     if constexpr (THROTTLE_LEVEL > 0)
     {
         matmul_configure_mop_throttled_no_mop<math_fidelity, THROTTLE_LEVEL>(
-            ct_dim, rt_dim, in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face);
+            ct_dim,
+            rt_dim,
+            in0_tile_r_dim,
+            in0_tile_c_dim,
+            in1_tile_r_dim,
+            in1_tile_c_dim,
+            partial_face);
     }
     else
     {
-        matmul_configure_mop_custom<math_fidelity>(ct_dim, rt_dim, in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face);
+        matmul_configure_mop_custom<math_fidelity>(
+            ct_dim,
+            rt_dim,
+            in0_tile_r_dim,
+            in0_tile_c_dim,
+            in1_tile_r_dim,
+            in1_tile_c_dim,
+            partial_face);
     }
     math::reset_counters(p_setrwc::SET_ABD_F);
 }
@@ -395,8 +422,8 @@ inline void _llk_math_matmul_no_mop_(
     const bool reuse_a                = ct_dim >= rt_dim;
     const std::uint32_t t_dim         = reuse_a ? rt_dim : ct_dim;
     const std::uint32_t rut_dim       = reuse_a ? ct_dim : rt_dim; // reuse-dim
-    constexpr int num_fidelity_phases = get_math_num_fidelity_phases(math_fidelity);
     constexpr bool high_fidelity      = math_fidelity != MathFidelity::LoFi;
+    const std::uint32_t num_fidelity_phases = matmul_no_mop_runtime_fidelity_phase_count;
 
     // Compute replay buffer length based on tile dimensions (same logic as in matmul_configure_mop)
     std::uint32_t replay_buf_len;

--- a/tt_llk_blackhole/llk_lib/experimental/llk_math_matmul_custom_no_mop.h
+++ b/tt_llk_blackhole/llk_lib/experimental/llk_math_matmul_custom_no_mop.h
@@ -22,13 +22,12 @@ static std::uint32_t matmul_no_mop_runtime_fidelity_increment   = 0;
 template <MathFidelity math_fidelity, int THROTTLE_LEVEL>
 inline void matmul_configure_addrmod_no_mop(
     const bool transpose,
-    const std::uint32_t in0_tile_r_dim = TILE_R_DIM,
-    const std::uint32_t in0_tile_c_dim = TILE_C_DIM,
-    const std::uint32_t in1_tile_r_dim = TILE_R_DIM,
-    const std::uint32_t in1_tile_c_dim = TILE_C_DIM,
-    const bool partial_face            = false,
-    const std::uint32_t fidelity_increment =
-        (math_fidelity != MathFidelity::LoFi) ? 1 : 0)
+    const std::uint32_t in0_tile_r_dim     = TILE_R_DIM,
+    const std::uint32_t in0_tile_c_dim     = TILE_C_DIM,
+    const std::uint32_t in1_tile_r_dim     = TILE_R_DIM,
+    const std::uint32_t in1_tile_c_dim     = TILE_C_DIM,
+    const bool partial_face                = false,
+    const std::uint32_t fidelity_increment = (math_fidelity != MathFidelity::LoFi) ? 1 : 0)
 {
     static_assert(THROTTLE_LEVEL >= 0 && THROTTLE_LEVEL <= 5, "THROTTLE_LEVEL must be in range [0, 5]");
 
@@ -123,13 +122,7 @@ inline void matmul_configure_addrmod_reinit(const bool transpose = false)
     // Reinit must restore the full matmul address-modifier contract used by replay.
     // In particular, transpose affects ADDR_MOD_1/4 and fidelity/throttle use ADDR_MOD_5/6.
     matmul_configure_addrmod_no_mop<math_fidelity, THROTTLE_LEVEL>(
-        transpose,
-        TILE_R_DIM,
-        TILE_C_DIM,
-        TILE_R_DIM,
-        TILE_C_DIM,
-        false,
-        matmul_no_mop_runtime_fidelity_increment);
+        transpose, TILE_R_DIM, TILE_C_DIM, TILE_R_DIM, TILE_C_DIM, false, matmul_no_mop_runtime_fidelity_increment);
 }
 
 // After sub_exp custom (which only clobbers ADDR_MOD 5,6,7), matmul only needs
@@ -166,7 +159,7 @@ inline void matmul_configure_mop_custom(
     // Col major layout in dest only impacts destination address increment
     // if col major layout faces are ordered as f0,f2,f1,f3
 
-    constexpr bool high_fidelity      = math_fidelity != MathFidelity::LoFi;
+    constexpr bool high_fidelity = math_fidelity != MathFidelity::LoFi;
 
     const bool reuse_a        = ct_dim >= rt_dim;
     const std::uint32_t t_dim = reuse_a ? rt_dim : ct_dim;
@@ -333,7 +326,7 @@ inline void matmul_configure_mop_throttled_no_mop(
     // Col major layout in dest only impacts destination address increment
     // if col major layout faces are ordered as f0,f2,f1,f3
 
-    constexpr bool high_fidelity      = math_fidelity != MathFidelity::LoFi;
+    constexpr bool high_fidelity = math_fidelity != MathFidelity::LoFi;
     static_assert((THROTTLE_LEVEL > 0) && (THROTTLE_LEVEL <= 5), "MM throttling only enabled for THROTTLE_LEVEL={1,2,3,4,5}");
     LLK_ASSERT(
         (in0_tile_r_dim == TILE_R_DIM) && (in0_tile_c_dim == TILE_C_DIM) && (in1_tile_r_dim == TILE_R_DIM) && (in1_tile_c_dim == TILE_C_DIM) && !partial_face,
@@ -358,47 +351,26 @@ inline void _llk_math_matmul_init_no_mop_(
     const std::uint32_t in0_tile_c_dim = TILE_C_DIM,
     const std::uint32_t in1_tile_r_dim = TILE_R_DIM,
     const std::uint32_t in1_tile_c_dim = TILE_C_DIM,
-    const std::uint32_t in0_dst_format = static_cast<std::uint32_t>(DataFormat::Float16_b),
-    const std::uint32_t in1_dst_format = static_cast<std::uint32_t>(DataFormat::Float16_b),
     const bool partial_face            = false,
     const std::uint32_t transpose      = 0,
     const std::uint32_t ct_dim         = 1,
-    const std::uint32_t rt_dim         = 1)
+    const std::uint32_t rt_dim         = 1,
+    const std::uint32_t in0_dst_format = static_cast<std::uint32_t>(DataFormat::Float16_b),
+    const std::uint32_t in1_dst_format = static_cast<std::uint32_t>(DataFormat::Float16_b))
 {
-    matmul_no_mop_runtime_fidelity_phase_count =
-        get_matmul_fidelity_phase_count(math_fidelity, in0_dst_format, in1_dst_format);
-    matmul_no_mop_runtime_fidelity_increment =
-        get_matmul_fidelity_increment(math_fidelity, in0_dst_format, in1_dst_format);
+    matmul_no_mop_runtime_fidelity_phase_count = get_matmul_fidelity_phase_count(math_fidelity, in0_dst_format, in1_dst_format);
+    matmul_no_mop_runtime_fidelity_increment   = get_matmul_fidelity_increment(math_fidelity, in0_dst_format, in1_dst_format);
 
     matmul_configure_addrmod_no_mop<math_fidelity, THROTTLE_LEVEL>(
-        transpose,
-        in0_tile_r_dim,
-        in0_tile_c_dim,
-        in1_tile_r_dim,
-        in1_tile_c_dim,
-        partial_face,
-        matmul_no_mop_runtime_fidelity_increment);
+        transpose, in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face, matmul_no_mop_runtime_fidelity_increment);
     if constexpr (THROTTLE_LEVEL > 0)
     {
         matmul_configure_mop_throttled_no_mop<math_fidelity, THROTTLE_LEVEL>(
-            ct_dim,
-            rt_dim,
-            in0_tile_r_dim,
-            in0_tile_c_dim,
-            in1_tile_r_dim,
-            in1_tile_c_dim,
-            partial_face);
+            ct_dim, rt_dim, in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face);
     }
     else
     {
-        matmul_configure_mop_custom<math_fidelity>(
-            ct_dim,
-            rt_dim,
-            in0_tile_r_dim,
-            in0_tile_c_dim,
-            in1_tile_r_dim,
-            in1_tile_c_dim,
-            partial_face);
+        matmul_configure_mop_custom<math_fidelity>(ct_dim, rt_dim, in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face);
     }
     math::reset_counters(p_setrwc::SET_ABD_F);
 }
@@ -419,10 +391,10 @@ inline void _llk_math_matmul_no_mop_(
     const std::uint32_t in1_tile_c_dim = TILE_C_DIM,
     const bool partial_face            = false)
 {
-    const bool reuse_a                = ct_dim >= rt_dim;
-    const std::uint32_t t_dim         = reuse_a ? rt_dim : ct_dim;
-    const std::uint32_t rut_dim       = reuse_a ? ct_dim : rt_dim; // reuse-dim
-    constexpr bool high_fidelity      = math_fidelity != MathFidelity::LoFi;
+    const bool reuse_a                      = ct_dim >= rt_dim;
+    const std::uint32_t t_dim               = reuse_a ? rt_dim : ct_dim;
+    const std::uint32_t rut_dim             = reuse_a ? ct_dim : rt_dim; // reuse-dim
+    constexpr bool high_fidelity            = math_fidelity != MathFidelity::LoFi;
     const std::uint32_t num_fidelity_phases = matmul_no_mop_runtime_fidelity_phase_count;
 
     // Compute replay buffer length based on tile dimensions (same logic as in matmul_configure_mop)

--- a/tt_llk_blackhole/llk_lib/llk_math_matmul.h
+++ b/tt_llk_blackhole/llk_lib/llk_math_matmul.h
@@ -33,9 +33,10 @@ inline void matmul_configure_addrmod(
     const bool partial_face                = false,
     const std::uint32_t fidelity_increment = is_high_fidelity(math_fidelity) ? 1 : 0)
 {
-    const bool is_in0_16x32 = (in0_tile_r_dim <= FACE_R_DIM) && (in0_tile_c_dim > FACE_C_DIM);
-    const bool is_in0_32x16 = (in0_tile_r_dim > FACE_R_DIM) && (in0_tile_c_dim <= FACE_C_DIM);
-    const bool is_in1_32x16 = (in1_tile_r_dim > FACE_R_DIM) && (in1_tile_c_dim <= FACE_C_DIM);
+    const bool is_in0_16x32          = (in0_tile_r_dim <= FACE_R_DIM) && (in0_tile_c_dim > FACE_C_DIM);
+    const bool is_in0_32x16          = (in0_tile_r_dim > FACE_R_DIM) && (in0_tile_c_dim <= FACE_C_DIM);
+    const bool is_in1_32x16          = (in1_tile_r_dim > FACE_R_DIM) && (in1_tile_c_dim <= FACE_C_DIM);
+    const auto fidelity_increment_u8 = static_cast<std::uint8_t>(fidelity_increment);
 
     // MVMUL does D = B*A
 
@@ -56,7 +57,7 @@ inline void matmul_configure_addrmod(
         .srca     = {.incr = 0, .clr = 1, .cr = 1},
         .srcb     = {.incr = 0, .clr = 1, .cr = 1},
         .dest     = {.incr = 0, .clr = 1, .cr = 1},
-        .fidelity = {.incr = fidelity_increment, .clr = 0},
+        .fidelity = {.incr = fidelity_increment_u8, .clr = 0},
     }
         .set(ADDR_MOD_5);
 

--- a/tt_llk_blackhole/llk_lib/llk_math_matmul.h
+++ b/tt_llk_blackhole/llk_lib/llk_math_matmul.h
@@ -26,13 +26,12 @@ static std::uint32_t matmul_runtime_fidelity_increment   = 0;
 template <MathFidelity math_fidelity, int THROTTLE_LEVEL>
 inline void matmul_configure_addrmod(
     const bool transpose,
-    const std::uint32_t in0_tile_r_dim = TILE_R_DIM,
-    const std::uint32_t in0_tile_c_dim = TILE_C_DIM,
-    const std::uint32_t in1_tile_r_dim = TILE_R_DIM,
-    const std::uint32_t in1_tile_c_dim = TILE_C_DIM,
-    const bool partial_face            = false,
-    const std::uint32_t fidelity_increment =
-        is_high_fidelity(math_fidelity) ? 1 : 0)
+    const std::uint32_t in0_tile_r_dim     = TILE_R_DIM,
+    const std::uint32_t in0_tile_c_dim     = TILE_C_DIM,
+    const std::uint32_t in1_tile_r_dim     = TILE_R_DIM,
+    const std::uint32_t in1_tile_c_dim     = TILE_C_DIM,
+    const bool partial_face                = false,
+    const std::uint32_t fidelity_increment = is_high_fidelity(math_fidelity) ? 1 : 0)
 {
     const bool is_in0_16x32 = (in0_tile_r_dim <= FACE_R_DIM) && (in0_tile_c_dim > FACE_C_DIM);
     const bool is_in0_32x16 = (in0_tile_r_dim > FACE_R_DIM) && (in0_tile_c_dim <= FACE_C_DIM);
@@ -280,13 +279,12 @@ template <MathFidelity math_fidelity>
 inline void matmul_configure_mop(
     const std::uint32_t ct_dim,
     const std::uint32_t rt_dim,
-    const std::uint32_t in0_tile_r_dim = TILE_R_DIM,
-    const std::uint32_t in0_tile_c_dim = TILE_C_DIM,
-    const std::uint32_t in1_tile_r_dim = TILE_R_DIM,
-    const std::uint32_t in1_tile_c_dim = TILE_C_DIM,
-    const bool partial_face            = false,
-    const std::uint32_t fidelity_phase_count =
-        is_high_fidelity(math_fidelity) ? to_underlying(math_fidelity) : 1)
+    const std::uint32_t in0_tile_r_dim       = TILE_R_DIM,
+    const std::uint32_t in0_tile_c_dim       = TILE_C_DIM,
+    const std::uint32_t in1_tile_r_dim       = TILE_R_DIM,
+    const std::uint32_t in1_tile_c_dim       = TILE_C_DIM,
+    const bool partial_face                  = false,
+    const std::uint32_t fidelity_phase_count = is_high_fidelity(math_fidelity) ? to_underlying(math_fidelity) : 1)
 {
     // in0 - loaded to SrcB
     // in1 - loaded to SrcA
@@ -517,13 +515,12 @@ template <MathFidelity math_fidelity, int THROTTLE_LEVEL>
 inline void matmul_configure_mop_throttled(
     const std::uint32_t ct_dim,
     const std::uint32_t rt_dim,
-    const std::uint32_t in0_tile_r_dim = TILE_R_DIM,
-    const std::uint32_t in0_tile_c_dim = TILE_C_DIM,
-    const std::uint32_t in1_tile_r_dim = TILE_R_DIM,
-    const std::uint32_t in1_tile_c_dim = TILE_C_DIM,
-    const bool partial_face            = false,
-    const std::uint32_t fidelity_phase_count =
-        is_high_fidelity(math_fidelity) ? to_underlying(math_fidelity) : 1)
+    const std::uint32_t in0_tile_r_dim       = TILE_R_DIM,
+    const std::uint32_t in0_tile_c_dim       = TILE_C_DIM,
+    const std::uint32_t in1_tile_r_dim       = TILE_R_DIM,
+    const std::uint32_t in1_tile_c_dim       = TILE_C_DIM,
+    const bool partial_face                  = false,
+    const std::uint32_t fidelity_phase_count = is_high_fidelity(math_fidelity) ? to_underlying(math_fidelity) : 1)
 {
     // in0 - loaded to SrcB
     // in1 - loaded to SrcA
@@ -562,7 +559,7 @@ inline void matmul_configure_mop_throttled(
             }
         });
 
-    const std::uint32_t outer_loops = (THROTTLE_LEVEL > 3) ? 2 : (high_fidelity ? fidelity_phase_count : 1);
+    const std::uint32_t outer_loops            = (THROTTLE_LEVEL > 3) ? 2 : (high_fidelity ? fidelity_phase_count : 1);
     const std::uint32_t inner_loops            = (!is_in1_16x32) ? 2 : 1;
     constexpr std::uint8_t addr_mod_inner_loop = (THROTTLE_LEVEL > 3) ? ADDR_MOD_2 : ADDR_MOD_4;
     ckernel_template tmp(
@@ -602,12 +599,12 @@ inline void _llk_math_matmul_init_(
     const std::uint32_t in0_tile_c_dim = TILE_C_DIM,
     const std::uint32_t in1_tile_r_dim = TILE_R_DIM,
     const std::uint32_t in1_tile_c_dim = TILE_C_DIM,
-    const std::uint32_t in0_dst_format = static_cast<std::uint32_t>(DataFormat::Float16_b),
-    const std::uint32_t in1_dst_format = static_cast<std::uint32_t>(DataFormat::Float16_b),
     const bool partial_face            = false,
     const std::uint32_t transpose      = 0,
     const std::uint32_t ct_dim         = 1,
-    const std::uint32_t rt_dim         = 1)
+    const std::uint32_t rt_dim         = 1,
+    const std::uint32_t in0_dst_format = static_cast<std::uint32_t>(DataFormat::Float16_b),
+    const std::uint32_t in1_dst_format = static_cast<std::uint32_t>(DataFormat::Float16_b))
 {
     // 16x16 inputs not supported - no dedicated math path; falls to 32x32 default which is incorrect for < 4 faces
     LLK_ASSERT(
@@ -616,43 +613,21 @@ inline void _llk_math_matmul_init_(
     // in1=32x16 NOT supported with transpose (no addr_mod handling)
     LLK_ASSERT(!(transpose && (in1_tile_r_dim == TILE_R_DIM) && (in1_tile_c_dim == FACE_C_DIM)), "Transpose with input 1 dimensions 32x16 not supported");
 
-    matmul_runtime_fidelity_phase_count =
-        get_matmul_fidelity_phase_count(math_fidelity, in0_dst_format, in1_dst_format);
-    matmul_runtime_fidelity_increment =
-        get_matmul_fidelity_increment(math_fidelity, in0_dst_format, in1_dst_format);
+    matmul_runtime_fidelity_phase_count = get_matmul_fidelity_phase_count(math_fidelity, in0_dst_format, in1_dst_format);
+    matmul_runtime_fidelity_increment   = get_matmul_fidelity_increment(math_fidelity, in0_dst_format, in1_dst_format);
 
     matmul_configure_addrmod<math_fidelity, THROTTLE_LEVEL>(
-        transpose,
-        in0_tile_r_dim,
-        in0_tile_c_dim,
-        in1_tile_r_dim,
-        in1_tile_c_dim,
-        partial_face,
-        matmul_runtime_fidelity_increment);
+        transpose, in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face, matmul_runtime_fidelity_increment);
 
     if constexpr (THROTTLE_LEVEL > 0)
     {
         matmul_configure_mop_throttled<math_fidelity, THROTTLE_LEVEL>(
-            ct_dim,
-            rt_dim,
-            in0_tile_r_dim,
-            in0_tile_c_dim,
-            in1_tile_r_dim,
-            in1_tile_c_dim,
-            partial_face,
-            matmul_runtime_fidelity_phase_count);
+            ct_dim, rt_dim, in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face, matmul_runtime_fidelity_phase_count);
     }
     else
     {
         matmul_configure_mop<math_fidelity>(
-            ct_dim,
-            rt_dim,
-            in0_tile_r_dim,
-            in0_tile_c_dim,
-            in1_tile_r_dim,
-            in1_tile_c_dim,
-            partial_face,
-            matmul_runtime_fidelity_phase_count);
+            ct_dim, rt_dim, in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face, matmul_runtime_fidelity_phase_count);
     }
     math::reset_counters(p_setrwc::SET_ABD_F);
 }

--- a/tt_llk_blackhole/llk_lib/llk_math_matmul.h
+++ b/tt_llk_blackhole/llk_lib/llk_math_matmul.h
@@ -12,12 +12,16 @@
 #include "cmath_common.h"
 #include "llk_assert.h"
 #include "llk_math_common.h"
+#include "llk_math_matmul_fidelity.h"
 
 #ifndef HF
 #define HF 0
 #endif
 
 using namespace ckernel;
+
+static std::uint32_t matmul_runtime_fidelity_phase_count = 1;
+static std::uint32_t matmul_runtime_fidelity_increment   = 0;
 
 template <MathFidelity math_fidelity, int THROTTLE_LEVEL>
 inline void matmul_configure_addrmod(
@@ -26,10 +30,10 @@ inline void matmul_configure_addrmod(
     const std::uint32_t in0_tile_c_dim = TILE_C_DIM,
     const std::uint32_t in1_tile_r_dim = TILE_R_DIM,
     const std::uint32_t in1_tile_c_dim = TILE_C_DIM,
-    const bool partial_face            = false)
+    const bool partial_face            = false,
+    const std::uint32_t fidelity_increment =
+        is_high_fidelity(math_fidelity) ? 1 : 0)
 {
-    constexpr std::uint32_t fidelity_increment = is_high_fidelity(math_fidelity) ? 1 : 0;
-
     const bool is_in0_16x32 = (in0_tile_r_dim <= FACE_R_DIM) && (in0_tile_c_dim > FACE_C_DIM);
     const bool is_in0_32x16 = (in0_tile_r_dim > FACE_R_DIM) && (in0_tile_c_dim <= FACE_C_DIM);
     const bool is_in1_32x16 = (in1_tile_r_dim > FACE_R_DIM) && (in1_tile_c_dim <= FACE_C_DIM);
@@ -280,7 +284,9 @@ inline void matmul_configure_mop(
     const std::uint32_t in0_tile_c_dim = TILE_C_DIM,
     const std::uint32_t in1_tile_r_dim = TILE_R_DIM,
     const std::uint32_t in1_tile_c_dim = TILE_C_DIM,
-    const bool partial_face            = false)
+    const bool partial_face            = false,
+    const std::uint32_t fidelity_phase_count =
+        is_high_fidelity(math_fidelity) ? to_underlying(math_fidelity) : 1)
 {
     // in0 - loaded to SrcB
     // in1 - loaded to SrcA
@@ -394,7 +400,7 @@ inline void matmul_configure_mop(
         });
 
     // TODO: can we commonize this?
-    constexpr std::uint32_t inner_loops = high_fidelity ? to_underlying(math_fidelity) : 1;
+    const std::uint32_t inner_loops = high_fidelity ? fidelity_phase_count : 1;
     ckernel_template tmp(1 /* outer loop */, inner_loops, lltt::replay_insn(ckernel::math::replay_buf_offset, replay_buf_len));
 
     if constexpr (high_fidelity)
@@ -515,7 +521,9 @@ inline void matmul_configure_mop_throttled(
     const std::uint32_t in0_tile_c_dim = TILE_C_DIM,
     const std::uint32_t in1_tile_r_dim = TILE_R_DIM,
     const std::uint32_t in1_tile_c_dim = TILE_C_DIM,
-    const bool partial_face            = false)
+    const bool partial_face            = false,
+    const std::uint32_t fidelity_phase_count =
+        is_high_fidelity(math_fidelity) ? to_underlying(math_fidelity) : 1)
 {
     // in0 - loaded to SrcB
     // in1 - loaded to SrcA
@@ -554,7 +562,7 @@ inline void matmul_configure_mop_throttled(
             }
         });
 
-    constexpr std::uint32_t outer_loops        = (THROTTLE_LEVEL > 3) ? 2 : (high_fidelity ? to_underlying(math_fidelity) : 1);
+    const std::uint32_t outer_loops = (THROTTLE_LEVEL > 3) ? 2 : (high_fidelity ? fidelity_phase_count : 1);
     const std::uint32_t inner_loops            = (!is_in1_16x32) ? 2 : 1;
     constexpr std::uint8_t addr_mod_inner_loop = (THROTTLE_LEVEL > 3) ? ADDR_MOD_2 : ADDR_MOD_4;
     ckernel_template tmp(
@@ -594,6 +602,8 @@ inline void _llk_math_matmul_init_(
     const std::uint32_t in0_tile_c_dim = TILE_C_DIM,
     const std::uint32_t in1_tile_r_dim = TILE_R_DIM,
     const std::uint32_t in1_tile_c_dim = TILE_C_DIM,
+    const std::uint32_t in0_dst_format = static_cast<std::uint32_t>(DataFormat::Float16_b),
+    const std::uint32_t in1_dst_format = static_cast<std::uint32_t>(DataFormat::Float16_b),
     const bool partial_face            = false,
     const std::uint32_t transpose      = 0,
     const std::uint32_t ct_dim         = 1,
@@ -606,16 +616,43 @@ inline void _llk_math_matmul_init_(
     // in1=32x16 NOT supported with transpose (no addr_mod handling)
     LLK_ASSERT(!(transpose && (in1_tile_r_dim == TILE_R_DIM) && (in1_tile_c_dim == FACE_C_DIM)), "Transpose with input 1 dimensions 32x16 not supported");
 
-    matmul_configure_addrmod<math_fidelity, THROTTLE_LEVEL>(transpose, in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face);
+    matmul_runtime_fidelity_phase_count =
+        get_matmul_fidelity_phase_count(math_fidelity, in0_dst_format, in1_dst_format);
+    matmul_runtime_fidelity_increment =
+        get_matmul_fidelity_increment(math_fidelity, in0_dst_format, in1_dst_format);
+
+    matmul_configure_addrmod<math_fidelity, THROTTLE_LEVEL>(
+        transpose,
+        in0_tile_r_dim,
+        in0_tile_c_dim,
+        in1_tile_r_dim,
+        in1_tile_c_dim,
+        partial_face,
+        matmul_runtime_fidelity_increment);
 
     if constexpr (THROTTLE_LEVEL > 0)
     {
         matmul_configure_mop_throttled<math_fidelity, THROTTLE_LEVEL>(
-            ct_dim, rt_dim, in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face);
+            ct_dim,
+            rt_dim,
+            in0_tile_r_dim,
+            in0_tile_c_dim,
+            in1_tile_r_dim,
+            in1_tile_c_dim,
+            partial_face,
+            matmul_runtime_fidelity_phase_count);
     }
     else
     {
-        matmul_configure_mop<math_fidelity>(ct_dim, rt_dim, in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face);
+        matmul_configure_mop<math_fidelity>(
+            ct_dim,
+            rt_dim,
+            in0_tile_r_dim,
+            in0_tile_c_dim,
+            in1_tile_r_dim,
+            in1_tile_c_dim,
+            partial_face,
+            matmul_runtime_fidelity_phase_count);
     }
     math::reset_counters(p_setrwc::SET_ABD_F);
 }
@@ -641,7 +678,7 @@ inline void _llk_math_matmul_(std::uint32_t dst_index, const std::uint32_t ct_di
 
             if constexpr (THROTTLE_LEVEL > 3 && high_fidelity)
             {
-                for (std::uint32_t phase = 0; phase < to_underlying(math_fidelity); phase++)
+                for (std::uint32_t phase = 0; phase < matmul_runtime_fidelity_phase_count; phase++)
                 {
                     ckernel_template::run();
                 }

--- a/tt_llk_blackhole/llk_lib/llk_math_matmul_fidelity.h
+++ b/tt_llk_blackhole/llk_lib/llk_math_matmul_fidelity.h
@@ -6,7 +6,7 @@
 
 #include <cstdint>
 
-#include "ckernel_defs.h"
+#include "../common/inc/ckernel_defs.h"
 
 namespace ckernel
 {

--- a/tt_llk_blackhole/llk_lib/llk_math_matmul_fidelity.h
+++ b/tt_llk_blackhole/llk_lib/llk_math_matmul_fidelity.h
@@ -6,61 +6,61 @@
 
 #include <cstdint>
 
-#include "llk_defs.h"
+#include "ckernel_defs.h"
 
-namespace ckernel {
+namespace ckernel
+{
 
-constexpr bool should_skip_hifi2_for_bf16_bfp4_matmul(
-    const MathFidelity math_fidelity, const std::uint32_t in0_dst_format, const std::uint32_t in1_dst_format) {
-    return math_fidelity == MathFidelity::HiFi3 &&
-           in0_dst_format == static_cast<std::uint32_t>(DataFormat::Float16_b) &&
-           (in1_dst_format == static_cast<std::uint32_t>(DataFormat::Bfp4) ||
-            in1_dst_format == static_cast<std::uint32_t>(DataFormat::Bfp4_b));
+constexpr bool should_skip_hifi2_for_bf16_bfp4_matmul(const MathFidelity math_fidelity, const std::uint32_t in0_dst_format, const std::uint32_t in1_dst_format)
+{
+    const std::uint32_t masked_in0_dst_format = masked_data_format(in0_dst_format);
+    const std::uint32_t masked_in1_dst_format = masked_data_format(in1_dst_format);
+
+    return math_fidelity == MathFidelity::HiFi3 && masked_in0_dst_format == static_cast<std::uint32_t>(DataFormat::Float16_b) &&
+           (masked_in1_dst_format == static_cast<std::uint32_t>(DataFormat::Bfp4) || masked_in1_dst_format == static_cast<std::uint32_t>(DataFormat::Bfp4_b));
 }
 
-constexpr bool should_skip_hifi2_for_bf16_bfp4_matmul(
-    const MathFidelity math_fidelity, const DataFormat in0_dst_format, const DataFormat in1_dst_format) {
-    return should_skip_hifi2_for_bf16_bfp4_matmul(
-        math_fidelity, static_cast<std::uint32_t>(in0_dst_format), static_cast<std::uint32_t>(in1_dst_format));
+constexpr bool should_skip_hifi2_for_bf16_bfp4_matmul(const MathFidelity math_fidelity, const DataFormat in0_dst_format, const DataFormat in1_dst_format)
+{
+    return should_skip_hifi2_for_bf16_bfp4_matmul(math_fidelity, static_cast<std::uint32_t>(in0_dst_format), static_cast<std::uint32_t>(in1_dst_format));
 }
 
 constexpr std::uint32_t get_matmul_fidelity_phase_count(
-    const MathFidelity math_fidelity, const std::uint32_t in0_dst_format, const std::uint32_t in1_dst_format) {
-    if (math_fidelity == MathFidelity::LoFi) {
+    const MathFidelity math_fidelity, const std::uint32_t in0_dst_format, const std::uint32_t in1_dst_format)
+{
+    if (math_fidelity == MathFidelity::LoFi)
+    {
         return 1;
     }
 
-    return should_skip_hifi2_for_bf16_bfp4_matmul(math_fidelity, in0_dst_format, in1_dst_format)
-               ? 2
-               : static_cast<std::uint32_t>(math_fidelity);
+    return should_skip_hifi2_for_bf16_bfp4_matmul(math_fidelity, in0_dst_format, in1_dst_format) ? 2 : static_cast<std::uint32_t>(math_fidelity);
 }
 
-constexpr std::uint32_t get_matmul_fidelity_increment(
-    const MathFidelity math_fidelity, const std::uint32_t in0_dst_format, const std::uint32_t in1_dst_format) {
-    if (math_fidelity == MathFidelity::LoFi) {
+constexpr std::uint32_t get_matmul_fidelity_increment(const MathFidelity math_fidelity, const std::uint32_t in0_dst_format, const std::uint32_t in1_dst_format)
+{
+    if (math_fidelity == MathFidelity::LoFi)
+    {
         return 0;
     }
 
     return should_skip_hifi2_for_bf16_bfp4_matmul(math_fidelity, in0_dst_format, in1_dst_format) ? 2 : 1;
 }
 
+static_assert(should_skip_hifi2_for_bf16_bfp4_matmul(MathFidelity::HiFi3, DataFormat::Float16_b, DataFormat::Bfp4_b));
 static_assert(
-    should_skip_hifi2_for_bf16_bfp4_matmul(MathFidelity::HiFi3, DataFormat::Float16_b, DataFormat::Bfp4_b));
-static_assert(
-    get_matmul_fidelity_phase_count(
-        MathFidelity::HiFi3, static_cast<std::uint32_t>(DataFormat::Float16_b), static_cast<std::uint32_t>(DataFormat::Bfp4_b)) ==
+    get_matmul_fidelity_phase_count(MathFidelity::HiFi3, static_cast<std::uint32_t>(DataFormat::Float16_b), static_cast<std::uint32_t>(DataFormat::Bfp4_b)) ==
     2);
 static_assert(
-    get_matmul_fidelity_increment(
-        MathFidelity::HiFi3, static_cast<std::uint32_t>(DataFormat::Float16_b), static_cast<std::uint32_t>(DataFormat::Bfp4_b)) ==
-    2);
+    get_matmul_fidelity_increment(MathFidelity::HiFi3, static_cast<std::uint32_t>(DataFormat::Float16_b), static_cast<std::uint32_t>(DataFormat::Bfp4_b)) == 2);
 static_assert(
     get_matmul_fidelity_phase_count(
-        MathFidelity::HiFi3, static_cast<std::uint32_t>(DataFormat::Float16_b), static_cast<std::uint32_t>(DataFormat::Float16_b)) ==
-    3);
+        MathFidelity::HiFi3, static_cast<std::uint32_t>(DataFormat::Float16_b), static_cast<std::uint32_t>(DataFormat::Float16_b)) == 3);
 static_assert(
-    get_matmul_fidelity_increment(
-        MathFidelity::HiFi3, static_cast<std::uint32_t>(DataFormat::Float16_b), static_cast<std::uint32_t>(DataFormat::Float16_b)) ==
+    get_matmul_fidelity_increment(MathFidelity::HiFi3, static_cast<std::uint32_t>(DataFormat::Float16_b), static_cast<std::uint32_t>(DataFormat::Float16_b)) ==
     1);
+static_assert(should_skip_hifi2_for_bf16_bfp4_matmul(
+    MathFidelity::HiFi3,
+    static_cast<std::uint32_t>(DataFormat::Float16_b) | (1u << DATA_FORMAT_BIT_COUNT),
+    static_cast<std::uint32_t>(DataFormat::Bfp4_b) | (1u << DATA_FORMAT_BIT_COUNT)));
 
-}  // namespace ckernel
+} // namespace ckernel

--- a/tt_llk_blackhole/llk_lib/llk_math_matmul_fidelity.h
+++ b/tt_llk_blackhole/llk_lib/llk_math_matmul_fidelity.h
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+#include "llk_defs.h"
+
+namespace ckernel {
+
+constexpr bool should_skip_hifi2_for_bf16_bfp4_matmul(
+    const MathFidelity math_fidelity, const std::uint32_t in0_dst_format, const std::uint32_t in1_dst_format) {
+    return math_fidelity == MathFidelity::HiFi3 &&
+           in0_dst_format == static_cast<std::uint32_t>(DataFormat::Float16_b) &&
+           (in1_dst_format == static_cast<std::uint32_t>(DataFormat::Bfp4) ||
+            in1_dst_format == static_cast<std::uint32_t>(DataFormat::Bfp4_b));
+}
+
+constexpr bool should_skip_hifi2_for_bf16_bfp4_matmul(
+    const MathFidelity math_fidelity, const DataFormat in0_dst_format, const DataFormat in1_dst_format) {
+    return should_skip_hifi2_for_bf16_bfp4_matmul(
+        math_fidelity, static_cast<std::uint32_t>(in0_dst_format), static_cast<std::uint32_t>(in1_dst_format));
+}
+
+constexpr std::uint32_t get_matmul_fidelity_phase_count(
+    const MathFidelity math_fidelity, const std::uint32_t in0_dst_format, const std::uint32_t in1_dst_format) {
+    if (math_fidelity == MathFidelity::LoFi) {
+        return 1;
+    }
+
+    return should_skip_hifi2_for_bf16_bfp4_matmul(math_fidelity, in0_dst_format, in1_dst_format)
+               ? 2
+               : static_cast<std::uint32_t>(math_fidelity);
+}
+
+constexpr std::uint32_t get_matmul_fidelity_increment(
+    const MathFidelity math_fidelity, const std::uint32_t in0_dst_format, const std::uint32_t in1_dst_format) {
+    if (math_fidelity == MathFidelity::LoFi) {
+        return 0;
+    }
+
+    return should_skip_hifi2_for_bf16_bfp4_matmul(math_fidelity, in0_dst_format, in1_dst_format) ? 2 : 1;
+}
+
+static_assert(
+    should_skip_hifi2_for_bf16_bfp4_matmul(MathFidelity::HiFi3, DataFormat::Float16_b, DataFormat::Bfp4_b));
+static_assert(
+    get_matmul_fidelity_phase_count(
+        MathFidelity::HiFi3, static_cast<std::uint32_t>(DataFormat::Float16_b), static_cast<std::uint32_t>(DataFormat::Bfp4_b)) ==
+    2);
+static_assert(
+    get_matmul_fidelity_increment(
+        MathFidelity::HiFi3, static_cast<std::uint32_t>(DataFormat::Float16_b), static_cast<std::uint32_t>(DataFormat::Bfp4_b)) ==
+    2);
+static_assert(
+    get_matmul_fidelity_phase_count(
+        MathFidelity::HiFi3, static_cast<std::uint32_t>(DataFormat::Float16_b), static_cast<std::uint32_t>(DataFormat::Float16_b)) ==
+    3);
+static_assert(
+    get_matmul_fidelity_increment(
+        MathFidelity::HiFi3, static_cast<std::uint32_t>(DataFormat::Float16_b), static_cast<std::uint32_t>(DataFormat::Float16_b)) ==
+    1);
+
+}  // namespace ckernel

--- a/tt_llk_wormhole_b0/llk_lib/llk_math_matmul.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_math_matmul.h
@@ -12,6 +12,7 @@
 #include "cmath_common.h"
 #include "llk_assert.h"
 #include "llk_math_common.h"
+#include "llk_math_matmul_fidelity.h"
 #include "lltt.h"
 
 #ifndef HF
@@ -20,6 +21,9 @@
 
 using namespace ckernel;
 
+static std::uint32_t matmul_runtime_fidelity_phase_count = 1;
+static std::uint32_t matmul_runtime_fidelity_increment   = 0;
+
 template <MathFidelity math_fidelity, int THROTTLE_LEVEL>
 inline void matmul_configure_addrmod(
     const bool transpose,
@@ -27,10 +31,10 @@ inline void matmul_configure_addrmod(
     const std::uint32_t in0_tile_c_dim = TILE_C_DIM,
     const std::uint32_t in1_tile_r_dim = TILE_R_DIM,
     const std::uint32_t in1_tile_c_dim = TILE_C_DIM,
-    const bool partial_face            = false)
+    const bool partial_face            = false,
+    const std::uint32_t fidelity_increment =
+        is_high_fidelity(math_fidelity) ? 1 : 0)
 {
-    constexpr std::uint32_t fidelity_increment = is_high_fidelity(math_fidelity) ? 1 : 0;
-
     const bool is_in0_16x32 = (in0_tile_r_dim <= FACE_R_DIM) && (in0_tile_c_dim > FACE_C_DIM);
     const bool is_in0_32x16 = (in0_tile_r_dim > FACE_R_DIM) && (in0_tile_c_dim <= FACE_C_DIM);
     const bool is_in1_32x16 = (in1_tile_r_dim > FACE_R_DIM) && (in1_tile_c_dim <= FACE_C_DIM);
@@ -304,7 +308,9 @@ inline void matmul_configure_mop(
     const std::uint32_t in0_tile_c_dim = TILE_C_DIM,
     const std::uint32_t in1_tile_r_dim = TILE_R_DIM,
     const std::uint32_t in1_tile_c_dim = TILE_C_DIM,
-    const bool partial_face            = false)
+    const bool partial_face            = false,
+    const std::uint32_t fidelity_phase_count =
+        is_high_fidelity(math_fidelity) ? to_underlying(math_fidelity) : 1)
 {
     // in0 - loaded to SrcB
     // in1 - loaded to SrcA
@@ -429,7 +435,7 @@ inline void matmul_configure_mop(
     }
 
     // TODO: can we commonize this?
-    constexpr std::uint32_t inner_loops = high_fidelity ? to_underlying(math_fidelity) : 1;
+    const std::uint32_t inner_loops = high_fidelity ? fidelity_phase_count : 1;
     ckernel_template tmp(1 /* outer loop */, inner_loops, lltt::replay_insn(ckernel::math::replay_buf_offset, replay_buf_len));
 
     if constexpr (high_fidelity)
@@ -597,7 +603,9 @@ inline void matmul_configure_mop_throttled(
     const std::uint32_t in0_tile_c_dim = TILE_C_DIM,
     const std::uint32_t in1_tile_r_dim = TILE_R_DIM,
     const std::uint32_t in1_tile_c_dim = TILE_C_DIM,
-    const bool partial_face            = false)
+    const bool partial_face            = false,
+    const std::uint32_t fidelity_phase_count =
+        is_high_fidelity(math_fidelity) ? to_underlying(math_fidelity) : 1)
 {
     // in0 - loaded to SrcB
     // in1 - loaded to SrcA
@@ -631,7 +639,7 @@ inline void matmul_configure_mop_throttled(
         run_throttled_sequence<THROTTLE_LEVEL, high_fidelity>(t_dim, reuse_a);
     }
 
-    constexpr std::uint32_t outer_loops        = (THROTTLE_LEVEL > 3) ? 2 : (high_fidelity ? to_underlying(math_fidelity) : 1);
+    const std::uint32_t outer_loops = (THROTTLE_LEVEL > 3) ? 2 : (high_fidelity ? fidelity_phase_count : 1);
     const std::uint32_t inner_loops            = (!is_in1_16x32) ? 2 : 1;
     constexpr std::uint32_t loop_instruction_0 = (THROTTLE_LEVEL == 5)   ? lltt::replay_insn(ckernel::math::replay_buf_offset + 1, 8)
                                                  : (THROTTLE_LEVEL == 4) ? lltt::replay_insn(ckernel::math::replay_buf_offset + 2, 6)
@@ -681,6 +689,8 @@ inline void _llk_math_matmul_init_(
     const std::uint32_t in0_tile_c_dim = TILE_C_DIM,
     const std::uint32_t in1_tile_r_dim = TILE_R_DIM,
     const std::uint32_t in1_tile_c_dim = TILE_C_DIM,
+    const std::uint32_t in0_dst_format = static_cast<std::uint32_t>(DataFormat::Float16_b),
+    const std::uint32_t in1_dst_format = static_cast<std::uint32_t>(DataFormat::Float16_b),
     const bool partial_face            = false,
     const std::uint32_t transpose      = 0,
     const std::uint32_t ct_dim         = 1,
@@ -694,7 +704,19 @@ inline void _llk_math_matmul_init_(
     LLK_ASSERT(
         !(transpose && (in1_tile_r_dim == TILE_R_DIM) && (in1_tile_c_dim == FACE_C_DIM)), "in1=32x16 not supported with transpose (no addr_mod handling)");
 
-    matmul_configure_addrmod<math_fidelity, THROTTLE_LEVEL>(transpose, in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face);
+    matmul_runtime_fidelity_phase_count =
+        get_matmul_fidelity_phase_count(math_fidelity, in0_dst_format, in1_dst_format);
+    matmul_runtime_fidelity_increment =
+        get_matmul_fidelity_increment(math_fidelity, in0_dst_format, in1_dst_format);
+
+    matmul_configure_addrmod<math_fidelity, THROTTLE_LEVEL>(
+        transpose,
+        in0_tile_r_dim,
+        in0_tile_c_dim,
+        in1_tile_r_dim,
+        in1_tile_c_dim,
+        partial_face,
+        matmul_runtime_fidelity_increment);
     const bool reuse_a        = ct_dim >= rt_dim;
     const std::uint32_t t_dim = reuse_a ? rt_dim : ct_dim;
     if (t_dim > 1)
@@ -716,11 +738,26 @@ inline void _llk_math_matmul_init_(
     if constexpr (THROTTLE_LEVEL > 0)
     {
         matmul_configure_mop_throttled<math_fidelity, THROTTLE_LEVEL>(
-            ct_dim, rt_dim, in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face);
+            ct_dim,
+            rt_dim,
+            in0_tile_r_dim,
+            in0_tile_c_dim,
+            in1_tile_r_dim,
+            in1_tile_c_dim,
+            partial_face,
+            matmul_runtime_fidelity_phase_count);
     }
     else
     {
-        matmul_configure_mop<math_fidelity>(ct_dim, rt_dim, in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face);
+        matmul_configure_mop<math_fidelity>(
+            ct_dim,
+            rt_dim,
+            in0_tile_r_dim,
+            in0_tile_c_dim,
+            in1_tile_r_dim,
+            in1_tile_c_dim,
+            partial_face,
+            matmul_runtime_fidelity_phase_count);
     }
     math::reset_counters(p_setrwc::SET_ABD_F);
 }
@@ -749,7 +786,7 @@ inline void _llk_math_matmul_(std::uint32_t dst_index, const std::uint32_t ct_di
             {
                 if constexpr (THROTTLE_LEVEL > 3 && high_fidelity)
                 {
-                    for (std::uint32_t phase = 0; phase < to_underlying(math_fidelity); phase++)
+                    for (std::uint32_t phase = 0; phase < matmul_runtime_fidelity_phase_count; phase++)
                     {
                         ckernel_template::run();
                     }
@@ -784,7 +821,7 @@ inline void _llk_math_matmul_(std::uint32_t dst_index, const std::uint32_t ct_di
             {
                 if constexpr (THROTTLE_LEVEL > 3 && high_fidelity)
                 {
-                    for (std::uint32_t phase = 0; phase < to_underlying(math_fidelity); phase++)
+                    for (std::uint32_t phase = 0; phase < matmul_runtime_fidelity_phase_count; phase++)
                     {
                         ckernel_template::run();
                     }
@@ -829,7 +866,7 @@ inline void _llk_math_matmul_(std::uint32_t dst_index, const std::uint32_t ct_di
                         dst_index + (reuse_a ? ct_dim * (t + 1) + rut : t + 1 + rut * ct_dim));
                     if constexpr (THROTTLE_LEVEL > 3 && high_fidelity)
                     {
-                        for (std::uint32_t phase = 0; phase < to_underlying(math_fidelity); phase++)
+                        for (std::uint32_t phase = 0; phase < matmul_runtime_fidelity_phase_count; phase++)
                         {
                             ckernel_template::run();
                         }

--- a/tt_llk_wormhole_b0/llk_lib/llk_math_matmul.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_math_matmul.h
@@ -27,13 +27,12 @@ static std::uint32_t matmul_runtime_fidelity_increment   = 0;
 template <MathFidelity math_fidelity, int THROTTLE_LEVEL>
 inline void matmul_configure_addrmod(
     const bool transpose,
-    const std::uint32_t in0_tile_r_dim = TILE_R_DIM,
-    const std::uint32_t in0_tile_c_dim = TILE_C_DIM,
-    const std::uint32_t in1_tile_r_dim = TILE_R_DIM,
-    const std::uint32_t in1_tile_c_dim = TILE_C_DIM,
-    const bool partial_face            = false,
-    const std::uint32_t fidelity_increment =
-        is_high_fidelity(math_fidelity) ? 1 : 0)
+    const std::uint32_t in0_tile_r_dim     = TILE_R_DIM,
+    const std::uint32_t in0_tile_c_dim     = TILE_C_DIM,
+    const std::uint32_t in1_tile_r_dim     = TILE_R_DIM,
+    const std::uint32_t in1_tile_c_dim     = TILE_C_DIM,
+    const bool partial_face                = false,
+    const std::uint32_t fidelity_increment = is_high_fidelity(math_fidelity) ? 1 : 0)
 {
     const bool is_in0_16x32 = (in0_tile_r_dim <= FACE_R_DIM) && (in0_tile_c_dim > FACE_C_DIM);
     const bool is_in0_32x16 = (in0_tile_r_dim > FACE_R_DIM) && (in0_tile_c_dim <= FACE_C_DIM);
@@ -304,13 +303,12 @@ template <MathFidelity math_fidelity>
 inline void matmul_configure_mop(
     const std::uint32_t ct_dim,
     const std::uint32_t rt_dim,
-    const std::uint32_t in0_tile_r_dim = TILE_R_DIM,
-    const std::uint32_t in0_tile_c_dim = TILE_C_DIM,
-    const std::uint32_t in1_tile_r_dim = TILE_R_DIM,
-    const std::uint32_t in1_tile_c_dim = TILE_C_DIM,
-    const bool partial_face            = false,
-    const std::uint32_t fidelity_phase_count =
-        is_high_fidelity(math_fidelity) ? to_underlying(math_fidelity) : 1)
+    const std::uint32_t in0_tile_r_dim       = TILE_R_DIM,
+    const std::uint32_t in0_tile_c_dim       = TILE_C_DIM,
+    const std::uint32_t in1_tile_r_dim       = TILE_R_DIM,
+    const std::uint32_t in1_tile_c_dim       = TILE_C_DIM,
+    const bool partial_face                  = false,
+    const std::uint32_t fidelity_phase_count = is_high_fidelity(math_fidelity) ? to_underlying(math_fidelity) : 1)
 {
     // in0 - loaded to SrcB
     // in1 - loaded to SrcA
@@ -599,13 +597,12 @@ template <MathFidelity math_fidelity, int THROTTLE_LEVEL>
 inline void matmul_configure_mop_throttled(
     const std::uint32_t ct_dim,
     const std::uint32_t rt_dim,
-    const std::uint32_t in0_tile_r_dim = TILE_R_DIM,
-    const std::uint32_t in0_tile_c_dim = TILE_C_DIM,
-    const std::uint32_t in1_tile_r_dim = TILE_R_DIM,
-    const std::uint32_t in1_tile_c_dim = TILE_C_DIM,
-    const bool partial_face            = false,
-    const std::uint32_t fidelity_phase_count =
-        is_high_fidelity(math_fidelity) ? to_underlying(math_fidelity) : 1)
+    const std::uint32_t in0_tile_r_dim       = TILE_R_DIM,
+    const std::uint32_t in0_tile_c_dim       = TILE_C_DIM,
+    const std::uint32_t in1_tile_r_dim       = TILE_R_DIM,
+    const std::uint32_t in1_tile_c_dim       = TILE_C_DIM,
+    const bool partial_face                  = false,
+    const std::uint32_t fidelity_phase_count = is_high_fidelity(math_fidelity) ? to_underlying(math_fidelity) : 1)
 {
     // in0 - loaded to SrcB
     // in1 - loaded to SrcA
@@ -639,7 +636,7 @@ inline void matmul_configure_mop_throttled(
         run_throttled_sequence<THROTTLE_LEVEL, high_fidelity>(t_dim, reuse_a);
     }
 
-    const std::uint32_t outer_loops = (THROTTLE_LEVEL > 3) ? 2 : (high_fidelity ? fidelity_phase_count : 1);
+    const std::uint32_t outer_loops            = (THROTTLE_LEVEL > 3) ? 2 : (high_fidelity ? fidelity_phase_count : 1);
     const std::uint32_t inner_loops            = (!is_in1_16x32) ? 2 : 1;
     constexpr std::uint32_t loop_instruction_0 = (THROTTLE_LEVEL == 5)   ? lltt::replay_insn(ckernel::math::replay_buf_offset + 1, 8)
                                                  : (THROTTLE_LEVEL == 4) ? lltt::replay_insn(ckernel::math::replay_buf_offset + 2, 6)
@@ -689,12 +686,12 @@ inline void _llk_math_matmul_init_(
     const std::uint32_t in0_tile_c_dim = TILE_C_DIM,
     const std::uint32_t in1_tile_r_dim = TILE_R_DIM,
     const std::uint32_t in1_tile_c_dim = TILE_C_DIM,
-    const std::uint32_t in0_dst_format = static_cast<std::uint32_t>(DataFormat::Float16_b),
-    const std::uint32_t in1_dst_format = static_cast<std::uint32_t>(DataFormat::Float16_b),
     const bool partial_face            = false,
     const std::uint32_t transpose      = 0,
     const std::uint32_t ct_dim         = 1,
-    const std::uint32_t rt_dim         = 1)
+    const std::uint32_t rt_dim         = 1,
+    const std::uint32_t in0_dst_format = static_cast<std::uint32_t>(DataFormat::Float16_b),
+    const std::uint32_t in1_dst_format = static_cast<std::uint32_t>(DataFormat::Float16_b))
 {
     // 16x16 inputs not supported - no dedicated math path; falls to 32x32 default which is incorrect for < 4 faces
     LLK_ASSERT(
@@ -704,19 +701,11 @@ inline void _llk_math_matmul_init_(
     LLK_ASSERT(
         !(transpose && (in1_tile_r_dim == TILE_R_DIM) && (in1_tile_c_dim == FACE_C_DIM)), "in1=32x16 not supported with transpose (no addr_mod handling)");
 
-    matmul_runtime_fidelity_phase_count =
-        get_matmul_fidelity_phase_count(math_fidelity, in0_dst_format, in1_dst_format);
-    matmul_runtime_fidelity_increment =
-        get_matmul_fidelity_increment(math_fidelity, in0_dst_format, in1_dst_format);
+    matmul_runtime_fidelity_phase_count = get_matmul_fidelity_phase_count(math_fidelity, in0_dst_format, in1_dst_format);
+    matmul_runtime_fidelity_increment   = get_matmul_fidelity_increment(math_fidelity, in0_dst_format, in1_dst_format);
 
     matmul_configure_addrmod<math_fidelity, THROTTLE_LEVEL>(
-        transpose,
-        in0_tile_r_dim,
-        in0_tile_c_dim,
-        in1_tile_r_dim,
-        in1_tile_c_dim,
-        partial_face,
-        matmul_runtime_fidelity_increment);
+        transpose, in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face, matmul_runtime_fidelity_increment);
     const bool reuse_a        = ct_dim >= rt_dim;
     const std::uint32_t t_dim = reuse_a ? rt_dim : ct_dim;
     if (t_dim > 1)
@@ -738,26 +727,12 @@ inline void _llk_math_matmul_init_(
     if constexpr (THROTTLE_LEVEL > 0)
     {
         matmul_configure_mop_throttled<math_fidelity, THROTTLE_LEVEL>(
-            ct_dim,
-            rt_dim,
-            in0_tile_r_dim,
-            in0_tile_c_dim,
-            in1_tile_r_dim,
-            in1_tile_c_dim,
-            partial_face,
-            matmul_runtime_fidelity_phase_count);
+            ct_dim, rt_dim, in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face, matmul_runtime_fidelity_phase_count);
     }
     else
     {
         matmul_configure_mop<math_fidelity>(
-            ct_dim,
-            rt_dim,
-            in0_tile_r_dim,
-            in0_tile_c_dim,
-            in1_tile_r_dim,
-            in1_tile_c_dim,
-            partial_face,
-            matmul_runtime_fidelity_phase_count);
+            ct_dim, rt_dim, in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face, matmul_runtime_fidelity_phase_count);
     }
     math::reset_counters(p_setrwc::SET_ABD_F);
 }

--- a/tt_llk_wormhole_b0/llk_lib/llk_math_matmul.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_math_matmul.h
@@ -34,9 +34,10 @@ inline void matmul_configure_addrmod(
     const bool partial_face                = false,
     const std::uint32_t fidelity_increment = is_high_fidelity(math_fidelity) ? 1 : 0)
 {
-    const bool is_in0_16x32 = (in0_tile_r_dim <= FACE_R_DIM) && (in0_tile_c_dim > FACE_C_DIM);
-    const bool is_in0_32x16 = (in0_tile_r_dim > FACE_R_DIM) && (in0_tile_c_dim <= FACE_C_DIM);
-    const bool is_in1_32x16 = (in1_tile_r_dim > FACE_R_DIM) && (in1_tile_c_dim <= FACE_C_DIM);
+    const bool is_in0_16x32          = (in0_tile_r_dim <= FACE_R_DIM) && (in0_tile_c_dim > FACE_C_DIM);
+    const bool is_in0_32x16          = (in0_tile_r_dim > FACE_R_DIM) && (in0_tile_c_dim <= FACE_C_DIM);
+    const bool is_in1_32x16          = (in1_tile_r_dim > FACE_R_DIM) && (in1_tile_c_dim <= FACE_C_DIM);
+    const auto fidelity_increment_u8 = static_cast<std::uint8_t>(fidelity_increment);
 
     // MVMUL does D = B*A
 
@@ -66,7 +67,7 @@ inline void matmul_configure_addrmod(
         .srca     = {.incr = 0, .clr = 1, .cr = 1},
         .srcb     = {.incr = 0, .clr = 1, .cr = 1},
         .dest     = {.incr = 0, .clr = 1, .cr = 1},
-        .fidelity = {.incr = fidelity_increment, .clr = 0},
+        .fidelity = {.incr = fidelity_increment_u8, .clr = 0},
         .bias     = {.incr = 1},
     }
         .set(ADDR_MOD_5);

--- a/tt_llk_wormhole_b0/llk_lib/llk_math_matmul_fidelity.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_math_matmul_fidelity.h
@@ -6,7 +6,7 @@
 
 #include <cstdint>
 
-#include "ckernel_defs.h"
+#include "../common/inc/ckernel_defs.h"
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/llk_lib/llk_math_matmul_fidelity.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_math_matmul_fidelity.h
@@ -6,61 +6,61 @@
 
 #include <cstdint>
 
-#include "llk_defs.h"
+#include "ckernel_defs.h"
 
-namespace ckernel {
+namespace ckernel
+{
 
-constexpr bool should_skip_hifi2_for_bf16_bfp4_matmul(
-    const MathFidelity math_fidelity, const std::uint32_t in0_dst_format, const std::uint32_t in1_dst_format) {
-    return math_fidelity == MathFidelity::HiFi3 &&
-           in0_dst_format == static_cast<std::uint32_t>(DataFormat::Float16_b) &&
-           (in1_dst_format == static_cast<std::uint32_t>(DataFormat::Bfp4) ||
-            in1_dst_format == static_cast<std::uint32_t>(DataFormat::Bfp4_b));
+constexpr bool should_skip_hifi2_for_bf16_bfp4_matmul(const MathFidelity math_fidelity, const std::uint32_t in0_dst_format, const std::uint32_t in1_dst_format)
+{
+    const std::uint32_t masked_in0_dst_format = masked_data_format(in0_dst_format);
+    const std::uint32_t masked_in1_dst_format = masked_data_format(in1_dst_format);
+
+    return math_fidelity == MathFidelity::HiFi3 && masked_in0_dst_format == static_cast<std::uint32_t>(DataFormat::Float16_b) &&
+           (masked_in1_dst_format == static_cast<std::uint32_t>(DataFormat::Bfp4) || masked_in1_dst_format == static_cast<std::uint32_t>(DataFormat::Bfp4_b));
 }
 
-constexpr bool should_skip_hifi2_for_bf16_bfp4_matmul(
-    const MathFidelity math_fidelity, const DataFormat in0_dst_format, const DataFormat in1_dst_format) {
-    return should_skip_hifi2_for_bf16_bfp4_matmul(
-        math_fidelity, static_cast<std::uint32_t>(in0_dst_format), static_cast<std::uint32_t>(in1_dst_format));
+constexpr bool should_skip_hifi2_for_bf16_bfp4_matmul(const MathFidelity math_fidelity, const DataFormat in0_dst_format, const DataFormat in1_dst_format)
+{
+    return should_skip_hifi2_for_bf16_bfp4_matmul(math_fidelity, static_cast<std::uint32_t>(in0_dst_format), static_cast<std::uint32_t>(in1_dst_format));
 }
 
 constexpr std::uint32_t get_matmul_fidelity_phase_count(
-    const MathFidelity math_fidelity, const std::uint32_t in0_dst_format, const std::uint32_t in1_dst_format) {
-    if (math_fidelity == MathFidelity::LoFi) {
+    const MathFidelity math_fidelity, const std::uint32_t in0_dst_format, const std::uint32_t in1_dst_format)
+{
+    if (math_fidelity == MathFidelity::LoFi)
+    {
         return 1;
     }
 
-    return should_skip_hifi2_for_bf16_bfp4_matmul(math_fidelity, in0_dst_format, in1_dst_format)
-               ? 2
-               : static_cast<std::uint32_t>(math_fidelity);
+    return should_skip_hifi2_for_bf16_bfp4_matmul(math_fidelity, in0_dst_format, in1_dst_format) ? 2 : static_cast<std::uint32_t>(math_fidelity);
 }
 
-constexpr std::uint32_t get_matmul_fidelity_increment(
-    const MathFidelity math_fidelity, const std::uint32_t in0_dst_format, const std::uint32_t in1_dst_format) {
-    if (math_fidelity == MathFidelity::LoFi) {
+constexpr std::uint32_t get_matmul_fidelity_increment(const MathFidelity math_fidelity, const std::uint32_t in0_dst_format, const std::uint32_t in1_dst_format)
+{
+    if (math_fidelity == MathFidelity::LoFi)
+    {
         return 0;
     }
 
     return should_skip_hifi2_for_bf16_bfp4_matmul(math_fidelity, in0_dst_format, in1_dst_format) ? 2 : 1;
 }
 
+static_assert(should_skip_hifi2_for_bf16_bfp4_matmul(MathFidelity::HiFi3, DataFormat::Float16_b, DataFormat::Bfp4_b));
 static_assert(
-    should_skip_hifi2_for_bf16_bfp4_matmul(MathFidelity::HiFi3, DataFormat::Float16_b, DataFormat::Bfp4_b));
-static_assert(
-    get_matmul_fidelity_phase_count(
-        MathFidelity::HiFi3, static_cast<std::uint32_t>(DataFormat::Float16_b), static_cast<std::uint32_t>(DataFormat::Bfp4_b)) ==
+    get_matmul_fidelity_phase_count(MathFidelity::HiFi3, static_cast<std::uint32_t>(DataFormat::Float16_b), static_cast<std::uint32_t>(DataFormat::Bfp4_b)) ==
     2);
 static_assert(
-    get_matmul_fidelity_increment(
-        MathFidelity::HiFi3, static_cast<std::uint32_t>(DataFormat::Float16_b), static_cast<std::uint32_t>(DataFormat::Bfp4_b)) ==
-    2);
+    get_matmul_fidelity_increment(MathFidelity::HiFi3, static_cast<std::uint32_t>(DataFormat::Float16_b), static_cast<std::uint32_t>(DataFormat::Bfp4_b)) == 2);
 static_assert(
     get_matmul_fidelity_phase_count(
-        MathFidelity::HiFi3, static_cast<std::uint32_t>(DataFormat::Float16_b), static_cast<std::uint32_t>(DataFormat::Float16_b)) ==
-    3);
+        MathFidelity::HiFi3, static_cast<std::uint32_t>(DataFormat::Float16_b), static_cast<std::uint32_t>(DataFormat::Float16_b)) == 3);
 static_assert(
-    get_matmul_fidelity_increment(
-        MathFidelity::HiFi3, static_cast<std::uint32_t>(DataFormat::Float16_b), static_cast<std::uint32_t>(DataFormat::Float16_b)) ==
+    get_matmul_fidelity_increment(MathFidelity::HiFi3, static_cast<std::uint32_t>(DataFormat::Float16_b), static_cast<std::uint32_t>(DataFormat::Float16_b)) ==
     1);
+static_assert(should_skip_hifi2_for_bf16_bfp4_matmul(
+    MathFidelity::HiFi3,
+    static_cast<std::uint32_t>(DataFormat::Float16_b) | (1u << DATA_FORMAT_BIT_COUNT),
+    static_cast<std::uint32_t>(DataFormat::Bfp4_b) | (1u << DATA_FORMAT_BIT_COUNT)));
 
-}  // namespace ckernel
+} // namespace ckernel

--- a/tt_llk_wormhole_b0/llk_lib/llk_math_matmul_fidelity.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_math_matmul_fidelity.h
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+#include "llk_defs.h"
+
+namespace ckernel {
+
+constexpr bool should_skip_hifi2_for_bf16_bfp4_matmul(
+    const MathFidelity math_fidelity, const std::uint32_t in0_dst_format, const std::uint32_t in1_dst_format) {
+    return math_fidelity == MathFidelity::HiFi3 &&
+           in0_dst_format == static_cast<std::uint32_t>(DataFormat::Float16_b) &&
+           (in1_dst_format == static_cast<std::uint32_t>(DataFormat::Bfp4) ||
+            in1_dst_format == static_cast<std::uint32_t>(DataFormat::Bfp4_b));
+}
+
+constexpr bool should_skip_hifi2_for_bf16_bfp4_matmul(
+    const MathFidelity math_fidelity, const DataFormat in0_dst_format, const DataFormat in1_dst_format) {
+    return should_skip_hifi2_for_bf16_bfp4_matmul(
+        math_fidelity, static_cast<std::uint32_t>(in0_dst_format), static_cast<std::uint32_t>(in1_dst_format));
+}
+
+constexpr std::uint32_t get_matmul_fidelity_phase_count(
+    const MathFidelity math_fidelity, const std::uint32_t in0_dst_format, const std::uint32_t in1_dst_format) {
+    if (math_fidelity == MathFidelity::LoFi) {
+        return 1;
+    }
+
+    return should_skip_hifi2_for_bf16_bfp4_matmul(math_fidelity, in0_dst_format, in1_dst_format)
+               ? 2
+               : static_cast<std::uint32_t>(math_fidelity);
+}
+
+constexpr std::uint32_t get_matmul_fidelity_increment(
+    const MathFidelity math_fidelity, const std::uint32_t in0_dst_format, const std::uint32_t in1_dst_format) {
+    if (math_fidelity == MathFidelity::LoFi) {
+        return 0;
+    }
+
+    return should_skip_hifi2_for_bf16_bfp4_matmul(math_fidelity, in0_dst_format, in1_dst_format) ? 2 : 1;
+}
+
+static_assert(
+    should_skip_hifi2_for_bf16_bfp4_matmul(MathFidelity::HiFi3, DataFormat::Float16_b, DataFormat::Bfp4_b));
+static_assert(
+    get_matmul_fidelity_phase_count(
+        MathFidelity::HiFi3, static_cast<std::uint32_t>(DataFormat::Float16_b), static_cast<std::uint32_t>(DataFormat::Bfp4_b)) ==
+    2);
+static_assert(
+    get_matmul_fidelity_increment(
+        MathFidelity::HiFi3, static_cast<std::uint32_t>(DataFormat::Float16_b), static_cast<std::uint32_t>(DataFormat::Bfp4_b)) ==
+    2);
+static_assert(
+    get_matmul_fidelity_phase_count(
+        MathFidelity::HiFi3, static_cast<std::uint32_t>(DataFormat::Float16_b), static_cast<std::uint32_t>(DataFormat::Float16_b)) ==
+    3);
+static_assert(
+    get_matmul_fidelity_increment(
+        MathFidelity::HiFi3, static_cast<std::uint32_t>(DataFormat::Float16_b), static_cast<std::uint32_t>(DataFormat::Float16_b)) ==
+    1);
+
+}  // namespace ckernel


### PR DESCRIPTION
## Summary
- add matmul fidelity scheduling helpers for the `HiFi3 + bf16 x bfp4` special case
- make the standard Wormhole and Blackhole matmul LLKs skip the redundant `HiFi2` replay phase for that operand-format pair
- apply the same runtime schedule to the Blackhole custom no-mop matmul path

## Issue
- Companion tt-metal issue: tenstorrent/tt-metal#39627
- Companion tt-metal PR: tenstorrent/tt-metal#39628

## Testing
- Integrated and validated via tt-metal PR `hifi3-bf16-bfp4-skip-hifi2`
- Focused LLK schedule tests are run from the companion tt-metal PR because the test target lives there

## CI Badge
[![PR Pipeline](https://github.com/tenstorrent/tt-llk/actions/workflows/on-pr.yml/badge.svg?branch=yieldthought%2Fhifi3-bf16-bfp4-skip-hifi2)](https://github.com/tenstorrent/tt-llk/actions/workflows/on-pr.yml?query=branch%3Ayieldthought%2Fhifi3-bf16-bfp4-skip-hifi2)
