### PR TITLE
Validate Int16: tilize + untilize

### DIFF
--- a/tests/python_tests/quasar/test_pack_untilize_quasar.py
+++ b/tests/python_tests/quasar/test_pack_untilize_quasar.py
@@ -51,13 +51,15 @@ def generate_pack_untilize_combinations(
 
     for fmt in formats_list:
         in_fmt = fmt.input_format
-        if in_fmt != fmt.output_format:
-            continue
 
         dest_acc_modes = (
             (DestAccumulation.Yes,)
             if in_fmt.is_32_bit()
-            else (DestAccumulation.No, DestAccumulation.Yes)
+            else (
+                (DestAccumulation.No,)
+                if in_fmt == DataFormat.Int16
+                else (DestAccumulation.No, DestAccumulation.Yes)
+            )
         )
 
         for dest_acc in dest_acc_modes:
@@ -71,7 +73,9 @@ PACK_UNTILIZE_FORMATS = input_output_formats(
     [
         DataFormat.Float16_b,
         DataFormat.Float16,
-    ]
+        DataFormat.Int16,
+    ],
+    same=True,  # Input format and output format are the same
 )
 ALL_PACK_UNTILIZE_COMBINATIONS = generate_pack_untilize_combinations(
     PACK_UNTILIZE_FORMATS

--- a/tests/python_tests/quasar/test_unpack_tilize_quasar.py
+++ b/tests/python_tests/quasar/test_unpack_tilize_quasar.py
@@ -64,13 +64,15 @@ def generate_unpack_tilize_combinations(
 
     for fmt in formats_list:
         in_fmt = fmt.input_format
-        if in_fmt != fmt.output_format:
-            continue
 
         if in_fmt.is_32_bit():
             continue  # Tilize 32b data into dest not yet supported
 
-        dest_acc_modes = (DestAccumulation.No, DestAccumulation.Yes)
+        dest_acc_modes = (
+            (DestAccumulation.No,)
+            if in_fmt == DataFormat.Int16
+            else (DestAccumulation.No, DestAccumulation.Yes)
+        )
         unpacker_engines = (UnpackerEngine.UnpA, UnpackerEngine.UnpB)
 
         for dest_acc in dest_acc_modes:
@@ -85,7 +87,9 @@ UNPACK_TILIZE_FORMATS = input_output_formats(
     [
         DataFormat.Float16_b,
         DataFormat.Float16,
-    ]
+        DataFormat.Int16,
+    ],
+    same=True,  # Input format and output format are the same
 )
 ALL_UNPACK_TILIZE_COMBINATIONS = generate_unpack_tilize_combinations(
     UNPACK_TILIZE_FORMATS


### PR DESCRIPTION
### Ticket
<!-- Link to Github Issue -->
https://github.com/tenstorrent/tt-llk/issues/1363
### Problem description
<!-- Provide context for the problem. -->
Int16 support needed for quasar tilize and untilize LLKs for Resnet model. This support already exists, LLKs successfully execute tilization for Int16.
### What's changed
<!-- Describe the approach used to solve the problem.
Summarize the changes made and its impact. -->
Added necessary tests in LLK test infra for Int16 tilize + untilize
### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring