### PR TITLE
Int8 Matmul functionality

### DIFF
--- a/tests/python_tests/helpers/golden_generators.py
+++ b/tests/python_tests/helpers/golden_generators.py
@@ -826,11 +826,19 @@ class MatmulGolden(FidelityMasking):
         if data_format.is_integer():
             t1 = t1.view(M, K1).to(torch.float32)
             t2 = t2.view(K2, N).to(torch.float32)
-            # need to clamp the result to the data format range, otherwise float32 -> int8 will not work correctly
-            # also int8 on hw is sign+magnitude, so we need to clamp to -127, 127
-            res = torch.clamp(torch.matmul(t1, t2).view(M * N), min=-127, max=127).to(
-                torch_format
-            )
+            # Clamp the result to the representable range of the integer data format.
+            # Use torch.iinfo for generality, and adjust for sign-magnitude int8 on hw
+            # (torch.int8 is two's complement with min=-128; hw uses -127 as lowest value).
+            info = torch.iinfo(torch_format)
+            clamp_min = info.min
+            clamp_max = info.max
+            if data_format == DataFormat.Int8:
+                clamp_min = info.min + 1
+            res = torch.clamp(
+                torch.matmul(t1, t2).view(M * N),
+                min=clamp_min,
+                max=clamp_max,
+            ).to(torch_format)
         else:
             MATH_FIDELITY_TO_ITER_COUNT = {
                 MathFidelity.LoFi: 0,

--- a/tests/python_tests/helpers/golden_generators.py
+++ b/tests/python_tests/helpers/golden_generators.py
@@ -826,7 +826,11 @@ class MatmulGolden(FidelityMasking):
         if data_format.is_integer():
             t1 = t1.view(M, K1).to(torch.float32)
             t2 = t2.view(K2, N).to(torch.float32)
-            res = torch.matmul(t1, t2).view(M * N).to(torch_format)
+            # need to clamp the result to the data format range, otherwise float32 -> int8 will not work correctly
+            # also int8 on hw is sign+magnitude, so we need to clamp to -127, 127
+            res = torch.clamp(torch.matmul(t1, t2).view(M * N), min=-127, max=127).to(
+                torch_format
+            )
         else:
             MATH_FIDELITY_TO_ITER_COUNT = {
                 MathFidelity.LoFi: 0,

--- a/tests/python_tests/helpers/golden_generators.py
+++ b/tests/python_tests/helpers/golden_generators.py
@@ -823,87 +823,31 @@ class MatmulGolden(FidelityMasking):
                     f"Matrix dimensions incompatible: A[{M},{K1}] × B[{K2},{N}]"
                 )
 
-            output_dimensions = [M, N]
+        if data_format.is_integer():
+            t1 = t1.view(M, K1).to(torch.float32)
+            t2 = t2.view(K2, N).to(torch.float32)
+            res = torch.matmul(t1, t2).view(M * N).to(torch_format)
+        else:
+            MATH_FIDELITY_TO_ITER_COUNT = {
+                MathFidelity.LoFi: 0,
+                MathFidelity.HiFi2: 1,
+                MathFidelity.HiFi3: 2,
+                MathFidelity.HiFi4: 3,
+            }
 
-        MATH_FIDELITY_TO_ITER_COUNT = {
-            MathFidelity.LoFi: 0,
-            MathFidelity.HiFi2: 1,
-            MathFidelity.HiFi3: 2,
-            MathFidelity.HiFi4: 3,
-        }
+            fidelity_iter_count = MATH_FIDELITY_TO_ITER_COUNT[math_fidelity]
 
-        fidelity_iter_count = MATH_FIDELITY_TO_ITER_COUNT[math_fidelity]
-
-        res = 0
-
-        if fidelity_iter_count == 0:
-
-            t1, t2 = self._apply_fidelity_masking(data_format, t1, t2, 0)
-            t1, t2 = t1.view(M, K1), t2.view(K2, N)
-            res = (
-                torch.matmul(t1, t2)
-                .view(output_dimensions[0] * output_dimensions[1])
-                .to(torch_format)
-            )
-
-        elif fidelity_iter_count == 1:
-
-            t1, t2 = self._apply_fidelity_masking(data_format, t1, t2, 0)
-            t1, t2 = t1.view(M, K1), t2.view(K2, N)
-            res = (
-                torch.matmul(t1, t2)
-                .view(output_dimensions[0] * output_dimensions[1])
-                .to(torch_format)
-            )
-
-            t1 = to_tensor(operand1, data_format)
-            t2 = to_tensor(operand2, data_format)
-            t1, t2 = self._apply_fidelity_masking(data_format, t1, t2, 1)
-            t1, t2 = t1.view(M, K1), t2.view(K2, N)
-            res += (
-                torch.matmul(t1, t2)
-                .view(output_dimensions[0] * output_dimensions[1])
-                .to(torch_format)
-            )
-
-        elif fidelity_iter_count == 2:
-
-            t1, t2 = self._apply_fidelity_masking(data_format, t1, t2, 0)
-            t1, t2 = t1.view(M, K1), t2.view(K2, N)
-            res = (
-                torch.matmul(t1, t2)
-                .view(output_dimensions[0] * output_dimensions[1])
-                .to(torch_format)
-            )
-
-            t1 = to_tensor(operand1, data_format)
-            t2 = to_tensor(operand2, data_format)
-            t1, t2 = self._apply_fidelity_masking(data_format, t1, t2, 1)
-            t1, t2 = t1.view(M, K1), t2.view(K2, N)
-            res += (
-                torch.matmul(t1, t2)
-                .view(output_dimensions[0] * output_dimensions[1])
-                .to(torch_format)
-            )
-
-            t1 = to_tensor(operand1, data_format)
-            t2 = to_tensor(operand2, data_format)
-            t1, t2 = self._apply_fidelity_masking(data_format, t1, t2, 2)
-            t1, t2 = t1.view(M, K1), t2.view(K2, N)
-            res += (
-                torch.matmul(t1, t2)
-                .view(output_dimensions[0] * output_dimensions[1])
-                .to(torch_format)
-            )
-
-        elif fidelity_iter_count == 3:
-
-            t1, t2 = t1.view(M, K1), t2.view(K2, N)
-            res = (
-                torch.matmul(t1, t2)
-                .view(output_dimensions[0] * output_dimensions[1])
-                .to(torch_format)
-            )
+            if fidelity_iter_count == 3:
+                t1, t2 = t1.view(M, K1), t2.view(K2, N)
+                res = torch.matmul(t1, t2).view(M * N).to(torch_format)
+            else:
+                res = torch.zeros(M * N, dtype=torch_format)
+                for phase in range(fidelity_iter_count + 1):
+                    t1 = to_tensor(operand1, data_format)
+                    t2 = to_tensor(operand2, data_format)
+                    t1, t2 = self._apply_fidelity_masking(data_format, t1, t2, phase)
+                    t1, t2 = t1.view(M, K1), t2.view(K2, N)
+                    res += torch.matmul(t1, t2).view(M * N).to(torch_format)
 
         if tilize:
             res = tilize_block(

--- a/tests/python_tests/helpers/stimuli_generator.py
+++ b/tests/python_tests/helpers/stimuli_generator.py
@@ -61,6 +61,7 @@ def generate_random_face(
     sfpu=True,
     face_r_dim=MAX_FACE_R_DIM,
     negative_values=False,
+    int_value_range=None,
 ):
     size = face_r_dim * FACE_C_DIM  # face_r_dim rows × FACE_C_DIM columns
 
@@ -74,11 +75,14 @@ def generate_random_face(
                     torch.ones(size, dtype=format_dict[stimuli_format]) * const_value
                 )
             else:
-                max_value = 127 if stimuli_format == DataFormat.Int8 else 255
-                min_value = -(max_value + 1) if negative_values else 0
+                if int_value_range is not None:
+                    min_value, max_value = int_value_range
+                else:
+                    max_value = 128 if stimuli_format == DataFormat.Int8 else 256
+                    min_value = -(max_value + 1) if negative_values else 0
                 srcA_face = torch.randint(
-                    low=-5,
-                    high=5,
+                    low=min_value,
+                    high=max_value,
                     size=(size,),
                     dtype=format_dict[stimuli_format],
                 )
@@ -325,6 +329,7 @@ def _generate_source_tensor(
     sfpu: bool,
     negative_values: bool,
     sequential: bool,
+    int_value_range=None,
 ) -> torch.Tensor:
     """
     Generate a source tensor with random or sequential values.
@@ -363,6 +368,7 @@ def _generate_source_tensor(
             sfpu=sfpu,
             face_r_dim=face_r_dim,
             negative_values=negative_values,
+            int_value_range=int_value_range,
         )
         src.extend(face.tolist())
 
@@ -446,6 +452,7 @@ def generate_stimuli(
     output_format=None,
     sequential_A=False,
     sequential_B=False,
+    int_value_range=None,
 ):
     """
     Generate stimuli data for testing - ORIGINAL backward-compatible version.
@@ -491,6 +498,7 @@ def generate_stimuli(
         sfpu=sfpu,
         negative_values=negative_values,
         sequential=sequential_A,
+        int_value_range=int_value_range,
     )
 
     srcB_tensor = _generate_source_tensor(
@@ -504,6 +512,7 @@ def generate_stimuli(
         sfpu=sfpu,
         negative_values=negative_values,
         sequential=sequential_B,
+        int_value_range=int_value_range,
     )
 
     srcA_tensor, srcB_tensor = _clamp_mx_tensors(

--- a/tests/python_tests/helpers/stimuli_generator.py
+++ b/tests/python_tests/helpers/stimuli_generator.py
@@ -77,8 +77,8 @@ def generate_random_face(
                 max_value = 127 if stimuli_format == DataFormat.Int8 else 255
                 min_value = -(max_value + 1) if negative_values else 0
                 srcA_face = torch.randint(
-                    low=min_value,
-                    high=max_value,
+                    low=-5,
+                    high=5,
                     size=(size,),
                     dtype=format_dict[stimuli_format],
                 )

--- a/tests/python_tests/helpers/stimuli_generator.py
+++ b/tests/python_tests/helpers/stimuli_generator.py
@@ -79,7 +79,7 @@ def generate_random_face(
                     min_value, max_value = int_value_range
                 else:
                     max_value = 128 if stimuli_format == DataFormat.Int8 else 256
-                    min_value = -(max_value + 1) if negative_values else 0
+                    min_value = -127 if negative_values else 0
                 srcA_face = torch.randint(
                     low=min_value,
                     high=max_value,

--- a/tests/python_tests/helpers/test_config.py
+++ b/tests/python_tests/helpers/test_config.py
@@ -575,6 +575,41 @@ class TestConfig:
         if TestConfig.SPEED_OF_LIGHT:
             return
 
+        TILE_SIZES = {
+            DataFormat.Int8: 64,
+            DataFormat.Bfp8_b: 68,
+            DataFormat.Float32: 256,
+        }
+
+        if self.formats_config is None:
+            pack_size, unpack_size_a, unpack_size_b = 128, 128, 128
+        else:
+            pack_size = TILE_SIZES.get(self.formats_config[0].output_format, 128)
+            unpack_size_a = TILE_SIZES.get(self.formats_config[0].input_format, 128)
+            unpack_size_b = TILE_SIZES.get(self.formats_config[0].input_format, 128)
+
+        if len(self.runtimes) > 0:
+            itd_param = next(
+                (param for param in self.runtimes if isinstance(param, IN_TILE_DIMS)),
+                None,
+            )
+            faces_param = next(
+                (param for param in self.runtimes if isinstance(param, NUM_FACES)), None
+            )
+            if itd_param and faces_param:
+                temp_num_faces_A = (
+                    faces_param.num_faces_A
+                    if faces_param.num_faces_A
+                    else faces_param.num_faces
+                )
+                if itd_param.in0_r_dim <= 16:
+                    pack_size = (pack_size // faces_param.num_faces) * (
+                        itd_param.in0_r_dim // self.variant_stimuli.face_r_dim
+                    )
+                    unpack_size_a = (unpack_size_a // temp_num_faces_A) * (
+                        itd_param.in0_r_dim // self.variant_stimuli.face_r_dim
+                    )
+
         argument_data = [
             self.pack_size,  # uint32_t TILE_SIZE_PACK;
             self.unpack_size_a,  # uint32_t TILE_SIZE_UNPACK_A;

--- a/tests/python_tests/helpers/test_config.py
+++ b/tests/python_tests/helpers/test_config.py
@@ -448,6 +448,7 @@ class TestConfig:
         self.dest_acc = dest_acc
 
         TILE_SIZES = {
+            DataFormat.Int8: 64,
             DataFormat.Bfp8_b: 68,
             DataFormat.Float32: 256,
         }
@@ -574,41 +575,6 @@ class TestConfig:
     def write_runtimes_to_L1(self, location: str = "0,0"):
         if TestConfig.SPEED_OF_LIGHT:
             return
-
-        TILE_SIZES = {
-            DataFormat.Int8: 64,
-            DataFormat.Bfp8_b: 68,
-            DataFormat.Float32: 256,
-        }
-
-        if self.formats_config is None:
-            pack_size, unpack_size_a, unpack_size_b = 128, 128, 128
-        else:
-            pack_size = TILE_SIZES.get(self.formats_config[0].output_format, 128)
-            unpack_size_a = TILE_SIZES.get(self.formats_config[0].input_format, 128)
-            unpack_size_b = TILE_SIZES.get(self.formats_config[0].input_format, 128)
-
-        if len(self.runtimes) > 0:
-            itd_param = next(
-                (param for param in self.runtimes if isinstance(param, IN_TILE_DIMS)),
-                None,
-            )
-            faces_param = next(
-                (param for param in self.runtimes if isinstance(param, NUM_FACES)), None
-            )
-            if itd_param and faces_param:
-                temp_num_faces_A = (
-                    faces_param.num_faces_A
-                    if faces_param.num_faces_A
-                    else faces_param.num_faces
-                )
-                if itd_param.in0_r_dim <= 16:
-                    pack_size = (pack_size // faces_param.num_faces) * (
-                        itd_param.in0_r_dim // self.variant_stimuli.face_r_dim
-                    )
-                    unpack_size_a = (unpack_size_a // temp_num_faces_A) * (
-                        itd_param.in0_r_dim // self.variant_stimuli.face_r_dim
-                    )
 
         argument_data = [
             self.pack_size,  # uint32_t TILE_SIZE_PACK;

--- a/tests/python_tests/test_matmul.py
+++ b/tests/python_tests/test_matmul.py
@@ -55,9 +55,7 @@ def generate_format_aware_matmul_combinations(
 
 
 # Generate format-aware combinations
-MATMUL_FORMATS = input_output_formats(
-    [DataFormat.Float16_b, DataFormat.Float16, DataFormat.Float32, DataFormat.Bfp8_b]
-)
+MATMUL_FORMATS = input_output_formats([DataFormat.Int8])
 DEST_ACC_MODES = [DestAccumulation.No, DestAccumulation.Yes]
 ALL_MATMUL_COMBINATIONS = generate_format_aware_matmul_combinations(
     MATMUL_FORMATS, DEST_ACC_MODES

--- a/tests/python_tests/test_matmul.py
+++ b/tests/python_tests/test_matmul.py
@@ -56,7 +56,7 @@ def generate_format_aware_matmul_combinations(
 
 # Generate format-aware combinations
 MATMUL_FORMATS = input_output_formats([DataFormat.Int8])
-DEST_ACC_MODES = [DestAccumulation.No, DestAccumulation.Yes]
+DEST_ACC_MODES = [DestAccumulation.Yes]
 ALL_MATMUL_COMBINATIONS = generate_format_aware_matmul_combinations(
     MATMUL_FORMATS, DEST_ACC_MODES
 )
@@ -64,9 +64,9 @@ ALL_MATMUL_COMBINATIONS = generate_format_aware_matmul_combinations(
 
 @parametrize(
     math_fidelity=[
-        MathFidelity.LoFi,
-        MathFidelity.HiFi2,
-        MathFidelity.HiFi3,
+        # MathFidelity.LoFi,
+        # MathFidelity.HiFi2,
+        # MathFidelity.HiFi3,
         MathFidelity.HiFi4,
     ],
     format_dest_acc_and_dims=ALL_MATMUL_COMBINATIONS,

--- a/tests/python_tests/test_matmul.py
+++ b/tests/python_tests/test_matmul.py
@@ -55,21 +55,38 @@ def generate_format_aware_matmul_combinations(
 
 
 # Generate format-aware combinations
-MATMUL_FORMATS = input_output_formats([DataFormat.Int8])
-DEST_ACC_MODES = [DestAccumulation.Yes]
+MATMUL_FORMATS = input_output_formats(
+    [DataFormat.Float16_b, DataFormat.Float16, DataFormat.Float32, DataFormat.Bfp8_b]
+)
+DEST_ACC_MODES = [DestAccumulation.No, DestAccumulation.Yes]
+
+# Int8: input and output must both be Int8, only DestAccumulation.Yes is valid
+INT8_MATMUL_FORMATS = input_output_formats([DataFormat.Int8], same=True)
+INT8_DEST_ACC_MODES = [DestAccumulation.Yes]
+
 ALL_MATMUL_COMBINATIONS = generate_format_aware_matmul_combinations(
     MATMUL_FORMATS, DEST_ACC_MODES
-)
+) + generate_format_aware_matmul_combinations(INT8_MATMUL_FORMATS, INT8_DEST_ACC_MODES)
+
+
+def get_valid_math_fidelities(format_dest_acc_and_dims):
+    """Return valid math fidelity values for the given format combination.
+    Int8 only supports HiFi4; all other formats support all fidelities.
+    """
+    fmt = format_dest_acc_and_dims[0]
+    if fmt.input_format == DataFormat.Int8:
+        return [MathFidelity.HiFi4]
+    return [
+        MathFidelity.LoFi,
+        MathFidelity.HiFi2,
+        MathFidelity.HiFi3,
+        MathFidelity.HiFi4,
+    ]
 
 
 @parametrize(
-    math_fidelity=[
-        # MathFidelity.LoFi,
-        # MathFidelity.HiFi2,
-        # MathFidelity.HiFi3,
-        MathFidelity.HiFi4,
-    ],
     format_dest_acc_and_dims=ALL_MATMUL_COMBINATIONS,
+    math_fidelity=get_valid_math_fidelities,
 )
 # Note: this test is used to test boot modes, that is why it has them piped as default arguments to the test itself
 def test_matmul(
@@ -85,12 +102,14 @@ def test_matmul(
     input_A_dimensions = format_dest_acc_and_dims[2][0]
     input_B_dimensions = format_dest_acc_and_dims[2][1]
 
+    int_range = (-5, 5) if formats.input_format == DataFormat.Int8 else None
     src_A, tile_cnt_A, src_B, tile_cnt_B = generate_stimuli(
         stimuli_format_A=formats.input_format,
         input_dimensions_A=input_A_dimensions,
         stimuli_format_B=formats.input_format,
         input_dimensions_B=input_B_dimensions,
         sfpu=False,
+        int_value_range=int_range,
     )
 
     # Calculate all matmul dimensions using helper function

--- a/tests/python_tests/test_matmul.py
+++ b/tests/python_tests/test_matmul.py
@@ -102,7 +102,7 @@ def test_matmul(
     input_A_dimensions = format_dest_acc_and_dims[2][0]
     input_B_dimensions = format_dest_acc_and_dims[2][1]
 
-    int_range = (-5, 5) if formats.input_format == DataFormat.Int8 else None
+    int_range = (-5, 6) if formats.input_format == DataFormat.Int8 else None
     src_A, tile_cnt_A, src_B, tile_cnt_B = generate_stimuli(
         stimuli_format_A=formats.input_format,
         input_dimensions_A=input_A_dimensions,

--- a/tests/sources/matmul_test.cpp
+++ b/tests/sources/matmul_test.cpp
@@ -84,6 +84,12 @@ void run_kernel(RUNTIME_PARAMETERS params)
         _llk_math_matmul_<MATH_FIDELITY>(0, params.CT_DIM, params.RT_DIM);
     }
     _llk_math_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+
+    // needed since _llk_math_hw_configure_ sets debug bit 11 when int8 math is enabled, but it never gets cleared
+    if (formats.math == to_underlying(DataFormat::Int8))
+    {
+        _llk_math_dbg_feature_enable_();
+    }
 }
 
 #endif


### PR DESCRIPTION
### Problem description

Int8 matmul needs support in the llk-infra

### What's changed

Added tile size for int8, this was the main thing missing.
Also added a bit more support for int8 in the infra.
-> need to be able to generate inputs within a certain range rather than whole int8 range, since MM will saturate and always return +/-127. -5 to 5 works well because it still hits clipping but most values are not saturated. Full range would work fine for a int8@int8->int32 test case in the future.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring

### Checklist
- [x] new tests added
