### PR TITLE
Tiny-tile port for llk_unpack_unary_operand and llk_pack

### DIFF
--- a/tests/python_tests/helpers/golden_generators.py
+++ b/tests/python_tests/helpers/golden_generators.py
@@ -1073,14 +1073,17 @@ class DataCopyGolden:
         torch_format = format_dict[data_format]
 
         # Derive tile geometry from TileShape if provided, else from legacy params
+        if tile_shape is None:
+            tile_shape = construct_tile_shape()
+
         if tile_shape is not None:
             tile_r = tile_shape.total_row_dim()
             tile_c = tile_shape.total_col_dim()
-            elements_per_tile_needed = tile_shape.total_tile_size()
-        else:
+            tile_size = tile_shape.total_tile_size()
+        else:  # for backward compatibility with existing tests that don't specify tile_shape
             tile_r = 32
             tile_c = 32
-            elements_per_tile_needed = face_r_dim * FACE_DIM * num_faces
+            tile_size = face_r_dim * FACE_DIM * num_faces
 
         height, width = input_dimensions[0], input_dimensions[1]
         tile_cnt = (height // tile_r) * (width // tile_c)
@@ -1089,17 +1092,8 @@ class DataCopyGolden:
         if not isinstance(operand1, torch.Tensor):
             operand1 = torch.tensor(operand1, dtype=torch_format)
 
-        # Input may be laid out as full 32×32 tile slots or pre-sized for this tile shape
-        total_elements = operand1.numel()
-        expected_exact_size = tile_cnt * elements_per_tile_needed
-
-        if total_elements == expected_exact_size:
-            tile_size = elements_per_tile_needed
-        else:
-            tile_size = total_elements // tile_cnt
-
         reshaped = operand1.view(tile_cnt, tile_size)
-        selected = reshaped[:, :elements_per_tile_needed]
+        selected = reshaped[:, :tile_size]
         result = selected.flatten()
 
         # Ensure result is in correct format if not already

--- a/tests/python_tests/helpers/golden_generators.py
+++ b/tests/python_tests/helpers/golden_generators.py
@@ -1067,38 +1067,36 @@ class DataCopyGolden:
         data_format,
         num_faces: int = 4,
         input_dimensions: list[int] = [32, 32],
-        face_r_dim: int = 16,  # Default to 16 for backward compatibility
+        face_r_dim: int = 16,
+        tile_shape=None,
     ):
         torch_format = format_dict[data_format]
 
-        height, width = input_dimensions[0], input_dimensions[1]
-
-        # Handle partial faces (face_r_dim < 16) as single tiles
-        if face_r_dim < 16:
-            tile_cnt = 1
+        # Derive tile geometry from TileShape if provided, else from legacy params
+        if tile_shape is not None:
+            tile_r = tile_shape.total_row_dim()
+            tile_c = tile_shape.total_col_dim()
+            elements_per_tile_needed = tile_shape.total_tile_size()
         else:
