### PR TITLE
Include llk_assert.h in tensor_shape.h

### DIFF
--- a/common/tensor_shape.h
+++ b/common/tensor_shape.h
@@ -7,6 +7,8 @@
 #include <array>
 #include <cstdint>
 
+#include "llk_assert.h"
+
 namespace ckernel
 {
 


### PR DESCRIPTION
### Ticket
<!-- Link to Github Issue -->

### Problem description
The llk_assert calls inside of tensor_shape.h depends on llk_assert.h being included previously. This breaks Quasar in tt-metal.

### What's changed
Include llk_assert.h in tensor_shape.h.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Assert validation](https://github.com/tenstorrent/tt-llk/blob/main/docs/Introduction_to_asserts.md) Complied with assert doc (if applicable)
