### PR TITLE
#39535: Smaller blocked pack MOP reconfig

### DIFF
--- a/tt_llk_blackhole/llk_lib/experimental/llk_pack_custom.h
+++ b/tt_llk_blackhole/llk_lib/experimental/llk_pack_custom.h
@@ -20,7 +20,7 @@
 // Precondition: a full _llk_pack_mop_config_ must have been called first
 // to program all 9 MOP registers. Safe when all CBs share the same tile
 // format (same num_faces, face_r_dim, tile_c_dim).
-inline void _llk_pack_mop_config_minimal_custom_(std::uint32_t num_faces, std::uint32_t num_tiles)
+inline void _llk_pack_set_mop_outer_loop_(std::uint32_t num_faces, std::uint32_t num_tiles)
 {
     volatile std::uint32_t* mop_cfg = reinterpret_cast<volatile std::uint32_t*>(TENSIX_MOP_CFG_BASE);
     ckernel::mop_sync();


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/39535

### Problem description
MOP reprogramming for blocked packing unnecessarily programs all MOP fields while just changing the outer dim.

### What's changed
Made a minimal MOP reprogramming function that just reprograms the outer loop.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Assert validation](https://github.com/tenstorrent/tt-llk/blob/main/docs/Introduction_to_asserts.md) Complied with assert doc (if applicable)
