### PR TITLE
Do not include sfpi_fp16.h header

### DIFF
--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_activations.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_activations.h
@@ -8,7 +8,6 @@
 
 #include "ckernel_defs.h"
 #include "sfpi.h"
-#include "sfpi_fp16.h"
 #include "sfpu/ckernel_sfpu_converter.h"
 #include "sfpu/ckernel_sfpu_exp.h"
 #include "sfpu/ckernel_sfpu_relu.h"

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_clamp.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_clamp.h
@@ -7,7 +7,6 @@
 #include <cstdint>
 
 #include "sfpi.h"
-#include "sfpi_fp16.h"
 
 namespace ckernel
 {

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_dropout.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_dropout.h
@@ -8,7 +8,6 @@
 
 #include "ckernel_ops.h"
 #include "sfpi.h"
-#include "sfpi_fp16.h"
 
 namespace ckernel
 {

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_elu.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_elu.h
@@ -9,7 +9,6 @@
 #include "ckernel_sfpu_converter.h"
 #include "ckernel_sfpu_exp.h"
 #include "sfpi.h"
-#include "sfpi_fp16.h"
 
 namespace ckernel::sfpu
 {

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_exp.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_exp.h
@@ -10,7 +10,6 @@
 #include "ckernel_ops.h"
 // clang-format off: sfpi_inline must be defined before ckernel_sfpu_polyval.h
 #include "sfpi.h"
-#include "sfpi_fp16.h"
 #include "ckernel_sfpu_polyval.h"
 // clang-format on
 #include "ckernel_sfpu_recip.h"

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_exp2.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_exp2.h
@@ -8,7 +8,6 @@
 
 #include "ckernel_sfpu_exp.h"
 #include "sfpi.h"
-#include "sfpi_fp16.h"
 
 namespace ckernel::sfpu
 {

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_gelu.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_gelu.h
@@ -10,7 +10,6 @@
 #include "ckernel_sfpu_exp.h"
 #include "ckernel_sfpu_load_config.h"
 #include "sfpi.h"
-#include "sfpi_fp16.h"
 
 namespace ckernel::sfpu
 {

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_hardtanh.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_hardtanh.h
@@ -7,7 +7,6 @@
 #include <cstdint>
 
 #include "sfpi.h"
-#include "sfpi_fp16.h"
 
 namespace ckernel
 {

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_log.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_log.h
@@ -7,7 +7,6 @@
 #include <cstdint>
 
 #include "sfpi.h"
-#include "sfpi_fp16.h"
 
 namespace ckernel
 {

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_relu.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_relu.h
@@ -8,7 +8,6 @@
 
 #include "ckernel_sfpu_converter.h"
 #include "sfpi.h"
-#include "sfpi_fp16.h"
 
 namespace ckernel
 {

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_rsqrt.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_rsqrt.h
@@ -7,7 +7,6 @@
 #include "ckernel_sfpu_rsqrt_compat.h"
 #include "ckernel_sfpu_sqrt.h"
 #include "sfpi.h"
-#include "sfpi_fp16.h"
 
 namespace ckernel
 {

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_rsqrt_compat.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_rsqrt_compat.h
@@ -6,7 +6,6 @@
 #pragma once
 
 #include "sfpi.h"
-#include "sfpi_fp16.h"
 
 namespace ckernel
 {

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_sqrt.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_sqrt.h
@@ -7,7 +7,6 @@
 
 #include "ckernel_sfpu_rsqrt_compat.h"
 #include "sfpi.h"
-#include "sfpi_fp16.h"
 
 namespace ckernel
 {

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_threshold.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_threshold.h
@@ -9,7 +9,6 @@
 
 #include "ckernel_defs.h"
 #include "sfpi.h"
-#include "sfpi_fp16.h"
 #include "sfpu/ckernel_sfpu_converter.h"
 
 namespace ckernel::sfpu

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_activations.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_activations.h
@@ -8,7 +8,6 @@
 
 #include "ckernel_defs.h"
 #include "sfpi.h"
-#include "sfpi_fp16.h"
 #include "sfpu/ckernel_sfpu_converter.h"
 #include "sfpu/ckernel_sfpu_exp.h"
 #include "sfpu/ckernel_sfpu_relu.h"

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_clamp.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_clamp.h
@@ -7,7 +7,6 @@
 #include <cstdint>
 
 #include "sfpi.h"
-#include "sfpi_fp16.h"
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_elu.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_elu.h
@@ -9,7 +9,6 @@
 #include "ckernel_sfpu_converter.h"
 #include "ckernel_sfpu_exp.h"
 #include "sfpi.h"
-#include "sfpi_fp16.h"
 
 namespace ckernel::sfpu
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_exp.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_exp.h
@@ -11,7 +11,6 @@
 #include "ckernel_sfpu_recip.h"
 #include "lltt.h"
 #include "sfpi.h"
-#include "sfpi_fp16.h"
 #include "sfpu/ckernel_sfpu_converter.h"
 
 namespace ckernel::sfpu

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_exp2.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_exp2.h
@@ -8,7 +8,6 @@
 
 #include "ckernel_sfpu_exp.h"
 #include "sfpi.h"
-#include "sfpi_fp16.h"
 
 namespace ckernel::sfpu
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_gelu.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_gelu.h
@@ -10,7 +10,6 @@
 #include "ckernel_sfpu_exp.h"
 #include "ckernel_sfpu_load_config.h"
 #include "sfpi.h"
-#include "sfpi_fp16.h"
 
 namespace ckernel::sfpu
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_hardtanh.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_hardtanh.h
@@ -7,7 +7,6 @@
 #include <cstdint>
 
 #include "sfpi.h"
-#include "sfpi_fp16.h"
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_log.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_log.h
@@ -7,7 +7,6 @@
 #include <cstdint>
 
 #include "sfpi.h"
-#include "sfpi_fp16.h"
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_relu.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_relu.h
@@ -9,7 +9,6 @@
 #include "ckernel_sfpu_converter.h"
 #include "ckernel_sfpu_load_config.h"
 #include "sfpi.h"
-#include "sfpi_fp16.h"
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_rsqrt.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_rsqrt.h
@@ -7,7 +7,6 @@
 #include "ckernel_sfpu_rsqrt_compat.h"
 #include "ckernel_sfpu_sqrt.h"
 #include "sfpi.h"
-#include "sfpi_fp16.h"
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_rsqrt_compat.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_rsqrt_compat.h
@@ -6,7 +6,6 @@
 #pragma once
 
 #include "sfpi.h"
-#include "sfpi_fp16.h"
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_sqrt.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_sqrt.h
@@ -7,7 +7,6 @@
 
 #include "ckernel_sfpu_rsqrt_compat.h"
 #include "sfpi.h"
-#include "sfpi_fp16.h"
 
 namespace ckernel
 {

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_threshold.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_threshold.h
@@ -9,7 +9,6 @@
 
 #include "ckernel_defs.h"
 #include "sfpi.h"
-#include "sfpi_fp16.h"
 #include "sfpu/ckernel_sfpu_converter.h"
 
 namespace ckernel::sfpu


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/40182

### Problem description
Theres no need to include sfpi_fp16.h header if you're including sfpi.h itself.  And there's no reason to include it if you're not doing that.  the types defined in it are integral to sfpi and it should be rolled into there.

### What's changed
Remove includes

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Assert validation](https://github.com/tenstorrent/tt-llk/blob/main/docs/Introduction_to_asserts.md) Complied with assert doc (if applicable)
