### PR TITLE
Fix for asserting tile shape

### DIFF
--- a/common/tensor_shape.h
+++ b/common/tensor_shape.h
@@ -91,9 +91,10 @@ inline void validate_tensor_shape_tile_dependent_ops_(const TensorShape &tensor_
     // is guarded by ENABLE_LLK_ASSERT to avoid any runtime impact when asserts are off.
     volatile const std::uint8_t num_faces  = tensor_shape.total_num_faces();
     volatile const std::uint8_t face_r_dim = tensor_shape.face_r_dim;
+    volatile const std::uint8_t face_c_dim = tensor_shape.face_c_dim;
     LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "total num_faces must be 1, 2, or 4");
     LLK_ASSERT(face_r_dim == 1 || face_r_dim == 2 || face_r_dim == 4 || face_r_dim == 8 || face_r_dim == 16, "face_r_dim must be 1, 2, 4, 8, 16");
-    LLK_ASSERT(tensor_shape.face_c_dim == 16, "face_c_dim must be 16");
+    LLK_ASSERT(face_c_dim == 16, "face_c_dim must be 16");
 #endif
 }
 


### PR DESCRIPTION
### Ticket

### Problem description
Currently, when using validate_tensor_shape_tile_dependent_ops_ it is possible for compiler to optimize out num_faces or face_r_dim causing LLK_ASSERT being hit and tt-triage printing num_faces = ? as param value.

### What's changed
Added volatile for num_faces and face_r_dim in validate_tensor_shape_tile_dependent_ops_ to prevent compiler optimizing out these variables. This way, it is not possible to get num_faces = ? at the moment of LLK_ASSERT validating its value.
Also, add macro ENABLE_LLK_ASSERT for the whole body, because adding volatile could potentially introduce perf regression when LLK_ASSERT-s are disabled.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Assert validation](https://github.com/tenstorrent/tt-llk/blob/main/docs/Introduction_to_asserts.md) Complied with assert doc (if applicable)
