### PR TITLE
[infra. coverage] Abort fix

### DIFF
--- a/tests/helpers/src/coverage.cpp
+++ b/tests/helpers/src/coverage.cpp
@@ -30,9 +30,10 @@ extern "C"
         LLK_ASSERT(false, "__gcov_merge_add: panic");
     }
 
-    void abort()
+    __attribute__((noinline)) void abort()
     {
         LLK_ASSERT(false, "abort: panic");
+        __builtin_unreachable();
     }
 
     std::uint32_t __umodsi3(std::uint32_t a, std::uint32_t b)


### PR DESCRIPTION
### Ticket
Coverage.cpp couldn't be compiled, thus coverage couldn't be ran at all and nightly was failing

### Problem description
When #1462 went in, it removed builtin unreachable compiler hint from asserts, exposing `void abort()` to a bug because abort is just llk assert that always asserts false. By stdlib's definition, abort _can not_ return. This meant that if there isn't this hint present, compiler would throw you _a warning_ that  abort _can return_ even though it _shouldn't_. This wouldn't be caught if it wasn't for `-Werror`.

### What's changed
Added the aforementioned `__builtin_unreachable();` and a hint to compiler never to inline this function.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Assert validation](https://github.com/tenstorrent/tt-llk/blob/main/docs/Introduction_to_asserts.md) Complied with assert doc (if applicable)
