### PR TITLE
fix: stop exalens server even on sigterm and sigquit

### DIFF
--- a/tests/python_tests/conftest.py
+++ b/tests/python_tests/conftest.py
@@ -272,6 +272,7 @@ _exalens_server: Optional[ExalensServer] = None
 @atexit.register
 def _stop_exalens_server():
     """atexit handler to ensure the tt-exalens server is stopped on process exit."""
+    global _exalens_server
     if _exalens_server is not None:
         _exalens_server.stop()
         _exalens_server = None


### PR DESCRIPTION
### Ticket
None

### Problem description
In case of SIGTERM (calling kill %% after moving pytest to background) or SIGQUIT, we'd keep the emulator process running and orphaned.

### What's changed
Added handlers for SIGTERM and SIGQUIT.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Assert validation](https://github.com/tenstorrent/tt-llk/blob/main/docs/Introduction_to_asserts.md) Complied with assert doc (if applicable)
