### PR TITLE
Use SFPI enums for SFP_STOCH_RND

### DIFF
--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_typecast.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_typecast.h
@@ -634,7 +634,7 @@ inline void _init_typecast_int32_to_fp16b_()
     TTI_SFPMAD(0, p_sfpu::LCONST_1, 0, 13, 4); // SFPMAD_MOD1_INDIRECT_VA
 
     // InstructionTemplate[2]
-    TTI_SFP_STOCH_RND(0, 0, 0, 0, 14, 1); // SFPSTOCHRND_MOD1_FP32_TO_FP16B
+    TTI_SFP_STOCH_RND(0, 0, 0, 0, 14, sfpi::SFPSTOCHRND_MOD1_FP32_TO_FP16B);
 
     // Macro 0: [v]
     {
@@ -689,7 +689,7 @@ inline void _init_typecast_uint16_to_fp16b_()
     TTI_SFPCAST(0, 12, 0);
 
     // InstructionTemplate[1]
-    TTI_SFP_STOCH_RND(0, 0, 0, 0, 13, 1); // SFPSTOCHRND_MOD1_FP32_TO_FP16B
+    TTI_SFP_STOCH_RND(0, 0, 0, 0, 13, sfpi::SFPSTOCHRND_MOD1_FP32_TO_FP16B);
 
     // Macro 0
     {
@@ -721,7 +721,7 @@ inline void _init_typecast_uint32_to_fp16b_()
     TTI_SFPMAD(0, p_sfpu::LCONST_1, 0, 13, 4); // SFPMAD_MOD1_INDIRECT_VA
 
     // InstructionTemplate[2]
-    TTI_SFP_STOCH_RND(0, 0, 0, 0, 14, 1); // SFPSTOCHRND_MOD1_FP32_TO_FP16B
+    TTI_SFP_STOCH_RND(0, 0, 0, 0, 14, sfpi::SFPSTOCHRND_MOD1_FP32_TO_FP16B);
 
     // Macro 0
     {
@@ -820,7 +820,7 @@ inline void _init_typecast_int32_to_uint16_()
     TTI_SFPSWAP(0, p_sfpu::LCONST_0, 12, 0xf); // L[VD] = max(0, L[VD])
 
     // InstructionTemplate[1]
-    TTI_SFP_STOCH_RND(0, 0, 0, 0, 13, 6); // SFPSTOCHRND_MOD1_FP32_TO_UINT16
+    TTI_SFP_STOCH_RND(0, 0, 0, 0, 13, sfpi::SFPSTOCHRND_MOD1_FP32_TO_UINT16);
 
     // Macro 0
     {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_typecast.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_typecast.h
@@ -654,7 +654,7 @@ inline void _init_typecast_int32_to_fp16b_()
     TTI_SFPMAD(0, p_sfpu::LCONST_1, 0, 13, 4); // SFPMAD_MOD1_INDIRECT_VA
 
     // InstructionTemplate[2]
-    TTI_SFP_STOCH_RND(0, 0, 0, 0, 14, 1); // SFPSTOCHRND_MOD1_FP32_TO_FP16B
+    TTI_SFP_STOCH_RND(0, 0, 0, 0, 14, sfpi::SFPSTOCHRND_MOD1_FP32_TO_FP16B);
 
     // Macro 0: [v]
     {
@@ -709,7 +709,7 @@ inline void _init_typecast_uint16_to_fp16b_()
     TTI_SFPCAST(0, 12, 0);
 
     // InstructionTemplate[1]
-    TTI_SFP_STOCH_RND(0, 0, 0, 0, 13, 1); // SFPSTOCHRND_MOD1_FP32_TO_FP16B
+    TTI_SFP_STOCH_RND(0, 0, 0, 0, 13, sfpi::SFPSTOCHRND_MOD1_FP32_TO_FP16B);
 
     // Macro 0
     {
@@ -741,7 +741,7 @@ inline void _init_typecast_uint32_to_fp16b_()
     TTI_SFPMAD(0, p_sfpu::LCONST_1, 0, 13, 4); // SFPMAD_MOD1_INDIRECT_VA
 
     // InstructionTemplate[2]
-    TTI_SFP_STOCH_RND(0, 0, 0, 0, 14, 1); // SFPSTOCHRND_MOD1_FP32_TO_FP16B
+    TTI_SFP_STOCH_RND(0, 0, 0, 0, 14, sfpi::SFPSTOCHRND_MOD1_FP32_TO_FP16B);
 
     // Macro 0
     {
@@ -863,7 +863,7 @@ inline void _init_typecast_int32_to_uint16_()
     TTI_SFPSWAP(0, p_sfpu::LCONST_0, 12, 0xf); // L[VD] = max(0, L[VD])
 
     // InstructionTemplate[1]
-    TTI_SFP_STOCH_RND(0, 0, 0, 0, 13, 6); // SFPSTOCHRND_MOD1_FP32_TO_UINT16
+    TTI_SFP_STOCH_RND(0, 0, 0, 0, 13, sfpi::SFPSTOCHRND_MOD1_FP32_TO_UINT16);
 
     // Macro 0
     {


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-llk/issues/1241

### Problem description
SFP_STOCH_RND typecast code was using magic int literals plus comments explaining them, which didn't even save any characters vs. using the sfpi enums.

### What's changed
Just use the named constants.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Assert validation](https://github.com/tenstorrent/tt-llk/blob/main/docs/Introduction_to_asserts.md) Complied with assert doc (if applicable)
