### PR TITLE
#39023: adjust location of part of unpacker setup

### DIFF
--- a/tt_llk_blackhole/llk_lib/llk_unpack_common.h
+++ b/tt_llk_blackhole/llk_lib/llk_unpack_common.h
@@ -99,6 +99,14 @@ inline void _llk_unpack_reconfig_data_format_srca_impl_(
     cfg_reg_rmw_tensix<THCON_SEC0_REG2_Out_data_format_RMW>(unpack_dst_format);
     TT_SETDMAREG(0, LOWER_HALFWORD(tile_size), 0, LO_16(p_gpr_unpack::TILE_SIZE_A)); // update gpr which holds tile size A
 
+    // Always update tile x_dim, z_dim, and ADC so that operands with
+    // different face_r_dim / num_faces (e.g. tiny tiles) are handled
+    // correctly even when data formats match.
+    const std::uint32_t face_dim = unpack_face_r_dim * FACE_C_DIM;
+    cfg_reg_rmw_tensix<THCON_SEC0_REG5_Tile_x_dim_cntx0_ADDR32, 0, 0xffffffff>(face_dim | (face_dim << 16));
+    cfg_reg_rmw_tensix<THCON_SEC0_REG0_TileDescriptor_ADDR32 + 1, 0, 0xffff0000>(0 | (unpack_num_faces << 16));
+    TT_SETADCXX(p_setadc::UNP_A, (unpack_face_r_dim << 4) - 1, 0x0);
+
     if constexpr (dim_stride_target == p_dim_stride_target::FACE_ROW_MAJOR)
     {
         std::uint32_t unpack_ch1_x_stride = (std::uint32_t)(unpack_dst_format & 0x3) == (std::uint32_t)DataFormat::Float32   ? 4
@@ -108,16 +116,6 @@ inline void _llk_unpack_reconfig_data_format_srca_impl_(
         // so we want to keep standard stride for one face
         std::uint32_t unpack_ch1_z_stride = FACE_C_DIM * FACE_R_DIM * unpack_ch1_x_stride;
         cfg_reg_rmw_tensix<UNP0_ADDR_CTRL_ZW_REG_1_Zstride_RMW>(unpack_ch1_z_stride);
-
-        // Program unpacker0 per context x_dim (face size in l1)
-        // Overrides value set by tile descriptor when thread override bit is set in unpack instruction
-        const std::uint32_t face_dim = unpack_face_r_dim * FACE_C_DIM;
-        cfg_reg_rmw_tensix<THCON_SEC0_REG5_Tile_x_dim_cntx0_ADDR32, 0, 0xffffffff>(face_dim | (face_dim << 16));
-
-        // Set Z-dim to number of faces
-        cfg_reg_rmw_tensix<THCON_SEC0_REG0_TileDescriptor_ADDR32 + 1, 0, 0xffff0000>(0 | (unpack_num_faces << 16));
-
-        TT_SETADCXX(p_setadc::UNP_A, (unpack_face_r_dim << 4) - 1, 0x0);
     }
 }
 

--- a/tt_llk_wormhole_b0/llk_lib/llk_unpack_common.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_unpack_common.h
@@ -97,6 +97,14 @@ inline void _llk_unpack_reconfig_data_format_srca_impl_(
     cfg_reg_rmw_tensix<THCON_SEC0_REG2_Out_data_format_RMW>(unpack_dst_format);
     TT_SETDMAREG(0, LOWER_HALFWORD(tile_size), 0, LO_16(p_gpr_unpack::TILE_SIZE_A)); // update gpr which holds tile size A
 
+    // Always update tile x_dim, z_dim, and ADC so that operands with
+    // different face_r_dim / num_faces (e.g. tiny tiles) are handled
+    // correctly even when data formats match.
+    const std::uint32_t face_dim = unpack_face_r_dim * FACE_C_DIM;
+    cfg_reg_rmw_tensix<THCON_SEC0_REG5_Tile_x_dim_cntx0_ADDR32, 0, 0xffffffff>(face_dim | (face_dim << 16));
+    cfg_reg_rmw_tensix<THCON_SEC0_REG0_TileDescriptor_ADDR32 + 1, 0, 0xffff0000>(0 | (unpack_num_faces << 16));
+    TT_SETADCXX(p_setadc::UNP_A, (unpack_face_r_dim << 4) - 1, 0x0);
+
     if constexpr (dim_stride_target == p_dim_stride_target::FACE_ROW_MAJOR)
     {
         std::uint32_t unpack_ch1_x_stride = (std::uint32_t)(unpack_dst_format & 0x3) == (std::uint32_t)DataFormat::Float32   ? 4
@@ -106,16 +114,6 @@ inline void _llk_unpack_reconfig_data_format_srca_impl_(
         // so we want to keep standard stride for one face
         std::uint32_t unpack_ch1_z_stride = FACE_C_DIM * FACE_R_DIM * unpack_ch1_x_stride;
         cfg_reg_rmw_tensix<UNP0_ADDR_CTRL_ZW_REG_1_Zstride_RMW>(unpack_ch1_z_stride);
-
-        // Program unpacker0 per context x_dim (face size in l1)
-        // Overrides value set by tile descriptor when thread override bit is set in unpack instruction
-        const std::uint32_t face_dim = unpack_face_r_dim * FACE_C_DIM;
-        cfg_reg_rmw_tensix<THCON_SEC0_REG5_Tile_x_dim_cntx0_ADDR32, 0, 0xffffffff>(face_dim | (face_dim << 16));
-
-        // Set Z-dim to number of faces
-        cfg_reg_rmw_tensix<THCON_SEC0_REG0_TileDescriptor_ADDR32 + 1, 0, 0xffff0000>(0 | (unpack_num_faces << 16));
-
-        TT_SETADCXX(p_setadc::UNP_A, (unpack_face_r_dim << 4) - 1, 0x0);
     }
 }
 


### PR DESCRIPTION
### Ticket
tt-metal issue https://github.com/tenstorrent/tt-metal/issues/39023

### Problem description
Tiny tile matmul test fails llk asserts because something is not configured properly

### What's changed
Change unpacker configuration location for tile related values

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Assert validation](https://github.com/tenstorrent/tt-llk/blob/main/docs/Introduction_to_asserts.md) Complied with assert doc (if applicable)
