### PR TITLE
fix: disable static assert on iteration count in exp

### DIFF
--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_exp.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_exp.h
@@ -423,7 +423,8 @@ void _calculate_exponential_(const std::uint16_t exp_base_scale_factor /* 1.0f i
         }
 #else
         // Code below is hand-unrolled for 8 iterations
-        static_assert(ITERATIONS == 8);
+        // so it doesn't respect ITERATIONS. TODO: tt-llk#1486
+        // static_assert(ITERATIONS == 8);
 
         // Sanitize the input values by loading from DEST, comparing against the value -88.5, and if the input value is more negative than that, swap the input
         // value with -88.5 and store back to DEST

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_exp.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_exp.h
@@ -417,7 +417,8 @@ void _calculate_exponential_(const std::uint16_t exp_base_scale_factor /* 1.0f i
         }
 #else
         // Code below is hand-unrolled for 8 iterations
-        static_assert(ITERATIONS == 8);
+        // so it doesn't respect ITERATIONS. TODO: tt-llk#1486
+        // static_assert(ITERATIONS == 8);
 
         // Sanitize the input values by loading from DEST, comparing against the value -88.5, and if the input value is more negative than that, swap the input
         // value with -88.5 and store back to DEST


### PR DESCRIPTION
### Ticket
#1486

### Problem description
exp implementation that is using LOADMACRO doesn't take ITERATIONS into account. Passing anything other than 8 doesn't get reflected in the code path, LOADMACRO will still execute 8 iterations, no matter the iteration count.

### What's changed
Disabled static asserts.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Assert validation](https://github.com/tenstorrent/tt-llk/blob/main/docs/Introduction_to_asserts.md) Complied with assert doc (if applicable)
