### PR TITLE
Optimize code size of hw config checks for UNPACK and PACK

### DIFF
--- a/tt_llk_blackhole/common/inc/cpack_common.h
+++ b/tt_llk_blackhole/common/inc/cpack_common.h
@@ -707,7 +707,7 @@ __attribute__((noinline)) bool are_packers_configured_correctly(
     }
 
     static_assert(NUM_PACKERS == 1, "NUM_PACKERS must be 1");
-    const pack_config_t config = read_pack_config()[0];
+    const pack_config_t config     = read_pack_config()[0];
     const pack_counters_t counters = read_pack_counters()[0];
 
     const bool isDataFormatCorrect =

--- a/tt_llk_blackhole/common/inc/cunpack_common.h
+++ b/tt_llk_blackhole/common/inc/cunpack_common.h
@@ -598,7 +598,7 @@ __attribute__((noinline)) bool is_unpacker_A_configured_correctly(
  * @return true if the current unpacker configuration matches all expected values, false otherwise
  */
 template <UnpackerProgramType program_type = UnpackerProgramType::ProgramByTile>
-__attribute__((noinline)) bool are_unpacker_AB_configured_correctly(
+__attribute__((noinline)) bool are_unpackers_AB_configured_correctly(
     const std::uint32_t unpA_src_format,
     const std::uint32_t unpA_dst_format,
     const std::uint32_t unpB_src_format,

--- a/tt_llk_wormhole_b0/common/inc/cpack_common.h
+++ b/tt_llk_wormhole_b0/common/inc/cpack_common.h
@@ -893,7 +893,7 @@ __attribute__((noinline)) bool are_packers_configured_correctly(
     for (std::uint32_t i = 0; i < NUM_PACKERS; i++)
     {
         pack_config_u config = {.val = {0}};
-        config.val[2] = cfg[config_word2_addrs[i]];
+        config.val[2]        = cfg[config_word2_addrs[i]];
         if (config.f.in_data_format != expected_src || config.f.out_data_format != expected_dst)
         {
             return false;
@@ -902,7 +902,7 @@ __attribute__((noinline)) bool are_packers_configured_correctly(
         if constexpr (program_type == PackerProgramType::ProgramByFace)
         {
             pack_counters_u counters = {.val = 0};
-            counters.val = cfg[PACK_COUNTERS_SEC0_pack_per_xy_plane_ADDR32 + i];
+            counters.val             = cfg[PACK_COUNTERS_SEC0_pack_per_xy_plane_ADDR32 + i];
             if (counters.f.pack_reads_per_xy_plane != face_r_dim)
             {
                 return false;

--- a/tt_llk_wormhole_b0/common/inc/cunpack_common.h
+++ b/tt_llk_wormhole_b0/common/inc/cunpack_common.h
@@ -595,7 +595,7 @@ __attribute__((noinline)) bool is_unpacker_A_configured_correctly(
  * @return true if the current unpacker configuration matches all expected values, false otherwise
  */
 template <UnpackerProgramType program_type = UnpackerProgramType::ProgramByTile>
-__attribute__((noinline)) bool are_unpacker_AB_configured_correctly(
+__attribute__((noinline)) bool are_unpackers_AB_configured_correctly(
     const std::uint32_t unpA_src_format,
     const std::uint32_t unpA_dst_format,
     const std::uint32_t unpB_src_format,


### PR DESCRIPTION
### Ticket
<!-- Link to Github Issue -->

### Problem description
Currently, are_unpacker_AB_configured_correctly, is_unpacker_A_configured_correctly and are_packers_configured_correctly are taking significant program size when LLK_ASSERTS are enabled. Some tests fail due to program size being too large.

### What's changed
The functions are refactored in a way to take less program size. The changes in this PR (alongside some other non/uplifted changes) are verified in metal:
Sanity: https://github.com/tenstorrent/tt-metal/actions/runs/23408605493
BHPC: https://github.com/tenstorrent/tt-metal/actions/runs/23404158236

Basically, the functions now leverage the known number of unpackers/packers and unwraps config/counters read helpers by unwrapping some of them. 

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Assert validation](https://github.com/tenstorrent/tt-llk/blob/main/docs/Introduction_to_asserts.md) Complied with assert doc (if applicable)
