### PR TITLE
[Skip uplift] Elu migrate to tt-llk

### DIFF
--- a/tests/helpers/include/sfpu_operations.h
+++ b/tests/helpers/include/sfpu_operations.h
@@ -62,8 +62,7 @@ void call_sfpu_operation(SfpuType operation, std::uint32_t math_format = 0, floa
             _calculate_cosine_<APPROX_MODE, ITERATIONS>(ITERATIONS);
             break;
         case SfpuType::elu:
-            _init_elu_<APPROX_MODE>();
-            _calculate_elu_<APPROX_MODE, ITERATIONS>(1);
+            _calculate_elu_<APPROX_MODE, is_fp32_dest_acc_en, ITERATIONS>(1);
             break;
         case SfpuType::exp2:
             _init_exp2_<APPROX_MODE>();

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_elu.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_elu.h
@@ -13,38 +13,28 @@
 namespace ckernel::sfpu
 {
 
-template <bool APPROXIMATION_MODE, int ITERATIONS>
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
 inline void _calculate_elu_(std::uint32_t slope)
 {
-    const bool SCALE_EN                       = false; // Elu does not use scale.
-    const bool SKIP_POSITIVE_CHECK            = false; // Elu does not skip positive check.
-    const std::uint16_t exp_base_scale_factor = p_sfpu::kCONST_1_FP16B;
-
     sfpi::vFloat s = Converter::as_float(slope);
-#pragma GCC unroll 0
+#pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++)
     {
         sfpi::vFloat v = sfpi::dst_reg[0];
-
         v_if (v < 0.0f)
         {
-            sfpi::vFloat v_exp = _calculate_exponential_piecewise_<APPROXIMATION_MODE, SCALE_EN, SKIP_POSITIVE_CHECK>(v, exp_base_scale_factor);
-            v                  = s * (v_exp - 1.0f);
+            sfpi::vFloat v_exp = _sfpu_exp_21f_bf16_<true>(v) - sfpi::vConst1; // is_fp32_dest_acc_en set to true to avoid rounding as
+                                                                               // it has to be done at the end of operation
+            sfpi::vFloat result = s * v_exp;
+            if constexpr (!is_fp32_dest_acc_en)
+            {
+                result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
+            }
+            sfpi::dst_reg[0] = result;
         }
         v_endif;
-
-        sfpi::dst_reg[0] = v;
-
         sfpi::dst_reg++;
     }
-}
-
-template <bool APPROXIMATION_MODE>
-inline void _init_elu_()
-{
-    const std::uint32_t EXP_BASE_SCALE_FACTOR = 0x3F800000;
-    const bool FAST_APPROX                    = false; // Elu does not use fast approximation.
-    _init_exponential_<APPROXIMATION_MODE, FAST_APPROX, EXP_BASE_SCALE_FACTOR>();
 }
 
 } // namespace ckernel::sfpu

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_elu.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_elu.h
@@ -13,38 +13,28 @@
 namespace ckernel::sfpu
 {
 
-template <bool APPROXIMATION_MODE, int ITERATIONS>
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
 inline void _calculate_elu_(std::uint32_t slope)
 {
-    const bool SCALE_EN                       = false; // Elu does not use scale.
-    const bool SKIP_POSITIVE_CHECK            = false; // Elu does not skip positive check.
-    const std::uint16_t exp_base_scale_factor = p_sfpu::kCONST_1_FP16B;
-
     sfpi::vFloat s = Converter::as_float(slope);
-#pragma GCC unroll 0
+#pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++)
     {
         sfpi::vFloat v = sfpi::dst_reg[0];
-
         v_if (v < 0.0f)
         {
-            sfpi::vFloat v_exp = _calculate_exponential_piecewise_<APPROXIMATION_MODE, SCALE_EN, SKIP_POSITIVE_CHECK>(v, exp_base_scale_factor);
-            v                  = s * (v_exp - 1.0f);
+            sfpi::vFloat v_exp = _sfpu_exp_21f_bf16_<true>(v) - sfpi::vConst1; // is_fp32_dest_acc_en set to true to avoid rounding as
+                                                                               // it has to be done at the end of operation
+            sfpi::vFloat result = s * v_exp;
+            if constexpr (!is_fp32_dest_acc_en)
+            {
+                result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
+            }
+            sfpi::dst_reg[0] = result;
         }
         v_endif;
-
-        sfpi::dst_reg[0] = v;
-
         sfpi::dst_reg++;
     }
-}
-
-template <bool APPROXIMATION_MODE>
-inline void _init_elu_()
-{
-    const std::uint32_t EXP_BASE_SCALE_FACTOR = 0x3F800000;
-    const bool FAST_APPROX                    = false; // Elu does not use fast approximation.
-    _init_exponential_<APPROXIMATION_MODE, FAST_APPROX, EXP_BASE_SCALE_FACTOR>();
 }
 
 } // namespace ckernel::sfpu


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/39523

### Problem description
Metal implementation and tt-llk implementation differ. Metal side has the updated code , and tt-llk uses exp-approx appraoch. Hence requires to be migrated to tt-llk as part of exp-approx task.

### What's changed
Migrated Metal ELU implemengtation to tt-llk 
### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring

### Checklist
- [x] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=virdhatchani/elu_migrate)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:virdhatchani/elu_migrate)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=virdhatchani/elu_migrate)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:virdhatchani/elu_migrate)
- [x] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=virdhatchani/elu_migrate)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:virdhatchani/elu_migrate)
- [ ] [Assert validation](https://github.com/tenstorrent/tt-llk/blob/main/docs/Introduction_to_asserts.md) Complied with assert doc (if applicable)
