### PR TITLE
Implement DISABLE_SFPLOADMACRO path for BH mul_int

### DIFF
--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_mul_int.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_mul_int.h
@@ -18,6 +18,21 @@ namespace sfpu
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void _mul_int_(const std::uint32_t dst_index_in0, const std::uint32_t dst_index_in1, const std::uint32_t dst_index_out)
 {
+    int offset0 = (dst_index_in0 * 32) << 1;
+    int offset1 = (dst_index_in1 * 32) << 1;
+
+#ifdef DISABLE_SFPLOADMACRO
+    int offset_out = (dst_index_out * 32) << 1;
+
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++)
+    {
+        TT_SFPLOAD(p_sfpu::LREG0, LO16, ADDR_MOD_7, offset0);
+        TT_SFPLOAD(p_sfpu::LREG1, LO16, ADDR_MOD_7, offset1);
+        TTI_SFPMUL24(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpu::LCONST_0, p_sfpu::LREG0, sfpi::SFPMUL24_MOD1_LOWER);
+        TT_SFPSTORE(p_sfpu::LREG0, LO16, ADDR_MOD_6, offset_out);
+    }
+#else
     // This uses SFPLOADMACRO to achieve a throughput of 1, 2, or 3 cycles per
     // input row:
     //
@@ -50,9 +65,6 @@ inline void _mul_int_(const std::uint32_t dst_index_in0, const std::uint32_t dst
     // 0 | ...  |        | [b] L16 = mul24_lo(a, b) |       |         |
     // 1 | ...  |        |                          |       |         |
     // 2 | ...  |        |                          |       | [b] L16 |
-
-    int offset0 = (dst_index_in0 * 32) << 1;
-    int offset1 = (dst_index_in1 * 32) << 1;
 
     constexpr int a = p_sfpu::LREG0;
     constexpr int b = p_sfpu::LREG1;
@@ -98,13 +110,15 @@ inline void _mul_int_(const std::uint32_t dst_index_in0, const std::uint32_t dst
     TTI_SFPNOP;
     TTI_SFPNOP;
     TTI_SFPNOP;
+#endif
 }
 
 template <bool APPROXIMATION_MODE>
 inline void _init_mul_int_()
 {
+#ifndef DISABLE_SFPLOADMACRO
     // InstructionTemplate[0]
-    TTI_SFPMUL24(p_sfpu::LREG0, 0, p_sfpu::LCONST_0, 12, 0);
+    TTI_SFPMUL24(p_sfpu::LREG0, 0, p_sfpu::LCONST_0, 12, sfpi::SFPMUL24_MOD1_LOWER);
 
     // Macro 0
     {
@@ -136,6 +150,7 @@ inline void _init_mul_int_()
     //   UnitDelayKind: {1,1}, (WaitForElapsedInstructions=1)
     // }
     TTI_SFPCONFIG(0x330, 8, 1);
+#endif
 }
 
 } // namespace sfpu


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-llk/issues/1241

### Problem description
WH mul_int path had a DISABLE_SFPLOADMACRO path but BH path was missing.

### What's changed
Add simple DISABLE_SFPLOADMACRO code path.
Also use sfpi::SFPMUL24_MOD1_LOWER constant in both paths.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Assert validation](https://github.com/tenstorrent/tt-llk/blob/main/docs/Introduction_to_asserts.md) Complied with assert doc (if applicable)