-            tile_cnt = (height // 32) * (width // 32)
+            tile_r = 32
+            tile_c = 32
+            elements_per_tile_needed = face_r_dim * FACE_DIM * num_faces
 
-        # Calculate elements based on variable face dimensions
-        # Each face is face_r_dim × 16, and we have num_faces
-        elements_per_tile_needed = face_r_dim * FACE_DIM * num_faces
+        height, width = input_dimensions[0], input_dimensions[1]
+        tile_cnt = (height // tile_r) * (width // tile_c)
 
         # Convert input to tensor if needed
         if not isinstance(operand1, torch.Tensor):
             operand1 = torch.tensor(operand1, dtype=torch_format)
 
-        # Determine actual tile size from input:
-        # If input is sized for partial faces (num_faces < 4), use elements_per_tile_needed
-        # Otherwise use full tile size
+        # Input may be laid out as full 32×32 tile slots or pre-sized for this tile shape
         total_elements = operand1.numel()
-        expected_partial_size = tile_cnt * elements_per_tile_needed
+        expected_exact_size = tile_cnt * elements_per_tile_needed
 
-        if total_elements == expected_partial_size:
-            # Input is already sized for num_faces, just pass through
+        if total_elements == expected_exact_size:
             tile_size = elements_per_tile_needed
         else:
-            # Input has full tiles, need to select elements
-            tile_size = height * width // tile_cnt if tile_cnt > 0 else height * width
+            tile_size = total_elements // tile_cnt
 
         reshaped = operand1.view(tile_cnt, tile_size)
         selected = reshaped[:, :elements_per_tile_needed]

--- a/tests/python_tests/helpers/param_config.py
+++ b/tests/python_tests/helpers/param_config.py
@@ -7,6 +7,7 @@ from itertools import product
 from typing import Iterator, List, Tuple
 
 import pytest
+from helpers.tile_shape import construct_tile_shape
 from typing_extensions import deprecated
 
 from .data_format_inference import is_format_combination_outlier
@@ -434,7 +435,7 @@ def get_max_dst_index(dest_sync: DestSync, dest_acc: bool, result_tiles: int) ->
     return max(max_tiles - result_tiles, 0)
 
 
-def generate_unary_input_dimensions(dest_acc, dest_sync=DestSync.Half):
+def generate_unary_input_dimensions(dest_acc, dest_sync=DestSync.Half, tile_shape=None):
     """Generate all possible input dimensions for unary operations.
     These dimensions are determined by the number of tiles that can fit into dest, which is determined by dest_sync and dest_acc.
     The generated input dimensions should ensure that all of the data fits into dest without any overflow when running unary operations.
@@ -454,8 +455,11 @@ def generate_unary_input_dimensions(dest_acc, dest_sync=DestSync.Half):
     capacity_divisor = 2 if dest_acc == DestAccumulation.Yes else 1
     max_tiles_in_dest = DEST_SYNC_TILE_LIMITS[dest_sync] // capacity_divisor
 
-    num_tile_rows = 32
-    num_tile_cols = 32
+    if tile_shape is None:
+        tile_shape = construct_tile_shape()
+
+    num_tile_rows = tile_shape.total_row_dim()
+    num_tile_cols = tile_shape.total_col_dim()
 
     return [
         [row * num_tile_rows, column * num_tile_cols]

--- a/tests/python_tests/quasar/test_pack_quasar.py
+++ b/tests/python_tests/quasar/test_pack_quasar.py
@@ -24,16 +24,19 @@ from helpers.param_config import (
     parametrize,
 )
 from helpers.stimuli_config import StimuliConfig
-from helpers.stimuli_generator import generate_stimuli
+from helpers.stimuli_generator import generate_stimuli_w_tile_dimensions
 from helpers.test_config import BootMode, TestConfig
 from helpers.test_variant_parameters import (
     DEST_SYNC,
     IMPLIED_MATH_FORMAT,
+    IN_FACE_DIMS,
     NUM_FACES,
     RELU_CONFIG,
     TEST_FACE_DIMS,
     TILE_COUNT,
 )
+from helpers.tile_constants import SUPPORTED_TILE_SIZES
+from helpers.tile_shape import construct_tile_shape
 from helpers.utils import passed_test
 from test_zzz_pack import is_relu_threshold_tolerance_issue
 
@@ -88,15 +91,6 @@ def generate_qsr_pack_combinations(
             return False
         return True
 
-    dimensions_cache = {
-        DestAccumulation.No: tuple(
-            generate_unary_input_dimensions(DestAccumulation.No)
-        ),
-        DestAccumulation.Yes: tuple(
-            generate_unary_input_dimensions(DestAccumulation.Yes)
-        ),
-    }
-
     all_relu_types = [
         PackerReluType.NoRelu,
         PackerReluType.ZeroRelu,
@@ -120,9 +114,15 @@ def generate_qsr_pack_combinations(
         )
         for dest_acc in get_dest_acc_modes(in_fmt):
             if is_supported_dest_mode_dependent_conversion(in_fmt, out_fmt, dest_acc):
-                for dimensions in dimensions_cache[dest_acc]:
-                    for relu_type in relu_types:
-                        combinations.append((fmt, dest_acc, dimensions, relu_type))
+                for tile_dims in SUPPORTED_TILE_SIZES:
+                    tile_shape = construct_tile_shape(tile_dims)
+                    for dimensions in generate_unary_input_dimensions(
+                        dest_acc, tile_shape=tile_shape
+                    ):
+                        for relu_type in relu_types:
+                            combinations.append(
+                                (fmt, dest_acc, dimensions, relu_type, tile_dims)
+                            )
 
     return combinations
 
@@ -145,21 +145,28 @@ PACK_FORMATS = input_output_formats(
     formats_dest_acc_input_dims=generate_qsr_pack_combinations(PACK_FORMATS),
 )
 def test_pack_quasar(formats_dest_acc_input_dims, boot_mode=BootMode.DEFAULT):
-    (formats, dest_acc, input_dimensions, relu_type) = formats_dest_acc_input_dims[0]
+    (formats, dest_acc, input_dimensions, relu_type, tile_dimensions) = (
+        formats_dest_acc_input_dims[0]
+    )
 
-    src_A, tile_cnt_A, src_B, _ = generate_stimuli(
+    tile_shape = construct_tile_shape(tile_dimensions)
+
+    src_A, tile_cnt_A, src_B, _ = generate_stimuli_w_tile_dimensions(
         stimuli_format_A=formats.input_format,
         input_dimensions_A=input_dimensions,
         stimuli_format_B=formats.input_format,
         input_dimensions_B=input_dimensions,
+        tile_dimensions=tile_dimensions,
     )
 
-    num_faces = 4
+    num_faces = tile_shape.total_num_faces()
+
     generate_golden = get_golden_generator(DataCopyGolden)
     golden_tensor = generate_golden(
         src_A,
         formats.output_format,
         num_faces=num_faces,
+        face_r_dim=tile_shape.face_r_dim,
         input_dimensions=input_dimensions,
     )
 
@@ -200,10 +207,11 @@ def test_pack_quasar(formats_dest_acc_input_dims, boot_mode=BootMode.DEFAULT):
             DEST_SYNC(),
         ],
         runtimes=[
-            TEST_FACE_DIMS(),
+            TEST_FACE_DIMS(tile_shape.face_r_dim),
             NUM_FACES(num_faces),
             TILE_COUNT(tile_cnt_A),
             RELU_CONFIG(relu_config),
+            IN_FACE_DIMS(tile_shape.num_faces_r_dim, tile_shape.num_faces_c_dim),
         ],
         variant_stimuli=StimuliConfig(
             src_A,
@@ -215,6 +223,9 @@ def test_pack_quasar(formats_dest_acc_input_dims, boot_mode=BootMode.DEFAULT):
             tile_count_B=tile_cnt_A,
             tile_count_res=tile_cnt_A,
             num_faces=num_faces,
+            face_r_dim=tile_shape.face_r_dim,
+            tile_dimensions=tile_dimensions,
+            use_dense_tile_dimensions=True,
         ),
         unpack_to_dest=unpack_to_dest,
         dest_acc=dest_acc,
@@ -231,7 +242,11 @@ def test_pack_quasar(formats_dest_acc_input_dims, boot_mode=BootMode.DEFAULT):
     res_tensor = torch.tensor(res_from_L1, dtype=torch_format)
 
     test_passed = passed_test(
-        golden_tensor, res_tensor, formats.output_format, print_errors=False
+        golden_tensor,
+        res_tensor,
+        formats.output_format,
+        print_errors=False,
+        tile_shape=tile_shape,
     )
 
     # Same method as test_pack.py for original ReLu testing and threshold tolerance issue

--- a/tests/python_tests/quasar/test_pack_quasar.py
+++ b/tests/python_tests/quasar/test_pack_quasar.py
@@ -29,8 +29,9 @@ from helpers.test_config import BootMode, TestConfig
 from helpers.test_variant_parameters import (
     DEST_SYNC,
     IMPLIED_MATH_FORMAT,
-    IN_FACE_DIMS,
     NUM_FACES,
+    NUM_FACES_C_DIM,
+    NUM_FACES_R_DIM,
     RELU_CONFIG,
     TEST_FACE_DIMS,
     TILE_COUNT,
@@ -67,11 +68,11 @@ def generate_qsr_pack_combinations(
     def get_dest_acc_modes(in_fmt):
         """Determine valid dest register modes depending on the input format."""
         # Having Int16 in src registers and Int32 in the dest register is not supported
+        if in_fmt == DataFormat.Int16:
+            return (DestAccumulation.No,)
         if in_fmt.is_32_bit():
             return (DestAccumulation.Yes,)
-        else:
-            return (DestAccumulation.No,)
-        return (DestAccumulation.No,)
+        return (DestAccumulation.No, DestAccumulation.Yes)
 
     def is_supported_dest_mode_dependent_conversion(in_fmt, out_fmt, dest_acc):
         """Check if the format conversion is supported by packer. These format conversions are dependent on the dest register mode."""
@@ -212,7 +213,8 @@ def test_pack_quasar(formats_dest_acc_input_dims, boot_mode=BootMode.DEFAULT):
             NUM_FACES(num_faces),
             TILE_COUNT(tile_cnt_A),
             RELU_CONFIG(relu_config),
-            IN_FACE_DIMS(tile_shape.num_faces_r_dim, tile_shape.num_faces_c_dim),
+            NUM_FACES_R_DIM(tile_shape.num_faces_r_dim),
+            NUM_FACES_C_DIM(tile_shape.num_faces_c_dim),
         ],
         variant_stimuli=StimuliConfig(
             src_A,

--- a/tests/python_tests/quasar/test_pack_quasar.py
+++ b/tests/python_tests/quasar/test_pack_quasar.py
@@ -67,11 +67,11 @@ def generate_qsr_pack_combinations(
     def get_dest_acc_modes(in_fmt):
         """Determine valid dest register modes depending on the input format."""
         # Having Int16 in src registers and Int32 in the dest register is not supported
-        if in_fmt == DataFormat.Int16:
-            return (DestAccumulation.No,)
         if in_fmt.is_32_bit():
             return (DestAccumulation.Yes,)
-        return (DestAccumulation.No, DestAccumulation.Yes)
+        else:
+            return (DestAccumulation.No,)
+        return (DestAccumulation.No,)
 
     def is_supported_dest_mode_dependent_conversion(in_fmt, out_fmt, dest_acc):
         """Check if the format conversion is supported by packer. These format conversions are dependent on the dest register mode."""
@@ -168,6 +168,7 @@ def test_pack_quasar(formats_dest_acc_input_dims, boot_mode=BootMode.DEFAULT):
         num_faces=num_faces,
         face_r_dim=tile_shape.face_r_dim,
         input_dimensions=input_dimensions,
+        tile_shape=tile_shape,
     )
 
     # Same method as test_pack.py for original ReLu testing and threshold tolerance issue

--- a/tests/python_tests/quasar/test_unpack_unary_operand_quasar.py
+++ b/tests/python_tests/quasar/test_unpack_unary_operand_quasar.py
@@ -25,20 +25,22 @@ from helpers.param_config import (
     parametrize,
 )
 from helpers.stimuli_config import StimuliConfig
-from helpers.stimuli_generator import generate_stimuli
+from helpers.stimuli_generator import generate_stimuli_w_tile_dimensions
 from helpers.test_config import BootMode, TestConfig
 from helpers.test_variant_parameters import (
     DATA_COPY_TYPE,
     DEST_SYNC,
     IMPLIED_MATH_FORMAT,
+    IN_FACE_DIMS,
     NUM_FACES,
     TEST_FACE_DIMS,
     TILE_COUNT,
     UNPACK_TRANS_FACES,
     UNPACK_TRANS_WITHIN_FACE,
     UNPACKER_ENGINE_SEL,
-    generate_input_dim,
 )
+from helpers.tile_constants import SUPPORTED_TILE_SIZES
+from helpers.tile_shape import construct_tile_shape
 from helpers.utils import passed_test
 
 
@@ -55,15 +57,6 @@ def generate_unpack_unary_operand_combinations(
 
     Returns: List of (format, dest_acc, transpose_en, unpacker_sel, input_dimensions) tuples
     """
-    dimensions_cache = {
-        DestAccumulation.No: tuple(
-            generate_unary_input_dimensions(DestAccumulation.No)
-        ),
-        DestAccumulation.Yes: tuple(
-            generate_unary_input_dimensions(DestAccumulation.Yes)
-        ),
-    }
-
     combinations = []
 
     for fmt in formats_list:
@@ -94,10 +87,27 @@ def generate_unpack_unary_operand_combinations(
                 continue
             for transpose_en in transpose_modes:
                 for unpacker_sel in unpacker_engines:
-                    for dimensions in dimensions_cache[dest_acc]:
-                        combinations.append(
-                            (fmt, dest_acc, transpose_en, unpacker_sel, dimensions)
-                        )
+                    # transpose is not supported for tiny-tiles
+                    tile_sizes = (
+                        ((32, 32),)
+                        if transpose_en == Transpose.Yes
+                        else SUPPORTED_TILE_SIZES
+                    )
+                    for tile_dims in tile_sizes:
+                        tile_shape = construct_tile_shape(tile_dims)
+                        for dimensions in generate_unary_input_dimensions(
+                            dest_acc, tile_shape=tile_shape
+                        ):
+                            combinations.append(
+                                (
+                                    fmt,
+                                    dest_acc,
+                                    transpose_en,
+                                    unpacker_sel,
+                                    dimensions,
+                                    tile_dims,
+                                )
+                            )
 
     return combinations
 
@@ -129,15 +139,19 @@ def test_unpack_unary_operand_quasar(
     transpose_en = formats_dest_acc_transpose_unpack_sel_dims[2]
     unpacker_sel = formats_dest_acc_transpose_unpack_sel_dims[3]
     input_dimensions = formats_dest_acc_transpose_unpack_sel_dims[4]
+    tile_dimensions = formats_dest_acc_transpose_unpack_sel_dims[5]
 
-    src_A, tile_cnt_A, src_B, _ = generate_stimuli(
+    tile_shape = construct_tile_shape(tile_dimensions)
+
+    src_A, tile_cnt_A, src_B, _ = generate_stimuli_w_tile_dimensions(
         stimuli_format_A=formats.input_format,
         input_dimensions_A=input_dimensions,
         stimuli_format_B=formats.input_format,
         input_dimensions_B=input_dimensions,
+        tile_dimensions=tile_dimensions,
     )
 
-    num_faces = 4
+    num_faces = tile_shape.total_num_faces()
 
     golden_src = (
         src_B if unpacker_sel == UnpackerEngine.UnpB else src_A
@@ -165,13 +179,13 @@ def test_unpack_unary_operand_quasar(
             formats.output_format,
             num_faces=num_faces,
             input_dimensions=input_dimensions,
+            face_r_dim=tile_shape.face_r_dim,
         )
 
     configuration = TestConfig(
         "sources/quasar/unpack_unary_operand_quasar_test.cpp",
         formats,
         templates=[
-            generate_input_dim(input_dimensions, input_dimensions),
             IMPLIED_MATH_FORMAT(ImpliedMathFormat.Yes),
             UNPACKER_ENGINE_SEL(unpacker_sel),
             DATA_COPY_TYPE(
@@ -184,9 +198,10 @@ def test_unpack_unary_operand_quasar(
             UNPACK_TRANS_WITHIN_FACE(transpose_en),
         ],
         runtimes=[
-            TEST_FACE_DIMS(),
+            TEST_FACE_DIMS(tile_shape.face_r_dim),
             NUM_FACES(num_faces),
             TILE_COUNT(tile_cnt_A),
+            IN_FACE_DIMS(tile_shape.num_faces_r_dim, tile_shape.num_faces_c_dim),
         ],
         variant_stimuli=StimuliConfig(
             src_A,
@@ -198,6 +213,9 @@ def test_unpack_unary_operand_quasar(
             tile_count_B=tile_cnt_A,
             tile_count_res=tile_cnt_A,
             num_faces=num_faces,
+            face_r_dim=tile_shape.face_r_dim,
+            tile_dimensions=tile_dimensions,
+            use_dense_tile_dimensions=True,
         ),
         unpack_to_dest=(
             formats.input_format.is_32_bit() and dest_acc == DestAccumulation.Yes
@@ -207,6 +225,7 @@ def test_unpack_unary_operand_quasar(
     )
 
     res_from_L1 = configuration.run().result
+    print(len(res_from_L1), len(golden_tensor))
 
     assert len(res_from_L1) == len(
         golden_tensor
@@ -216,5 +235,5 @@ def test_unpack_unary_operand_quasar(
     res_tensor = torch.tensor(res_from_L1, dtype=torch_format)
 
     assert passed_test(
-        golden_tensor, res_tensor, formats.output_format
+        golden_tensor, res_tensor, formats.output_format, tile_shape=tile_shape
     ), "Assert against golden failed"

--- a/tests/python_tests/quasar/test_unpack_unary_operand_quasar.py
+++ b/tests/python_tests/quasar/test_unpack_unary_operand_quasar.py
@@ -31,8 +31,9 @@ from helpers.test_variant_parameters import (
     DATA_COPY_TYPE,
     DEST_SYNC,
     IMPLIED_MATH_FORMAT,
-    IN_FACE_DIMS,
     NUM_FACES,
+    NUM_FACES_C_DIM,
+    NUM_FACES_R_DIM,
     TEST_FACE_DIMS,
     TILE_COUNT,
     UNPACK_TRANS_FACES,
@@ -63,10 +64,9 @@ def generate_unpack_unary_operand_combinations(
         in_fmt = fmt.input_format
 
         dest_acc_modes = (
-            # TODO: Clarify dest_acc needs
             (DestAccumulation.Yes,)
             if in_fmt.is_32_bit()
-            else (DestAccumulation.No,)
+            else (DestAccumulation.No, DestAccumulation.Yes)
         )
         transpose_modes = (
             (Transpose.No,) if in_fmt.is_32_bit() else (Transpose.No, Transpose.Yes)
@@ -203,7 +203,8 @@ def test_unpack_unary_operand_quasar(
             TEST_FACE_DIMS(tile_shape.face_r_dim),
             NUM_FACES(num_faces),
             TILE_COUNT(tile_cnt_A),
-            IN_FACE_DIMS(tile_shape.num_faces_r_dim, tile_shape.num_faces_c_dim),
+            NUM_FACES_R_DIM(tile_shape.num_faces_r_dim),
+            NUM_FACES_C_DIM(tile_shape.num_faces_c_dim),
         ],
         variant_stimuli=StimuliConfig(
             src_A,

--- a/tests/python_tests/quasar/test_unpack_unary_operand_quasar.py
+++ b/tests/python_tests/quasar/test_unpack_unary_operand_quasar.py
@@ -63,9 +63,10 @@ def generate_unpack_unary_operand_combinations(
         in_fmt = fmt.input_format
 
         dest_acc_modes = (
+            # TODO: Clarify dest_acc needs
             (DestAccumulation.Yes,)
             if in_fmt.is_32_bit()
-            else (DestAccumulation.No, DestAccumulation.Yes)
+            else (DestAccumulation.No,)
         )
         transpose_modes = (
             (Transpose.No,) if in_fmt.is_32_bit() else (Transpose.No, Transpose.Yes)
@@ -180,6 +181,7 @@ def test_unpack_unary_operand_quasar(
             num_faces=num_faces,
             input_dimensions=input_dimensions,
             face_r_dim=tile_shape.face_r_dim,
+            tile_shape=tile_shape,
         )
 
     configuration = TestConfig(
@@ -225,7 +227,6 @@ def test_unpack_unary_operand_quasar(
     )
 
     res_from_L1 = configuration.run().result
-    print(len(res_from_L1), len(golden_tensor))
 
     assert len(res_from_L1) == len(
         golden_tensor

--- a/tests/sources/quasar/pack_quasar_test.cpp
+++ b/tests/sources/quasar/pack_quasar_test.cpp
@@ -53,6 +53,12 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     buffer_descriptor_u bd_val = {0};
 
+    TileShape tile_shape_A = {
+        .num_faces   = params.num_faces,
+        .face_r_dim  = params.TEST_FACE_R_DIM,
+        .face_c_dim  = params.TEST_FACE_C_DIM,
+        .narrow_tile = ((params.num_faces_c_dim_A < params.num_faces_r_dim_A) || (params.num_faces == 1))};
+
     bd_val.f.l1_addr_16B = L1_ADDRESS(params.buffer_A[0]);
     bd_val.f.format      = static_cast<std::uint8_t>(formats.unpack_A_src);
     bd_val.f.x_dim       = params.TEST_FACE_C_DIM;
@@ -73,8 +79,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
     {
         _llk_unpack_configure_unary_<SELECTED_UNPACKER>(td_val);
     }
-    _llk_unpack_unary_operand_init_<SELECTED_UNPACKER, false /*transpose*/, is_fp32_dest_acc_en>(buf_desc_id, num_tiles_per_unpack, params.num_faces);
-    _llk_unpack_unary_operand_<SELECTED_UNPACKER>(0, params.num_faces, params.in0_face_c_dim);
+    _llk_unpack_unary_operand_init_<SELECTED_UNPACKER, false /*transpose*/, is_fp32_dest_acc_en>(buf_desc_id, tile_shape_A, num_tiles_per_unpack);
+    _llk_unpack_unary_operand_<SELECTED_UNPACKER>(0, tile_shape_A);
 
     if constexpr (unpack_to_dest)
     {
@@ -151,6 +157,12 @@ void run_kernel(RUNTIME_PARAMETERS params)
         set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
     }
 
+    TileShape tile_shape_A = {
+        .num_faces   = params.num_faces,
+        .face_r_dim  = params.TEST_FACE_R_DIM,
+        .face_c_dim  = params.TEST_FACE_C_DIM,
+        .narrow_tile = ((params.num_faces_c_dim_A < params.num_faces_r_dim_A) || (params.num_faces == 1))};
+
     buffer_descriptor_u bd_val = {0};
     tdma_descriptor_t tdma_desc;
 
@@ -167,8 +179,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _configure_buf_desc_table_(tdma_desc.buf_desc_id, tdma_desc.buf_desc);
     _llk_pack_hw_configure_<p_pacr::PACK0>(tdma_desc);
     const ckernel::ReluConfig relu_config = ckernel::ReluConfig::from_packed(params.RELU_CONFIG);
-    _llk_pack_init_<p_pacr::PACK0, is_fp32_dest_acc_en>(buf_desc_id, num_tiles_per_pack, params.num_faces, relu_config);
-    _llk_pack_<p_pacr::PACK0>(0, 0, params.num_faces, params.in0_face_c_dim);
+    _llk_pack_init_<p_pacr::PACK0, is_fp32_dest_acc_en>(buf_desc_id, tile_shape_A, num_tiles_per_pack, relu_config);
+    _llk_pack_<p_pacr::PACK0>(0, 0, tile_shape_A);
     _llk_pack_dest_dvalid_section_done_<dest_sync, is_fp32_dest_acc_en>();
 }
 #endif

--- a/tests/sources/quasar/pack_quasar_test.cpp
+++ b/tests/sources/quasar/pack_quasar_test.cpp
@@ -55,9 +55,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     bd_val.f.l1_addr_16B = L1_ADDRESS(params.buffer_A[0]);
     bd_val.f.format      = static_cast<std::uint8_t>(formats.unpack_A_src);
-    bd_val.f.x_dim       = params->TEST_FACE_C_DIM;
-    bd_val.f.y_dim       = params->TEST_FACE_R_DIM;
-    bd_val.f.z_dim       = (params->num_faces == 4) ? params->num_faces : 1;
+    bd_val.f.x_dim       = params.TEST_FACE_C_DIM;
+    bd_val.f.y_dim       = params.TEST_FACE_R_DIM;
+    bd_val.f.z_dim       = (params.num_faces == 4) ? params.num_faces : 1;
 
     td_val.buf_desc        = bd_val;
     td_val.buf_desc_id     = buf_desc_id;
@@ -73,8 +73,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
     {
         _llk_unpack_configure_unary_<SELECTED_UNPACKER>(td_val);
     }
-    _llk_unpack_unary_operand_init_<SELECTED_UNPACKER, false /*transpose*/, is_fp32_dest_acc_en>(buf_desc_id, num_tiles_per_unpack, params->num_faces);
-    _llk_unpack_unary_operand_<SELECTED_UNPACKER>(0, params->num_faces, params->in0_face_c_dim);
+    _llk_unpack_unary_operand_init_<SELECTED_UNPACKER, false /*transpose*/, is_fp32_dest_acc_en>(buf_desc_id, num_tiles_per_unpack, params.num_faces);
+    _llk_unpack_unary_operand_<SELECTED_UNPACKER>(0, params.num_faces, params.in0_face_c_dim);
 
     if constexpr (unpack_to_dest)
     {
@@ -156,9 +156,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     bd_val.f.l1_addr_16B = L1_ADDRESS(params.buffer_Res[0]);
     bd_val.f.format      = static_cast<std::uint8_t>(formats.pack_dst);
-    bd_val.f.x_dim       = params->TEST_FACE_C_DIM;
-    bd_val.f.y_dim       = params->TEST_FACE_R_DIM;
-    bd_val.f.z_dim       = (params->num_faces == 4) ? params->num_faces : 1;
+    bd_val.f.x_dim       = params.TEST_FACE_C_DIM;
+    bd_val.f.y_dim       = params.TEST_FACE_R_DIM;
+    bd_val.f.z_dim       = (params.num_faces == 4) ? params.num_faces : 1;
 
     tdma_desc.buf_desc        = bd_val;
     tdma_desc.buf_desc_id     = buf_desc_id;
@@ -166,9 +166,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     _configure_buf_desc_table_(tdma_desc.buf_desc_id, tdma_desc.buf_desc);
     _llk_pack_hw_configure_<p_pacr::PACK0>(tdma_desc);
-    const ckernel::ReluConfig relu_config = ckernel::ReluConfig::from_packed(params->RELU_CONFIG);
-    _llk_pack_init_<p_pacr::PACK0, is_fp32_dest_acc_en>(buf_desc_id, num_tiles_per_pack, params->num_faces, relu_config);
-    _llk_pack_<p_pacr::PACK0>(0, 0, params->num_faces, params->in0_face_c_dim);
+    const ckernel::ReluConfig relu_config = ckernel::ReluConfig::from_packed(params.RELU_CONFIG);
+    _llk_pack_init_<p_pacr::PACK0, is_fp32_dest_acc_en>(buf_desc_id, num_tiles_per_pack, params.num_faces, relu_config);
+    _llk_pack_<p_pacr::PACK0>(0, 0, params.num_faces, params.in0_face_c_dim);
     _llk_pack_dest_dvalid_section_done_<dest_sync, is_fp32_dest_acc_en>();
 }
 #endif

--- a/tests/sources/quasar/pack_quasar_test.cpp
+++ b/tests/sources/quasar/pack_quasar_test.cpp
@@ -55,9 +55,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     bd_val.f.l1_addr_16B = L1_ADDRESS(params.buffer_A[0]);
     bd_val.f.format      = static_cast<std::uint8_t>(formats.unpack_A_src);
-    bd_val.f.x_dim       = params.TEST_FACE_C_DIM;
-    bd_val.f.y_dim       = params.TEST_FACE_R_DIM;
-    bd_val.f.z_dim       = params.num_faces;
+    bd_val.f.x_dim       = params->TEST_FACE_C_DIM;
+    bd_val.f.y_dim       = params->TEST_FACE_R_DIM;
+    bd_val.f.z_dim       = (params->num_faces == 4) ? params->num_faces : 1;
 
     td_val.buf_desc        = bd_val;
     td_val.buf_desc_id     = buf_desc_id;
@@ -73,8 +73,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
     {
         _llk_unpack_configure_unary_<SELECTED_UNPACKER>(td_val);
     }
-    _llk_unpack_unary_operand_init_<SELECTED_UNPACKER, false /*transpose*/, is_fp32_dest_acc_en>(buf_desc_id, num_tiles_per_unpack);
-    _llk_unpack_unary_operand_<SELECTED_UNPACKER>(0);
+    _llk_unpack_unary_operand_init_<SELECTED_UNPACKER, false /*transpose*/, is_fp32_dest_acc_en>(buf_desc_id, num_tiles_per_unpack, params->num_faces);
+    _llk_unpack_unary_operand_<SELECTED_UNPACKER>(0, params->num_faces, params->in0_face_c_dim);
 
     if constexpr (unpack_to_dest)
     {
@@ -156,9 +156,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     bd_val.f.l1_addr_16B = L1_ADDRESS(params.buffer_Res[0]);
     bd_val.f.format      = static_cast<std::uint8_t>(formats.pack_dst);
-    bd_val.f.x_dim       = params.TEST_FACE_C_DIM;
-    bd_val.f.y_dim       = params.TEST_FACE_R_DIM;
-    bd_val.f.z_dim       = params.num_faces;
+    bd_val.f.x_dim       = params->TEST_FACE_C_DIM;
+    bd_val.f.y_dim       = params->TEST_FACE_R_DIM;
+    bd_val.f.z_dim       = (params->num_faces == 4) ? params->num_faces : 1;
 
     tdma_desc.buf_desc        = bd_val;
     tdma_desc.buf_desc_id     = buf_desc_id;
@@ -166,9 +166,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     _configure_buf_desc_table_(tdma_desc.buf_desc_id, tdma_desc.buf_desc);
     _llk_pack_hw_configure_<p_pacr::PACK0>(tdma_desc);
-    const ckernel::ReluConfig relu_config = ckernel::ReluConfig::from_packed(params.RELU_CONFIG);
-    _llk_pack_init_<p_pacr::PACK0, is_fp32_dest_acc_en>(buf_desc_id, num_tiles_per_pack, relu_config);
-    _llk_pack_<p_pacr::PACK0>(0, 0);
+    const ckernel::ReluConfig relu_config = ckernel::ReluConfig::from_packed(params->RELU_CONFIG);
+    _llk_pack_init_<p_pacr::PACK0, is_fp32_dest_acc_en>(buf_desc_id, num_tiles_per_pack, params->num_faces, relu_config);
+    _llk_pack_<p_pacr::PACK0>(0, 0, params->num_faces, params->in0_face_c_dim);
     _llk_pack_dest_dvalid_section_done_<dest_sync, is_fp32_dest_acc_en>();
 }
 #endif

--- a/tests/sources/quasar/unpack_unary_operand_quasar_test.cpp
+++ b/tests/sources/quasar/unpack_unary_operand_quasar_test.cpp
@@ -54,9 +54,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     bd_val.f.l1_addr_16B = l1_addr_16B;
     bd_val.f.format      = static_cast<std::uint8_t>(formats.unpack_A_src);
-    bd_val.f.x_dim       = params->TEST_FACE_C_DIM;
-    bd_val.f.y_dim       = params->TEST_FACE_R_DIM;
-    bd_val.f.z_dim       = (params->num_faces == 4) ? params->num_faces : 1;
+    bd_val.f.x_dim       = params.TEST_FACE_C_DIM;
+    bd_val.f.y_dim       = params.TEST_FACE_R_DIM;
+    bd_val.f.z_dim       = (params.num_faces == 4) ? params.num_faces : 1;
 
     td_val.buf_desc        = bd_val;
     td_val.buf_desc_id     = buf_desc_id;
@@ -73,8 +73,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
         _llk_unpack_configure_unary_<UNPACKER_ENGINE_SEL>(td_val);
     }
 
-    _llk_unpack_unary_operand_init_<UNPACKER_ENGINE_SEL, TRANSPOSE_EN, is_fp32_dest_acc_en>(buf_desc_id, num_tiles_per_unpack, params->num_faces);
-    _llk_unpack_unary_operand_<UNPACKER_ENGINE_SEL>(0, params->num_faces, params->in0_face_c_dim);
+    _llk_unpack_unary_operand_init_<UNPACKER_ENGINE_SEL, TRANSPOSE_EN, is_fp32_dest_acc_en>(buf_desc_id, num_tiles_per_unpack, params.num_faces);
+    _llk_unpack_unary_operand_<UNPACKER_ENGINE_SEL>(0, params.num_faces, params.in0_face_c_dim);
 
     if (unpack_to_dest)
     {
@@ -150,9 +150,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     bd_val.f.l1_addr_16B = params.buffer_Res[0] / 16;
     bd_val.f.format      = static_cast<std::uint8_t>(formats.pack_dst);
-    bd_val.f.x_dim       = params->TEST_FACE_C_DIM;
-    bd_val.f.y_dim       = params->TEST_FACE_R_DIM;
-    bd_val.f.z_dim       = (params->num_faces == 4) ? params->num_faces : 1;
+    bd_val.f.x_dim       = params.TEST_FACE_C_DIM;
+    bd_val.f.y_dim       = params.TEST_FACE_R_DIM;
+    bd_val.f.z_dim       = (params.num_faces == 4) ? params.num_faces : 1;
 
     tdma_desc.buf_desc        = bd_val;
     tdma_desc.buf_desc_id     = buf_desc_id;
@@ -160,8 +160,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     _configure_buf_desc_table_(tdma_desc.buf_desc_id, tdma_desc.buf_desc);
     _llk_pack_hw_configure_<p_pacr::PACK0>(tdma_desc);
-    _llk_pack_init_<p_pacr::PACK0>(buf_desc_id, num_tiles_per_pack, params->num_faces);
-    _llk_pack_<p_pacr::PACK0>(0, 0, params->num_faces, params->in0_face_c_dim);
+    _llk_pack_init_<p_pacr::PACK0>(buf_desc_id, num_tiles_per_pack, params.num_faces);
+    _llk_pack_<p_pacr::PACK0>(0, 0, params.num_faces, params.in0_face_c_dim);
     _llk_pack_dest_dvalid_section_done_<dest_sync, is_fp32_dest_acc_en>();
 }
 #endif

--- a/tests/sources/quasar/unpack_unary_operand_quasar_test.cpp
+++ b/tests/sources/quasar/unpack_unary_operand_quasar_test.cpp
@@ -54,9 +54,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     bd_val.f.l1_addr_16B = l1_addr_16B;
     bd_val.f.format      = static_cast<std::uint8_t>(formats.unpack_A_src);
-    bd_val.f.x_dim       = params.TEST_FACE_C_DIM;
-    bd_val.f.y_dim       = params.TEST_FACE_R_DIM;
-    bd_val.f.z_dim       = params.num_faces;
+    bd_val.f.x_dim       = params->TEST_FACE_C_DIM;
+    bd_val.f.y_dim       = params->TEST_FACE_R_DIM;
+    bd_val.f.z_dim       = (params->num_faces == 4) ? params->num_faces : 1;
 
     td_val.buf_desc        = bd_val;
     td_val.buf_desc_id     = buf_desc_id;
@@ -73,8 +73,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
         _llk_unpack_configure_unary_<UNPACKER_ENGINE_SEL>(td_val);
     }
 
-    _llk_unpack_unary_operand_init_<UNPACKER_ENGINE_SEL, TRANSPOSE_EN, is_fp32_dest_acc_en>(buf_desc_id, num_tiles_per_unpack);
-    _llk_unpack_unary_operand_<UNPACKER_ENGINE_SEL>(0);
+    _llk_unpack_unary_operand_init_<UNPACKER_ENGINE_SEL, TRANSPOSE_EN, is_fp32_dest_acc_en>(buf_desc_id, num_tiles_per_unpack, params->num_faces);
+    _llk_unpack_unary_operand_<UNPACKER_ENGINE_SEL>(0, params->num_faces, params->in0_face_c_dim);
 
     if (unpack_to_dest)
     {
@@ -150,9 +150,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     bd_val.f.l1_addr_16B = params.buffer_Res[0] / 16;
     bd_val.f.format      = static_cast<std::uint8_t>(formats.pack_dst);
-    bd_val.f.x_dim       = params.TEST_FACE_C_DIM;
-    bd_val.f.y_dim       = params.TEST_FACE_R_DIM;
-    bd_val.f.z_dim       = params.num_faces;
+    bd_val.f.x_dim       = params->TEST_FACE_C_DIM;
+    bd_val.f.y_dim       = params->TEST_FACE_R_DIM;
+    bd_val.f.z_dim       = (params->num_faces == 4) ? params->num_faces : 1;
 
     tdma_desc.buf_desc        = bd_val;
     tdma_desc.buf_desc_id     = buf_desc_id;
@@ -160,8 +160,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     _configure_buf_desc_table_(tdma_desc.buf_desc_id, tdma_desc.buf_desc);
     _llk_pack_hw_configure_<p_pacr::PACK0>(tdma_desc);
-    _llk_pack_init_<p_pacr::PACK0>(buf_desc_id, num_tiles_per_pack);
-    _llk_pack_<p_pacr::PACK0>(0, 0);
+    _llk_pack_init_<p_pacr::PACK0>(buf_desc_id, num_tiles_per_pack, params->num_faces);
+    _llk_pack_<p_pacr::PACK0>(0, 0, params->num_faces, params->in0_face_c_dim);
     _llk_pack_dest_dvalid_section_done_<dest_sync, is_fp32_dest_acc_en>();
 }
 #endif

--- a/tests/sources/quasar/unpack_unary_operand_quasar_test.cpp
+++ b/tests/sources/quasar/unpack_unary_operand_quasar_test.cpp
@@ -38,6 +38,12 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     buffer_descriptor_u bd_val = {0};
 
+    TileShape tile_shape_A = {
+        .num_faces   = params.num_faces,
+        .face_r_dim  = params.TEST_FACE_R_DIM,
+        .face_c_dim  = params.TEST_FACE_C_DIM,
+        .narrow_tile = ((params.num_faces_c_dim_A < params.num_faces_r_dim_A) || (params.num_faces == 1))};
+
     // Qsr has one transpose argument, if set it does both transpose faces and within face
     // The py test will set transpose faces and transpose within face to the same value
     constexpr bool TRANSPOSE_EN = UNPACK_TRANSPOSE_FACES && UNPACK_TRANSPOSE_WITHIN_FACE;
@@ -73,8 +79,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
         _llk_unpack_configure_unary_<UNPACKER_ENGINE_SEL>(td_val);
     }
 
-    _llk_unpack_unary_operand_init_<UNPACKER_ENGINE_SEL, TRANSPOSE_EN, is_fp32_dest_acc_en>(buf_desc_id, num_tiles_per_unpack, params.num_faces);
-    _llk_unpack_unary_operand_<UNPACKER_ENGINE_SEL>(0, params.num_faces, params.in0_face_c_dim);
+    _llk_unpack_unary_operand_init_<UNPACKER_ENGINE_SEL, TRANSPOSE_EN, is_fp32_dest_acc_en>(buf_desc_id, tile_shape_A, num_tiles_per_unpack);
+    _llk_unpack_unary_operand_<UNPACKER_ENGINE_SEL>(0, tile_shape_A);
 
     if (unpack_to_dest)
     {
@@ -145,6 +151,12 @@ void run_kernel(RUNTIME_PARAMETERS params)
         set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
     }
 
+    TileShape tile_shape_A = {
+        .num_faces   = params.num_faces,
+        .face_r_dim  = params.TEST_FACE_R_DIM,
+        .face_c_dim  = params.TEST_FACE_C_DIM,
+        .narrow_tile = ((params.num_faces_c_dim_A < params.num_faces_r_dim_A) || (params.num_faces == 1))};
+
     buffer_descriptor_u bd_val = {0};
     tdma_descriptor_t tdma_desc;
 
@@ -160,8 +172,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     _configure_buf_desc_table_(tdma_desc.buf_desc_id, tdma_desc.buf_desc);
     _llk_pack_hw_configure_<p_pacr::PACK0>(tdma_desc);
-    _llk_pack_init_<p_pacr::PACK0>(buf_desc_id, num_tiles_per_pack, params.num_faces);
-    _llk_pack_<p_pacr::PACK0>(0, 0, params.num_faces, params.in0_face_c_dim);
+    _llk_pack_init_<p_pacr::PACK0>(buf_desc_id, tile_shape_A, num_tiles_per_pack);
+    _llk_pack_<p_pacr::PACK0>(0, 0, tile_shape_A);
     _llk_pack_dest_dvalid_section_done_<dest_sync, is_fp32_dest_acc_en>();
 }
 #endif

--- a/tt_llk_quasar/common/inc/ckernel_trisc_common.h
+++ b/tt_llk_quasar/common/inc/ckernel_trisc_common.h
@@ -148,6 +148,29 @@ inline void _set_dest_section_base_(const std::uint32_t base_addr)
 }
 
 /**
+ * @brief Helper function to calculate log2 for FPU rows
+ * since FPU rows are <=16, and are power of 2, can use
+ * simplified higher perf method
+ * @param val: Input value to log2 operation
+ */
+inline std::uint32_t rows_log2(const std::uint32_t math_rows)
+{
+    switch (math_rows)
+    {
+        case 16:
+            return 4;
+        case 8:
+            return 3;
+        case 4:
+            return 2;
+        case 2:
+            return 1;
+        default:
+            return 0;
+    }
+}
+
+/**
  * @brief Returns dest buffer base addr according to dest_bank_id
  * Bank 0 -> addr = 0
  * Bank 1 -> addr = 512

--- a/tt_llk_quasar/common/inc/cmath_common.h
+++ b/tt_llk_quasar/common/inc/cmath_common.h
@@ -11,10 +11,11 @@ namespace ckernel::math
 {
 
 // Number of rows for MATH functions
-constexpr static std::uint32_t ELTWISE_MATH_ROWS = MATH_ROWS; // 8 for quasar, 4 for trinity
-constexpr static std::uint32_t MOVE_MATH_ROWS[3] = {8, 4, 1};
-constexpr static unsigned int SFP_ROWS           = 2;
-constexpr static std::uint32_t TRISC_ID          = 1;
+constexpr static std::uint32_t ELTWISE_MATH_ROWS       = MATH_ROWS; // 8 for quasar, 4 for trinity
+constexpr static std::uint32_t MOVE_MATH_ROWS[3]       = {8, 4, 1};
+constexpr static unsigned int SFP_ROWS                 = 2;
+constexpr static std::uint32_t TRISC_ID                = 1;
+constexpr static std::uint32_t NUM_ROWS_PER_TILE_FRD_8 = 16;
 
 // Struct for the ALU addresses
 constexpr std::uint32_t NUM_WORDS_ALU_FORMAT = 3;

--- a/tt_llk_quasar/llk_lib/llk_math_eltwise_unary_datacopy.h
+++ b/tt_llk_quasar/llk_lib/llk_math_eltwise_unary_datacopy.h
@@ -91,7 +91,7 @@ inline void _llk_math_eltwise_unary_datacopy_addrmod_(const std::uint32_t num_ro
     addr_mod_t {
         .srca = {.clr = use_srca},
         .srcb = {.clr = use_srcb},
-        .dest = {.incr = num_rows_dest},
+        .dest = {.incr = ELTWISE_MATH_ROWS},
     }
         .set(ADDR_MOD_1);
 }
@@ -124,7 +124,7 @@ inline void _llk_math_eltwise_unary_datacopy_init_(const std::uint32_t num_rows_
         {
             for (std::uint32_t mr : MOVE_MATH_ROWS)
             {
-                if (_divisible_by_pow_two_(num_rows_per_matrix, mr))
+                if (_divisible_by_pow_two_(std::max(num_rows_per_matrix, NUM_ROWS_PER_TILE_FRD_8), mr))
                 {
                     return mr;
                 }
@@ -134,7 +134,8 @@ inline void _llk_math_eltwise_unary_datacopy_init_(const std::uint32_t num_rows_
     }();
 
     _llk_math_eltwise_unary_datacopy_addrmod_<DATA_COPY_TYPE>(num_rows_per_move_instrn);
-    _llk_math_eltwise_unary_datacopy_mop_config_<DATA_COPY_TYPE, IS_32b_DEST_EN>(num_rows_per_matrix, num_matrices, num_rows_per_move_instrn);
+    _llk_math_eltwise_unary_datacopy_mop_config_<DATA_COPY_TYPE, IS_32b_DEST_EN>(
+        std::max(num_rows_per_matrix, NUM_ROWS_PER_TILE_FRD_8), num_matrices, num_rows_per_move_instrn);
 
     // Reset all counters
     _reset_counters_<p_setrwc::SET_ABD_F>();
@@ -148,7 +149,9 @@ inline void _llk_math_eltwise_unary_datacopy_init_(const std::uint32_t num_rows_
  */
 inline void _llk_math_eltwise_unary_datacopy_(const std::uint32_t num_rows_per_tile, const std::uint32_t tile_idx)
 {
-    _set_dst_write_addr_by_rows_(num_rows_per_tile, tile_idx);
+    // For face_r_dim => 8, dest is dense with tiles. For face_r_dim < 8, dest is sparse with tiles and tiles are placed every 8 rows.
+    // If num_rows_per_tile is less than that of face_r_dim = 8, replace it to ensure face_r_dim = 8 sparse layout.
+    _set_dst_write_addr_by_rows_(std::max(num_rows_per_tile, NUM_ROWS_PER_TILE_FRD_8), tile_idx);
 
     // Run MOP
     ckernel::ckernel_template::run_bank0_sw_cntl(instrn_buffer);

--- a/tt_llk_quasar/llk_lib/llk_pack.h
+++ b/tt_llk_quasar/llk_lib/llk_pack.h
@@ -18,14 +18,15 @@ using namespace ckernel;
  * @param buf_desc_id: The buffer descriptor ID where the buffer information is
  * stored in the buffer descriptor table, values = 16-31
  * @param num_tiles: number of tiles to pack at a time
+ * @param num_faces: number of faces in the tiles to unpack
  */
 template <std::uint8_t PACK_SEL>
-inline void _llk_pack_mop_config_(const std::uint8_t buf_desc_id, const std::uint32_t num_tiles)
+inline void _llk_pack_mop_config_(const std::uint8_t buf_desc_id, const std::uint32_t num_tiles, const std::uint32_t num_faces)
 {
     static_assert((PACK_SEL == p_pacr::PACK0) || (PACK_SEL == p_pacr::PACK1), "PACK_SEL can only be set to p_pacr::PACK0/PACK1");
 
-    const std::uint32_t MOP_OUTER_LOOP = 1;
-    const std::uint32_t MOP_INNER_LOOP = num_tiles;
+    const std::uint32_t MOP_OUTER_LOOP = num_tiles;
+    const std::uint32_t MOP_INNER_LOOP = (num_faces == NUM_FACES) ? 1 : num_faces;
 
     // RT: Use defines to remove these constexpr, and replace with a single TT_OP_PACR_FACE_INC
     std::uint32_t pack_instrn;
@@ -40,7 +41,6 @@ inline void _llk_pack_mop_config_(const std::uint8_t buf_desc_id, const std::uin
     }
 
     ckernel_template temp(MOP_OUTER_LOOP, MOP_INNER_LOOP, pack_instrn);
-
     temp.program_bank0_sw_cntl(instrn_buffer);
 }
 
@@ -58,9 +58,12 @@ inline void _llk_pack_mop_config_(const std::uint8_t buf_desc_id, const std::uin
  */
 template <std::uint8_t PACK_SEL, bool EN_32B_DEST = false>
 inline void _llk_pack_init_(
-    const std::uint8_t buf_desc_id, const std::uint32_t num_tiles = NUM_TILES, const ckernel::ReluConfig& relu_config = ckernel::ReluConfig::none())
+    const std::uint8_t buf_desc_id,
+    const std::uint32_t num_tiles          = NUM_TILES,
+    const std::uint32_t num_faces          = NUM_FACES,
+    const ckernel::ReluConfig& relu_config = ckernel::ReluConfig::none())
 {
-    _llk_pack_mop_config_<PACK_SEL>(buf_desc_id, num_tiles);
+    _llk_pack_mop_config_<PACK_SEL>(buf_desc_id, num_tiles, num_faces);
     _llk_pack_relu_config_<PACK_SEL, EN_32B_DEST>(relu_config);
 }
 
@@ -75,9 +78,7 @@ inline void _llk_pack_init_(
  */
 template <std::uint8_t PACK_SEL>
 inline void _llk_pack_(
-    const std::uint32_t start_math_dest_tile_idx, const std::uint32_t start_l1_tile_idx
-
-)
+    const std::uint32_t start_math_dest_tile_idx, const std::uint32_t start_l1_tile_idx, const std::uint32_t num_faces, const std::uint32_t c_dim_faces)
 {
     //(TODO) RT: for the best performance, setting counters should be placed in a REPLAY buffer
     // in the mop_config, but for back compatibility with APIs, the counter functions must
@@ -85,9 +86,18 @@ inline void _llk_pack_(
 
     // Set Source (math destination) counter to face index offset
     // Set dst (l1 output) counter to face index offset
-    TT_SET_SRC_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, PACK_SEL, start_math_dest_tile_idx);
-    TT_SET_DST_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, PACK_SEL, start_l1_tile_idx);
-
+    if (num_faces == NUM_FACES) // Using full tiles
+    {
+        TT_SET_SRC_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, PACK_SEL, start_math_dest_tile_idx);
+        TT_SET_DST_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, PACK_SEL, start_l1_tile_idx);
+    }
+    else // Using tiny-tiles
+    {
+        // For tiny-tiles, each face is considered a separate tile in HW. We need to multiply the tile idx by c_dim_faces to get the correct SW defined tile
+        // offset.
+        TT_SET_SRC_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, PACK_SEL, start_math_dest_tile_idx * c_dim_faces);
+        TT_SET_DST_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, PACK_SEL, start_l1_tile_idx * c_dim_faces);
+    }
     // Runs MOP
     ckernel::ckernel_template::run_bank0_sw_cntl(instrn_buffer);
 }

--- a/tt_llk_quasar/llk_lib/llk_pack.h
+++ b/tt_llk_quasar/llk_lib/llk_pack.h
@@ -18,10 +18,10 @@ using namespace ckernel;
  * @param buf_desc_id: The buffer descriptor ID where the buffer information is
  * stored in the buffer descriptor table, values = 16-31
  * @param num_tiles: number of tiles to pack at a time
- * @param num_faces: number of faces in the tiles to unpack
+ * @param num_faces: number of faces in the tiles to unpack, default to NUM_FACES
  */
 template <std::uint8_t PACK_SEL>
-inline void _llk_pack_mop_config_(const std::uint8_t buf_desc_id, const std::uint32_t num_tiles, const std::uint32_t num_faces)
+inline void _llk_pack_mop_config_(const std::uint8_t buf_desc_id, const std::uint32_t num_tiles, const std::uint32_t num_faces = NUM_FACES)
 {
     static_assert((PACK_SEL == p_pacr::PACK0) || (PACK_SEL == p_pacr::PACK1), "PACK_SEL can only be set to p_pacr::PACK0/PACK1");
 
@@ -54,6 +54,7 @@ inline void _llk_pack_mop_config_(const std::uint8_t buf_desc_id, const std::uin
  * @param buf_desc_id: The buffer descriptor ID where the buffer information is
  * stored in the buffer descriptor table, values = 16-31
  * @param num_tiles: number of tiles to pack at a time
+ * @param num_faces: number of faces in the tiles to pack, default to NUM_FACES
  * @param relu_config ReLU config (mode + threshold).
  */
 template <std::uint8_t PACK_SEL, bool EN_32B_DEST = false>
@@ -78,7 +79,10 @@ inline void _llk_pack_init_(
  */
 template <std::uint8_t PACK_SEL>
 inline void _llk_pack_(
-    const std::uint32_t start_math_dest_tile_idx, const std::uint32_t start_l1_tile_idx, const std::uint32_t num_faces, const std::uint32_t c_dim_faces)
+    const std::uint32_t start_math_dest_tile_idx,
+    const std::uint32_t start_l1_tile_idx,
+    const std::uint32_t num_faces   = NUM_FACES,
+    const std::uint32_t c_dim_faces = (NUM_FACES >> 1))
 {
     //(TODO) RT: for the best performance, setting counters should be placed in a REPLAY buffer
     // in the mop_config, but for back compatibility with APIs, the counter functions must

--- a/tt_llk_quasar/llk_lib/llk_pack.h
+++ b/tt_llk_quasar/llk_lib/llk_pack.h
@@ -21,18 +21,18 @@ using namespace ckernel;
  * @param num_faces: number of faces in the tiles to unpack, default to NUM_FACES
  */
 template <std::uint8_t PACK_SEL>
-inline void _llk_pack_mop_config_(const std::uint8_t buf_desc_id, const std::uint32_t num_tiles, const std::uint32_t num_faces = NUM_FACES)
+inline void _llk_pack_mop_config_(const std::uint8_t buf_desc_id, const std::uint32_t num_tiles, const TileShape& tile_shape)
 {
     static_assert((PACK_SEL == p_pacr::PACK0) || (PACK_SEL == p_pacr::PACK1), "PACK_SEL can only be set to p_pacr::PACK0/PACK1");
 
     const std::uint32_t MOP_OUTER_LOOP = num_tiles;
-    const std::uint32_t MOP_INNER_LOOP = (num_faces == NUM_FACES) ? 1 : num_faces;
+    const std::uint32_t MOP_INNER_LOOP = (tile_shape.num_faces == NUM_FACES) ? 1 : tile_shape.num_faces;
 
     // RT: Use defines to remove these constexpr, and replace with a single TT_OP_PACR_FACE_INC
     std::uint32_t pack_instrn;
     if constexpr (PACK_SEL == p_pacr::PACK0)
     {
-        pack_instrn = TT_OP_PACR0_TILE_INC(1 /*Dest Tile Idx*/, 1 /*Src Tile Idx*/, buf_desc_id, 0);
+        pack_instrn = TT_OP_PACR0_TILE_INC(1 /*Dest Tile Idx*/, 0 /*Src Tile Idx*/, buf_desc_id, 0);
     }
     else
     {
@@ -40,7 +40,17 @@ inline void _llk_pack_mop_config_(const std::uint8_t buf_desc_id, const std::uin
         pack_instrn = TT_OP_PACR1_TILE_INC(1 /*Dest Tile Idx*/, 0, buf_desc_id, 0);
     }
 
-    ckernel_template temp(MOP_OUTER_LOOP, MOP_INNER_LOOP, pack_instrn);
+    std::uint32_t incr_to_next_face;
+    if (tile_shape.num_faces < NUM_FACES && tile_shape.face_r_dim < (FACE_R_DIM >> 1)) // Using sparse tiling: jump to the next index w/ tile
+    {
+        incr_to_next_face = TT_OP_INC_SRC_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, PACK_SEL, (FACE_R_DIM >> (rows_log2(tile_shape.face_r_dim) + 1)));
+    }
+    else // Using dense tiling: just increment to the next tile
+    {
+        incr_to_next_face = TT_OP_INC_SRC_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, PACK_SEL, 1);
+    }
+
+    ckernel_template temp(MOP_OUTER_LOOP, MOP_INNER_LOOP, pack_instrn, incr_to_next_face);
     temp.program_bank0_sw_cntl(instrn_buffer);
 }
 
@@ -60,11 +70,11 @@ inline void _llk_pack_mop_config_(const std::uint8_t buf_desc_id, const std::uin
 template <std::uint8_t PACK_SEL, bool EN_32B_DEST = false>
 inline void _llk_pack_init_(
     const std::uint8_t buf_desc_id,
+    const TileShape& tile_shape,
     const std::uint32_t num_tiles          = NUM_TILES,
-    const std::uint32_t num_faces          = NUM_FACES,
     const ckernel::ReluConfig& relu_config = ckernel::ReluConfig::none())
 {
-    _llk_pack_mop_config_<PACK_SEL>(buf_desc_id, num_tiles, num_faces);
+    _llk_pack_mop_config_<PACK_SEL>(buf_desc_id, num_tiles, tile_shape);
     _llk_pack_relu_config_<PACK_SEL, EN_32B_DEST>(relu_config);
 }
 
@@ -78,11 +88,7 @@ inline void _llk_pack_init_(
  * that packer can start packing into
  */
 template <std::uint8_t PACK_SEL>
-inline void _llk_pack_(
-    const std::uint32_t start_math_dest_tile_idx,
-    const std::uint32_t start_l1_tile_idx,
-    const std::uint32_t num_faces   = NUM_FACES,
-    const std::uint32_t c_dim_faces = (NUM_FACES >> 1))
+inline void _llk_pack_(const std::uint32_t start_math_dest_tile_idx, const std::uint32_t start_l1_tile_idx, const TileShape& tile_shape)
 {
     //(TODO) RT: for the best performance, setting counters should be placed in a REPLAY buffer
     // in the mop_config, but for back compatibility with APIs, the counter functions must
@@ -90,17 +96,26 @@ inline void _llk_pack_(
 
     // Set Source (math destination) counter to face index offset
     // Set dst (l1 output) counter to face index offset
-    if (num_faces == NUM_FACES) // Using full tiles
+    if (tile_shape.num_faces == NUM_FACES) // Using full tiles
     {
         TT_SET_SRC_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, PACK_SEL, start_math_dest_tile_idx);
         TT_SET_DST_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, PACK_SEL, start_l1_tile_idx);
     }
     else // Using tiny-tiles
     {
-        // For tiny-tiles, each face is considered a separate tile in HW. We need to multiply the tile idx by c_dim_faces to get the correct SW defined tile
+        // For face_r_dim >= 8, dest is dense with tiles. For face_r_dim < 8, dest is sparse and tiles are placed every 8 rows.
+        // HW defined tiny-tile is registered with 1 face. To map to SW defined tile with different faces, the indices must be multiplied to get the correct
         // offset.
-        TT_SET_SRC_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, PACK_SEL, start_math_dest_tile_idx * c_dim_faces);
-        TT_SET_DST_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, PACK_SEL, start_l1_tile_idx * c_dim_faces);
+        if (tile_shape.face_r_dim < (FACE_R_DIM >> 1))
+        {
+            TT_SET_SRC_TILE_FACE_ROW_IDX(
+                p_set_inc_sel::TILE_SEL, PACK_SEL, start_math_dest_tile_idx * tile_shape.num_faces * (FACE_R_DIM >> (rows_log2(tile_shape.face_r_dim) + 1)));
+        }
+        else
+        {
+            TT_SET_SRC_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, PACK_SEL, start_math_dest_tile_idx * tile_shape.num_faces);
+        }
+        TT_SET_DST_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, PACK_SEL, start_l1_tile_idx * tile_shape.num_faces);
     }
     // Runs MOP
     ckernel::ckernel_template::run_bank0_sw_cntl(instrn_buffer);

--- a/tt_llk_quasar/llk_lib/llk_unpack_unary_operand.h
+++ b/tt_llk_quasar/llk_lib/llk_unpack_unary_operand.h
@@ -13,16 +13,85 @@ using namespace ckernel;
 /**
  * @brief MOP configuration for unpack of unary operations
  * @details Sets up MOP for unpacking a single operand by tiles
+ * Specialized for tiny-tile unpack where each face is a separate tile in HW.
+ * Works for any unpack resource
+ * @tparam UNP_SEL: Selects which unpacker resource to use,
+ * values = p_unpacr::UNP_A/p_unpacr::UNP_B/p_unpacr::UNP_DEST
+ * @tparam IS_32b_DEST_EN: Set to True to enable using Math destination Register in 32-bit mode
+ * @param buf_desc_id: The buffer descriptor ID where the buffer information is
+ * stored in the buffer descriptor table, values = 0 - 16
+ * @param num_tiles: number of tiles to unpack at a time for a single operand
+ * @param num_faces: number of faces in the tiles to unpack
+ */
+template <std::uint32_t UNP_SEL, bool IS_32b_DEST_EN>
+inline void _llk_unpack_unary_operand_tiny_tile_mop_config_(const std::uint32_t buf_desc_id, const std::uint32_t num_tiles, const std::uint32_t num_faces)
+{
+    static_assert(
+        (UNP_SEL == p_unpacr::UNP_A) || (UNP_SEL == p_unpacr::UNP_B) || (UNP_SEL == p_unpacr::UNP_DEST),
+        "UNP_SEL can only be set to p_unpacr::UNP_A/UNP_B/UNP_DEST");
+
+    const std::uint32_t MOP_OUTER_LOOP = num_tiles;
+    const std::uint32_t MOP_INNER_LOOP = num_faces;
+
+    // For UNP_A/UNP_B: Dst Tile Idx Inc = 0 so each face overwrites the same SrcA/B tile slot.
+    // Dvalid is set per face so math can consume each face before the next one arrives.
+    // For UNP_DEST: Dst Tile Idx Inc = 1 to place faces at consecutive dest positions (no math involved).
+    std::uint32_t unpack_tile_instrn;
+    std::uint32_t unpack_tile_w_dvalid_instrn;
+    std::uint32_t reset_dest_tile_cnt_instrn =
+        TT_OP_SET_DST_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, UNP_SEL == p_unpacr::UNP_DEST ? p_unpacr::UNP_A : UNP_SEL, 0);
+
+    if constexpr (UNP_SEL == p_unpacr::UNP_A)
+    {
+        unpack_tile_instrn          = TT_OP_UNPACR0_TILE_INC(1 /*Dst Tile Idx*/, 1 /*Src Tile Idx*/, buf_desc_id, 0 /*Set Dvalid*/);
+        unpack_tile_w_dvalid_instrn = TT_OP_UNPACR0_TILE_INC(1 /*Dst Tile Idx*/, 1 /*Src Tile Idx*/, buf_desc_id, 1 /*Set Dvalid*/);
+    }
+    else if constexpr (UNP_SEL == p_unpacr::UNP_B)
+    {
+        unpack_tile_instrn          = TT_OP_UNPACR1_TILE_INC(1 /*Dst Tile Idx*/, 1 /*Src Tile Idx*/, buf_desc_id, 0 /*Set Dvalid*/);
+        unpack_tile_w_dvalid_instrn = TT_OP_UNPACR1_TILE_INC(1 /*Dst Tile Idx*/, 1 /*Src Tile Idx*/, buf_desc_id, 1 /*Set Dvalid*/);
+    }
+    else if constexpr (UNP_SEL == p_unpacr::UNP_DEST)
+    {
+        unpack_tile_instrn = TT_OP_UNPACR_DEST_TILE_INC(1, 1 /*Src Tile Idx*/, buf_desc_id, 0 /*Set Dvalid*/);
+    }
+
+    ckernel_template temp(MOP_OUTER_LOOP, MOP_INNER_LOOP, unpack_tile_instrn);
+
+    if constexpr (UNP_SEL != p_unpacr::UNP_DEST)
+    {
+        // TODO: Figure out why setting unpack_tile_w_dvalid_instrn using set_last_outer_loop_instr did not work
+        temp.set_inner_loop_len(MOP_INNER_LOOP - 1); // Inner loop iterates over num_faces-1 where the dvalid unpacking is done as the END_OP
+        temp.set_end_ops(unpack_tile_w_dvalid_instrn, reset_dest_tile_cnt_instrn);
+    }
+
+    // If IS_32b_DEST_EN and UNP_SEL = UNP_A, zero out the SRCB reg
+    // The only test in which there is a unary upk to SRCA with 32b DF is the datacopy kernel, which uses ELWADD
+    if constexpr (UNP_SEL == p_unpacr::UNP_A && IS_32b_DEST_EN)
+    {
+        temp.set_start_op(TT_OP_UNPACR_NOP(p_unpacr::UNP_B, 1 /*Dvalid*/, 0, 0, 0 /*clear to 0*/, 0 /*clear to 0*/));
+    }
+    else if constexpr (UNP_SEL == p_unpacr::UNP_B && IS_32b_DEST_EN)
+    {
+        temp.set_start_op(TT_OP_UNPACR_NOP(p_unpacr::UNP_A, 1 /*Dvalid*/, 0, 0, 0 /*clear to 0*/, 0 /*clear to 0*/));
+    }
+
+    temp.program_bank0_sw_cntl(instrn_buffer);
+}
+
+/**
+ * @brief MOP configuration for unpack of unary operations
+ * @details Sets up MOP for unpacking a single operand by tiles
  * works for any unpack resource
  * @tparam UNP_SEL: Selects which unpacker resource to use,
  * values = p_unpacr::UNP_A/p_unpacr::UNP_B/p_unpacr::UNP_DEST
  * @tparam IS_32b_DEST_EN: Set to True to enable using Math destination Register in 32-bit mode
  * @param buf_desc_id: The buffer descriptor ID where the buffer information is
  * stored in the buffer descriptor table, values = 0 - 16
- * @param num_tiles: number of tiles to unpack at a time for a single operand, default 1 tile of 32x32
+ * @param num_tiles: number of tiles to unpack at a time for a single operand
  */
 template <std::uint32_t UNP_SEL, bool IS_32b_DEST_EN>
-inline void _llk_unpack_unary_operand_mop_config_(const std::uint32_t buf_desc_id, const std::uint32_t num_tiles)
+inline void _llk_unpack_unary_operand_full_tile_mop_config_(const std::uint32_t buf_desc_id, const std::uint32_t num_tiles)
 {
     static_assert(
         (UNP_SEL == p_unpacr::UNP_A) || (UNP_SEL == p_unpacr::UNP_B) || (UNP_SEL == p_unpacr::UNP_DEST),
@@ -69,10 +138,13 @@ inline void _llk_unpack_unary_operand_mop_config_(const std::uint32_t buf_desc_i
  * @param buf_desc_id: The buffer descriptor ID where the buffer information is
  * stored in the buffer descriptor table, values = 0 - 16
  * @param num_tiles: number of tiles to unpack at a time for a single operand, default 1 tile of 32x32
+ * @note Does NOT support tiny-tiles
  */
 template <std::uint32_t UNP_SEL, bool IS_32b_DEST_EN>
 inline void _llk_unpack_unary_operand_transpose_mop_config_(const std::uint32_t buf_desc_id, const std::uint32_t num_tiles)
 {
+    // TODO: Add a runtime assert to check that num_faces == NUM_FACES, as the current transpose implementation only supports regular tile dimensions with 4
+    // faces
     static_assert((UNP_SEL == p_unpacr::UNP_A) || (UNP_SEL == p_unpacr::UNP_B), "UNP_SEL can only be p_unpacr::UNP_A or p_unpacr::UNP_B for unpack transpose");
 
     const std::uint32_t MOP_OUTER_LOOP = num_tiles;
@@ -130,6 +202,7 @@ inline void _llk_unpack_unary_operand_transpose_mop_config_(const std::uint32_t 
  * @tparam reuse_dest: Which source register is reused from dest (DEST_TO_SRCA or DEST_TO_SRCB)
  * @param buf_desc_id: The buffer descriptor ID for the CB source
  * @param num_tiles: number of tiles to unpack
+ * @param num_faces: number of faces in the tiles to unpack
  */
 template <std::uint32_t UNP_SEL, EltwiseBinaryReuseDestType reuse_dest>
 inline void _llk_unpack_unary_operand_reuse_dest_mop_config_(const std::uint32_t buf_desc_id, const std::uint32_t num_tiles, const std::uint32_t num_faces)
@@ -147,17 +220,28 @@ inline void _llk_unpack_unary_operand_reuse_dest_mop_config_(const std::uint32_t
     // Unpack one face from CB with auto-increment of src face index.
     // Dst_Face_Idx_Inc=0: always write to face 0 position (FPU reads from 0 after CLR_AB).
     // Src_Face_Idx_Inc=1: advance through L1 tile faces 0→1→2→3 (wraps back to 0).
-    const std::uint32_t face_inc_op = (CB_UNP == p_unpacr::UNP_A)
-                                          ? TT_OP_UNPACR0_FACE_INC(0 /*Dst_Face_Inc*/, 1 /*Src_Face_Inc*/, 0, 0, buf_desc_id, 1 /*SetDatValid*/)
-                                          : TT_OP_UNPACR1_FACE_INC(0 /*Dst_Face_Inc*/, 1 /*Src_Face_Inc*/, 0, 0, buf_desc_id, 1 /*SetDatValid*/);
-
-    // MOP: outer=num_tiles, inner=num_faces
-    // Each inner iteration: NOP (dvalid for dummy src) + FACE_INC (unpack face + inc src face)
-    // END_OP: increment CB tile counter after all faces of a tile are processed
-    ckernel_template temp(num_tiles, num_faces, nop_op, face_inc_op);
-    temp.set_end_op(TT_OP_INC_SRC_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, CB_UNP, 1));
-
-    temp.program_bank0_sw_cntl(instrn_buffer);
+    if (num_faces == NUM_FACES) // Using regular tile dimensions
+    {
+        const std::uint32_t face_inc_op = (CB_UNP == p_unpacr::UNP_A)
+                                              ? TT_OP_UNPACR0_FACE_INC(0 /*Dst_Face_Inc*/, 1 /*Src_Face_Inc*/, 0, 0, buf_desc_id, 1 /*SetDatValid*/)
+                                              : TT_OP_UNPACR1_FACE_INC(0 /*Dst_Face_Inc*/, 1 /*Src_Face_Inc*/, 0, 0, buf_desc_id, 1 /*SetDatValid*/);
+        // MOP: outer=num_tiles, inner=num_faces
+        // Each inner iteration: NOP (dvalid for dummy src) + FACE_INC (unpack face + inc src face)
+        // END_OP: increment CB tile counter after all faces of a tile are processed
+        ckernel_template temp(num_tiles, num_faces, nop_op, face_inc_op);
+        temp.set_end_op(TT_OP_INC_SRC_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, CB_UNP, 1));
+        temp.program_bank0_sw_cntl(instrn_buffer);
+    }
+    else // Using tiny-tiles
+    {
+        const std::uint32_t face_inc_op = (CB_UNP == p_unpacr::UNP_A)
+                                              ? TT_OP_UNPACR0_TILE_INC(0 /*Dst_Tile_Idx_Inc*/, 1 /*Src_Tile_Idx_Inc*/, buf_desc_id, 1 /*SetDatValid*/)
+                                              : TT_OP_UNPACR1_TILE_INC(0 /*Dst_Tile_Idx_Inc*/, 1 /*Src_Tile_Idx_Inc*/, buf_desc_id, 1 /*SetDatValid*/);
+        // MOP: outer=num_tiles, inner=num_faces
+        // Each inner iteration: NOP (dvalid for dummy src) + FACE_INC (unpack face + inc src face)
+        ckernel_template temp(num_tiles, num_faces, nop_op, face_inc_op);
+        temp.program_bank0_sw_cntl(instrn_buffer);
+    }
 }
 
 /**
@@ -170,6 +254,7 @@ inline void _llk_unpack_unary_operand_reuse_dest_mop_config_(const std::uint32_t
  * @param buf_desc_id: The buffer descriptor ID where the buffer information is
  * stored in the buffer descriptor table, values = 0 - 16
  * @param num_tiles: number of tiles to unpack at a time for a single operand, default 1 tile of 32x32
+ * @param num_faces: number of faces per tile to unpack, default is 4
  */
 template <std::uint32_t UNP_SEL, bool TRANSPOSE_EN, bool IS_32b_DEST_EN, EltwiseBinaryReuseDestType reuse_dest = EltwiseBinaryReuseDestType::NONE>
 inline void _llk_unpack_unary_operand_init_(
@@ -196,7 +281,14 @@ inline void _llk_unpack_unary_operand_init_(
     }
     else
     {
-        _llk_unpack_unary_operand_mop_config_<UNP_SEL, IS_32b_DEST_EN>(buf_desc_id, num_tiles);
+        if (num_faces == NUM_FACES) // Using regular tile dimensions
+        {
+            _llk_unpack_unary_operand_full_tile_mop_config_<UNP_SEL, IS_32b_DEST_EN>(buf_desc_id, num_tiles);
+        }
+        else // Using tiny-tiles
+        {
+            _llk_unpack_unary_operand_tiny_tile_mop_config_<UNP_SEL, IS_32b_DEST_EN>(buf_desc_id, num_tiles, num_faces);
+        }
     }
 }
 
@@ -208,7 +300,7 @@ inline void _llk_unpack_unary_operand_init_(
  * @param l1_tile_idx: Index into the L1 buffer for a tile
  */
 template <std::uint32_t UNP_SEL, EltwiseBinaryReuseDestType reuse_dest = EltwiseBinaryReuseDestType::NONE>
-inline void _llk_unpack_unary_operand_(const std::uint32_t l1_tile_idx)
+inline void _llk_unpack_unary_operand_(const std::uint32_t l1_tile_idx, const std::uint32_t num_faces, std::uint32_t c_dim_faces)
 {
     // RT: for the best performance, setting counters should be placed in a REPLAY buffer
     // in the mop_config, but for back compatibility with APIs, the counter functions must
@@ -218,15 +310,22 @@ inline void _llk_unpack_unary_operand_(const std::uint32_t l1_tile_idx)
     {
         // For reuse_dest, set source counter for the unpacker that reads from the Circular Buffer.
         // The other source register is filled by MOVD2A/B on the math side.
+        // For tiny-tiles, each face is considered a separate tile in HW. We need to multiply the tile idx by c_dim_faces to get the correct SW defined tile
+        // offset.
         constexpr std::uint32_t CB_UNP = (reuse_dest == EltwiseBinaryReuseDestType::DEST_TO_SRCA) ? p_unpacr::UNP_B : p_unpacr::UNP_A;
-        TT_SET_SRC_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, CB_UNP, l1_tile_idx);
+        TT_SET_SRC_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, CB_UNP, (num_faces == NUM_FACES) ? l1_tile_idx : l1_tile_idx * c_dim_faces);
         TTI_SET_DST_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, CB_UNP, 0);
     }
     else
     {
         // Reset Dest counters for Unpacker to 0
         // Set Source counter to L1 base + offset
-        TT_SET_SRC_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, UNP_SEL == p_unpacr::UNP_DEST ? p_unpacr::UNP_A : UNP_SEL, l1_tile_idx);
+        // For tiny-tiles, each face is considered a separate tile in HW. We need to multiply the tile idx by c_dim_faces to get the correct SW defined tile
+        // offset.
+        TT_SET_SRC_TILE_FACE_ROW_IDX(
+            p_set_inc_sel::TILE_SEL,
+            UNP_SEL == p_unpacr::UNP_DEST ? p_unpacr::UNP_A : UNP_SEL,
+            (num_faces == NUM_FACES) ? l1_tile_idx : l1_tile_idx * c_dim_faces);
         TTI_SET_DST_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, UNP_SEL == p_unpacr::UNP_DEST ? p_unpacr::UNP_A : UNP_SEL, 0);
     }
 

--- a/tt_llk_quasar/llk_lib/llk_unpack_unary_operand.h
+++ b/tt_llk_quasar/llk_lib/llk_unpack_unary_operand.h
@@ -24,14 +24,14 @@ using namespace ckernel;
  * @param num_faces: number of faces in the tiles to unpack
  */
 template <std::uint32_t UNP_SEL, bool IS_32b_DEST_EN>
-inline void _llk_unpack_unary_operand_tiny_tile_mop_config_(const std::uint32_t buf_desc_id, const std::uint32_t num_tiles, const std::uint32_t num_faces)
+inline void _llk_unpack_unary_operand_tiny_tile_mop_config_(const std::uint32_t buf_desc_id, const std::uint32_t num_tiles, const TileShape& tile_shape)
 {
     static_assert(
         (UNP_SEL == p_unpacr::UNP_A) || (UNP_SEL == p_unpacr::UNP_B) || (UNP_SEL == p_unpacr::UNP_DEST),
         "UNP_SEL can only be set to p_unpacr::UNP_A/UNP_B/UNP_DEST");
 
     const std::uint32_t MOP_OUTER_LOOP = num_tiles;
-    const std::uint32_t MOP_INNER_LOOP = num_faces;
+    const std::uint32_t MOP_INNER_LOOP = tile_shape.num_faces;
 
     // For UNP_A/UNP_B: Dst Tile Idx Inc = 0 so each face overwrites the same SrcA/B tile slot.
     // Dvalid is set per face so math can consume each face before the next one arrives.
@@ -41,19 +41,21 @@ inline void _llk_unpack_unary_operand_tiny_tile_mop_config_(const std::uint32_t 
     std::uint32_t reset_dest_tile_cnt_instrn =
         TT_OP_SET_DST_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, UNP_SEL == p_unpacr::UNP_DEST ? p_unpacr::UNP_A : UNP_SEL, 0);
 
+    std::uint32_t dest_tile_idx_inc = (tile_shape.face_r_dim < (FACE_R_DIM >> 1)) ? (FACE_R_DIM >> (rows_log2(tile_shape.face_r_dim) + 1)) : 1;
+
     if constexpr (UNP_SEL == p_unpacr::UNP_A)
     {
-        unpack_tile_instrn          = TT_OP_UNPACR0_TILE_INC(1 /*Dst Tile Idx*/, 1 /*Src Tile Idx*/, buf_desc_id, 0 /*Set Dvalid*/);
-        unpack_tile_w_dvalid_instrn = TT_OP_UNPACR0_TILE_INC(1 /*Dst Tile Idx*/, 1 /*Src Tile Idx*/, buf_desc_id, 1 /*Set Dvalid*/);
+        unpack_tile_instrn          = TT_OP_UNPACR0_TILE_INC(dest_tile_idx_inc /*Dst Tile Idx*/, 1 /*Src Tile Idx*/, buf_desc_id, 0 /*Set Dvalid*/);
+        unpack_tile_w_dvalid_instrn = TT_OP_UNPACR0_TILE_INC(dest_tile_idx_inc /*Dst Tile Idx*/, 1 /*Src Tile Idx*/, buf_desc_id, 1 /*Set Dvalid*/);
     }
     else if constexpr (UNP_SEL == p_unpacr::UNP_B)
     {
-        unpack_tile_instrn          = TT_OP_UNPACR1_TILE_INC(1 /*Dst Tile Idx*/, 1 /*Src Tile Idx*/, buf_desc_id, 0 /*Set Dvalid*/);
-        unpack_tile_w_dvalid_instrn = TT_OP_UNPACR1_TILE_INC(1 /*Dst Tile Idx*/, 1 /*Src Tile Idx*/, buf_desc_id, 1 /*Set Dvalid*/);
+        unpack_tile_instrn          = TT_OP_UNPACR1_TILE_INC(dest_tile_idx_inc /*Dst Tile Idx*/, 1 /*Src Tile Idx*/, buf_desc_id, 0 /*Set Dvalid*/);
+        unpack_tile_w_dvalid_instrn = TT_OP_UNPACR1_TILE_INC(dest_tile_idx_inc /*Dst Tile Idx*/, 1 /*Src Tile Idx*/, buf_desc_id, 1 /*Set Dvalid*/);
     }
     else if constexpr (UNP_SEL == p_unpacr::UNP_DEST)
     {
-        unpack_tile_instrn = TT_OP_UNPACR_DEST_TILE_INC(1, 1 /*Src Tile Idx*/, buf_desc_id, 0 /*Set Dvalid*/);
+        unpack_tile_instrn = TT_OP_UNPACR_DEST_TILE_INC(dest_tile_idx_inc, 1 /*Src Tile Idx*/, buf_desc_id, 0 /*Set Dvalid*/);
     }
 
     ckernel_template temp(MOP_OUTER_LOOP, MOP_INNER_LOOP, unpack_tile_instrn);
@@ -205,7 +207,7 @@ inline void _llk_unpack_unary_operand_transpose_mop_config_(const std::uint32_t 
  * @param num_faces: number of faces in the tiles to unpack
  */
 template <std::uint32_t UNP_SEL, EltwiseBinaryReuseDestType reuse_dest>
-inline void _llk_unpack_unary_operand_reuse_dest_mop_config_(const std::uint32_t buf_desc_id, const std::uint32_t num_tiles, const std::uint32_t num_faces)
+inline void _llk_unpack_unary_operand_reuse_dest_mop_config_(const std::uint32_t buf_desc_id, const std::uint32_t num_tiles, const TileShape& tile_shape)
 {
     static_assert(reuse_dest != EltwiseBinaryReuseDestType::NONE, "reuse_dest must be DEST_TO_SRCA or DEST_TO_SRCB");
 
@@ -220,7 +222,7 @@ inline void _llk_unpack_unary_operand_reuse_dest_mop_config_(const std::uint32_t
     // Unpack one face from CB with auto-increment of src face index.
     // Dst_Face_Idx_Inc=0: always write to face 0 position (FPU reads from 0 after CLR_AB).
     // Src_Face_Idx_Inc=1: advance through L1 tile faces 0→1→2→3 (wraps back to 0).
-    if (num_faces == NUM_FACES) // Using regular tile dimensions
+    if (tile_shape.num_faces == NUM_FACES) // Using regular tile dimensions
     {
         const std::uint32_t face_inc_op = (CB_UNP == p_unpacr::UNP_A)
                                               ? TT_OP_UNPACR0_FACE_INC(0 /*Dst_Face_Inc*/, 1 /*Src_Face_Inc*/, 0, 0, buf_desc_id, 1 /*SetDatValid*/)
@@ -228,7 +230,7 @@ inline void _llk_unpack_unary_operand_reuse_dest_mop_config_(const std::uint32_t
         // MOP: outer=num_tiles, inner=num_faces
         // Each inner iteration: NOP (dvalid for dummy src) + FACE_INC (unpack face + inc src face)
         // END_OP: increment CB tile counter after all faces of a tile are processed
-        ckernel_template temp(num_tiles, num_faces, nop_op, face_inc_op);
+        ckernel_template temp(num_tiles, tile_shape.num_faces, nop_op, face_inc_op);
         temp.set_end_op(TT_OP_INC_SRC_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, CB_UNP, 1));
         temp.program_bank0_sw_cntl(instrn_buffer);
     }
@@ -239,7 +241,7 @@ inline void _llk_unpack_unary_operand_reuse_dest_mop_config_(const std::uint32_t
                                               : TT_OP_UNPACR1_TILE_INC(0 /*Dst_Tile_Idx_Inc*/, 1 /*Src_Tile_Idx_Inc*/, buf_desc_id, 1 /*SetDatValid*/);
         // MOP: outer=num_tiles, inner=num_faces
         // Each inner iteration: NOP (dvalid for dummy src) + FACE_INC (unpack face + inc src face)
-        ckernel_template temp(num_tiles, num_faces, nop_op, face_inc_op);
+        ckernel_template temp(num_tiles, tile_shape.num_faces, nop_op, face_inc_op);
         temp.program_bank0_sw_cntl(instrn_buffer);
     }
 }
@@ -257,8 +259,7 @@ inline void _llk_unpack_unary_operand_reuse_dest_mop_config_(const std::uint32_t
  * @param num_faces: number of faces per tile to unpack, default is 4
  */
 template <std::uint32_t UNP_SEL, bool TRANSPOSE_EN, bool IS_32b_DEST_EN, EltwiseBinaryReuseDestType reuse_dest = EltwiseBinaryReuseDestType::NONE>
-inline void _llk_unpack_unary_operand_init_(
-    const std::uint32_t buf_desc_id, const std::uint32_t num_tiles = NUM_TILES, const std::uint32_t num_faces = NUM_FACES)
+inline void _llk_unpack_unary_operand_init_(const std::uint32_t buf_desc_id, TileShape& tile_shape, const std::uint32_t num_tiles = NUM_TILES)
 {
     static_assert(!(TRANSPOSE_EN && reuse_dest != EltwiseBinaryReuseDestType::NONE), "Transpose is not supported with reuse_dest");
 
@@ -273,7 +274,7 @@ inline void _llk_unpack_unary_operand_init_(
 
     if constexpr (reuse_dest != EltwiseBinaryReuseDestType::NONE)
     {
-        _llk_unpack_unary_operand_reuse_dest_mop_config_<UNP_SEL, reuse_dest>(buf_desc_id, num_tiles, num_faces);
+        _llk_unpack_unary_operand_reuse_dest_mop_config_<UNP_SEL, reuse_dest>(buf_desc_id, num_tiles, tile_shape);
     }
     else if constexpr (TRANSPOSE_EN)
     {
@@ -281,13 +282,13 @@ inline void _llk_unpack_unary_operand_init_(
     }
     else
     {
-        if (num_faces == NUM_FACES || num_faces == 1) // Using regular tile dimensions
+        if (tile_shape.num_faces == NUM_FACES || tile_shape.num_faces == 1) // Using regular tile dimensions
         {
             _llk_unpack_unary_operand_full_tile_mop_config_<UNP_SEL, IS_32b_DEST_EN>(buf_desc_id, num_tiles);
         }
         else // Using tiny-tiles
         {
-            _llk_unpack_unary_operand_tiny_tile_mop_config_<UNP_SEL, IS_32b_DEST_EN>(buf_desc_id, num_tiles, num_faces);
+            _llk_unpack_unary_operand_tiny_tile_mop_config_<UNP_SEL, IS_32b_DEST_EN>(buf_desc_id, num_tiles, tile_shape);
         }
     }
 }
@@ -300,7 +301,7 @@ inline void _llk_unpack_unary_operand_init_(
  * @param l1_tile_idx: Index into the L1 buffer for a tile
  */
 template <std::uint32_t UNP_SEL, EltwiseBinaryReuseDestType reuse_dest = EltwiseBinaryReuseDestType::NONE>
-inline void _llk_unpack_unary_operand_(const std::uint32_t l1_tile_idx, const std::uint32_t num_faces = NUM_FACES, std::uint32_t c_dim_faces = (NUM_FACES >> 1))
+inline void _llk_unpack_unary_operand_(const std::uint32_t l1_tile_idx, const TileShape& tile_shape)
 {
     // RT: for the best performance, setting counters should be placed in a REPLAY buffer
     // in the mop_config, but for back compatibility with APIs, the counter functions must
@@ -310,22 +311,22 @@ inline void _llk_unpack_unary_operand_(const std::uint32_t l1_tile_idx, const st
     {
         // For reuse_dest, set source counter for the unpacker that reads from the Circular Buffer.
         // The other source register is filled by MOVD2A/B on the math side.
-        // For tiny-tiles, each face is considered a separate tile in HW. We need to multiply the tile idx by c_dim_faces to get the correct SW defined tile
+        // For tiny-tiles, each face is considered a separate tile in HW. We need to multiply the tile idx by num_faces to get the correct SW defined tile
         // offset.
         constexpr std::uint32_t CB_UNP = (reuse_dest == EltwiseBinaryReuseDestType::DEST_TO_SRCA) ? p_unpacr::UNP_B : p_unpacr::UNP_A;
-        TT_SET_SRC_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, CB_UNP, (num_faces == NUM_FACES) ? l1_tile_idx : l1_tile_idx * c_dim_faces);
+        TT_SET_SRC_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, CB_UNP, (tile_shape.num_faces == NUM_FACES) ? l1_tile_idx : l1_tile_idx * tile_shape.num_faces);
         TTI_SET_DST_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, CB_UNP, 0);
     }
     else
     {
         // Reset Dest counters for Unpacker to 0
         // Set Source counter to L1 base + offset
-        // For tiny-tiles, each face is considered a separate tile in HW. We need to multiply the tile idx by c_dim_faces to get the correct SW defined tile
+        // For tiny-tiles, each face is considered a separate tile in HW. We need to multiply the tile idx by num_faces to get the correct SW defined tile
         // offset.
         TT_SET_SRC_TILE_FACE_ROW_IDX(
             p_set_inc_sel::TILE_SEL,
             UNP_SEL == p_unpacr::UNP_DEST ? p_unpacr::UNP_A : UNP_SEL,
-            (num_faces == NUM_FACES) ? l1_tile_idx : l1_tile_idx * c_dim_faces);
+            (tile_shape.num_faces == NUM_FACES) ? l1_tile_idx : l1_tile_idx * tile_shape.num_faces);
         TTI_SET_DST_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, UNP_SEL == p_unpacr::UNP_DEST ? p_unpacr::UNP_A : UNP_SEL, 0);
     }
 

--- a/tt_llk_quasar/llk_lib/llk_unpack_unary_operand.h
+++ b/tt_llk_quasar/llk_lib/llk_unpack_unary_operand.h
@@ -281,7 +281,7 @@ inline void _llk_unpack_unary_operand_init_(
     }
     else
     {
-        if (num_faces == NUM_FACES) // Using regular tile dimensions
+        if (num_faces == NUM_FACES || num_faces == 1) // Using regular tile dimensions
         {
             _llk_unpack_unary_operand_full_tile_mop_config_<UNP_SEL, IS_32b_DEST_EN>(buf_desc_id, num_tiles);
         }
@@ -300,7 +300,7 @@ inline void _llk_unpack_unary_operand_init_(
  * @param l1_tile_idx: Index into the L1 buffer for a tile
  */
 template <std::uint32_t UNP_SEL, EltwiseBinaryReuseDestType reuse_dest = EltwiseBinaryReuseDestType::NONE>
-inline void _llk_unpack_unary_operand_(const std::uint32_t l1_tile_idx, const std::uint32_t num_faces, std::uint32_t c_dim_faces)
+inline void _llk_unpack_unary_operand_(const std::uint32_t l1_tile_idx, const std::uint32_t num_faces = NUM_FACES, std::uint32_t c_dim_faces = (NUM_FACES >> 1))
 {
     // RT: for the best performance, setting counters should be placed in a REPLAY buffer
     // in the mop_config, but for back compatibility with APIs, the counter functions must


### PR DESCRIPTION
### Ticket
<!-- Link to Github Issue -->
#1460 

### Problem description
<!-- Provide context for the problem. -->
Currently, llk_unpack_unary_operand and llk_pack do not support tiny-tiles. Need to add support for tiny-tiles to unlock tiny-tile testing for more LLKs

### What's changed
<!-- Describe the approach used to solve the problem.
Summarize the changes made and its impact. -->
Added support for tiny-tiles for llk_unpack_unary_operand and llk_pack

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Assert validation](https://github.com/tenstorrent/tt-llk/blob/main/docs/Introduction_to_asserts.md) Complied with assert doc (if applicable)
