### PR TITLE
[Quasar] Do not take math fidelity into account for gmpool replay buf length

### DIFF
--- a/tt_llk_quasar/llk_lib/llk_math_reduce.h
+++ b/tt_llk_quasar/llk_lib/llk_math_reduce.h
@@ -48,8 +48,8 @@ inline void _llk_math_reduce_col_mop_config_(const TileShape& tile_shape)
     const std::uint32_t MOP_OUTER_LOOP          = 1;
     const std::uint32_t MOP_INNER_LOOP          = (tile_shape.num_faces >= 2) ? (tile_shape.num_faces >> 1) : tile_shape.num_faces;
     constexpr std::uint32_t NUM_FIDELITY_PHASES = MATH_FIDELITY_TYPE == ckernel::MathFidelity::LoFi ? 0 : to_underlying(MATH_FIDELITY_TYPE) - 1;
-    constexpr bool RUN_FID_LOOPS       = (MATH_FIDELITY_TYPE != ckernel::MathFidelity::LoFi && (POOL_TYPE == PoolType::AVG || POOL_TYPE == PoolType::SUM));
-    const std::uint32_t replay_buf_len = 2 + (2 * NUM_FIDELITY_PHASES);
+    constexpr bool RUN_FID_LOOPS           = (MATH_FIDELITY_TYPE != ckernel::MathFidelity::LoFi && (POOL_TYPE == PoolType::AVG || POOL_TYPE == PoolType::SUM));
+    constexpr std::uint32_t replay_buf_len = 2 + (RUN_FID_LOOPS ? (2 * NUM_FIDELITY_PHASES) : 0);
 
     load_replay_buf(
         0,
@@ -106,7 +106,7 @@ inline void _llk_math_reduce_row_mop_config_(const TileShape& tile_shape)
     constexpr std::uint32_t MOP_OUTER_LOOP      = 1;
     constexpr std::uint32_t MOP_INNER_LOOP      = 1;
     // Replay buf max len is 32, NUM_FIDELITY_PHASES will be larger than 3, hypothetical limit of 19 + 12 = 31
-    constexpr std::uint32_t replay_buf_len = 19 + (4 * NUM_FIDELITY_PHASES);
+    constexpr std::uint32_t replay_buf_len = 19 + (RUN_FID_LOOPS ? (4 * NUM_FIDELITY_PHASES) : 0);
 
     load_replay_buf(
         0,
@@ -219,8 +219,9 @@ inline void _llk_math_reduce_scalar_mop_config_(const TileShape& tile_shape)
     constexpr std::uint32_t MOP_OUTER_LOOP      = 1;
     constexpr std::uint32_t MOP_INNER_LOOP      = 1;
     constexpr std::uint32_t NUM_FIDELITY_PHASES = MATH_FIDELITY_TYPE == ckernel::MathFidelity::LoFi ? 0 : to_underlying(MATH_FIDELITY_TYPE) - 1;
-    const std::uint32_t replay_buf_len          = 6 + tile_shape.num_faces - 1 + ((tile_shape.num_faces - 1) * NUM_FIDELITY_PHASES) + (2 * NUM_FIDELITY_PHASES);
     constexpr bool RUN_FID_LOOPS = (MATH_FIDELITY_TYPE != ckernel::MathFidelity::LoFi && (POOL_TYPE == PoolType::AVG || POOL_TYPE == PoolType::SUM));
+    const std::uint32_t replay_buf_len =
+        6 + tile_shape.num_faces - 1 + (RUN_FID_LOOPS ? ((tile_shape.num_faces - 1) * NUM_FIDELITY_PHASES) + (2 * NUM_FIDELITY_PHASES) : 0);
 
     load_replay_buf(
         0,


### PR DESCRIPTION
### Ticket
<!-- Link to Github Issue -->

### Problem description
Math fidelity does not work/do anything for pool_type=MAX.
Inside of the reduce llks bool RUN_FID_LOOPS is false for pool_type=MAX, which excludes some instructions. 
However, the replay_buf_len still takes math fidelity into account. If someone were to pass math fid != LoFi and pool_type=MAX it would hang. 

### What's changed
Excluded math_fid from replay_buf_len for pool_type=MAX. MAX tests pass if someone programs HiFi.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Assert validation](https://github.com/tenstorrent/tt-llk/blob/main/docs/Introduction_to_asserts.md) Complied with assert doc (if applicable)
