### PR TITLE
Revert #1504 (88712f37) infra BRISC/test changes

### DIFF
--- a/tests/helpers/include/boot.h
+++ b/tests/helpers/include/boot.h
@@ -9,7 +9,6 @@
 
 #include "cfg_defines.h"
 #include "ckernel.h"
-#include "ckernel_helper.h"
 
 // C-runtime related linker symbols
 extern volatile char __ldm_bss_start[], __ldm_bss_end[];
@@ -68,20 +67,15 @@ void _fini(void)
 {
 }
 
-using mailbox_t = volatile std::uint32_t*;
-
-#ifdef ARCH_WORMHOLE
-constexpr std::uint32_t TRISC_START_BASE    = 0x16DFF0;
-constexpr std::uint32_t TRISC_CONFIG_REGS[] = {TRISC_RESET_PC_SEC0_PC_ADDR32, TRISC_RESET_PC_SEC1_PC_ADDR32, TRISC_RESET_PC_SEC2_PC_ADDR32};
-
-mailbox_t trisc_start_addresses = reinterpret_cast<mailbox_t>(TRISC_START_BASE);
-#endif
-
-TT_ALWAYS_INLINE void device_setup()
+inline void device_setup()
 {
 #if defined(ARCH_WORMHOLE)
     // Use array-based initialization for consecutive TRISC addresses
-    volatile std::uint32_t tt_reg_ptr* cfg_regs = reinterpret_cast<volatile std::uint32_t tt_reg_ptr*>(TENSIX_CFG_BASE);
+    constexpr std::uint32_t TRISC_START_BASE    = 0x16DFF0;
+    constexpr std::uint32_t TRISC_CONFIG_REGS[] = {TRISC_RESET_PC_SEC0_PC_ADDR32, TRISC_RESET_PC_SEC1_PC_ADDR32, TRISC_RESET_PC_SEC2_PC_ADDR32};
+
+    volatile std::uint32_t* const trisc_start_addresses = reinterpret_cast<volatile std::uint32_t*>(TRISC_START_BASE);
+    volatile std::uint32_t tt_reg_ptr* cfg_regs         = reinterpret_cast<volatile std::uint32_t tt_reg_ptr*>(TENSIX_CFG_BASE);
 
     for (unsigned int i = 0; i < std::size(TRISC_CONFIG_REGS); ++i)
     {
@@ -123,54 +117,23 @@ TT_ALWAYS_INLINE void device_setup()
 #endif
 }
 
+inline void clear_trisc_soft_reset()
+{
 #ifdef ARCH_QUASAR
-constexpr std::uint32_t TRISC_SOFT_RESET_MASK = 0x3000;
+    constexpr std::uint32_t TRISC_SOFT_RESET_MASK = 0x3000;
 #else
-constexpr std::uint32_t TRISC_SOFT_RESET_MASK = 0x7000;
+    constexpr std::uint32_t TRISC_SOFT_RESET_MASK = 0x7000;
 #endif
 
-TT_ALWAYS_INLINE void clear_trisc_soft_reset()
-{
+    volatile std::uint32_t* reset_before = reinterpret_cast<std::uint32_t*>(0x64FF0);
+    volatile std::uint32_t* reset_after  = reinterpret_cast<std::uint32_t*>(0x64FF4);
+
     std::uint32_t soft_reset = ckernel::reg_read(RISCV_DEBUG_REG_SOFT_RESET_0);
+    *reset_before            = soft_reset;
+
     soft_reset &= ~TRISC_SOFT_RESET_MASK;
     ckernel::reg_write(RISCV_DEBUG_REG_SOFT_RESET_0, soft_reset);
 
-    do
-    {
-        ckernel::invalidate_data_cache();
-    } while (ckernel::reg_read(RISCV_DEBUG_REG_SOFT_RESET_0) != soft_reset);
-}
-
-TT_ALWAYS_INLINE void set_triscs_soft_reset()
-{
-    std::uint32_t soft_reset = ckernel::reg_read(RISCV_DEBUG_REG_SOFT_RESET_0);
-    soft_reset |= TRISC_SOFT_RESET_MASK;
-    ckernel::reg_write(RISCV_DEBUG_REG_SOFT_RESET_0, soft_reset);
-    do
-    {
-        ckernel::invalidate_data_cache();
-    } while (ckernel::reg_read(RISCV_DEBUG_REG_SOFT_RESET_0) != soft_reset);
-}
-
-TT_ALWAYS_INLINE void enable_branch_prediction()
-{
-    volatile std::uint32_t* tt_reg_ptr cfg_ptr = ckernel::get_cfg_pointer();
-    cfg_ptr[DISABLE_RISC_BP_Disable_main_ADDR32] &= ~DISABLE_RISC_BP_Disable_main_MASK;
-}
-
-TT_ALWAYS_INLINE void disable_branch_prediction()
-{
-    volatile std::uint32_t* tt_reg_ptr cfg_ptr = ckernel::get_cfg_pointer();
-    cfg_ptr[DISABLE_RISC_BP_Disable_main_ADDR32] |= DISABLE_RISC_BP_Disable_main_MASK;
-}
-
-template <typename T, typename U, typename = std::enable_if_t<std::is_trivially_copyable_v<T> && std::is_trivially_assignable_v<T&, U>>>
-inline void commit_store(volatile T* ptr, U&& val)
-{
-    ckernel::store_blocking(ptr, val);
-
-    do
-    {
-        asm volatile("nop");
-    } while (ckernel::load_blocking(ptr) != val);
+    soft_reset   = ckernel::reg_read(RISCV_DEBUG_REG_SOFT_RESET_0);
+    *reset_after = soft_reset;
 }

--- a/tests/helpers/src/brisc.cpp
+++ b/tests/helpers/src/brisc.cpp
@@ -4,141 +4,25 @@
 
 #include <cstdint>
 
-#include "boot.h"
-
 #ifdef LLK_BOOT_MODE_BRISC
-
-// Mailbox addresses
-#ifdef COVERAGE
-mailbox_t mailboxes_arr = (mailbox_t)0x6DFB8U;
-#else
-mailbox_t mailboxes_arr = (mailbox_t)0x1FFB8U;
-#endif
-
-#ifdef ARCH_WORMHOLE
-#define ARCH_CYCLE_MICRO_SECOND 1000
-#endif
-#ifdef ARCH_BLACKHOLE
-#define ARCH_CYCLE_MICRO_SECOND 1350
-#endif
-
-mailbox_t mailbox_unpack = mailboxes_arr;
-mailbox_t mailbox_math   = mailboxes_arr + 1;
-mailbox_t mailbox_pack   = mailboxes_arr + 2;
-
-mailbox_t brisc_command_buffer = mailboxes_arr + 3; // 2 entries
-mailbox_t brisc_counter        = mailboxes_arr + 5;
-
-mailbox_t brisc_bread0 = mailboxes_arr + 6;
-mailbox_t brisc_bread1 = mailboxes_arr + 7;
-
-mailbox_t profiler_barrier = (mailbox_t)0x16AFF4U;
-
-enum class BriscCommandState : std::uint32_t
-{
-    IDLE_STATE                        = 0,
-    START_TRISCS                      = 1,
-    RESET_TRISCS                      = 2,
-    UPDATE_START_ADDR_CACHE_AND_START = 3,
-};
-
-void reset_state(std::uint32_t& counter)
-{
-    counter++;
-    ckernel::store_blocking(brisc_command_buffer + (counter & 1), static_cast<std::uint32_t>(BriscCommandState::IDLE_STATE));
-    commit_store(brisc_counter, counter);
-}
-
-int main()
-{
-    disable_branch_prediction();
-
-    std::uint32_t counter = 0;
-
-    ckernel::store_blocking(brisc_command_buffer, 0);
-    ckernel::store_blocking(brisc_command_buffer + 1, 0);
-    ckernel::store_blocking(brisc_counter, 0);
-    ckernel::store_blocking(brisc_bread0, 0);
-    ckernel::store_blocking(brisc_bread1, 0);
-
-#ifdef ARCH_WORMHOLE
-    // Array for keeping last known addresses of _start symbol in kernel ELF, for T[0-2]
-    std::uint32_t TRISC_ADDR_CACHE[3] = {};
-#endif
-
-    while (true)
-    {
-        ckernel::invalidate_data_cache();
-
-        switch (static_cast<BriscCommandState>(ckernel::load_blocking(brisc_command_buffer + (counter & 1))))
-        {
-            // Wormhole specific, on Blackhole this command has same behaviour as BriscCommandState::START_TRISCS
-            case BriscCommandState::UPDATE_START_ADDR_CACHE_AND_START:
-#ifdef ARCH_WORMHOLE
-                // Elf loader can't put T[0-2] PCs to point to _start addresses of every ELF. Thus host needs to write them at particular location,
-                // in case of LLK testing infra, that is last 12 bytes of L1, for T[0-2] to read from right after it's released from reset. Side-effect
-                // of this action(s) is that T[0-2] reset these locations after they read them for this purpose. Because of this, when host loads new ELFs
-                // it needs to tell BRISC to cache those values again, which this block of code does. Afterwards it proceeds with regular kernel start sequence
-                for (int i = 0; i < 3; i++)
-                {
-                    TRISC_ADDR_CACHE[i] = ckernel::load_blocking(trisc_start_addresses + i);
-                }
-#endif
-                [[fallthrough]];
-            case BriscCommandState::START_TRISCS:
-
-#ifdef ARCH_WORMHOLE
-                // Load cached addresses of _start symbol of every kernel ELF is case of Wormhole
-                for (int i = 0; i < 3; i++)
-                {
-                    commit_store(trisc_start_addresses + i, TRISC_ADDR_CACHE[i]);
-                }
-#endif
-
-                commit_store(mailbox_math, ckernel::RESET_VAL);
-                commit_store(mailbox_unpack, ckernel::RESET_VAL);
-                commit_store(mailbox_pack, ckernel::RESET_VAL);
-
-                commit_store(profiler_barrier, 0U);
-                commit_store(profiler_barrier + 1, 0U);
-                commit_store(profiler_barrier + 2, 0U);
-
-                device_setup();
-                clear_trisc_soft_reset();
-
-                reset_state(counter);
-                commit_store(brisc_bread0, counter);
-                break;
-
-            case BriscCommandState::RESET_TRISCS:
-                set_triscs_soft_reset();
-
-                reset_state(counter);
-                commit_store(brisc_bread1, counter);
-                break;
-
-            default:
-                break;
-        }
-
-        // Wait for 1us before polling again
-        ckernel::wait(ARCH_CYCLE_MICRO_SECOND);
-    }
-}
-
-#else
-
-int main()
-{
-}
-
+#include "boot.h"
 #endif
 
 extern "C" __attribute__((section(".init"), naked, noreturn)) std::uint32_t _start()
 {
     do_crt0();
+#ifdef LLK_BOOT_MODE_BRISC
+    device_setup();
 
-    main();
+    // Reset profiler barrier before releasing T[0-2] from reset
+    volatile std::uint32_t *ptr = (std::uint32_t *)0x16AFF4;
+    ckernel::store_blocking(ptr, 0);
+    ckernel::store_blocking(ptr + 1, 0);
+    ckernel::store_blocking(ptr + 2, 0);
+
+    // Release reset of triscs here in order to achieve brisc <-> trisc synchronization
+    clear_trisc_soft_reset();
+#endif
 
     for (;;)
     {

--- a/tests/helpers/src/trisc.cpp
+++ b/tests/helpers/src/trisc.cpp
@@ -34,17 +34,17 @@ extern "C"
 {
     extern void gcov_dump(void);
 }
-constexpr std::uint32_t mailboxes_start = 0x6DFB8;
+constexpr std::uint32_t mailboxes_start = 0x6DFC0;
 #else
-constexpr std::uint32_t mailboxes_start = 0x1FFB8;
+constexpr std::uint32_t mailboxes_start = 0x1FFC0;
 #endif
 
 #if defined(LLK_TRISC_UNPACK)
-constexpr std::uint32_t mailbox_offset = 0;
-#elif defined(LLK_TRISC_MATH)
 constexpr std::uint32_t mailbox_offset = sizeof(std::uint32_t);
-#elif defined(LLK_TRISC_PACK)
+#elif defined(LLK_TRISC_MATH)
 constexpr std::uint32_t mailbox_offset = 2 * sizeof(std::uint32_t);
+#elif defined(LLK_TRISC_PACK)
+constexpr std::uint32_t mailbox_offset = 3 * sizeof(std::uint32_t);
 #endif
 
 void copy_runtimes_from_L1(struct RuntimeParams* temp_args)
@@ -55,7 +55,7 @@ void copy_runtimes_from_L1(struct RuntimeParams* temp_args)
 
 int main(void)
 {
-    mailbox_t mailbox = reinterpret_cast<volatile std::uint32_t*>(mailboxes_start + mailbox_offset);
+    volatile std::uint32_t* const mailbox = reinterpret_cast<volatile std::uint32_t*>(mailboxes_start + mailbox_offset);
 
 #if defined(LLK_TRISC_UNPACK) && defined(LLK_BOOT_MODE_TRISC)
     device_setup();

--- a/tests/python_tests/helpers/device.py
+++ b/tests/python_tests/helpers/device.py
@@ -30,8 +30,7 @@ from ttexalens.tt_exalens_lib import (
 
 from .dump import TensixDump
 from .fused_operation import FusedOperation
-from .llk_params import BriscCmd, DataFormat, MailboxesPerf, format_dict
-from .logger import logger
+from .llk_params import DataFormat, MailboxesPerf, format_dict
 from .pack import (
     pack_bfp8_b,
     pack_bfp16,
@@ -163,31 +162,6 @@ def set_tensix_soft_reset(
     )
 
 
-common_counter = 0
-
-
-def commit_brisc_command(
-    location="0,0", command: BriscCmd = BriscCmd.IDLE_STATE, timeout=0.1
-):
-    global common_counter
-
-    if common_counter & 1:
-        write_words_to_device(location, Mailbox.BriscCommand1.value, [command.value])
-    else:
-        write_words_to_device(location, Mailbox.BriscCommand0.value, [command.value])
-
-    common_counter += 1
-    end_time = time.time() + timeout
-    while time.time() < end_time:
-        temp_value = read_word_from_device(location, Mailbox.BriscCounter.value, 0)
-        if temp_value == common_counter:
-            return
-
-    logger.error(f"{command.name} -> {hex(Mailbox.BriscCommand0.value)}")
-
-    raise TimeoutError("Polling brisc command timed out")
-
-
 def assert_if_all_in_reset(location: str = "0,0", place: str = ""):
     soft_reset = get_register_store(location, 0).read_register(
         "RISCV_DEBUG_REG_SOFT_RESET_0"
@@ -304,7 +278,7 @@ def wait_for_tensix_operations_finished(elfs, core_loc="0,0", timeout=2):
         TensixDump.try_process_request(tensix_dumps, core_loc)
 
         if completed == mailboxes:
-            commit_brisc_command(core_loc, BriscCmd.RESET_TRISCS)
+            set_tensix_soft_reset(1, location=core_loc)
             return tensix_dumps
 
     handle_if_assert_hit(
@@ -321,8 +295,9 @@ def wait_for_tensix_operations_finished(elfs, core_loc="0,0", timeout=2):
 def reset_mailboxes(location: str = "0,0"):
     """Reset all core mailboxes (Unpacker, Math, Packer) before each test."""
 
+    mailboxes_start_value = min([core.value for core in Mailbox])
     write_words_to_device(
-        location=location, addr=Mailbox.Unpacker, data=[0xA3, 0xA3, 0xA3]
+        location=location, addr=mailboxes_start_value, data=len(Mailbox) * [0xA3]
     )
 
 

--- a/tests/python_tests/helpers/llk_params.py
+++ b/tests/python_tests/helpers/llk_params.py
@@ -344,28 +344,15 @@ class StableSort(Enum):
 
 
 class MailboxesPerf(Enum):
-    Unpacker = 0x1FFB8
-    Math = Unpacker + 4
-    Packer = Unpacker + 8
-    BriscCommand0 = Unpacker + 12
-    BriscCommand1 = Unpacker + 16
-    BriscCounter = Unpacker + 20
+    Unpacker = 0x1FFC4
+    Math = 0x1FFC8
+    Packer = 0x1FFCC
 
 
 class MailboxesDebug(Enum):
-    Unpacker = 0x6DFB8
-    Math = Unpacker + 4
-    Packer = Unpacker + 8
-    BriscCommand0 = Unpacker + 12
-    BriscCommand1 = Unpacker + 16
-    BriscCounter = Unpacker + 20
-
-
-class BriscCmd(Enum):
-    IDLE_STATE = 0
-    START_TRISCS = 1
-    RESET_TRISCS = 2
-    UPDATE_START_ADDR_CACHE_AND_START = 3
+    Unpacker = 0x6DFC4
+    Math = 0x6DFC8
+    Packer = 0x6DFCC
 
 
 format_tile_sizes = {

--- a/tests/python_tests/helpers/perf.py
+++ b/tests/python_tests/helpers/perf.py
@@ -363,6 +363,7 @@ class PerfConfig(TestConfig):
                 self.write_runtimes_to_L1(location)
                 elfs = self.run_elf_files(location)
                 wait_for_tensix_operations_finished(elfs, location)
+
                 profiler_data = Profiler.get_data(
                     self.test_name, self.variant_id, location
                 )

--- a/tests/python_tests/helpers/test_config.py
+++ b/tests/python_tests/helpers/test_config.py
@@ -36,8 +36,8 @@ from .device import (
     CHIP_DEFAULT_BOOT_MODES,
     BootMode,
     RiscCore,
-    commit_brisc_command,
     exalens_device_setup,
+    reset_mailboxes,
     set_tensix_soft_reset,
     wait_for_tensix_operations_finished,
 )
@@ -51,22 +51,9 @@ from .format_config import (
     DataFormat,
     InputOutputFormat,
 )
-from .llk_params import (
-    BriscCmd,
-    DestAccumulation,
-    L1Accumulation,
-    MailboxesDebug,
-    MailboxesPerf,
-)
-from .logger import logger
+from .llk_params import DestAccumulation, L1Accumulation, MailboxesDebug, MailboxesPerf
 from .stimuli_config import StimuliConfig
-from .test_variant_parameters import (
-    IN_TILE_DIMS,
-    NUM_FACES,
-    RuntimeParameter,
-    TemplateParameter,
-)
-from .utils import create_directories, run_shell_command
+from .test_variant_parameters import RuntimeParameter, TemplateParameter
 
 
 class ProfilerBuild(Enum):
@@ -77,6 +64,16 @@ class ProfilerBuild(Enum):
 class CoverageBuild(Enum):
     Yes = "true"
     No = "false"
+
+
+from .logger import logger
+from .test_variant_parameters import (
+    IN_TILE_DIMS,
+    NUM_FACES,
+    RuntimeParameter,
+    TemplateParameter,
+)
+from .utils import create_directories, run_shell_command
 
 
 class TestMode(Enum):
@@ -679,18 +676,31 @@ class TestConfig:
         return (OPTIONS_COMPILE, MEMORY_LAYOUT_LD_SCRIPT, NON_COVERAGE_OPTIONS_COMPILE)
 
     def build_shared_artefacts(self):
-        if TestConfig.SHARED_ARTEFACTS_AVAILABLE:
-            return
+        # Profiler builds require different shared artefacts (trisc.cpp compiles with -DLLK_PROFILER)
+        is_profiler = self.profiler_build == ProfilerBuild.Yes
 
-        shared_obj_dir = TestConfig.SHARED_OBJ_DIR
-        shared_elf_dir = TestConfig.SHARED_ELF_DIR
-        lock_file = "/tmp/tt-llk-build-shared.lock"
+        # Select appropriate directories, flags, and lock based on build type
+        if is_profiler:
+            if TestConfig.PROFILER_SHARED_ARTEFACTS_AVAILABLE:
+                return
+            shared_obj_dir = TestConfig.PROFILER_SHARED_OBJ_DIR
+            shared_elf_dir = TestConfig.PROFILER_SHARED_ELF_DIR
+            lock_file = "/tmp/tt-llk-build-shared-profiler.lock"
+        else:
+            if TestConfig.SHARED_ARTEFACTS_AVAILABLE:
+                return
+            shared_obj_dir = TestConfig.SHARED_OBJ_DIR
+            shared_elf_dir = TestConfig.SHARED_ELF_DIR
+            lock_file = "/tmp/tt-llk-build-shared.lock"
 
         done_marker = shared_obj_dir / ".shared_complete"
 
         # Fast path: if shared artefacts are already built
         if done_marker.exists():
-            TestConfig.SHARED_ARTEFACTS_AVAILABLE = True
+            if is_profiler:
+                TestConfig.PROFILER_SHARED_ARTEFACTS_AVAILABLE = True
+            else:
+                TestConfig.SHARED_ARTEFACTS_AVAILABLE = True
             return
 
         # Acquire lock for building shared artefacts
@@ -699,14 +709,17 @@ class TestConfig:
         with lock:
             # Check again inside lock
             if done_marker.exists():
-                TestConfig.SHARED_ARTEFACTS_AVAILABLE = True
+                if is_profiler:
+                    TestConfig.PROFILER_SHARED_ARTEFACTS_AVAILABLE = True
+                else:
+                    TestConfig.SHARED_ARTEFACTS_AVAILABLE = True
                 return
 
             _, local_memory_layout_ld, local_non_coverage = (
                 self.resolve_compile_options()
             )
 
-            if TestConfig.WITH_COVERAGE:
+            if self.coverage_build == CoverageBuild.Yes:
                 compile_command = (  # coverage.o : coverage.cpp
                     f"{TestConfig.GXX} {TestConfig.ARCH_NON_COMPUTE} {TestConfig.OPTIONS_ALL} {local_non_coverage} "
                     f'-fno-strict-aliasing -c -o {shared_obj_dir / "coverage.o"} {TestConfig.RISCV_SOURCES / "coverage.cpp"}'
@@ -717,7 +730,6 @@ class TestConfig:
             if TestConfig.CHIP_ARCH != ChipArchitecture.QUASAR:
                 compile_command = (  # brisc.elf : brisc.cpp
                     f"{TestConfig.GXX} {TestConfig.ARCH_NON_COMPUTE} {TestConfig.OPTIONS_ALL} {TestConfig.OPTIONS_LINK} {local_non_coverage} "
-                    f'{"-DCOVERAGE " if TestConfig.WITH_COVERAGE else ""}'
                     f'-T{local_memory_layout_ld} -T{TestConfig.LINKER_SCRIPTS / "brisc.ld"} -T{TestConfig.LINKER_SCRIPTS / "sections.ld"} '
                     f'-o {shared_elf_dir / "brisc.elf"} {TestConfig.RISCV_SOURCES / "brisc.cpp"}'
                 )
@@ -726,7 +738,10 @@ class TestConfig:
 
             # Mark shared artefacts as complete
             done_marker.touch()
-            TestConfig.SHARED_ARTEFACTS_AVAILABLE = True
+            if is_profiler:
+                TestConfig.PROFILER_SHARED_ARTEFACTS_AVAILABLE = True
+            else:
+                TestConfig.SHARED_ARTEFACTS_AVAILABLE = True
 
     def generate_compile_time_data_formats(self) -> list[str]:
         header_content: list[str] = [
@@ -1014,7 +1029,7 @@ class TestConfig:
             fd.write(coverage_stream)
 
     BRISC_ELF_LOADED: ClassVar[bool] = False
-    LAST_LOADED_ELFS: ClassVar[Path] = Path()
+    PROFILER_BRISC_ELF_LOADED: ClassVar[bool] = False
 
     def run_elf_files(self, location="0,0") -> list:
         boot_mode = (
@@ -1029,19 +1044,10 @@ class TestConfig:
         ):
             raise ValueError("Quasar only supports TRISC boot mode")
 
-        if boot_mode == BootMode.BRISC:
-            if not TestConfig.BRISC_ELF_LOADED:
-                set_tensix_soft_reset(1, location=location)
-                TestConfig.BRISC_ELF_LOADED = True
-                load_elf(
-                    elf_file=str((TestConfig.SHARED_ELF_DIR / "brisc.elf").absolute()),
-                    location=location,
-                    risc_name="brisc",
-                    verify_write=False,
-                )
-                set_tensix_soft_reset(0, [RiscCore.BRISC], location)
-
+        set_tensix_soft_reset(1, location=location)
         # unsafe, ordering is not guaranteed :(
+
+        reset_mailboxes(location)
         TensixDump.initialize(location)
 
         VARIANT_ELF_DIR = (
@@ -1053,47 +1059,61 @@ class TestConfig:
             for trisc_name in TestConfig.KERNEL_COMPONENTS
         ]
 
-        if TestConfig.LAST_LOADED_ELFS != VARIANT_ELF_DIR:
-            TestConfig.LAST_LOADED_ELFS = VARIANT_ELF_DIR
-
-            for i, elf_file_path in enumerate(elfs):
-                if TestConfig.CHIP_ARCH == ChipArchitecture.WORMHOLE:
-                    start_address = load_elf(
-                        elf_file=elf_file_path,
-                        location=location,
-                        risc_name=f"trisc{i}",
-                        return_start_address=True,
-                        verify_write=False,
-                    )
-                    write_words_to_device(
-                        location, TestConfig.TRISC_START_ADDRS[i], [start_address]
-                    )
-                else:
-                    load_elf(
-                        elf_file=elf_file_path,
-                        location=location,
-                        risc_name=f"trisc{i}",
-                        neo_id=(
-                            0
-                            if TestConfig.CHIP_ARCH == ChipArchitecture.QUASAR
-                            else None
-                        ),
-                        verify_write=False,
-                    )
-
-            if (
-                boot_mode == BootMode.BRISC
-                and TestConfig.CHIP_ARCH == ChipArchitecture.WORMHOLE
-            ):
-                # Instruct Brisc to update it's start addresses cache before it releases T[0-2] from reset
-                commit_brisc_command(
-                    location, BriscCmd.UPDATE_START_ADDR_CACHE_AND_START
+        for i, elf in enumerate(elfs):
+            if TestConfig.CHIP_ARCH == ChipArchitecture.WORMHOLE:
+                start_address = load_elf(
+                    elf_file=elf,
+                    location=location,
+                    risc_name=f"trisc{i}",
+                    neo_id=(
+                        0 if TestConfig.CHIP_ARCH == ChipArchitecture.QUASAR else None
+                    ),
+                    return_start_address=True,
+                    verify_write=False,
                 )
-                return elfs
+                write_words_to_device(
+                    location, TestConfig.TRISC_START_ADDRS[i], [start_address]
+                )
+            else:
+                load_elf(
+                    elf_file=elf,
+                    location=location,
+                    risc_name=f"trisc{i}",
+                    neo_id=(
+                        0 if TestConfig.CHIP_ARCH == ChipArchitecture.QUASAR else None
+                    ),
+                    verify_write=False,
+                )
 
         match boot_mode:
             case BootMode.BRISC:
-                commit_brisc_command(location, BriscCmd.START_TRISCS)
+                # Use correct shared ELF directory and loading flag based on profiler build
+                is_profiler = self.profiler_build == ProfilerBuild.Yes
+                if is_profiler:
+                    if not TestConfig.PROFILER_BRISC_ELF_LOADED:
+                        TestConfig.PROFILER_BRISC_ELF_LOADED = True
+                        load_elf(
+                            elf_file=str(
+                                (
+                                    TestConfig.PROFILER_SHARED_ELF_DIR / "brisc.elf"
+                                ).absolute()
+                            ),
+                            location=location,
+                            risc_name="brisc",
+                            verify_write=False,
+                        )
+                else:
+                    if not TestConfig.BRISC_ELF_LOADED:
+                        TestConfig.BRISC_ELF_LOADED = True
+                        load_elf(
+                            elf_file=str(
+                                (TestConfig.SHARED_ELF_DIR / "brisc.elf").absolute()
+                            ),
+                            location=location,
+                            risc_name="brisc",
+                            verify_write=False,
+                        )
+                set_tensix_soft_reset(0, [RiscCore.BRISC], location)
             case BootMode.TRISC:
                 set_tensix_soft_reset(0, [RiscCore.TRISC0], location)
             case BootMode.EXALENS:

--- a/tests/python_tests/helpers/utils.py
+++ b/tests/python_tests/helpers/utils.py
@@ -290,11 +290,11 @@ def passed_test(
     tolerance = get_tolerance(output_data_format)
 
     if custom_atol is not None and custom_atol >= 0:
-        logger.debug("Overriding atol from {} to {}", tolerance.atol, custom_atol)
+        logger.info("Overriding atol from {} to {}", tolerance.atol, custom_atol)
         tolerance = tolerance._replace(atol=custom_atol)
 
     if custom_rtol is not None and custom_rtol >= 0:
-        logger.debug("Overriding rtol from {} to {}", tolerance.rtol, custom_rtol)
+        logger.info("Overriding rtol from {} to {}", tolerance.rtol, custom_rtol)
         tolerance = tolerance._replace(rtol=custom_rtol)
 
     golden_tensor = golden_tensor.type(format_dict[output_data_format])
@@ -413,7 +413,7 @@ def passed_test(
         target_pcc = 0.98
 
     if custom_pcc_threshold is not None:
-        logger.debug(
+        logger.info(
             "Overriding PCC threshold from {} to {}", target_pcc, custom_pcc_threshold
         )
         target_pcc = custom_pcc_threshold

--- a/tests/python_tests/test_profiler_overhead.py
+++ b/tests/python_tests/test_profiler_overhead.py
@@ -4,7 +4,6 @@
 import pytest
 from conftest import skip_for_coverage
 from helpers.chip_architecture import ChipArchitecture, get_chip_architecture
-from helpers.device import wait_for_tensix_operations_finished
 from helpers.perf import PerfConfig
 from helpers.profiler import Profiler
 from helpers.test_config import TestConfig, TestMode
@@ -36,9 +35,7 @@ def test_profiler_overhead(workers_tensix_coordinates):
 
     configuration.generate_variant_hash()
     configuration.build_elfs()
-    elfs = configuration.run_elf_files(workers_tensix_coordinates)
-
-    wait_for_tensix_operations_finished(elfs, workers_tensix_coordinates)
+    configuration.run_elf_files(workers_tensix_coordinates)
 
     runtime = Profiler.get_data(
         configuration.test_name, configuration.variant_id, workers_tensix_coordinates

--- a/tests/python_tests/z_state/reconfig/test_math_reconfig.py
+++ b/tests/python_tests/z_state/reconfig/test_math_reconfig.py
@@ -3,7 +3,6 @@
 
 from itertools import product
 
-from conftest import skip_for_blackhole, skip_for_wormhole
 from helpers.dump import TensixDump
 from helpers.format_config import DataFormat, FormatConfig
 from helpers.llk_params import (
@@ -45,8 +44,6 @@ def get_valid_dest_acc(to_from_int8: bool) -> bool:
     )
 
 
-@skip_for_wormhole
-@skip_for_blackhole
 @parametrize(
     formats=generate_valid_formats(
         [

--- a/tests/sources/matmul_unpack_tilize_test.cpp
+++ b/tests/sources/matmul_unpack_tilize_test.cpp
@@ -16,8 +16,8 @@ std::uint32_t math_sync_tile_dst_index = 0;
 std::uint32_t tile_size                = 128;
 
 // Remove later
-constexpr std::uint32_t buffer_A_tilized = 0xA0000;
-constexpr std::uint32_t buffer_B_tilized = 0xA1000;
+constexpr std::uint32_t buffer_A_tilized = 0x1e000;
+constexpr std::uint32_t buffer_B_tilized = 0x1f000;
 
 // Translation of these lines:
 // const FormatConfig(&formats_array)[2] = params.formats;


### PR DESCRIPTION
## Summary

Reverts `88712f37` (**#1504**): BRISC polling refactor, `run_elf_files` / `LAST_LOADED_ELFS`, and related test infra.

## Why

That work assumed BRISC-centric bring-up and removed `reset_mailboxes()` at the start of `run_elf_files`. **Quasar has no BRISC**, which broke Quasar tests (e.g. `commit_brisc_command` timeouts, stale completion mailboxes / PCC issues). This restores pre-#1504 behavior until a Quasar-safe design is merged.

## Commit

Revert: `d4f37596` on `atuzuner/revert-88712f37-infra-1504`.