### PR TITLE
Add separate input/output tile support for unary SFPU ops

### DIFF
--- a/tests/python_tests/test_unary_sfpu_with_output.py
+++ b/tests/python_tests/test_unary_sfpu_with_output.py
@@ -1,0 +1,106 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+#
+# Test for _llk_math_eltwise_unary_sfpu_params_with_output_
+# Validates that unary SFPU abs can write to a different dest tile than the input.
+# The test loads 1 tile to dest[0], applies abs from dest[0]->dest[1], packs both.
+# Checks: tile 1 == abs(input), tile 0 is preserved (all negative values stay negative).
+
+import torch
+from helpers.format_config import DataFormat
+from helpers.golden_generators import UnarySFPUGolden, get_golden_generator
+from helpers.llk_params import DestAccumulation, MathOperation, format_dict
+from helpers.param_config import input_output_formats, parametrize
+from helpers.stimuli_config import StimuliConfig
+from helpers.stimuli_generator import generate_stimuli
+from helpers.test_config import TestConfig
+from helpers.test_variant_parameters import TILE_COUNT, generate_input_dim
+from helpers.utils import passed_test
+
+
+@parametrize(
+    formats=input_output_formats(
+        [
+            DataFormat.Float16_b,
+        ]
+    ),
+    dest_acc=[DestAccumulation.Yes],
+)
+def test_unary_sfpu_with_output(formats, dest_acc, workers_tensix_coordinates):
+    """Test that unary SFPU abs writes to a separate output tile while preserving input."""
+    torch.manual_seed(42)
+
+    input_dimensions = [32, 32]  # 1 tile
+
+    # Generate stimuli with negative values so abs produces a visible change
+    src_A, tile_cnt_A, src_B, tile_cnt_B = generate_stimuli(
+        stimuli_format_A=formats.input_format,
+        input_dimensions_A=input_dimensions,
+        stimuli_format_B=formats.input_format,
+        input_dimensions_B=input_dimensions,
+    )
+
+    # Make all input values negative to clearly test abs and preservation
+    src_A = -torch.abs(src_A.float())
+
+    # Generate golden for the abs result (tile 1)
+    generate_golden = get_golden_generator(UnarySFPUGolden)
+    golden_abs = generate_golden(
+        MathOperation.Abs,
+        src_A,
+        formats.output_format,
+        dest_acc,
+        formats.input_format,
+        input_dimensions,
+    )
+
+    configuration = TestConfig(
+        "sources/unary_sfpu_with_output_test.cpp",
+        formats,
+        templates=[
+            generate_input_dim(input_dimensions, input_dimensions),
+        ],
+        runtimes=[TILE_COUNT(tile_cnt_A)],
+        variant_stimuli=StimuliConfig(
+            src_A,
+            formats.input_format,
+            src_B,
+            formats.input_format,
+            formats.output_format,
+            tile_count_A=tile_cnt_A,
+            tile_count_B=tile_cnt_B,
+            tile_count_res=2,  # 2 output tiles: preserved input + abs result
+        ),
+        dest_acc=dest_acc,
+        unpack_to_dest=(
+            formats.input_format.is_32_bit() and dest_acc == DestAccumulation.Yes
+        ),
+        compile_time_formats=True,
+    )
+    res_from_L1 = configuration.run(workers_tensix_coordinates).result
+
+    torch_format = format_dict[formats.output_format]
+
+    # Split result into 2 tiles (1024 elements each for 32x32)
+    elements_per_tile = 1024
+    assert (
+        len(res_from_L1) >= 2 * elements_per_tile
+    ), f"Expected at least {2 * elements_per_tile} result elements, got {len(res_from_L1)}"
+
+    tile_0 = torch.tensor(res_from_L1[:elements_per_tile], dtype=torch_format)
+    tile_1 = torch.tensor(
+        res_from_L1[elements_per_tile : 2 * elements_per_tile], dtype=torch_format
+    )
+
+    # Check 1: tile 1 (abs result) matches golden
+    assert passed_test(
+        golden_abs, tile_1, formats.output_format
+    ), "Tile 1 (abs result) does not match golden"
+
+    # Check 2: tile 0 (preserved input) should have all non-positive values
+    # (since we made all inputs negative, if tile 0 was overwritten by abs it would be positive)
+    num_positive = (tile_0 > 0).sum().item()
+    assert num_positive == 0, (
+        f"Tile 0 (preserved input) has {num_positive} positive values - "
+        "input tile was corrupted by the abs operation"
+    )

--- a/tests/sources/unary_sfpu_with_output_test.cpp
+++ b/tests/sources/unary_sfpu_with_output_test.cpp
@@ -1,0 +1,132 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Test for _llk_math_eltwise_unary_sfpu_params_with_output_
+// Validates that unary SFPU ops can write to a different dest tile than they read from.
+// Loads 1 input tile to dest[0], applies abs from dest[0] -> dest[1], packs both.
+// dest[0] should be preserved (original input), dest[1] should be abs(input).
+
+#include <cstdint>
+#include <cstdio>
+
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "llk_defs.h"
+#include "params.h"
+
+// Globals
+std::uint32_t unp_cfg_context              = 0;
+std::uint32_t pack_sync_tile_dst_ptr       = 0;
+std::uint32_t math_sync_tile_dst_index     = 0;
+static constexpr ckernel::DstSync DST_SYNC = ckernel::DstSync::SyncHalf;
+
+#ifdef LLK_TRISC_UNPACK
+
+#include "llk_unpack_A.h"
+#include "llk_unpack_common.h"
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+#if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
+    const FormatConfig& formats = params.formats;
+#endif
+    _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
+        formats.unpack_A_src, formats.unpack_B_src, formats.unpack_A_dst, formats.unpack_B_dst, FACE_R_DIM, FACE_R_DIM, TILE_NUM_FACES, TILE_NUM_FACES);
+
+    _llk_unpack_A_init_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
+        0, 0, FACE_R_DIM, TILE_NUM_FACES, formats.unpack_A_src, formats.unpack_A_dst);
+
+    // Unpack 1 input tile
+    _llk_unpack_A_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
+        L1_ADDRESS(params.buffer_A[0]), formats.unpack_A_src, formats.unpack_A_dst);
+}
+
+#endif
+
+#ifdef LLK_TRISC_MATH
+
+#include "ckernel_sfpu.h"
+#include "llk_math_common.h"
+#include "llk_math_eltwise_unary_datacopy.h"
+#include "llk_math_eltwise_unary_sfpu.h"
+
+using namespace ckernel;
+using namespace ckernel::sfpu;
+
+// Define DST_SYNC_MODE and DST_ACCUM_MODE so LLK SFPU params helpers compile in this TU.
+#define DST_SYNC_MODE  DST_SYNC
+#define DST_ACCUM_MODE is_fp32_dest_acc_en
+#include "llk_math_eltwise_unary_sfpu_params.h"
+#undef DST_SYNC_MODE
+#undef DST_ACCUM_MODE
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+#if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
+    const FormatConfig& formats = params.formats;
+#endif
+
+#ifdef ARCH_BLACKHOLE
+    _llk_math_eltwise_unary_datacopy_init_<DataCopyType::A2D, is_fp32_dest_acc_en, BroadcastType::NONE, false, false>(TILE_NUM_FACES, formats.math);
+#else
+    _llk_math_eltwise_unary_datacopy_init_<DataCopyType::A2D, is_fp32_dest_acc_en, BroadcastType::NONE, false>(TILE_NUM_FACES, formats.math);
+#endif
+    _llk_math_hw_configure_<is_fp32_dest_acc_en>(formats.math, formats.math);
+    _llk_math_pack_sync_init_<DST_SYNC, is_fp32_dest_acc_en>();
+
+    // Init SFPU for abs operation
+    _llk_math_eltwise_unary_sfpu_init_<SfpuType::abs>();
+
+    _llk_math_wait_for_dest_available_<DST_SYNC>();
+
+    // Datacopy input tile to dest[0]
+    _llk_math_eltwise_unary_datacopy_<DataCopyType::A2D, DST_SYNC, is_fp32_dest_acc_en, BroadcastType::NONE, unpack_to_dest>(0, formats.math, formats.math);
+
+    // Apply abs from dest[0] -> dest[1] using direct indexed addressing.
+    // The same _calculate_abs_ function is used — the params_with_output_ appends
+    // (dst_index_in, dst_index_out) after the normal args, which match the default
+    // parameters added to _calculate_abs_.
+    _llk_math_eltwise_unary_sfpu_params_with_output_<false>(
+        ckernel::sfpu::_calculate_abs_<false, 8>,
+        0, // dst_index_in
+        1, // dst_index_out
+        static_cast<int>(VectorMode::RC),
+        8 // iterations per face
+    );
+
+    _llk_math_dest_section_done_<DST_SYNC, is_fp32_dest_acc_en>();
+}
+
+#endif
+
+#ifdef LLK_TRISC_PACK
+
+#include "llk_pack.h"
+#include "llk_pack_common.h"
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+#if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
+    const FormatConfig& formats = params.formats;
+#endif
+#ifdef ARCH_BLACKHOLE
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, false, false>(formats.pack_src, formats.pack_dst, FACE_R_DIM * FACE_C_DIM * TILE_NUM_FACES);
+    _llk_pack_init_<false, false>(formats.pack_dst, FACE_R_DIM, TILE_C_DIM, TILE_NUM_FACES);
+    _llk_pack_dest_init_<DST_SYNC, is_fp32_dest_acc_en>();
+#else
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, false>(formats.pack_src, formats.pack_dst, FACE_R_DIM * FACE_C_DIM * TILE_NUM_FACES);
+    _llk_pack_init_<false, false>(formats.pack_dst, FACE_R_DIM, TILE_NUM_FACES);
+    _llk_pack_dest_init_<DST_SYNC, is_fp32_dest_acc_en, false>();
+#endif
+
+    _llk_packer_wait_for_math_done_();
+
+    // Pack 2 tiles: dest[0] (preserved input) and dest[1] (abs result)
+    _llk_pack_<DST_SYNC, is_fp32_dest_acc_en, false>(0, L1_ADDRESS(params.buffer_Res[0]));
+    _llk_pack_<DST_SYNC, is_fp32_dest_acc_en, false>(1, L1_ADDRESS(params.buffer_Res[1]));
+
+    _llk_pack_dest_section_done_<DST_SYNC, is_fp32_dest_acc_en>();
+}
+
+#endif

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_abs.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_abs.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "sfpi.h"
 
 namespace ckernel
@@ -12,13 +14,14 @@ namespace sfpu
 {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_abs_(const int iterations)
+inline void _calculate_abs_(const int iterations, const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
     // SFPU microcode
     for (int d = 0; d < iterations; d++)
     {
-        sfpi::vFloat v   = sfpi::dst_reg[0];
-        sfpi::dst_reg[0] = sfpi::abs(v);
+        sfpi::vFloat v                                    = sfpi::dst_reg[dst_index_in * dst_tile_size_sfpi];
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = sfpi::abs(v);
         sfpi::dst_reg++;
     }
 }

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_activations.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_activations.h
@@ -70,27 +70,29 @@ inline void apply_activation(sfpi::vFloat& v)
 }
 
 template <bool APPROXIMATION_MODE, ActivationType ACTIVATION_TYPE, int ITERATIONS = 8>
-inline void _calculate_activation_(std::uint32_t param0, std::uint32_t param1)
+inline void _calculate_activation_(std::uint32_t param0, std::uint32_t param1, const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++)
     {
-        sfpi::vFloat v = sfpi::dst_reg[0];
+        sfpi::vFloat v = sfpi::dst_reg[dst_index_in * dst_tile_size_sfpi];
         apply_activation<APPROXIMATION_MODE, ACTIVATION_TYPE>(v, param0, param1);
-        sfpi::dst_reg[0] = v;
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = v;
         sfpi::dst_reg++;
     }
 }
 
 template <bool APPROXIMATION_MODE, ActivationType ACTIVATION_TYPE, int ITERATIONS>
-inline void _calculate_activation_()
+inline void _calculate_activation_(const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++)
     {
-        sfpi::vFloat v = sfpi::dst_reg[0];
+        sfpi::vFloat v = sfpi::dst_reg[dst_index_in * dst_tile_size_sfpi];
         apply_activation<APPROXIMATION_MODE, ACTIVATION_TYPE>(v);
-        sfpi::dst_reg[0] = v;
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = v;
         sfpi::dst_reg++;
     }
 }

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_clamp.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_clamp.h
@@ -14,8 +14,15 @@ namespace sfpu
 {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_clamp_(const int iterations, std::uint32_t param0, std::uint32_t param1, std::uint32_t param2)
+inline void _calculate_clamp_(
+    const int iterations,
+    std::uint32_t param0,
+    std::uint32_t param1,
+    std::uint32_t param2,
+    const std::uint32_t dst_index_in  = 0,
+    const std::uint32_t dst_index_out = 0)
 {
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
     // All params are in FP16 format
     // param0 = min
     // param1 = max
@@ -30,7 +37,7 @@ inline void _calculate_clamp_(const int iterations, std::uint32_t param0, std::u
 #pragma GCC unroll 0
     for (int d = 0; d < iterations; d++)
     {
-        sfpi::vFloat val = sfpi::dst_reg[0];
+        sfpi::vFloat val = sfpi::dst_reg[dst_index_in * dst_tile_size_sfpi];
 
         v_if (val < min)
         {
@@ -42,7 +49,7 @@ inline void _calculate_clamp_(const int iterations, std::uint32_t param0, std::u
         }
         v_endif;
 
-        sfpi::dst_reg[0] = val + offset;
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = val + offset;
 
         sfpi::dst_reg++;
     }

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_comp.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_comp.h
@@ -31,8 +31,9 @@ sfpi_inline void _calculate_comp_init_flag_(bool check, sfpi::vFloat& flag1, sfp
 }
 
 template <bool APPROXIMATION_MODE, bool invert_output, bool check_zero, bool second_check, bool is_less_than_equal_zero, int ITERATIONS>
-inline void _calculate_comp_(const int iterations, std::uint32_t exponent_size_8)
+inline void _calculate_comp_(const int iterations, std::uint32_t exponent_size_8, const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
     // output_0 and output_1 hold the outputs use use when a zero or negative check is true/false.
     // False = 0.0 = kCONST_0 (5/8-bit exponent format)
     // True  = 1.0 = kCONST_1_FP16B (8-bit exponent format)
@@ -44,7 +45,7 @@ inline void _calculate_comp_(const int iterations, std::uint32_t exponent_size_8
 
     for (int d = 0; d < iterations; d++)
     {
-        sfpi::vFloat v = sfpi::dst_reg[0];
+        sfpi::vFloat v = sfpi::dst_reg[dst_index_in * dst_tile_size_sfpi];
         sfpi::vFloat flag1, flag2;
         if constexpr (check_zero)
         {
@@ -100,7 +101,7 @@ inline void _calculate_comp_(const int iterations, std::uint32_t exponent_size_8
             result = flag1;
         }
 
-        sfpi::dst_reg[0] = result;
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = result;
 
         sfpi::dst_reg++;
     }
@@ -194,13 +195,14 @@ inline void apply_zero_comp<SfpuType::less_than_equal_zero>(sfpi::vFloat& v, std
 }
 
 template <bool APPROXIMATION_MODE, SfpuType COMP_MODE, int ITERATIONS = 8>
-inline void _calculate_zero_comp_(std::uint32_t exponent_size_8)
+inline void _calculate_zero_comp_(std::uint32_t exponent_size_8, const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
     for (int d = ZERO; d < ITERATIONS; d++)
     {
-        sfpi::vFloat v = sfpi::dst_reg[0];
+        sfpi::vFloat v = sfpi::dst_reg[dst_index_in * dst_tile_size_sfpi];
         apply_zero_comp<COMP_MODE>(v, exponent_size_8);
-        sfpi::dst_reg[0] = v;
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = v;
         sfpi::dst_reg++;
     }
 }
@@ -293,13 +295,14 @@ inline void apply_zero_comp_int<SfpuType::greater_than_equal_zero>(sfpi::vInt& v
 }
 
 template <bool APPROXIMATION_MODE, SfpuType COMP_MODE, int ITERATIONS = 8>
-inline void _calculate_zero_comp_int_()
+inline void _calculate_zero_comp_int_(const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
     for (int d = ZERO; d < ITERATIONS; d++)
     {
-        sfpi::vInt v = sfpi::dst_reg[0];
+        sfpi::vInt v = sfpi::dst_reg[dst_index_in * dst_tile_size_sfpi];
         apply_zero_comp_int<COMP_MODE>(v);
-        sfpi::dst_reg[0] = v;
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = v;
         sfpi::dst_reg++;
     }
 }
@@ -414,17 +417,18 @@ inline void apply_unary_int_comp<SfpuType::unary_le>(sfpi::vInt& v, int scalar, 
 }
 
 template <bool APPROXIMATION_MODE, SfpuType COMP_MODE, int ITERATIONS = 8>
-inline void _calculate_comp_unary_int_(int scalar)
+inline void _calculate_comp_unary_int_(int scalar, const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
 #pragma GCC unroll 8
     for (int d = ZERO; d < ITERATIONS; d++)
     {
-        sfpi::vInt v   = sfpi::dst_reg[0];
+        sfpi::vInt v   = sfpi::dst_reg[dst_index_in * dst_tile_size_sfpi];
         sfpi::vInt val = ZERO;
 
         apply_unary_int_comp<COMP_MODE>(v, scalar, val);
 
-        sfpi::dst_reg[0] = val;
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = val;
         sfpi::dst_reg++;
     }
 }
@@ -523,19 +527,20 @@ inline void apply_unary_float_comp<SfpuType::unary_le>(sfpi::vFloat v, sfpi::vFl
 }
 
 template <bool APPROXIMATION_MODE, SfpuType COMP_MODE, int ITERATIONS = 8>
-inline void _calculate_comp_unary_(std::uint32_t value)
+inline void _calculate_comp_unary_(std::uint32_t value, const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
-    const sfpi::vFloat s = value;
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
+    const sfpi::vFloat s                       = value;
 
 #pragma GCC unroll 8
     for (int d = ZERO; d < ITERATIONS; d++)
     {
-        sfpi::vFloat v   = sfpi::dst_reg[0];
+        sfpi::vFloat v   = sfpi::dst_reg[dst_index_in * dst_tile_size_sfpi];
         sfpi::vFloat val = ZERO;
 
         apply_unary_float_comp<COMP_MODE>(v, s, val);
 
-        sfpi::dst_reg[0] = val;
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = val;
         sfpi::dst_reg++;
     }
 }

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_elu.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_elu.h
@@ -14,17 +14,18 @@ namespace ckernel::sfpu
 {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_elu_(std::uint32_t slope)
+inline void _calculate_elu_(std::uint32_t slope, const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
-    const bool SCALE_EN                       = false; // Elu does not use scale.
-    const bool SKIP_POSITIVE_CHECK            = false; // Elu does not skip positive check.
-    const std::uint16_t exp_base_scale_factor = p_sfpu::kCONST_1_FP16B;
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
+    const bool SCALE_EN                        = false; // Elu does not use scale.
+    const bool SKIP_POSITIVE_CHECK             = false; // Elu does not skip positive check.
+    const std::uint16_t exp_base_scale_factor  = p_sfpu::kCONST_1_FP16B;
 
     sfpi::vFloat s = Converter::as_float(slope);
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++)
     {
-        sfpi::vFloat v = sfpi::dst_reg[0];
+        sfpi::vFloat v = sfpi::dst_reg[dst_index_in * dst_tile_size_sfpi];
 
         v_if (v < 0.0f)
         {
@@ -33,7 +34,7 @@ inline void _calculate_elu_(std::uint32_t slope)
         }
         v_endif;
 
-        sfpi::dst_reg[0] = v;
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = v;
 
         sfpi::dst_reg++;
     }

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_exp.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_exp.h
@@ -405,7 +405,8 @@ inline sfpi::vFloat _calculate_exponential_piecewise_(sfpi::vFloat in, const std
 }
 
 template <bool APPROXIMATION_MODE, bool SCALE_EN, int ITERATIONS, bool FAST_APPROX, bool SKIP_POSITIVE_CHECK, bool CLAMP_NEGATIVE = true>
-void _calculate_exponential_(const std::uint16_t exp_base_scale_factor /* 1.0f in BF16 */)
+void _calculate_exponential_(
+    const std::uint16_t exp_base_scale_factor /* 1.0f in BF16 */, const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
     if constexpr (FAST_APPROX && APPROXIMATION_MODE && CLAMP_NEGATIVE)
     {
@@ -599,12 +600,14 @@ void _calculate_exponential_(const std::uint16_t exp_base_scale_factor /* 1.0f i
 #endif
     else
     {
+        constexpr std::uint32_t dst_tile_size_sfpi = 32;
+
         // Unroll 8 best for approx, unroll 0 for precise, compiler figures this out
         for (int d = 0; d < ITERATIONS; d++)
         {
-            sfpi::vFloat in     = sfpi::dst_reg[0];
+            sfpi::vFloat in     = sfpi::dst_reg[dst_index_in * dst_tile_size_sfpi];
             sfpi::vFloat result = _calculate_exponential_piecewise_<APPROXIMATION_MODE, SCALE_EN, SKIP_POSITIVE_CHECK>(in, exp_base_scale_factor);
-            sfpi::dst_reg[0]    = result;
+            sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = result;
             sfpi::dst_reg++;
         }
     }

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_exp2.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_exp2.h
@@ -13,20 +13,21 @@ namespace ckernel::sfpu
 {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_exp2_()
+inline void _calculate_exp2_(const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
-    const bool SCALE_EN                       = false; // Exp2 does not use scale.
-    const bool SKIP_POSITIVE_CHECK            = false; // Exp2 does not skip positive check.
-    const std::uint16_t exp_base_scale_factor = p_sfpu::kCONST_1_FP16B;
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
+    const bool SCALE_EN                        = false; // Exp2 does not use scale.
+    const bool SKIP_POSITIVE_CHECK             = false; // Exp2 does not skip positive check.
+    const std::uint16_t exp_base_scale_factor  = p_sfpu::kCONST_1_FP16B;
 
     for (int d = 0; d < ITERATIONS; d++)
     {
-        sfpi::vFloat v = sfpi::dst_reg[0];
+        sfpi::vFloat v = sfpi::dst_reg[dst_index_in * dst_tile_size_sfpi];
         // log(2) = 0.6931471805;
         v = v * 0.6931471805f;
         // exp = e^(v)
         sfpi::vFloat exp = _calculate_exponential_piecewise_<APPROXIMATION_MODE, SCALE_EN, SKIP_POSITIVE_CHECK>(v, exp_base_scale_factor);
-        sfpi::dst_reg[0] = exp;
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = exp;
         sfpi::dst_reg++;
     }
 }

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_fill.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_fill.h
@@ -14,14 +14,15 @@ namespace ckernel::sfpu
 {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_fill_(const float value)
+inline void _calculate_fill_(const float value, const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
     // SFPU microcode
     sfpi::vFloat fill_val = value;
 
     for (int d = 0; d < ITERATIONS; d++)
     {
-        sfpi::dst_reg[0] = fill_val;
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = fill_val;
         sfpi::dst_reg++;
     }
 }
@@ -50,14 +51,15 @@ inline void _calculate_fill_int_(const std::uint32_t value)
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_fill_bitcast_(const std::uint32_t value_bit_mask)
+inline void _calculate_fill_bitcast_(const std::uint32_t value_bit_mask, const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
     // SFPU microcode
     sfpi::vFloat fill_val = Converter::as_float(value_bit_mask);
 
     for (int d = 0; d < ITERATIONS; d++)
     {
-        sfpi::dst_reg[0] = fill_val;
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = fill_val;
         sfpi::dst_reg++;
     }
 }

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_gelu.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_gelu.h
@@ -37,14 +37,15 @@ inline sfpi::vFloat _calculate_gelu_core_(sfpi::vFloat in)
 }
 
 template <int ITERATIONS>
-inline void _calculate_gelu_appx_()
+inline void _calculate_gelu_appx_(const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
-    sfpi::vUInt l0 = sfpi::l_reg[sfpi::LRegs::LReg0];
-    sfpi::vUInt l1 = sfpi::l_reg[sfpi::LRegs::LReg1];
-    sfpi::vUInt l2 = sfpi::l_reg[sfpi::LRegs::LReg2];
-    sfpi::vUInt l4 = sfpi::l_reg[sfpi::LRegs::LReg4];
-    sfpi::vUInt l5 = sfpi::l_reg[sfpi::LRegs::LReg5];
-    sfpi::vUInt l6 = sfpi::l_reg[sfpi::LRegs::LReg6];
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
+    sfpi::vUInt l0                             = sfpi::l_reg[sfpi::LRegs::LReg0];
+    sfpi::vUInt l1                             = sfpi::l_reg[sfpi::LRegs::LReg1];
+    sfpi::vUInt l2                             = sfpi::l_reg[sfpi::LRegs::LReg2];
+    sfpi::vUInt l4                             = sfpi::l_reg[sfpi::LRegs::LReg4];
+    sfpi::vUInt l5                             = sfpi::l_reg[sfpi::LRegs::LReg5];
+    sfpi::vUInt l6                             = sfpi::l_reg[sfpi::LRegs::LReg6];
 
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++)
@@ -58,13 +59,13 @@ inline void _calculate_gelu_appx_()
 
         // sfpi::dst_reg[0] = result;
 
-        sfpi::vFloat in      = sfpi::dst_reg[0];
+        sfpi::vFloat in      = sfpi::dst_reg[dst_index_in * dst_tile_size_sfpi];
         sfpi::vFloat half    = sfpi::vConstFloatPrgm0;
         sfpi::vFloat half_in = in * half;
         sfpi::vFloat result  = lut2_sign(in, l0, l1, l2, l4, l5, l6);
         result               = half_in + result;
 
-        sfpi::dst_reg[0] = result;
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = result;
 
         sfpi::dst_reg++;
 
@@ -85,35 +86,37 @@ inline void _calculate_gelu_appx_()
 }
 
 template <int ITERATIONS>
-inline void _calculate_gelu_accurate_()
+inline void _calculate_gelu_accurate_(const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
-    constexpr bool scaled = true;
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
+    constexpr bool scaled                      = true;
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++)
     {
-        sfpi::vFloat in     = sfpi::dst_reg[0];
-        sfpi::vFloat result = _calculate_cdf_appx_(in, scaled);
-        sfpi::dst_reg[0]    = result;
+        sfpi::vFloat in                                   = sfpi::dst_reg[dst_index_in * dst_tile_size_sfpi];
+        sfpi::vFloat result                               = _calculate_cdf_appx_(in, scaled);
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = result;
         sfpi::dst_reg++;
     }
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_gelu_()
+inline void _calculate_gelu_(const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
     if constexpr (APPROXIMATION_MODE)
     {
-        _calculate_gelu_appx_<ITERATIONS>();
+        _calculate_gelu_appx_<ITERATIONS>(dst_index_in, dst_index_out);
     }
     else
     {
-        _calculate_gelu_accurate_<ITERATIONS>();
+        _calculate_gelu_accurate_<ITERATIONS>(dst_index_in, dst_index_out);
     }
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_gelu_derivative_()
+inline void _calculate_gelu_derivative_(const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
     if constexpr (APPROXIMATION_MODE)
     {
         constexpr int lut_mode = 1; // SFPLUTFP32_MOD0_FP16_6ENTRY_TABLE1
@@ -129,14 +132,14 @@ inline void _calculate_gelu_derivative_()
 #pragma GCC unroll 0
         for (int d = 0; d < ITERATIONS; d++)
         {
-            sfpi::vFloat val = sfpi::dst_reg[0];
+            sfpi::vFloat val = sfpi::dst_reg[dst_index_in * dst_tile_size_sfpi];
             val              = lut2(val, l0, l1, l2, l4, l5, l6, lut_mode);
             v_if (val < 0.0F)
             {
                 val = val + 1.0f;
             }
             v_endif;
-            sfpi::dst_reg[0] = val;
+            sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = val;
             sfpi::dst_reg++;
         }
 
@@ -158,7 +161,7 @@ inline void _calculate_gelu_derivative_()
 #pragma GCC unroll 0
         for (int d = 0; d < ITERATIONS; d++)
         {
-            sfpi::vFloat in             = sfpi::dst_reg[0];
+            sfpi::vFloat in             = sfpi::dst_reg[dst_index_in * dst_tile_size_sfpi];
             sfpi::vFloat neg_half_sq_in = in * in * -0.5f;
 
             // exp = e^(val)
@@ -171,7 +174,7 @@ inline void _calculate_gelu_derivative_()
 
             result = lut(result, l0, l1, imm2);
 
-            sfpi::dst_reg[0] = partial + result + 0.5f;
+            sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = partial + result + 0.5f;
             sfpi::dst_reg++;
         }
 

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_hardtanh.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_hardtanh.h
@@ -14,8 +14,15 @@ namespace sfpu
 {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_hardtanh_(const int iterations, std::uint32_t param0, std::uint32_t param1, std::uint32_t param2)
+inline void _calculate_hardtanh_(
+    const int iterations,
+    std::uint32_t param0,
+    std::uint32_t param1,
+    std::uint32_t param2,
+    const std::uint32_t dst_index_in  = 0,
+    const std::uint32_t dst_index_out = 0)
 {
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
     // All params are in FP16_B format
     // param0 = -(neg_threshold)
     // param1 = -(pos_threshold - neg_threshold)
@@ -28,7 +35,7 @@ inline void _calculate_hardtanh_(const int iterations, std::uint32_t param0, std
 #pragma GCC unroll 0
     for (int d = 0; d < iterations; d++)
     {
-        sfpi::vFloat val = sfpi::dst_reg[0];
+        sfpi::vFloat val = sfpi::dst_reg[dst_index_in * dst_tile_size_sfpi];
 
         val += p0; // 12 bits
         v_if (val < 0.0f)
@@ -46,7 +53,7 @@ inline void _calculate_hardtanh_(const int iterations, std::uint32_t param0, std
 
         val += p2; // 12 bits
 
-        sfpi::dst_reg[0] = val;
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = val;
 
         sfpi::dst_reg++;
     }

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_isinf_isnan.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_isinf_isnan.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "ckernel.h"
 #include "ckernel_defs.h"
 #include "sfpi.h"
@@ -118,32 +120,33 @@ inline sfpi::vFloat _calculate_isfinite_(const sfpi::vFloat& v)
 }
 
 template <SfpuType operation, bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_sfpu_isinf_isnan_()
+inline void _calculate_sfpu_isinf_isnan_(const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++)
     {
-        sfpi::vFloat in = sfpi::dst_reg[0];
+        sfpi::vFloat in = sfpi::dst_reg[dst_index_in * dst_tile_size_sfpi];
 
         if constexpr (operation == SfpuType::isinf)
         {
-            sfpi::dst_reg[0] = _calculate_isinf_<APPROXIMATION_MODE>(in);
+            sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = _calculate_isinf_<APPROXIMATION_MODE>(in);
         }
         else if constexpr (operation == SfpuType::isposinf)
         {
-            sfpi::dst_reg[0] = _calculate_isposinf_<APPROXIMATION_MODE>(in);
+            sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = _calculate_isposinf_<APPROXIMATION_MODE>(in);
         }
         else if constexpr (operation == SfpuType::isneginf)
         {
-            sfpi::dst_reg[0] = _calculate_isneginf_<APPROXIMATION_MODE>(in);
+            sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = _calculate_isneginf_<APPROXIMATION_MODE>(in);
         }
         else if constexpr (operation == SfpuType::isnan)
         {
-            sfpi::dst_reg[0] = _calculate_isnan_<APPROXIMATION_MODE>(in);
+            sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = _calculate_isnan_<APPROXIMATION_MODE>(in);
         }
         else if constexpr (operation == SfpuType::isfinite)
         {
-            sfpi::dst_reg[0] = _calculate_isfinite_<APPROXIMATION_MODE>(in);
+            sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = _calculate_isfinite_<APPROXIMATION_MODE>(in);
         }
 
         sfpi::dst_reg++;

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_log.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_log.h
@@ -14,7 +14,7 @@ namespace sfpu
 {
 
 template <bool HAS_BASE_SCALING>
-sfpi_inline void _calculate_log_body_(const std::uint32_t log_base_scale_factor, const std::uint32_t dst_idx = 0)
+sfpi_inline void _calculate_log_body_(const std::uint32_t log_base_scale_factor, const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
     // size of each tile in Dest is 64/SFP_DESTREG_STRIDE = 32 rows when using sfpi to load/store
     constexpr std::uint32_t dst_tile_size_sfpi = 32;
@@ -22,7 +22,7 @@ sfpi_inline void _calculate_log_body_(const std::uint32_t log_base_scale_factor,
     ////////////////////////////
     // Load From dest + "normalize to calculation range"
     ////////////////////////////
-    sfpi::vFloat in = sfpi::dst_reg[dst_idx * dst_tile_size_sfpi];
+    sfpi::vFloat in = sfpi::dst_reg[dst_index_in * dst_tile_size_sfpi];
     sfpi::vFloat x  = setexp(in, 127); // set exp to exp bias (put in range of 1-2)
 
     // XXXXXX ask Namal? if we can derive the coefficients below to higher precision
@@ -71,7 +71,7 @@ sfpi_inline void _calculate_log_body_(const std::uint32_t log_base_scale_factor,
     }
     v_endif;
 
-    sfpi::dst_reg[dst_idx * dst_tile_size_sfpi] = result;
+    sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = result;
 }
 
 sfpi_inline sfpi::vFloat _calculate_log_body_no_init_(sfpi::vFloat base)
@@ -106,12 +106,13 @@ sfpi_inline sfpi::vFloat _calculate_log_body_no_init_(sfpi::vFloat base)
 }
 
 template <bool APPROXIMATION_MODE, bool HAS_BASE_SCALING, int ITERATIONS>
-inline void _calculate_log_(const int iterations, std::uint32_t log_base_scale_factor)
+inline void _calculate_log_(
+    const int iterations, std::uint32_t log_base_scale_factor, const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
     {
-        _calculate_log_body_<HAS_BASE_SCALING>(log_base_scale_factor);
+        _calculate_log_body_<HAS_BASE_SCALING>(log_base_scale_factor, dst_index_in, dst_index_out);
         sfpi::dst_reg++;
     }
 }

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_negative.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_negative.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "sfpi.h"
 
 namespace ckernel
@@ -12,25 +14,27 @@ namespace sfpu
 {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_negative_()
+inline void _calculate_negative_(const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++)
     {
-        sfpi::vFloat val = sfpi::dst_reg[0];
-        sfpi::dst_reg[0] = -val;
+        sfpi::vFloat val                                  = sfpi::dst_reg[dst_index_in * dst_tile_size_sfpi];
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = -val;
         sfpi::dst_reg++;
     }
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_negative_int_()
+inline void _calculate_negative_int_(const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++)
     {
-        sfpi::vInt val   = sfpi::dst_reg[0];
-        sfpi::dst_reg[0] = -val;
+        sfpi::vInt val                                    = sfpi::dst_reg[dst_index_in * dst_tile_size_sfpi];
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = -val;
         sfpi::dst_reg++;
     }
 }

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_recip.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_recip.h
@@ -255,8 +255,12 @@ inline void _calculate_reciprocal_fast_24b_5c_(const int iterations)
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS, bool is_fp32_dest_acc_en>
-inline void _calculate_reciprocal_internal_(const int iterations)
+inline void _calculate_reciprocal_internal_(const int iterations, const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
+    // BH fast reciprocal paths use TTI instructions with implicit addressing;
+    // dst_index_in/dst_index_out are reserved for future use.
+    (void)dst_index_in;
+    (void)dst_index_out;
     if constexpr (APPROXIMATION_MODE)
     {
         _calculate_reciprocal_fast_7b_(iterations);
@@ -272,7 +276,7 @@ inline void _calculate_reciprocal_internal_(const int iterations)
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS, bool is_fp32_dest_acc_en, bool legacy_compat = false>
-inline void _calculate_reciprocal_(const int iterations)
+inline void _calculate_reciprocal_(const int iterations, const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
     if constexpr (legacy_compat)
     {
@@ -280,7 +284,7 @@ inline void _calculate_reciprocal_(const int iterations)
     }
     else
     {
-        _calculate_reciprocal_internal_<APPROXIMATION_MODE, ITERATIONS, is_fp32_dest_acc_en>(iterations);
+        _calculate_reciprocal_internal_<APPROXIMATION_MODE, ITERATIONS, is_fp32_dest_acc_en>(iterations, dst_index_in, dst_index_out);
     }
 }
 

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_relu.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_relu.h
@@ -51,11 +51,12 @@ sfpi_inline sfpi::vFloat _relu_max_body_(sfpi::vFloat val, sfpi::vFloat threshol
 }
 
 template <typename VecType, bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _relu_max_impl_(const int iterations, VecType threshold)
+inline void _relu_max_impl_(const int iterations, VecType threshold, const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
     for (int d = 0; d < iterations; d++)
     {
-        VecType result = sfpi::dst_reg[0];
+        VecType result = sfpi::dst_reg[dst_index_in * dst_tile_size_sfpi];
         v_if (result > threshold)
         {
             result = threshold;
@@ -66,7 +67,7 @@ inline void _relu_max_impl_(const int iterations, VecType threshold)
             result = 0;
         }
         v_endif;
-        sfpi::dst_reg[0] = result;
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = result;
         sfpi::dst_reg++;
     }
 }
@@ -102,14 +103,15 @@ inline void _relu_max_(T threshold)
 }
 
 template <typename VecType, bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _relu_min_impl_(const int iterations, VecType threshold)
+inline void _relu_min_impl_(const int iterations, VecType threshold, const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
     for (int d = 0; d < iterations; d++)
     {
-        VecType a = sfpi::dst_reg[0];
+        VecType a = sfpi::dst_reg[dst_index_in * dst_tile_size_sfpi];
         v_if (a < threshold)
         {
-            sfpi::dst_reg[0] = threshold;
+            sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = threshold;
         }
         v_endif;
         sfpi::dst_reg++;

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_rounding_ops.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_rounding_ops.h
@@ -7,6 +7,7 @@
 
 #include <array>
 #include <climits>
+#include <cstdint>
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
@@ -138,8 +139,10 @@ inline sfpi::vFloat _round_even_(sfpi::vFloat v)
 }
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
-void _calculate_round_(const int decimals)
+void _calculate_round_(const int decimals, const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
+
     const auto exp10i = [](int n)
     {
         if (n > 38) // 38 is max decimal places float32 can store for positive values
@@ -160,9 +163,9 @@ void _calculate_round_(const int decimals)
 
     for (int d = 0; d < ITERATIONS; ++d)
     {
-        sfpi::vFloat v      = sfpi::dst_reg[0];
-        sfpi::vFloat result = inverse * _round_even_(v * coeff);
-        sfpi::dst_reg[0]    = result;
+        sfpi::vFloat v                                    = sfpi::dst_reg[dst_index_in * dst_tile_size_sfpi];
+        sfpi::vFloat result                               = inverse * _round_even_(v * coeff);
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = result;
         sfpi::dst_reg++;
     }
 }

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_rsqrt.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_rsqrt.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "ckernel_sfpu_rsqrt_compat.h"
 #include "ckernel_sfpu_sqrt.h"
 #include "sfpi.h"
@@ -14,7 +16,7 @@ namespace sfpu
 {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS, bool fp32_dest_acc_en, bool FAST_APPROX, bool legacy_compat = false>
-inline void _calculate_rsqrt_(int iterations)
+inline void _calculate_rsqrt_(int iterations, const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
     if constexpr (legacy_compat)
     {
@@ -22,7 +24,7 @@ inline void _calculate_rsqrt_(int iterations)
     }
     else
     {
-        return _calculate_sqrt_internal_<APPROXIMATION_MODE, ITERATIONS, fp32_dest_acc_en, true, FAST_APPROX>(iterations);
+        return _calculate_sqrt_internal_<APPROXIMATION_MODE, ITERATIONS, fp32_dest_acc_en, true, FAST_APPROX>(iterations, dst_index_in, dst_index_out);
     }
 }
 

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_rsqrt_compat.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_rsqrt_compat.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "sfpi.h"
 
 namespace ckernel
@@ -97,13 +99,52 @@ sfpi_inline sfpi::vFloat _reciprocal_compat_(const sfpi::vFloat in)
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS, bool fp32_dest_acc_en>
-inline void _calculate_rsqrt_compat_(const int iterations)
+inline void _calculate_rsqrt_compat_(const int iterations, const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
     {
-        sfpi::dst_reg[0] = _sqrt_compat_<APPROXIMATION_MODE, 2>(sfpi::dst_reg[0]);
-        sfpi::vFloat in  = sfpi::dst_reg[0];
+        sfpi::dst_reg[dst_index_in * dst_tile_size_sfpi] = _sqrt_compat_<APPROXIMATION_MODE, 2>(sfpi::dst_reg[dst_index_in * dst_tile_size_sfpi]);
+        sfpi::vFloat in                                  = sfpi::dst_reg[dst_index_in * dst_tile_size_sfpi];
+        sfpi::vFloat out                                 = _reciprocal_compat_<APPROXIMATION_MODE ? 2 : 3>(in);
+        v_if (in < 0.0)
+        {
+            out = -out;
+        }
+        v_endif;
+        if constexpr (fp32_dest_acc_en || APPROXIMATION_MODE)
+        {
+            sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = out;
+        }
+        else
+        {
+            sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = sfpi::reinterpret<sfpi::vFloat>(float_to_fp16b(out, 0));
+        }
+        sfpi::dst_reg++;
+    }
+}
+
+template <bool APPROXIMATION_MODE, int ITERATIONS, bool fp32_dest_acc_en>
+inline void _calculate_sqrt_compat_(const int iterations, const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
+{
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
+#pragma GCC unroll 8
+    for (int d = 0; d < iterations; d++)
+    {
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = _sqrt_compat_<APPROXIMATION_MODE, 2>(sfpi::dst_reg[dst_index_in * dst_tile_size_sfpi]);
+        sfpi::dst_reg++;
+    }
+}
+
+template <bool APPROXIMATION_MODE, int ITERATIONS, bool fp32_dest_acc_en>
+inline void _calculate_reciprocal_compat_(const int iterations, const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
+{
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
+#pragma GCC unroll 8
+    for (int d = 0; d < iterations; d++)
+    {
+        sfpi::vFloat in  = sfpi::dst_reg[dst_index_in * dst_tile_size_sfpi];
         sfpi::vFloat out = _reciprocal_compat_<APPROXIMATION_MODE ? 2 : 3>(in);
         v_if (in < 0.0)
         {
@@ -112,47 +153,11 @@ inline void _calculate_rsqrt_compat_(const int iterations)
         v_endif;
         if constexpr (fp32_dest_acc_en || APPROXIMATION_MODE)
         {
-            sfpi::dst_reg[0] = out;
+            sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = out;
         }
         else
         {
-            sfpi::dst_reg[0] = sfpi::reinterpret<sfpi::vFloat>(float_to_fp16b(out, 0));
-        }
-        sfpi::dst_reg++;
-    }
-}
-
-template <bool APPROXIMATION_MODE, int ITERATIONS, bool fp32_dest_acc_en>
-inline void _calculate_sqrt_compat_(const int iterations)
-{
-#pragma GCC unroll 8
-    for (int d = 0; d < iterations; d++)
-    {
-        sfpi::dst_reg[0] = _sqrt_compat_<APPROXIMATION_MODE, 2>(sfpi::dst_reg[0]);
-        sfpi::dst_reg++;
-    }
-}
-
-template <bool APPROXIMATION_MODE, int ITERATIONS, bool fp32_dest_acc_en>
-inline void _calculate_reciprocal_compat_(const int iterations)
-{
-#pragma GCC unroll 8
-    for (int d = 0; d < iterations; d++)
-    {
-        sfpi::vFloat in  = sfpi::dst_reg[0];
-        sfpi::vFloat out = _reciprocal_compat_<APPROXIMATION_MODE ? 2 : 3>(in);
-        v_if (in < 0.0)
-        {
-            out = -out;
-        }
-        v_endif;
-        if constexpr (fp32_dest_acc_en || APPROXIMATION_MODE)
-        {
-            sfpi::dst_reg[0] = out;
-        }
-        else
-        {
-            sfpi::dst_reg[0] = sfpi::reinterpret<sfpi::vFloat>(float_to_fp16b(out, 0));
+            sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = sfpi::reinterpret<sfpi::vFloat>(float_to_fp16b(out, 0));
         }
         sfpi::dst_reg++;
     }

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_sigmoid.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_sigmoid.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "ckernel_sfpu_load_config.h"
 #include "sfpi.h"
 
@@ -13,22 +15,23 @@ namespace sfpu
 {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_sigmoid_(const int iterations)
+inline void _calculate_sigmoid_(const int iterations, const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
-    constexpr int lut_mode = 0; // SFPLUTFP32_MOD0_FP16_6ENTRY_TABLE1
-    sfpi::vUInt l0         = sfpi::l_reg[sfpi::LRegs::LReg0];
-    sfpi::vUInt l1         = sfpi::l_reg[sfpi::LRegs::LReg1];
-    sfpi::vUInt l2         = sfpi::l_reg[sfpi::LRegs::LReg2];
-    sfpi::vUInt l4         = sfpi::l_reg[sfpi::LRegs::LReg4];
-    sfpi::vUInt l5         = sfpi::l_reg[sfpi::LRegs::LReg5];
-    sfpi::vUInt l6         = sfpi::l_reg[sfpi::LRegs::LReg6];
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
+    constexpr int lut_mode                     = 0; // SFPLUTFP32_MOD0_FP16_6ENTRY_TABLE1
+    sfpi::vUInt l0                             = sfpi::l_reg[sfpi::LRegs::LReg0];
+    sfpi::vUInt l1                             = sfpi::l_reg[sfpi::LRegs::LReg1];
+    sfpi::vUInt l2                             = sfpi::l_reg[sfpi::LRegs::LReg2];
+    sfpi::vUInt l4                             = sfpi::l_reg[sfpi::LRegs::LReg4];
+    sfpi::vUInt l5                             = sfpi::l_reg[sfpi::LRegs::LReg5];
+    sfpi::vUInt l6                             = sfpi::l_reg[sfpi::LRegs::LReg6];
 
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
     {
-        sfpi::vFloat val = sfpi::dst_reg[0];
+        sfpi::vFloat val = sfpi::dst_reg[dst_index_in * dst_tile_size_sfpi];
 
-        sfpi::dst_reg[0] = lut2(val, l0, l1, l2, l4, l5, l6, lut_mode) + 0.5f;
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = lut2(val, l0, l1, l2, l4, l5, l6, lut_mode) + 0.5f;
 
         sfpi::dst_reg++;
     }

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_sign.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_sign.h
@@ -15,18 +15,19 @@ namespace sfpu
 {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_sign_(const int iterations, std::uint32_t exponent_size_8)
+inline void _calculate_sign_(const int iterations, std::uint32_t exponent_size_8, const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
 // All params are in FP16 format
 // uint format = 1;
 #pragma GCC unroll 0
     for (int d = 0; d < iterations; d++)
     {
-        sfpi::vFloat v   = sfpi::dst_reg[0];
-        sfpi::dst_reg[0] = sfpi::vConst1;
+        sfpi::vFloat v                                    = sfpi::dst_reg[dst_index_in * dst_tile_size_sfpi];
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = sfpi::vConst1;
         v_if (v < 0.0F)
         {
-            sfpi::dst_reg[0] = sfpi::vConstNeg1;
+            sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = sfpi::vConstNeg1;
         }
         v_endif;
 
@@ -34,7 +35,7 @@ inline void _calculate_sign_(const int iterations, std::uint32_t exponent_size_8
         // param0 != 0 is Float16 format and exp bias needs to be removed for zero check.
         v_if (_sfpu_is_fp16_zero_(v, exponent_size_8))
         {
-            sfpi::dst_reg[0] = sfpi::vConst0;
+            sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = sfpi::vConst0;
         }
         v_endif;
 

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_silu.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_silu.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "ckernel_sfpu_polyval.h"
 #include "sfpi.h"
 
@@ -26,12 +28,13 @@ inline sfpi::vFloat _sigmoid_piecewise_linear_positive_(sfpi::vFloat val)
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_silu_()
+inline void _calculate_silu_(const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++)
     {
-        sfpi::vFloat val    = sfpi::dst_reg[0];
+        sfpi::vFloat val    = sfpi::dst_reg[dst_index_in * dst_tile_size_sfpi];
         sfpi::vFloat result = sfpi::abs(val);
         result              = _sigmoid_piecewise_linear_positive_(result);
         v_if (val < 0.0f)
@@ -39,7 +42,7 @@ inline void _calculate_silu_()
             result = 1.0f - result;
         }
         v_endif;
-        sfpi::dst_reg[0] = val * result;
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = val * result;
         sfpi::dst_reg++;
     }
 }

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_sqrt.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_sqrt.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "ckernel_sfpu_rsqrt_compat.h"
 #include "sfpi.h"
 
@@ -114,26 +116,27 @@ sfpi_inline sfpi::vFloat _calculate_sqrt_body_(const sfpi::vFloat x)
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS, bool fp32_dest_acc_en, bool RECIPROCAL, bool FAST_APPROX>
-inline void _calculate_sqrt_internal_(const int iterations)
+inline void _calculate_sqrt_internal_(const int iterations, const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
     {
-        sfpi::vFloat tmp = _calculate_sqrt_body_<APPROXIMATION_MODE, RECIPROCAL, FAST_APPROX>(sfpi::dst_reg[0]);
+        sfpi::vFloat tmp = _calculate_sqrt_body_<APPROXIMATION_MODE, RECIPROCAL, FAST_APPROX>(sfpi::dst_reg[dst_index_in * dst_tile_size_sfpi]);
         if constexpr (fp32_dest_acc_en)
         {
-            sfpi::dst_reg[0] = tmp;
+            sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = tmp;
         }
         else
         {
-            sfpi::dst_reg[0] = sfpi::reinterpret<sfpi::vFloat>(float_to_fp16b(tmp, 0));
+            sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = sfpi::reinterpret<sfpi::vFloat>(float_to_fp16b(tmp, 0));
         }
         sfpi::dst_reg++;
     }
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS, bool fp32_dest_acc_en, bool FAST_APPROX, bool legacy_compat = false>
-inline void _calculate_sqrt_(int iterations)
+inline void _calculate_sqrt_(int iterations, const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
     if constexpr (legacy_compat)
     {
@@ -141,7 +144,7 @@ inline void _calculate_sqrt_(int iterations)
     }
     else
     {
-        return _calculate_sqrt_internal_<APPROXIMATION_MODE, ITERATIONS, fp32_dest_acc_en, false, FAST_APPROX>(iterations);
+        return _calculate_sqrt_internal_<APPROXIMATION_MODE, ITERATIONS, fp32_dest_acc_en, false, FAST_APPROX>(iterations, dst_index_in, dst_index_out);
     }
 }
 

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_tanh.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_tanh.h
@@ -15,8 +15,9 @@ namespace sfpu
 {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_tanh_(const int iterations)
+inline void _calculate_tanh_(const int iterations, const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
     // SFPU microcode
     sfpi::vUInt l0 = sfpi::l_reg[sfpi::LRegs::LReg0];
     sfpi::vUInt l1 = sfpi::l_reg[sfpi::LRegs::LReg1];
@@ -25,9 +26,9 @@ inline void _calculate_tanh_(const int iterations)
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
     {
-        sfpi::vFloat val = sfpi::dst_reg[0];
-        val              = lut(val, l0, l1, l2);
-        sfpi::dst_reg[0] = val;
+        sfpi::vFloat val                                  = sfpi::dst_reg[dst_index_in * dst_tile_size_sfpi];
+        val                                               = lut(val, l0, l1, l2);
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = val;
 
         sfpi::dst_reg++;
     }

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_tanh_derivative.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_tanh_derivative.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "sfpi.h"
 
 namespace ckernel
@@ -12,24 +14,25 @@ namespace sfpu
 {
 
 template <bool APPROXIMATION_MODE, int WITH_PRECOMPUTED_TANH, int ITERATIONS>
-inline void _calculate_tanh_derivative_(const int iterations)
+inline void _calculate_tanh_derivative_(const int iterations, const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
-    sfpi::vUInt l0 = sfpi::l_reg[sfpi::LRegs::LReg0];
-    sfpi::vUInt l1 = sfpi::l_reg[sfpi::LRegs::LReg1];
-    sfpi::vUInt l2 = sfpi::l_reg[sfpi::LRegs::LReg2];
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
+    sfpi::vUInt l0                             = sfpi::l_reg[sfpi::LRegs::LReg0];
+    sfpi::vUInt l1                             = sfpi::l_reg[sfpi::LRegs::LReg1];
+    sfpi::vUInt l2                             = sfpi::l_reg[sfpi::LRegs::LReg2];
 
     // tanh'(x) = 1 - (tanh(x))^2
     for (int d = 0; d < iterations; d++)
     {
-        sfpi::vFloat val = sfpi::dst_reg[0];
+        sfpi::vFloat val = sfpi::dst_reg[dst_index_in * dst_tile_size_sfpi];
 
         if constexpr (!WITH_PRECOMPUTED_TANH)
         {
             val = lut(val, l0, l1, l2);
         }
 
-        val              = val * (-val) + sfpi::vConst1;
-        sfpi::dst_reg[0] = val;
+        val                                               = val * (-val) + sfpi::vConst1;
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = val;
 
         sfpi::dst_reg++;
     }

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_threshold.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_threshold.h
@@ -18,8 +18,9 @@ template <typename T>
 constexpr bool is_supported_threshold_type_v = std::is_same_v<T, float> || std::is_same_v<T, std::uint32_t>;
 
 template <bool APPROXIMATION_MODE, int ITERATIONS, typename T>
-inline void _calculate_threshold_(T threshold, T value)
+inline void _calculate_threshold_(T threshold, T value, const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
     static_assert(is_supported_threshold_type_v<T>, "Type T must be either float or uint32_t");
 
     sfpi::vFloat v_threshold;
@@ -37,11 +38,11 @@ inline void _calculate_threshold_(T threshold, T value)
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++)
     {
-        sfpi::vFloat in = sfpi::dst_reg[0];
+        sfpi::vFloat in = sfpi::dst_reg[dst_index_in * dst_tile_size_sfpi];
 
         v_if (in <= v_threshold)
         {
-            sfpi::dst_reg[0] = v_value;
+            sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = v_value;
         }
         v_endif;
 

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_trigonometry.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_trigonometry.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <limits>
 
 #include "ckernel_sfpu_log.h"
@@ -80,12 +81,14 @@ sfpi_inline sfpi::vFloat _sfpu_cosine_maclaurin_series_(sfpi::vFloat val)
 // Legacy implementation
 // Candidate for removal in future versions. See https://github.com/tenstorrent/tt-llk/issues/225 for more details.
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_sine_(const int iterations)
+inline void _calculate_sine_(const int iterations, const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
+
     // SFPU microcode
     for (int d = 0; d < iterations; d++)
     {
-        sfpi::vFloat v             = sfpi::dst_reg[0];
+        sfpi::vFloat v             = sfpi::dst_reg[dst_index_in * dst_tile_size_sfpi];
         v                          = 0.318309886183791f * v; // *1/pi to get number of pi rads.
         sfpi::vInt whole_v         = sfpi::float_to_int16(v, 0);
         sfpi::vFloat whole_v_float = sfpi::int32_to_float(whole_v, 0);
@@ -99,7 +102,7 @@ inline void _calculate_sine_(const int iterations)
             v *= -1;
         }
         v_endif;
-        sfpi::dst_reg[0] = v;
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = v;
         sfpi::dst_reg++;
     }
 }
@@ -107,12 +110,14 @@ inline void _calculate_sine_(const int iterations)
 // Legacy implementation, replaced by newer void _calculate_sine_() which produces more accurate results
 // Candidate for removal in future versions. See https://github.com/tenstorrent/tt-llk/issues/225 for more details.
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_cosine_(const int iterations)
+inline void _calculate_cosine_(const int iterations, const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
+
     // SFPU microcode
     for (int d = 0; d < iterations; d++)
     {
-        sfpi::vFloat v             = sfpi::dst_reg[0];
+        sfpi::vFloat v             = sfpi::dst_reg[dst_index_in * dst_tile_size_sfpi];
         v                          = 0.318309886183791f * v; // *1/pi to get number of pi rads.
         sfpi::vInt whole_v         = sfpi::float_to_int16(v, 0);
         sfpi::vFloat whole_v_float = sfpi::int32_to_float(whole_v, 0);
@@ -126,7 +131,7 @@ inline void _calculate_cosine_(const int iterations)
             v *= -1;
         }
         v_endif;
-        sfpi::dst_reg[0] = v;
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = v;
         sfpi::dst_reg++;
     }
 }
@@ -134,27 +139,29 @@ inline void _calculate_cosine_(const int iterations)
 // https://en.wikipedia.org/wiki/Inverse_hyperbolic_functions#Definitions_in_terms_of_logarithms
 // acosh(x) = log(x + sqrt(x^2 - 1))
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_acosh_()
+inline void _calculate_acosh_(const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
+
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++)
     {
-        sfpi::vFloat inp = sfpi::dst_reg[0];
+        sfpi::vFloat inp = sfpi::dst_reg[dst_index_in * dst_tile_size_sfpi];
         v_if (inp < sfpi::vConst1)
         {
-            sfpi::dst_reg[0] = std::numeric_limits<float>::quiet_NaN();
+            sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = std::numeric_limits<float>::quiet_NaN();
         }
         v_elseif (inp == sfpi::vConst1)
         {
-            sfpi::dst_reg[0] = sfpi::vConst0;
+            sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = sfpi::vConst0;
         }
         v_else
         {
-            sfpi::vFloat tmp = inp * inp;
-            tmp              = tmp - sfpi::vConst1;
-            tmp              = _calculate_sqrt_body_<APPROXIMATION_MODE>(tmp);
-            tmp              = tmp + inp;
-            sfpi::dst_reg[0] = _calculate_log_body_no_init_(tmp);
+            sfpi::vFloat tmp                                  = inp * inp;
+            tmp                                               = tmp - sfpi::vConst1;
+            tmp                                               = _calculate_sqrt_body_<APPROXIMATION_MODE>(tmp);
+            tmp                                               = tmp + inp;
+            sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = _calculate_log_body_no_init_(tmp);
         }
         v_endif;
         sfpi::dst_reg++;
@@ -163,19 +170,21 @@ inline void _calculate_acosh_()
 
 // asinh(x) = log(x + sqrt(x^2 + 1))
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_asinh_()
+inline void _calculate_asinh_(const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
+
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++)
     {
-        sfpi::vFloat inp = sfpi::dst_reg[0];
-        sfpi::vFloat tmp = inp * inp + sfpi::vConst1;
-        tmp              = _calculate_sqrt_body_<APPROXIMATION_MODE>(tmp);
-        tmp              = tmp + sfpi::abs(inp);
-        sfpi::dst_reg[0] = _calculate_log_body_no_init_(tmp);
+        sfpi::vFloat inp                                  = sfpi::dst_reg[dst_index_in * dst_tile_size_sfpi];
+        sfpi::vFloat tmp                                  = inp * inp + sfpi::vConst1;
+        tmp                                               = _calculate_sqrt_body_<APPROXIMATION_MODE>(tmp);
+        tmp                                               = tmp + sfpi::abs(inp);
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = _calculate_log_body_no_init_(tmp);
         v_if (inp < sfpi::vConst0)
         {
-            sfpi::dst_reg[0] = -sfpi::dst_reg[0];
+            sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = -sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi];
         }
         v_endif;
         sfpi::dst_reg++;
@@ -184,21 +193,23 @@ inline void _calculate_asinh_()
 
 // atanh[x] = 0.5 * ln((1 + x) / (1 - x))
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
-inline void _calculate_atanh_()
+inline void _calculate_atanh_(const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
+
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++)
     {
-        sfpi::vFloat inp     = sfpi::dst_reg[0];
+        sfpi::vFloat inp     = sfpi::dst_reg[dst_index_in * dst_tile_size_sfpi];
         sfpi::vFloat abs_inp = sfpi::abs(inp);
         v_if (abs_inp > sfpi::vConst1)
         {
-            sfpi::dst_reg[0] = std::numeric_limits<float>::quiet_NaN();
+            sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = std::numeric_limits<float>::quiet_NaN();
         }
         v_elseif (abs_inp == sfpi::vConst1)
         {
-            sfpi::vFloat inf = std::numeric_limits<float>::infinity();
-            sfpi::dst_reg[0] = sfpi::setsgn(inf, inp);
+            sfpi::vFloat inf                                  = std::numeric_limits<float>::infinity();
+            sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = sfpi::setsgn(inf, inp);
         }
         v_else
         {
@@ -214,9 +225,9 @@ inline void _calculate_atanh_()
             {
                 den = sfpi::reinterpret<sfpi::vFloat>(float_to_fp16b(tmp, 0));
             }
-            num              = num * den;
-            den              = _calculate_log_body_no_init_(num);
-            sfpi::dst_reg[0] = 0.5f * den;
+            num                                               = num * den;
+            den                                               = _calculate_log_body_no_init_(num);
+            sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = 0.5f * den;
         }
         v_endif;
         sfpi::dst_reg++;

--- a/tt_llk_blackhole/llk_lib/llk_math_eltwise_unary_sfpu_params.h
+++ b/tt_llk_blackhole/llk_lib/llk_math_eltwise_unary_sfpu_params.h
@@ -62,3 +62,57 @@ inline void _llk_math_eltwise_unary_sfpu_params_(
     }
     _llk_math_eltwise_unary_sfpu_done_();
 }
+
+// Variant that supports writing to a different output tile than the input tile.
+// Uses absolute addressing (base=0) and appends tile indices after the callable's
+// normal args. The callable must accept (...args, dst_index_in, dst_index_out)
+// as its last two parameters (with defaults of 0 for backward compatibility).
+template <bool APPROXIMATE, typename Callable, typename... Args>
+inline void _llk_math_eltwise_unary_sfpu_params_with_output_(
+    Callable&& sfpu_func, std::uint32_t dst_index_in, std::uint32_t dst_index_out, int vector_mode = static_cast<int>(VectorMode::RC), Args&&... args)
+{
+    LLK_ASSERT((dst_index_in < get_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE, DstTileShape::Tile32x32>()), "dst_index_in exceeds max dest tiles");
+    LLK_ASSERT((dst_index_out < get_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE, DstTileShape::Tile32x32>()), "dst_index_out exceeds max dest tiles");
+
+    // Start from base 0 for absolute tile addressing (same as binary SFPU)
+    _llk_math_eltwise_unary_sfpu_start_<DST_SYNC_MODE>(0);
+
+    VectorMode mode = static_cast<VectorMode>(vector_mode);
+
+    if (mode == VectorMode::R)
+    {
+#pragma GCC unroll 0
+        for (int face = 0; face < 2; face++)
+        {
+            std::forward<Callable>(sfpu_func)(std::forward<Args>(args)..., dst_index_in, dst_index_out);
+            _llk_math_eltwise_unary_sfpu_inc_dst_face_addr_();
+        }
+        _llk_math_eltwise_unary_sfpu_inc_dst_face_addr_();
+        _llk_math_eltwise_unary_sfpu_inc_dst_face_addr_();
+    }
+    else if (mode == VectorMode::C)
+    {
+#pragma GCC unroll 0
+        for (int face = 0; face < 2; face++)
+        {
+            std::forward<Callable>(sfpu_func)(std::forward<Args>(args)..., dst_index_in, dst_index_out);
+            _llk_math_eltwise_unary_sfpu_inc_dst_face_addr_();
+            _llk_math_eltwise_unary_sfpu_inc_dst_face_addr_();
+        }
+    }
+    else if (mode == VectorMode::RC)
+    {
+#pragma GCC unroll 0
+        for (int face = 0; face < 4; face++)
+        {
+            std::forward<Callable>(sfpu_func)(std::forward<Args>(args)..., dst_index_in, dst_index_out);
+            _llk_math_eltwise_unary_sfpu_inc_dst_face_addr_();
+        }
+    }
+    else
+    {
+        std::forward<Callable>(sfpu_func)(std::forward<Args>(args)..., dst_index_in, dst_index_out);
+    }
+
+    _llk_math_eltwise_unary_sfpu_done_();
+}

--- a/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_add.h
+++ b/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_add.h
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
+#include <cstdint>
+
 #include "ckernel_trisc_common.h"
 #include "cmath_common.h"
 
@@ -10,7 +12,13 @@ namespace ckernel
 {
 namespace sfpu
 {
-inline void _calculate_add_(const int iterations, const int in0_offset_idx, const int in1_offset_idx, const int out_offset_idx)
+inline void _calculate_add_(
+    const int iterations,
+    const int in0_offset_idx,
+    const int in1_offset_idx,
+    const int out_offset_idx,
+    const std::uint32_t dst_index_in  = 0,
+    const std::uint32_t dst_index_out = 0)
 {
     for (int d = 0; d < iterations; d++)
     {

--- a/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_exp.h
+++ b/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_exp.h
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
+#include <cstdint>
+
 #include "ckernel_trisc_common.h"
 #include "cmath_common.h"
 
@@ -10,30 +12,27 @@ namespace ckernel
 {
 namespace sfpu
 {
-// Calculates EXP for number of rows of output SFPU ops (Quasar = 2 rows)
 template <bool APPROXIMATION_MODE>
-inline void _calculate_exp_sfp_rows_()
+inline void _calculate_exp_(const int iterations, const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
-    TTI_SFPLOAD(p_sfpu::LREG0, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0, 0); // load from dest into lreg[0], uses ADDR_MOD_7 (set to all zeroes)
+    constexpr std::uint32_t dst_tile_size = 64; // Tile32x32 on Quasar
+    const std::uint32_t in_offset         = dst_index_in * dst_tile_size;
+    const std::uint32_t out_offset        = dst_index_out * dst_tile_size;
 
-    // SFPARECIP, approx version of reciprocal
-    if constexpr (APPROXIMATION_MODE)
-    {
-        TTI_SFPNONLINEAR(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpnonlinear::EXP_MODE); // Read value from lreg[0], approximate recip, load back into lreg[1]
-    }
-
-    // Store from lreg[1] into dest register
-    TTI_SFPSTORE(p_sfpu::LREG1, 0, ADDR_MOD_7, 0, 0);
-}
-
-template <bool APPROXIMATION_MODE>
-inline void _calculate_exp_(const int iterations)
-{
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
     {
-        _calculate_exp_sfp_rows_<APPROXIMATION_MODE>();
-        ckernel::math::_incr_counters_<0x0, 0x0, ckernel::math::SFP_ROWS, 0x0>(); // does the dest_reg++ (increments by 2 rows)
+        TT_SFPLOAD(
+            p_sfpu::LREG0, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0, in_offset + (d << 1)); // load from dest into lreg[0], uses ADDR_MOD_7 (set to all zeroes)
+
+        // SFPARECIP, approx version of reciprocal
+        if constexpr (APPROXIMATION_MODE)
+        {
+            TTI_SFPNONLINEAR(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpnonlinear::EXP_MODE); // Read value from lreg[0], approximate recip, load back into lreg[1]
+        }
+
+        // Store from lreg[1] into dest register
+        TT_SFPSTORE(p_sfpu::LREG1, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0, out_offset + (d << 1));
     }
 }
 

--- a/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_gelu.h
+++ b/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_gelu.h
@@ -48,23 +48,21 @@ inline void _init_gelu_()
     _sfpu_load_config32_(0xC, 0xB122, 0xA3AE);
 }
 
-// Calculates GELU for number of rows of output SFPU ops (Quasar = 2 rows)
-inline void _calculate_gelu_sfp_rows_()
+inline void _calculate_gelu_(const int iterations, const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
-    TTI_SFPLOAD(p_sfpu::LREG3, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0, 0); // load from dest into lreg[3], uses ADDR_MOD_7 (set to all zeroes)
+    constexpr std::uint32_t dst_tile_size = 64; // Tile32x32 on Quasar
+    const std::uint32_t in_offset         = dst_index_in * dst_tile_size;
+    const std::uint32_t out_offset        = dst_index_out * dst_tile_size;
 
-    TTI_SFPLUTFP32(p_sfpu::LREG4, 0x2); // Calculate piecewise part on lreg[3] and store in lreg[4], using FP16 6-entry format mode 1 LUT
-    TTI_SFPMAD(p_sfpu::LREG6, p_sfpu::LREG3, p_sfpu::LREG4, p_sfpu::LREG5, 0); // 0.5 * x + piecewise result, store in lreg[5]
-    TTI_SFPSTORE(p_sfpu::LREG5, 0, ADDR_MOD_7, 0, 0);                          // store from lreg[5] into dest register
-}
-
-inline void _calculate_gelu_(const int iterations)
-{
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
     {
-        _calculate_gelu_sfp_rows_();
-        ckernel::math::_incr_counters_<0x0, 0x0, ckernel::math::SFP_ROWS, 0x0>(); // does the dest_reg++ (increments by 2 rows)
+        TT_SFPLOAD(
+            p_sfpu::LREG3, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0, in_offset + (d << 1)); // load from dest into lreg[3], uses ADDR_MOD_7 (set to all zeroes)
+
+        TTI_SFPLUTFP32(p_sfpu::LREG4, 0x2); // Calculate piecewise part on lreg[3] and store in lreg[4], using FP16 6-entry format mode 1 LUT
+        TTI_SFPMAD(p_sfpu::LREG6, p_sfpu::LREG3, p_sfpu::LREG4, p_sfpu::LREG5, 0);                 // 0.5 * x + piecewise result, store in lreg[5]
+        TT_SFPSTORE(p_sfpu::LREG5, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0, out_offset + (d << 1)); // store from lreg[5] into dest register
     }
 }
 

--- a/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_lrelu.h
+++ b/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_lrelu.h
@@ -12,96 +12,92 @@ namespace ckernel
 {
 namespace sfpu
 {
-// Calculates Leaky RELU for number of rows of output SFPU ops (Quasar = 2 rows)
-inline void _calculate_lrelu_sfp_rows_()
-{
-    TTI_SFPLOAD(p_sfpu::LREG0, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0, 0); // load from dest into lreg[0], uses ADDR_MOD_7 (set to all zeroes)
-
-    TTI_SFPSETCC(0, p_sfpu::LREG0, 0); // condition - if value in LREG0 is negative //will set cc result reg
-
-    TTI_SFPMAD(p_sfpu::LREG0, p_sfpu::LREG2, p_sfpu::LCONST_0, p_sfpu::LREG0, 0); // Multiply and add - LREG0 * LREG2 + LCONST_0 (x * slope + 0)
-
-    TTI_SFPENCC(0, 0); // clear cc result reg
-
-    // Store from lreg0 into dest register
-    TTI_SFPSTORE(p_sfpu::LREG0, 0, ADDR_MOD_7, 0, 0);
-}
-
 // Implements leaky relu which return x when x > 0 and x*slope when x < 0
-inline void _calculate_lrelu_(const int iterations, const std::uint32_t slope)
+inline void _calculate_lrelu_(const int iterations, const std::uint32_t slope, const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
+    constexpr std::uint32_t dst_tile_size = 64; // Tile32x32 on Quasar
+    const std::uint32_t in_offset         = dst_index_in * dst_tile_size;
+    const std::uint32_t out_offset        = dst_index_out * dst_tile_size;
+
     TTI_SFPLOADI(p_sfpu::LREG2, 0 /*Float16_b*/, (slope >> 16)); // store slope in LREG2
     TTI_SFPENCC(1, 2);                                           // enable cc
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
     {
-        _calculate_lrelu_sfp_rows_();
-        ckernel::math::_incr_counters_<0x0, 0x0, ckernel::math::SFP_ROWS, 0x0>(); // does the dest_reg++ (increments by 2 rows)
+        TT_SFPLOAD(
+            p_sfpu::LREG0, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0, in_offset + (d << 1)); // load from dest into lreg[0], uses ADDR_MOD_7 (set to all zeroes)
+
+        TTI_SFPSETCC(0, p_sfpu::LREG0, 0); // condition - if value in LREG0 is negative //will set cc result reg
+
+        TTI_SFPMAD(p_sfpu::LREG0, p_sfpu::LREG2, p_sfpu::LCONST_0, p_sfpu::LREG0, 0); // Multiply and add - LREG0 * LREG2 + LCONST_0 (x * slope + 0)
+
+        TTI_SFPENCC(0, 0); // clear cc result reg
+
+        // Store from lreg0 into dest register
+        TT_SFPSTORE(p_sfpu::LREG0, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0, out_offset + (d << 1));
     }
     TTI_SFPENCC(0, 2); // disable cc
-}
-
-// Calculates RELU MIN for number of rows of output SFPU ops (Quasar = 2 rows)
-inline void _calculate_relu_min_sfp_rows_()
-{
-    TTI_SFPLOAD(p_sfpu::LREG0, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0, 0); // load from dest into lreg[0], uses ADDR_MOD_7 (set to all zeroes)
-
-    // where lreg0 < threshold, load 0 into LREG0[x]
-    TTI_SFPGT(0, p_sfpu::LREG0, p_sfpu::LREG2, 0x1 /*cc mode*/);
-
-    TTI_SFPLOADI(p_sfpu::LREG0, 0, 0); // Load 0 into lreg0[x]
-
-    TTI_SFPENCC(0, 0); // clear cc result reg
-
-    // Store from lreg0 into dest register
-    TTI_SFPSTORE(p_sfpu::LREG0, 0, ADDR_MOD_7, 0, 0);
 }
 
 // Implements relu min which returns x when x > threshold, otherwise return 0
-inline void _calculate_relu_min_(const int iterations, const std::uint32_t threshold)
+inline void _calculate_relu_min_(
+    const int iterations, const std::uint32_t threshold, const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
+    constexpr std::uint32_t dst_tile_size = 64; // Tile32x32 on Quasar
+    const std::uint32_t in_offset         = dst_index_in * dst_tile_size;
+    const std::uint32_t out_offset        = dst_index_out * dst_tile_size;
+
     TTI_SFPLOADI(p_sfpu::LREG2, 0 /*Float16_b*/, (threshold >> 16)); // store slope in LREG2
     TTI_SFPENCC(1, 2);                                               // enable cc
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
     {
-        _calculate_relu_min_sfp_rows_();
-        ckernel::math::_incr_counters_<0x0, 0x0, ckernel::math::SFP_ROWS, 0x0>(); // does the dest_reg++ (increments by 2 rows)
+        TT_SFPLOAD(
+            p_sfpu::LREG0, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0, in_offset + (d << 1)); // load from dest into lreg[0], uses ADDR_MOD_7 (set to all zeroes)
+
+        // where lreg0 < threshold, load 0 into LREG0[x]
+        TTI_SFPGT(0, p_sfpu::LREG0, p_sfpu::LREG2, 0x1 /*cc mode*/);
+
+        TTI_SFPLOADI(p_sfpu::LREG0, 0, 0); // Load 0 into lreg0[x]
+
+        TTI_SFPENCC(0, 0); // clear cc result reg
+
+        // Store from lreg0 into dest register
+        TT_SFPSTORE(p_sfpu::LREG0, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0, out_offset + (d << 1));
     }
     TTI_SFPENCC(0, 2); // disable cc
 }
 
-// Calculates RELU MAX for number of rows of output SFPU ops (Quasar = 2 rows)
-inline void _calculate_relu_max_sfp_rows_()
-{
-    TTI_SFPLOAD(p_sfpu::LREG0, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0, 0); // load from dest into lreg[0], uses ADDR_MOD_7 (set to all zeroes)
-
-    // If x > threshold, x = threshold
-    TTI_SFPGT(0, p_sfpu::LREG2, p_sfpu::LREG0, 0x1 /*cc mode*/);
-
-    TTI_SFPMOV(p_sfpu::LREG2 /*src*/, p_sfpu::LREG0 /*dest*/, 0); // copy threshold value into LREG0 where LREG0 > threshold
-
-    // Classic Relu: Max(x, 0)
-    TTI_SFPSETCC(0, p_sfpu::LREG0, 0); // condition - if value in LREG0 is negative
-
-    TTI_SFPLOADI(p_sfpu::LREG0, 0, 0); // Load 0 into lreg0[x]
-
-    TTI_SFPENCC(0, 0); // reset cc
-
-    // Store from lreg0 into dest register
-    TTI_SFPSTORE(p_sfpu::LREG0, 0, ADDR_MOD_7, 0, 0);
-}
-
 // Implements relu max
-inline void _calculate_relu_max_(const int iterations, const std::uint32_t threshold)
+inline void _calculate_relu_max_(
+    const int iterations, const std::uint32_t threshold, const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
+    constexpr std::uint32_t dst_tile_size = 64; // Tile32x32 on Quasar
+    const std::uint32_t in_offset         = dst_index_in * dst_tile_size;
+    const std::uint32_t out_offset        = dst_index_out * dst_tile_size;
+
     TTI_SFPLOADI(p_sfpu::LREG2, 0 /*Float16_b*/, (threshold >> 16)); // store slope in LREG2
     TTI_SFPENCC(1, 2);                                               // enable cc
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
     {
-        _calculate_relu_max_sfp_rows_();
-        ckernel::math::_incr_counters_<0x0, 0x0, ckernel::math::SFP_ROWS, 0x0>(); // does the dest_reg++ (increments by 2 rows)
+        TT_SFPLOAD(
+            p_sfpu::LREG0, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0, in_offset + (d << 1)); // load from dest into lreg[0], uses ADDR_MOD_7 (set to all zeroes)
+
+        // If x > threshold, x = threshold
+        TTI_SFPGT(0, p_sfpu::LREG2, p_sfpu::LREG0, 0x1 /*cc mode*/);
+
+        TTI_SFPMOV(p_sfpu::LREG2 /*src*/, p_sfpu::LREG0 /*dest*/, 0); // copy threshold value into LREG0 where LREG0 > threshold
+
+        // Classic Relu: Max(x, 0)
+        TTI_SFPSETCC(0, p_sfpu::LREG0, 0); // condition - if value in LREG0 is negative
+
+        TTI_SFPLOADI(p_sfpu::LREG0, 0, 0); // Load 0 into lreg0[x]
+
+        TTI_SFPENCC(0, 0); // reset cc
+
+        // Store from lreg0 into dest register
+        TT_SFPSTORE(p_sfpu::LREG0, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0, out_offset + (d << 1));
     }
     TTI_SFPENCC(0, 2); // disable cc
 }

--- a/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_recip.h
+++ b/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_recip.h
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
+#include <cstdint>
+
 #include "ckernel_trisc_common.h"
 #include "cmath_common.h"
 
@@ -10,30 +12,27 @@ namespace ckernel
 {
 namespace sfpu
 {
-// Calculates RECIP for number of rows of output SFPU ops (Quasar = 2 rows)
 template <bool APPROXIMATION_MODE>
-inline void _calculate_reciprocal_sfp_rows_()
+inline void _calculate_reciprocal_(const int iterations, const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
-    TTI_SFPLOAD(p_sfpu::LREG0, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0, 0); // load from dest into lreg[0], uses ADDR_MOD_7 (set to all zeroes)
+    constexpr std::uint32_t dst_tile_size = 64; // Tile32x32 on Quasar
+    const std::uint32_t in_offset         = dst_index_in * dst_tile_size;
+    const std::uint32_t out_offset        = dst_index_out * dst_tile_size;
 
-    // SFPARECIP, approx version of reciprocal
-    if constexpr (APPROXIMATION_MODE)
-    {
-        TTI_SFPNONLINEAR(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpnonlinear::RECIP_MODE); // Read value from lreg[0], approximate recip, load back into lreg[1]
-    }
-
-    // Store from lreg[1] into dest register
-    TTI_SFPSTORE(p_sfpu::LREG1, 0, ADDR_MOD_7, 0, 0);
-}
-
-template <bool APPROXIMATION_MODE>
-inline void _calculate_reciprocal_(const int iterations)
-{
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
     {
-        _calculate_reciprocal_sfp_rows_<APPROXIMATION_MODE>();
-        ckernel::math::_incr_counters_<0x0, 0x0, ckernel::math::SFP_ROWS, 0x0>(); // does the dest_reg++ (increments by 2 rows)
+        TT_SFPLOAD(
+            p_sfpu::LREG0, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0, in_offset + (d << 1)); // load from dest into lreg[0], uses ADDR_MOD_7 (set to all zeroes)
+
+        // SFPARECIP, approx version of reciprocal
+        if constexpr (APPROXIMATION_MODE)
+        {
+            TTI_SFPNONLINEAR(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpnonlinear::RECIP_MODE); // Read value from lreg[0], approximate recip, load back into lreg[1]
+        }
+
+        // Store from lreg[1] into dest register
+        TT_SFPSTORE(p_sfpu::LREG1, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0, out_offset + (d << 1));
     }
 }
 

--- a/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_relu.h
+++ b/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_relu.h
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
+#include <cstdint>
+
 #include "ckernel_trisc_common.h"
 #include "cmath_common.h"
 
@@ -10,26 +12,24 @@ namespace ckernel
 {
 namespace sfpu
 {
-// Calculates RELU for number of rows of output SFPU ops (Quasar = 2 rows)
-inline void _calculate_relu_sfp_rows_()
-{
-    TTI_SFPLOAD(p_sfpu::LREG0, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0, 0); // load from dest into lreg[0], uses ADDR_MOD_7 (set to all zeroes)
-
-    // SFPARECIP with RELU_MODE does relu eltwise
-    TTI_SFPNONLINEAR(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpnonlinear::RELU_MODE); // Read value from lreg[0], get relu value, load back into lreg[1]
-
-    // Store from lreg[1] into dest register
-    TTI_SFPSTORE(p_sfpu::LREG1, 0, ADDR_MOD_7, 0, 0);
-}
-
 // Implements standard relu which does max(0, x)
-inline void _calculate_relu_(const int iterations)
+inline void _calculate_relu_(const int iterations, const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
+    constexpr std::uint32_t dst_tile_size = 64; // Tile32x32 on Quasar
+    const std::uint32_t in_offset         = dst_index_in * dst_tile_size;
+    const std::uint32_t out_offset        = dst_index_out * dst_tile_size;
+
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
     {
-        _calculate_relu_sfp_rows_();
-        ckernel::math::_incr_counters_<0x0, 0x0, ckernel::math::SFP_ROWS, 0x0>(); // does the dest_reg++ (increments by 2 rows)
+        TT_SFPLOAD(
+            p_sfpu::LREG0, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0, in_offset + (d << 1)); // load from dest into lreg[0], uses ADDR_MOD_7 (set to all zeroes)
+
+        // SFPARECIP with RELU_MODE does relu eltwise
+        TTI_SFPNONLINEAR(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpnonlinear::RELU_MODE); // Read value from lreg[0], get relu value, load back into lreg[1]
+
+        // Store from lreg[1] into dest register
+        TT_SFPSTORE(p_sfpu::LREG1, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0, out_offset + (d << 1));
     }
 }
 

--- a/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_rsqrt.h
+++ b/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_rsqrt.h
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
+#include <cstdint>
+
 #include "ckernel_ops.h"
 #include "ckernel_trisc_common.h"
 #include "cmath_common.h"
@@ -11,29 +13,25 @@ namespace ckernel
 {
 namespace sfpu
 {
-// Calculates RSQRT (reciprocal square root) for number of rows of output SFPU ops (Quasar = 2 rows)
-// Always uses approximate mode (sqrt + recip) for optimal performance
-inline void _calculate_rsqrt_sfp_rows_()
+inline void _calculate_rsqrt_(const int iterations, const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
-    TTI_SFPLOAD(p_sfpu::LREG0, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0, 0); // load from dest into lreg[0]
+    constexpr std::uint32_t dst_tile_size = 64; // Tile32x32 on Quasar
+    const std::uint32_t in_offset         = dst_index_in * dst_tile_size;
+    const std::uint32_t out_offset        = dst_index_out * dst_tile_size;
 
-    // First compute sqrt(x) into LREG1
-    TTI_SFPNONLINEAR(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpnonlinear::SQRT_MODE); // Read value from lreg[0], sqrt, load back into lreg[1]
-
-    // Then compute 1/sqrt(x) = recip(sqrt(x)) into LREG2
-    TTI_SFPNONLINEAR(p_sfpu::LREG1, p_sfpu::LREG2, p_sfpnonlinear::RECIP_MODE); // Read value from lreg[1], recip, load back into lreg[2]
-
-    // Store from lreg[2] into dest register
-    TTI_SFPSTORE(p_sfpu::LREG2, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0, 0);
-}
-
-inline void _calculate_rsqrt_(const int iterations)
-{
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
     {
-        _calculate_rsqrt_sfp_rows_();
-        ckernel::math::_incr_counters_<0x0, 0x0, ckernel::math::SFP_ROWS, 0x0>(); // does the dest_reg++ (increments by 2 rows)
+        TT_SFPLOAD(p_sfpu::LREG0, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0, in_offset + (d << 1)); // load from dest into lreg[0]
+
+        // First compute sqrt(x) into LREG1
+        TTI_SFPNONLINEAR(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpnonlinear::SQRT_MODE); // Read value from lreg[0], sqrt, load back into lreg[1]
+
+        // Then compute 1/sqrt(x) = recip(sqrt(x)) into LREG2
+        TTI_SFPNONLINEAR(p_sfpu::LREG1, p_sfpu::LREG2, p_sfpnonlinear::RECIP_MODE); // Read value from lreg[1], recip, load back into lreg[2]
+
+        // Store from lreg[2] into dest register
+        TT_SFPSTORE(p_sfpu::LREG2, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0, out_offset + (d << 1));
     }
 }
 

--- a/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_sigmoid.h
+++ b/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_sigmoid.h
@@ -27,23 +27,21 @@ inline void _calculate_sigmoid_regs_(const std::uint32_t src_reg, const std::uin
     TTI_SFPNONLINEAR(work_reg, dest_reg, p_sfpnonlinear::RECIP_MODE);      // Read value from work_reg, approximate recip, load back into dest_reg
 }
 
-// Calculates SIGMOID for number of rows of output SFPU ops (Quasar = 2 rows)
-inline void _calculate_sigmoid_sfp_rows_()
+inline void _calculate_sigmoid_(const int iterations, const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
-    TTI_SFPLOAD(p_sfpu::LREG0, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0, 0); // load from dest into lreg[0], uses ADDR_MOD_7 (set to all zeroes)
+    constexpr std::uint32_t dst_tile_size = 64; // Tile32x32 on Quasar
+    const std::uint32_t in_offset         = dst_index_in * dst_tile_size;
+    const std::uint32_t out_offset        = dst_index_out * dst_tile_size;
 
-    _calculate_sigmoid_regs_(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpu::LREG0); // calculate sigmoid using lreg[0] as src and dest, and lreg[1] as work register
-
-    TTI_SFPSTORE(p_sfpu::LREG0, 0, ADDR_MOD_7, 0, 0); // store from lreg[0] into dest register
-}
-
-inline void _calculate_sigmoid_(const int iterations)
-{
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
     {
-        _calculate_sigmoid_sfp_rows_();
-        ckernel::math::_incr_counters_<0x0, 0x0, ckernel::math::SFP_ROWS, 0x0>(); // does the dest_reg++ (increments by 2 rows)
+        TT_SFPLOAD(
+            p_sfpu::LREG0, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0, in_offset + (d << 1)); // load from dest into lreg[0], uses ADDR_MOD_7 (set to all zeroes)
+
+        _calculate_sigmoid_regs_(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpu::LREG0); // calculate sigmoid using lreg[0] as src and dest, and lreg[1] as work register
+
+        TT_SFPSTORE(p_sfpu::LREG0, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0, out_offset + (d << 1)); // store from lreg[0] into dest register
     }
 }
 

--- a/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_silu.h
+++ b/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_silu.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "ckernel_ops.h"
 #include "ckernel_sfpu_sigmoid.h"
 #include "ckernel_trisc_common.h"
@@ -13,25 +15,23 @@ namespace ckernel
 {
 namespace sfpu
 {
-// Calculates SILU for number of rows of output SFPU ops (Quasar = 2 rows)
-inline void _calculate_silu_sfp_rows_()
+inline void _calculate_silu_(const int iterations, const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
-    TTI_SFPLOAD(p_sfpu::LREG0, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0, 0); // load from dest into lreg[0], uses ADDR_MOD_7 (set to all zeroes)
+    constexpr std::uint32_t dst_tile_size = 64; // Tile32x32 on Quasar
+    const std::uint32_t in_offset         = dst_index_in * dst_tile_size;
+    const std::uint32_t out_offset        = dst_index_out * dst_tile_size;
 
-    // Calculate sigmoid using lreg[0] as src, lreg[1] as work register, and lreg[2] as dest (since we need the original value for the final multiply)
-    _calculate_sigmoid_regs_(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpu::LREG2);
-    TTI_SFPMUL(p_sfpu::LREG0, p_sfpu::LREG2, p_sfpu::LCONST_0, p_sfpu::LREG1, 0); // Multiply lreg[0] * lreg[2], store result in lreg[1]
-
-    TTI_SFPSTORE(p_sfpu::LREG1, 0, ADDR_MOD_7, 0, 0); // store from lreg[1] into dest register
-}
-
-inline void _calculate_silu_(const int iterations)
-{
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
     {
-        _calculate_silu_sfp_rows_();
-        ckernel::math::_incr_counters_<0x0, 0x0, ckernel::math::SFP_ROWS, 0x0>(); // does the dest_reg++ (increments by 2 rows)
+        TT_SFPLOAD(
+            p_sfpu::LREG0, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0, in_offset + (d << 1)); // load from dest into lreg[0], uses ADDR_MOD_7 (set to all zeroes)
+
+        // Calculate sigmoid using lreg[0] as src, lreg[1] as work register, and lreg[2] as dest (since we need the original value for the final multiply)
+        _calculate_sigmoid_regs_(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpu::LREG2);
+        TTI_SFPMUL(p_sfpu::LREG0, p_sfpu::LREG2, p_sfpu::LCONST_0, p_sfpu::LREG1, 0); // Multiply lreg[0] * lreg[2], store result in lreg[1]
+
+        TT_SFPSTORE(p_sfpu::LREG1, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0, out_offset + (d << 1)); // store from lreg[1] into dest register
     }
 }
 

--- a/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_sqrt.h
+++ b/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_sqrt.h
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
+#include <cstdint>
+
 #include "ckernel_trisc_common.h"
 #include "cmath_common.h"
 
@@ -10,30 +12,27 @@ namespace ckernel
 {
 namespace sfpu
 {
-// Calculates SQRT for number of rows of output SFPU ops (Quasar = 2 rows)
 template <bool APPROXIMATION_MODE>
-inline void _calculate_sqrt_sfp_rows_()
+inline void _calculate_sqrt_(const int iterations, const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
-    TTI_SFPLOAD(p_sfpu::LREG0, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0, 0); // load from dest into lreg[0], uses ADDR_MOD_7 (set to all zeroes)
+    constexpr std::uint32_t dst_tile_size = 64; // Tile32x32 on Quasar
+    const std::uint32_t in_offset         = dst_index_in * dst_tile_size;
+    const std::uint32_t out_offset        = dst_index_out * dst_tile_size;
 
-    // SFPARECIP, approx version of sqrt
-    if constexpr (APPROXIMATION_MODE)
-    {
-        TTI_SFPNONLINEAR(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpnonlinear::SQRT_MODE); // Read value from lreg[0], approximate sqrt, load back into lreg[1]
-    }
-
-    // Store from lreg[1] into dest register
-    TTI_SFPSTORE(p_sfpu::LREG1, 0, ADDR_MOD_7, 0, 0);
-}
-
-template <bool APPROXIMATION_MODE>
-inline void _calculate_sqrt_(const int iterations)
-{
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
     {
-        _calculate_sqrt_sfp_rows_<APPROXIMATION_MODE>();
-        ckernel::math::_incr_counters_<0x0, 0x0, ckernel::math::SFP_ROWS, 0x0>(); // does the dest_reg++ (increments by 2 rows)
+        TT_SFPLOAD(
+            p_sfpu::LREG0, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0, in_offset + (d << 1)); // load from dest into lreg[0], uses ADDR_MOD_7 (set to all zeroes)
+
+        // SFPARECIP, approx version of sqrt
+        if constexpr (APPROXIMATION_MODE)
+        {
+            TTI_SFPNONLINEAR(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpnonlinear::SQRT_MODE); // Read value from lreg[0], approximate sqrt, load back into lreg[1]
+        }
+
+        // Store from lreg[1] into dest register
+        TT_SFPSTORE(p_sfpu::LREG1, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0, out_offset + (d << 1));
     }
 }
 

--- a/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_square.h
+++ b/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_square.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "ckernel_ops.h"
 #include "ckernel_trisc_common.h"
 #include "cmath_common.h"
@@ -12,24 +14,20 @@ namespace ckernel
 {
 namespace sfpu
 {
-// Calculates SQUARE for number of rows of output SFPU ops (Quasar = 2 rows)
-template <bool APPROXIMATION_MODE>
-inline void _calculate_square_sfp_rows_()
+inline void _calculate_square_(const int iterations, const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
-    TTI_SFPLOAD(p_sfpu::LREG0, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0, 0); // load from dest into lreg[0]
-    // Multiply LREG0 * LREG0, store result in LREG0
-    TTI_SFPMUL(p_sfpu::LREG0, p_sfpu::LREG0, p_sfpu::LCONST_0, p_sfpu::LREG0, 0);
-    // Store result back to destination
-    TTI_SFPSTORE(p_sfpu::LREG0, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0, 0);
-}
+    constexpr std::uint32_t dst_tile_size = 64; // Tile32x32 on Quasar
+    const std::uint32_t in_offset         = dst_index_in * dst_tile_size;
+    const std::uint32_t out_offset        = dst_index_out * dst_tile_size;
 
-inline void _calculate_square_(const int iterations)
-{
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
     {
-        _calculate_square_sfp_rows_<false>();
-        ckernel::math::_incr_counters_<0x0, 0x0, ckernel::math::SFP_ROWS, 0x0>(); // does the dest_reg++ (increments by 2 rows)
+        TT_SFPLOAD(p_sfpu::LREG0, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0, in_offset + (d << 1)); // load from dest into lreg[0]
+        // Multiply LREG0 * LREG0, store result in LREG0
+        TTI_SFPMUL(p_sfpu::LREG0, p_sfpu::LREG0, p_sfpu::LCONST_0, p_sfpu::LREG0, 0);
+        // Store result back to destination
+        TT_SFPSTORE(p_sfpu::LREG0, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0, out_offset + (d << 1));
     }
 }
 

--- a/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_tanh.h
+++ b/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_tanh.h
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
+#include <cstdint>
+
 #include "ckernel_trisc_common.h"
 #include "cmath_common.h"
 
@@ -10,30 +12,27 @@ namespace ckernel
 {
 namespace sfpu
 {
-// Calculates RECIP for number of rows of output SFPU ops (Quasar = 2 rows)
 template <bool APPROXIMATION_MODE>
-inline void _calculate_tanh_sfp_rows_()
+inline void _calculate_tanh_(const int iterations, const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
-    TTI_SFPLOAD(p_sfpu::LREG0, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0, 0); // load from dest into lreg[0], uses ADDR_MOD_7 (set to all zeroes)
+    constexpr std::uint32_t dst_tile_size = 64; // Tile32x32 on Quasar
+    const std::uint32_t in_offset         = dst_index_in * dst_tile_size;
+    const std::uint32_t out_offset        = dst_index_out * dst_tile_size;
 
-    // SFPARECIP, approx version of reciprocal
-    if constexpr (APPROXIMATION_MODE)
-    {
-        TTI_SFPNONLINEAR(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpnonlinear::TANH_MODE); // Read value from lreg[0], approximate recip, load back into lreg[1]
-    }
-
-    // Store from lreg[1] into dest register
-    TTI_SFPSTORE(p_sfpu::LREG1, 0, ADDR_MOD_7, 0, 0);
-}
-
-template <bool APPROXIMATION_MODE>
-inline void _calculate_tanh_(const int iterations)
-{
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
     {
-        _calculate_tanh_sfp_rows_<APPROXIMATION_MODE>();
-        ckernel::math::_incr_counters_<0x0, 0x0, ckernel::math::SFP_ROWS, 0x0>(); // does the dest_reg++ (increments by 2 rows)
+        TT_SFPLOAD(
+            p_sfpu::LREG0, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0, in_offset + (d << 1)); // load from dest into lreg[0], uses ADDR_MOD_7 (set to all zeroes)
+
+        // SFPARECIP, approx version of reciprocal
+        if constexpr (APPROXIMATION_MODE)
+        {
+            TTI_SFPNONLINEAR(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpnonlinear::TANH_MODE); // Read value from lreg[0], approximate recip, load back into lreg[1]
+        }
+
+        // Store from lreg[1] into dest register
+        TT_SFPSTORE(p_sfpu::LREG1, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0, out_offset + (d << 1));
     }
 }
 

--- a/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_typecast_fp16b_uint16.h
+++ b/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_typecast_fp16b_uint16.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "ckernel_trisc_common.h"
 #include "cmath_common.h"
 
@@ -11,28 +13,27 @@ namespace ckernel
 {
 namespace sfpu
 {
-// Calculates Typecast for number of rows of output SFPU ops (Quasar = 2 rows)
-inline void _calculate_typecast_fp16b_to_uint16_rows()
+inline void _calculate_typecast_fp16b_to_uint16_(const int iterations, const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
-    TTI_SFPLOAD(p_sfpu::LREG0, p_sfpu::sfpmem::FP16B, ADDR_MOD_7, 0, 0); // load from dest into lreg[0], uses ADDR_MOD_7 (set to all zeroes)
+    constexpr std::uint32_t dst_tile_size = 64; // Tile32x32 on Quasar
+    const std::uint32_t in_offset         = dst_index_in * dst_tile_size;
+    const std::uint32_t out_offset        = dst_index_out * dst_tile_size;
 
-    TTI_SFPENCC(0, 1);                 // CC_en <= 1, CC_res <= 1 # TODO - Luka: why do we need this? Why can't we just skip this?
-    TTI_SFPSETCC(0, p_sfpu::LREG0, 0); // CC_res <= (LREG0 < 0)
-    TTI_SFPLOADI(p_sfpu::LREG0, 0, 0); // loads zeros where lreg[0] is negative
-    TTI_SFPENCC(0, 1);                 // CC_en <= 1, CC_res <= 1 (for all)
-
-    TTI_SFP_STOCH_RND(p_sfpu::sfp_stochrnd_rnd_mod::NearEven, 0, 0, p_sfpu::LREG0, p_sfpu::LREG1, (1 << 3) | ckernel::p_sfpu::sfp_stochrnd_mod::FP32_TO_UINT16);
-
-    TTI_SFPSTORE(p_sfpu::LREG1, p_sfpu::sfpmem::UINT16, ADDR_MOD_7, 0, 0); // Store from lreg[1] into dest register
-}
-
-inline void _calculate_typecast_fp16b_to_uint16_(const int iterations)
-{
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
     {
-        _calculate_typecast_fp16b_to_uint16_rows();
-        ckernel::math::_incr_counters_<0x0, 0x0, ckernel::math::SFP_ROWS, 0x0>(); // does the dest_reg++ (increments by 2 rows)
+        TT_SFPLOAD(
+            p_sfpu::LREG0, p_sfpu::sfpmem::FP16B, ADDR_MOD_7, 0, in_offset + (d << 1)); // load from dest into lreg[0], uses ADDR_MOD_7 (set to all zeroes)
+
+        TTI_SFPENCC(0, 1);                 // CC_en <= 1, CC_res <= 1 # TODO - Luka: why do we need this? Why can't we just skip this?
+        TTI_SFPSETCC(0, p_sfpu::LREG0, 0); // CC_res <= (LREG0 < 0)
+        TTI_SFPLOADI(p_sfpu::LREG0, 0, 0); // loads zeros where lreg[0] is negative
+        TTI_SFPENCC(0, 1);                 // CC_en <= 1, CC_res <= 1 (for all)
+
+        TTI_SFP_STOCH_RND(
+            p_sfpu::sfp_stochrnd_rnd_mod::NearEven, 0, 0, p_sfpu::LREG0, p_sfpu::LREG1, (1 << 3) | ckernel::p_sfpu::sfp_stochrnd_mod::FP32_TO_UINT16);
+
+        TT_SFPSTORE(p_sfpu::LREG1, p_sfpu::sfpmem::UINT16, ADDR_MOD_7, 0, out_offset + (d << 1)); // Store from lreg[1] into dest register
     }
 }
 

--- a/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_typecast_int32_fp32.h
+++ b/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_typecast_int32_fp32.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "ckernel_trisc_common.h"
 #include "cmath_common.h"
 
@@ -11,24 +13,22 @@ namespace ckernel
 {
 namespace sfpu
 {
-// Calculates Typecast for number of rows of output SFPU ops (Quasar = 2 rows)
-inline void _calculate_typecast_int32_to_fp32_rows()
+inline void _calculate_typecast_int32_to_fp32_(const int iterations, const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
-    TTI_SFPLOAD(p_sfpu::LREG0, p_sfpu::sfpmem::INT32, ADDR_MOD_7, 0, 0); // load from dest into lreg[0], uses ADDR_MOD_7 (set to all zeroes)
-    // TTI_SFPCAST(p_sfpu::LREG0, p_sfpu::LREG2, 3); //convert from 2s complement to sign+magnitude
+    constexpr std::uint32_t dst_tile_size = 64; // Tile32x32 on Quasar
+    const std::uint32_t in_offset         = dst_index_in * dst_tile_size;
+    const std::uint32_t out_offset        = dst_index_out * dst_tile_size;
 
-    TTI_SFPCAST(p_sfpu::LREG0, p_sfpu::LREG1, 0); // convert from int32 sign+mag to fp32 using rnd nearest even
-
-    TTI_SFPSTORE(p_sfpu::LREG1, p_sfpu::sfpmem::FP32, ADDR_MOD_7, 0, 0); // Store from lreg[1] into dest register
-}
-
-inline void _calculate_typecast_int32_to_fp32_(const int iterations)
-{
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
     {
-        _calculate_typecast_int32_to_fp32_rows();
-        ckernel::math::_incr_counters_<0x0, 0x0, ckernel::math::SFP_ROWS, 0x0>(); // does the dest_reg++ (increments by 2 rows)
+        TT_SFPLOAD(
+            p_sfpu::LREG0, p_sfpu::sfpmem::INT32, ADDR_MOD_7, 0, in_offset + (d << 1)); // load from dest into lreg[0], uses ADDR_MOD_7 (set to all zeroes)
+        // TTI_SFPCAST(p_sfpu::LREG0, p_sfpu::LREG2, 3); //convert from 2s complement to sign+magnitude
+
+        TTI_SFPCAST(p_sfpu::LREG0, p_sfpu::LREG1, 0); // convert from int32 sign+mag to fp32 using rnd nearest even
+
+        TT_SFPSTORE(p_sfpu::LREG1, p_sfpu::sfpmem::FP32, ADDR_MOD_7, 0, out_offset + (d << 1)); // Store from lreg[1] into dest register
     }
 }
 

--- a/tt_llk_quasar/llk_lib/llk_math_eltwise_unary_sfpu_common.h
+++ b/tt_llk_quasar/llk_lib/llk_math_eltwise_unary_sfpu_common.h
@@ -6,6 +6,7 @@
 #include <cstdint>
 
 #include "cmath_common.h"
+#include "llk_assert.h"
 #include "llk_defs.h"
 using namespace ckernel::math;
 
@@ -92,6 +93,30 @@ inline void _llk_math_eltwise_unary_sfpu_params_(F&& sfpu_func, std::uint32_t ds
     for (std::uint32_t face = 0; face < NUM_FACES; face++)
     {
         sfpu_func(static_cast<ARGS&&>(args)...);
+
+        // Move to the next face
+        _llk_math_eltwise_unary_sfpu_inc_dst_face_addr_();
+    }
+
+    _llk_math_eltwise_unary_sfpu_done_();
+}
+
+/**
+ * @brief Runs SFPU operation for a tile with separate input and output tile indices.
+ * Uses absolute addressing (base=0) and appends tile indices after the callable's
+ * normal args. The callable must accept (...args, dst_index_in, dst_index_out) as
+ * its last two parameters (with defaults of 0 for backward compatibility) and use
+ * TT_SFPLOAD/TT_SFPSTORE with tile offsets (dst_index * 64 for Tile32x32).
+ */
+template <bool APPROXIMATE, class F, class... ARGS>
+inline void _llk_math_eltwise_unary_sfpu_params_with_output_(F&& sfpu_func, std::uint32_t dst_index_in, std::uint32_t dst_index_out, ARGS&&... args)
+{
+    // Start from base 0 for absolute tile addressing
+    _llk_math_eltwise_unary_sfpu_start_(0);
+
+    for (std::uint32_t face = 0; face < NUM_FACES; face++)
+    {
+        sfpu_func(static_cast<ARGS&&>(args)..., dst_index_in, dst_index_out);
 
         // Move to the next face
         _llk_math_eltwise_unary_sfpu_inc_dst_face_addr_();

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_abs.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_abs.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "sfpi.h"
 
 namespace ckernel
@@ -12,13 +14,14 @@ namespace sfpu
 {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_abs_(const int iterations)
+inline void _calculate_abs_(const int iterations, const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
     // SFPU microcode
     for (int d = 0; d < iterations; d++)
     {
-        sfpi::vFloat v   = sfpi::dst_reg[0];
-        sfpi::dst_reg[0] = sfpi::abs(v);
+        sfpi::vFloat v                                    = sfpi::dst_reg[dst_index_in * dst_tile_size_sfpi];
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = sfpi::abs(v);
         sfpi::dst_reg++;
     }
 }

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_activations.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_activations.h
@@ -70,27 +70,29 @@ inline void apply_activation(sfpi::vFloat& v)
 }
 
 template <bool APPROXIMATION_MODE, ActivationType ACTIVATION_TYPE, int ITERATIONS = 8>
-inline void _calculate_activation_(std::uint32_t param0, std::uint32_t param1)
+inline void _calculate_activation_(std::uint32_t param0, std::uint32_t param1, const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++)
     {
-        sfpi::vFloat v = sfpi::dst_reg[0];
+        sfpi::vFloat v = sfpi::dst_reg[dst_index_in * dst_tile_size_sfpi];
         apply_activation<APPROXIMATION_MODE, ACTIVATION_TYPE>(v, param0, param1);
-        sfpi::dst_reg[0] = v;
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = v;
         sfpi::dst_reg++;
     }
 }
 
 template <bool APPROXIMATION_MODE, ActivationType ACTIVATION_TYPE, int ITERATIONS>
-inline void _calculate_activation_()
+inline void _calculate_activation_(const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++)
     {
-        sfpi::vFloat v = sfpi::dst_reg[0];
+        sfpi::vFloat v = sfpi::dst_reg[dst_index_in * dst_tile_size_sfpi];
         apply_activation<APPROXIMATION_MODE, ACTIVATION_TYPE>(v);
-        sfpi::dst_reg[0] = v;
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = v;
         sfpi::dst_reg++;
     }
 }

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_clamp.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_clamp.h
@@ -14,8 +14,15 @@ namespace sfpu
 {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_clamp_(const int iterations, std::uint32_t param0, std::uint32_t param1, std::uint32_t param2)
+inline void _calculate_clamp_(
+    const int iterations,
+    std::uint32_t param0,
+    std::uint32_t param1,
+    std::uint32_t param2,
+    const std::uint32_t dst_index_in  = 0,
+    const std::uint32_t dst_index_out = 0)
 {
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
     // All params are in FP16 format
     // param0 = min
     // param1 = max
@@ -30,7 +37,7 @@ inline void _calculate_clamp_(const int iterations, std::uint32_t param0, std::u
 #pragma GCC unroll 0
     for (int d = 0; d < iterations; d++)
     {
-        sfpi::vFloat val = sfpi::dst_reg[0];
+        sfpi::vFloat val = sfpi::dst_reg[dst_index_in * dst_tile_size_sfpi];
 
         v_if (val < min)
         {
@@ -42,7 +49,7 @@ inline void _calculate_clamp_(const int iterations, std::uint32_t param0, std::u
         }
         v_endif;
 
-        sfpi::dst_reg[0] = val + offset;
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = val + offset;
 
         sfpi::dst_reg++;
     }

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_comp.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_comp.h
@@ -31,8 +31,9 @@ sfpi_inline void _calculate_comp_init_flag_(bool check, sfpi::vFloat& flag1, sfp
 }
 
 template <bool APPROXIMATION_MODE, bool invert_output, bool check_zero, bool second_check, bool is_less_than_equal_zero, int ITERATIONS>
-inline void _calculate_comp_(const int iterations, std::uint32_t exponent_size_8)
+inline void _calculate_comp_(const int iterations, std::uint32_t exponent_size_8, const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
     // output_0 and output_1 hold the outputs use use when a zero or negative check is true/false.
     // False = 0.0 = kCONST_0 (5/8-bit exponent format)
     // True  = 1.0 = kCONST_1_FP16B (8-bit exponent format)
@@ -44,7 +45,7 @@ inline void _calculate_comp_(const int iterations, std::uint32_t exponent_size_8
 
     for (int d = ZERO; d < iterations; d++)
     {
-        sfpi::vFloat v = sfpi::dst_reg[0];
+        sfpi::vFloat v = sfpi::dst_reg[dst_index_in * dst_tile_size_sfpi];
         sfpi::vFloat flag1, flag2;
         if constexpr (check_zero)
         {
@@ -100,7 +101,7 @@ inline void _calculate_comp_(const int iterations, std::uint32_t exponent_size_8
             result = flag1;
         }
 
-        sfpi::dst_reg[0] = result;
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = result;
 
         sfpi::dst_reg++;
     }
@@ -194,13 +195,14 @@ inline void apply_zero_comp<SfpuType::less_than_equal_zero>(sfpi::vFloat& v, std
 }
 
 template <bool APPROXIMATION_MODE, SfpuType COMP_MODE, int ITERATIONS = 8>
-inline void _calculate_zero_comp_(std::uint32_t exponent_size_8)
+inline void _calculate_zero_comp_(std::uint32_t exponent_size_8, const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
     for (int d = ZERO; d < ITERATIONS; d++)
     {
-        sfpi::vFloat v = sfpi::dst_reg[0];
+        sfpi::vFloat v = sfpi::dst_reg[dst_index_in * dst_tile_size_sfpi];
         apply_zero_comp<COMP_MODE>(v, exponent_size_8);
-        sfpi::dst_reg[0] = v;
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = v;
         sfpi::dst_reg++;
     }
 }
@@ -293,13 +295,14 @@ inline void apply_zero_comp_int<SfpuType::greater_than_equal_zero>(sfpi::vInt& v
 }
 
 template <bool APPROXIMATION_MODE, SfpuType COMP_MODE, int ITERATIONS = 8>
-inline void _calculate_zero_comp_int_()
+inline void _calculate_zero_comp_int_(const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
     for (int d = ZERO; d < ITERATIONS; d++)
     {
-        sfpi::vInt v = sfpi::dst_reg[0];
+        sfpi::vInt v = sfpi::dst_reg[dst_index_in * dst_tile_size_sfpi];
         apply_zero_comp_int<COMP_MODE>(v);
-        sfpi::dst_reg[0] = v;
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = v;
         sfpi::dst_reg++;
     }
 }
@@ -528,17 +531,18 @@ inline void apply_unary_comp_int<SfpuType::unary_le>(sfpi::vInt& val, const sfpi
 }
 
 template <bool APPROXIMATION_MODE, SfpuType COMP_MODE, int ITERATIONS = 8>
-inline void _calculate_comp_unary_int_(int scalar)
+inline void _calculate_comp_unary_int_(int scalar, const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
 #pragma GCC unroll 8
     for (int d = ZERO; d < ITERATIONS; d++)
     {
-        sfpi::vInt v   = sfpi::dst_reg[0];
+        sfpi::vInt v   = sfpi::dst_reg[dst_index_in * dst_tile_size_sfpi];
         sfpi::vInt val = ZERO;
 
         apply_unary_comp_int<COMP_MODE>(val, v, scalar);
 
-        sfpi::dst_reg[0] = val;
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = val;
         sfpi::dst_reg++;
     }
 }
@@ -631,19 +635,20 @@ inline void apply_unary_comp_float<SfpuType::unary_le>(sfpi::vFloat& val, const 
 }
 
 template <bool APPROXIMATION_MODE, SfpuType COMP_MODE, int ITERATIONS = 8>
-inline void _calculate_comp_unary_(std::uint32_t value)
+inline void _calculate_comp_unary_(std::uint32_t value, const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
-    sfpi::vFloat s = value;
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
+    sfpi::vFloat s                             = value;
 
 #pragma GCC unroll 8
     for (int d = ZERO; d < ITERATIONS; d++)
     {
-        sfpi::vFloat v = sfpi::dst_reg[0];
+        sfpi::vFloat v = sfpi::dst_reg[dst_index_in * dst_tile_size_sfpi];
         sfpi::vFloat val;
 
         apply_unary_comp_float<COMP_MODE>(val, v, s);
 
-        sfpi::dst_reg[0] = val;
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = val;
         sfpi::dst_reg++;
     }
 }

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_elu.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_elu.h
@@ -14,17 +14,18 @@ namespace ckernel::sfpu
 {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_elu_(std::uint32_t slope)
+inline void _calculate_elu_(std::uint32_t slope, const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
-    const bool SCALE_EN                       = false; // Elu does not use scale.
-    const bool SKIP_POSITIVE_CHECK            = false; // Elu does not skip positive check.
-    const std::uint16_t exp_base_scale_factor = p_sfpu::kCONST_1_FP16B;
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
+    const bool SCALE_EN                        = false; // Elu does not use scale.
+    const bool SKIP_POSITIVE_CHECK             = false; // Elu does not skip positive check.
+    const std::uint16_t exp_base_scale_factor  = p_sfpu::kCONST_1_FP16B;
 
     sfpi::vFloat s = Converter::as_float(slope);
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++)
     {
-        sfpi::vFloat v = sfpi::dst_reg[0];
+        sfpi::vFloat v = sfpi::dst_reg[dst_index_in * dst_tile_size_sfpi];
 
         v_if (v < 0.0f)
         {
@@ -33,7 +34,7 @@ inline void _calculate_elu_(std::uint32_t slope)
         }
         v_endif;
 
-        sfpi::dst_reg[0] = v;
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = v;
 
         sfpi::dst_reg++;
     }

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_exp.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_exp.h
@@ -399,7 +399,8 @@ inline sfpi::vFloat _calculate_exponential_piecewise_(sfpi::vFloat in, const std
 }
 
 template <bool APPROXIMATION_MODE, bool SCALE_EN, int ITERATIONS, bool FAST_APPROX, bool SKIP_POSITIVE_CHECK, bool CLAMP_NEGATIVE = true>
-void _calculate_exponential_(const std::uint16_t exp_base_scale_factor /* 1.0f in BF16 */)
+void _calculate_exponential_(
+    const std::uint16_t exp_base_scale_factor /* 1.0f in BF16 */, const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
     if constexpr (FAST_APPROX && APPROXIMATION_MODE && CLAMP_NEGATIVE)
     {
@@ -593,12 +594,14 @@ void _calculate_exponential_(const std::uint16_t exp_base_scale_factor /* 1.0f i
 #endif
     else
     {
+        constexpr std::uint32_t dst_tile_size_sfpi = 32;
+
         // Unroll 8 best for approx, unroll 0 for precise, compiler figures this out
         for (int d = 0; d < ITERATIONS; d++)
         {
-            sfpi::vFloat val    = sfpi::dst_reg[0];
+            sfpi::vFloat val    = sfpi::dst_reg[dst_index_in * dst_tile_size_sfpi];
             sfpi::vFloat result = _calculate_exponential_piecewise_<APPROXIMATION_MODE, SCALE_EN, SKIP_POSITIVE_CHECK>(val, exp_base_scale_factor);
-            sfpi::dst_reg[0]    = result;
+            sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = result;
             sfpi::dst_reg++;
         }
     }

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_exp2.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_exp2.h
@@ -13,20 +13,21 @@ namespace ckernel::sfpu
 {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_exp2_()
+inline void _calculate_exp2_(const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
-    const bool SCALE_EN                       = false; // Exp2 does not use scale.
-    const bool SKIP_POSITIVE_CHECK            = false; // Exp2 does not skip positive check.
-    const std::uint16_t exp_base_scale_factor = p_sfpu::kCONST_1_FP16B;
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
+    const bool SCALE_EN                        = false; // Exp2 does not use scale.
+    const bool SKIP_POSITIVE_CHECK             = false; // Exp2 does not skip positive check.
+    const std::uint16_t exp_base_scale_factor  = p_sfpu::kCONST_1_FP16B;
 
     for (int d = 0; d < ITERATIONS; d++)
     {
-        sfpi::vFloat v = sfpi::dst_reg[0];
+        sfpi::vFloat v = sfpi::dst_reg[dst_index_in * dst_tile_size_sfpi];
         // log(2) = 0.6931471805;
         v = v * 0.6931471805f;
         // exp = e^(v)
         sfpi::vFloat exp = _calculate_exponential_piecewise_<APPROXIMATION_MODE, SCALE_EN, SKIP_POSITIVE_CHECK>(v, exp_base_scale_factor);
-        sfpi::dst_reg[0] = exp;
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = exp;
         sfpi::dst_reg++;
     }
 }

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_fill.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_fill.h
@@ -14,14 +14,15 @@ namespace ckernel::sfpu
 {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_fill_(const float value)
+inline void _calculate_fill_(const float value, const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
     // SFPU microcode
     sfpi::vFloat fill_val = value;
 
     for (int d = 0; d < ITERATIONS; d++)
     {
-        sfpi::dst_reg[0] = fill_val;
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = fill_val;
         sfpi::dst_reg++;
     }
 }
@@ -50,14 +51,15 @@ inline void _calculate_fill_int_(const std::uint32_t value)
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_fill_bitcast_(const std::uint32_t value_bit_mask)
+inline void _calculate_fill_bitcast_(const std::uint32_t value_bit_mask, const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
     // SFPU microcode
     sfpi::vFloat fill_val = Converter::as_float(value_bit_mask);
 
     for (int d = 0; d < ITERATIONS; d++)
     {
-        sfpi::dst_reg[0] = fill_val;
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = fill_val;
         sfpi::dst_reg++;
     }
 }

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_gelu.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_gelu.h
@@ -37,14 +37,15 @@ inline sfpi::vFloat _calculate_gelu_core_(sfpi::vFloat in)
 }
 
 template <int ITERATIONS>
-inline void _calculate_gelu_appx_()
+inline void _calculate_gelu_appx_(const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
-    sfpi::vUInt l0 = sfpi::l_reg[sfpi::LRegs::LReg0];
-    sfpi::vUInt l1 = sfpi::l_reg[sfpi::LRegs::LReg1];
-    sfpi::vUInt l2 = sfpi::l_reg[sfpi::LRegs::LReg2];
-    sfpi::vUInt l4 = sfpi::l_reg[sfpi::LRegs::LReg4];
-    sfpi::vUInt l5 = sfpi::l_reg[sfpi::LRegs::LReg5];
-    sfpi::vUInt l6 = sfpi::l_reg[sfpi::LRegs::LReg6];
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
+    sfpi::vUInt l0                             = sfpi::l_reg[sfpi::LRegs::LReg0];
+    sfpi::vUInt l1                             = sfpi::l_reg[sfpi::LRegs::LReg1];
+    sfpi::vUInt l2                             = sfpi::l_reg[sfpi::LRegs::LReg2];
+    sfpi::vUInt l4                             = sfpi::l_reg[sfpi::LRegs::LReg4];
+    sfpi::vUInt l5                             = sfpi::l_reg[sfpi::LRegs::LReg5];
+    sfpi::vUInt l6                             = sfpi::l_reg[sfpi::LRegs::LReg6];
 
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++)
@@ -58,13 +59,13 @@ inline void _calculate_gelu_appx_()
 
         // sfpi::dst_reg[0] = result;
 
-        sfpi::vFloat in      = sfpi::dst_reg[0];
+        sfpi::vFloat in      = sfpi::dst_reg[dst_index_in * dst_tile_size_sfpi];
         sfpi::vFloat half    = sfpi::vConstFloatPrgm0;
         sfpi::vFloat half_in = in * half;
         sfpi::vFloat result  = lut2_sign(in, l0, l1, l2, l4, l5, l6);
         result               = half_in + result;
 
-        sfpi::dst_reg[0] = result;
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = result;
 
         sfpi::dst_reg++;
 
@@ -85,35 +86,37 @@ inline void _calculate_gelu_appx_()
 }
 
 template <int ITERATIONS>
-inline void _calculate_gelu_accurate_()
+inline void _calculate_gelu_accurate_(const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
-    constexpr bool scaled = true;
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
+    constexpr bool scaled                      = true;
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++)
     {
-        sfpi::vFloat in     = sfpi::dst_reg[0];
-        sfpi::vFloat result = _calculate_cdf_appx_(in, scaled);
-        sfpi::dst_reg[0]    = result;
+        sfpi::vFloat in                                   = sfpi::dst_reg[dst_index_in * dst_tile_size_sfpi];
+        sfpi::vFloat result                               = _calculate_cdf_appx_(in, scaled);
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = result;
         sfpi::dst_reg++;
     }
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_gelu_()
+inline void _calculate_gelu_(const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
     if constexpr (APPROXIMATION_MODE)
     {
-        _calculate_gelu_appx_<ITERATIONS>();
+        _calculate_gelu_appx_<ITERATIONS>(dst_index_in, dst_index_out);
     }
     else
     {
-        _calculate_gelu_accurate_<ITERATIONS>();
+        _calculate_gelu_accurate_<ITERATIONS>(dst_index_in, dst_index_out);
     }
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_gelu_derivative_()
+inline void _calculate_gelu_derivative_(const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
     if constexpr (APPROXIMATION_MODE)
     {
         constexpr int lut_mode = 1; // SFPLUTFP32_MOD0_FP16_6ENTRY_TABLE1
@@ -129,14 +132,14 @@ inline void _calculate_gelu_derivative_()
 #pragma GCC unroll 0
         for (int d = 0; d < ITERATIONS; d++)
         {
-            sfpi::vFloat val = sfpi::dst_reg[0];
+            sfpi::vFloat val = sfpi::dst_reg[dst_index_in * dst_tile_size_sfpi];
             val              = lut2(val, l0, l1, l2, l4, l5, l6, lut_mode);
             v_if (val < 0.0F)
             {
                 val = val + 1.0f;
             }
             v_endif;
-            sfpi::dst_reg[0] = val;
+            sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = val;
             sfpi::dst_reg++;
         }
 
@@ -158,7 +161,7 @@ inline void _calculate_gelu_derivative_()
 #pragma GCC unroll 0
         for (int d = 0; d < ITERATIONS; d++)
         {
-            sfpi::vFloat in             = sfpi::dst_reg[0];
+            sfpi::vFloat in             = sfpi::dst_reg[dst_index_in * dst_tile_size_sfpi];
             sfpi::vFloat neg_half_sq_in = in * in * -0.5f;
 
             // exp = e^(val)
@@ -171,7 +174,7 @@ inline void _calculate_gelu_derivative_()
 
             result = lut(result, l0, l1, imm2);
 
-            sfpi::dst_reg[0] = partial + result + 0.5f;
+            sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = partial + result + 0.5f;
             sfpi::dst_reg++;
         }
 

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_hardtanh.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_hardtanh.h
@@ -14,8 +14,15 @@ namespace sfpu
 {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_hardtanh_(const int iterations, std::uint32_t param0, std::uint32_t param1, std::uint32_t param2)
+inline void _calculate_hardtanh_(
+    const int iterations,
+    std::uint32_t param0,
+    std::uint32_t param1,
+    std::uint32_t param2,
+    const std::uint32_t dst_index_in  = 0,
+    const std::uint32_t dst_index_out = 0)
 {
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
     // All params are in FP16_B format
     // param0 = -(neg_threshold)
     // param1 = -(pos_threshold - neg_threshold)
@@ -28,7 +35,7 @@ inline void _calculate_hardtanh_(const int iterations, std::uint32_t param0, std
 #pragma GCC unroll 0
     for (int d = 0; d < iterations; d++)
     {
-        sfpi::vFloat val = sfpi::dst_reg[0];
+        sfpi::vFloat val = sfpi::dst_reg[dst_index_in * dst_tile_size_sfpi];
 
         val += p0; // 12 bits
         v_if (val < 0.0f)
@@ -46,7 +53,7 @@ inline void _calculate_hardtanh_(const int iterations, std::uint32_t param0, std
 
         val += p2; // 12 bits
 
-        sfpi::dst_reg[0] = val;
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = val;
 
         sfpi::dst_reg++;
     }

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_isinf_isnan.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_isinf_isnan.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "ckernel.h"
 #include "ckernel_defs.h"
 #include "sfpi.h"
@@ -118,32 +120,33 @@ inline sfpi::vFloat _calculate_isfinite_(const sfpi::vFloat& v)
 }
 
 template <SfpuType operation, bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_sfpu_isinf_isnan_()
+inline void _calculate_sfpu_isinf_isnan_(const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++)
     {
-        sfpi::vFloat in = sfpi::dst_reg[0];
+        sfpi::vFloat in = sfpi::dst_reg[dst_index_in * dst_tile_size_sfpi];
 
         if constexpr (operation == SfpuType::isinf)
         {
-            sfpi::dst_reg[0] = _calculate_isinf_<APPROXIMATION_MODE>(in);
+            sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = _calculate_isinf_<APPROXIMATION_MODE>(in);
         }
         else if constexpr (operation == SfpuType::isposinf)
         {
-            sfpi::dst_reg[0] = _calculate_isposinf_<APPROXIMATION_MODE>(in);
+            sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = _calculate_isposinf_<APPROXIMATION_MODE>(in);
         }
         else if constexpr (operation == SfpuType::isneginf)
         {
-            sfpi::dst_reg[0] = _calculate_isneginf_<APPROXIMATION_MODE>(in);
+            sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = _calculate_isneginf_<APPROXIMATION_MODE>(in);
         }
         else if constexpr (operation == SfpuType::isnan)
         {
-            sfpi::dst_reg[0] = _calculate_isnan_<APPROXIMATION_MODE>(in);
+            sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = _calculate_isnan_<APPROXIMATION_MODE>(in);
         }
         else if constexpr (operation == SfpuType::isfinite)
         {
-            sfpi::dst_reg[0] = _calculate_isfinite_<APPROXIMATION_MODE>(in);
+            sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = _calculate_isfinite_<APPROXIMATION_MODE>(in);
         }
 
         sfpi::dst_reg++;

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_log.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_log.h
@@ -14,7 +14,7 @@ namespace sfpu
 {
 
 template <bool HAS_BASE_SCALING>
-sfpi_inline void _calculate_log_body_(const std::uint32_t log_base_scale_factor, const std::uint32_t dst_idx = 0)
+sfpi_inline void _calculate_log_body_(const std::uint32_t log_base_scale_factor, const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
     // size of each tile in Dest is 64/SFP_DESTREG_STRIDE = 32 rows when using sfpi to load/store
     constexpr std::uint32_t dst_tile_size_sfpi = 32;
@@ -22,7 +22,7 @@ sfpi_inline void _calculate_log_body_(const std::uint32_t log_base_scale_factor,
     ////////////////////////////
     // Load From dest + "normalize to calculation range"
     ////////////////////////////
-    sfpi::vFloat in = sfpi::dst_reg[dst_idx * dst_tile_size_sfpi];
+    sfpi::vFloat in = sfpi::dst_reg[dst_index_in * dst_tile_size_sfpi];
     sfpi::vFloat x  = setexp(in, 127); // set exp to exp bias (put in range of 1-2)
 
     // XXXXXX ask Namal? if we can derive the coefficients below to higher precision
@@ -71,7 +71,7 @@ sfpi_inline void _calculate_log_body_(const std::uint32_t log_base_scale_factor,
     }
     v_endif;
 
-    sfpi::dst_reg[dst_idx * dst_tile_size_sfpi] = result;
+    sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = result;
 }
 
 sfpi_inline sfpi::vFloat _calculate_log_body_no_init_(sfpi::vFloat base)
@@ -106,12 +106,13 @@ sfpi_inline sfpi::vFloat _calculate_log_body_no_init_(sfpi::vFloat base)
 }
 
 template <bool APPROXIMATION_MODE, bool HAS_BASE_SCALING, int ITERATIONS>
-inline void _calculate_log_(const int iterations, std::uint32_t log_base_scale_factor)
+inline void _calculate_log_(
+    const int iterations, std::uint32_t log_base_scale_factor, const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
     {
-        _calculate_log_body_<HAS_BASE_SCALING>(log_base_scale_factor);
+        _calculate_log_body_<HAS_BASE_SCALING>(log_base_scale_factor, dst_index_in, dst_index_out);
         sfpi::dst_reg++;
     }
 }

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_negative.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_negative.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "sfpi.h"
 
 namespace ckernel
@@ -12,27 +14,29 @@ namespace sfpu
 {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_negative_()
+inline void _calculate_negative_(const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++)
     {
-        sfpi::vFloat val = sfpi::dst_reg[0];
-        sfpi::dst_reg[0] = -val;
+        sfpi::vFloat val                                  = sfpi::dst_reg[dst_index_in * dst_tile_size_sfpi];
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = -val;
         sfpi::dst_reg++;
     }
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_negative_int_()
+inline void _calculate_negative_int_(const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++)
     {
-        sfpi::vInt val = sfpi::dst_reg[0];
+        sfpi::vInt val = sfpi::dst_reg[dst_index_in * dst_tile_size_sfpi];
         v_if (val != 0)
         {
-            sfpi::dst_reg[0] = sfpi::reinterpret<sfpi::vInt>(-sfpi::reinterpret<sfpi::vFloat>(val));
+            sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = sfpi::reinterpret<sfpi::vInt>(-sfpi::reinterpret<sfpi::vFloat>(val));
         }
         v_endif;
         sfpi::dst_reg++;

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_recip.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_recip.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "ckernel_sfpu_rsqrt_compat.h"
 #include "sfpi.h"
 
@@ -76,27 +78,28 @@ sfpi_inline sfpi::vFloat _sfpu_reciprocal_(const sfpi::vFloat in)
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS, bool is_fp32_dest_acc_en>
-inline void _calculate_reciprocal_internal_(const int iterations)
+inline void _calculate_reciprocal_internal_(const int iterations, const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
     {
-        sfpi::vFloat in = sfpi::dst_reg[0];
+        sfpi::vFloat in = sfpi::dst_reg[dst_index_in * dst_tile_size_sfpi];
 
         if constexpr (APPROXIMATION_MODE)
         {
-            sfpi::dst_reg[0] = _sfpu_reciprocal_<0>(in);
+            sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = _sfpu_reciprocal_<0>(in);
         }
         else
         {
             if constexpr (is_fp32_dest_acc_en)
             {
-                sfpi::dst_reg[0] = _sfpu_reciprocal_<2>(in);
+                sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = _sfpu_reciprocal_<2>(in);
             }
             else
             {
-                sfpi::vFloat out = _sfpu_reciprocal_<1>(in);
-                sfpi::dst_reg[0] = sfpi::reinterpret<sfpi::vFloat>(float_to_fp16b(out, 0));
+                sfpi::vFloat out                                  = _sfpu_reciprocal_<1>(in);
+                sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = sfpi::reinterpret<sfpi::vFloat>(float_to_fp16b(out, 0));
             }
         }
 
@@ -105,7 +108,7 @@ inline void _calculate_reciprocal_internal_(const int iterations)
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS, bool is_fp32_dest_acc_en, bool legacy_compat = false>
-inline void _calculate_reciprocal_(const int iterations)
+inline void _calculate_reciprocal_(const int iterations, const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
     if constexpr (legacy_compat)
     {
@@ -113,7 +116,7 @@ inline void _calculate_reciprocal_(const int iterations)
     }
     else
     {
-        _calculate_reciprocal_internal_<APPROXIMATION_MODE, ITERATIONS, is_fp32_dest_acc_en>(iterations);
+        _calculate_reciprocal_internal_<APPROXIMATION_MODE, ITERATIONS, is_fp32_dest_acc_en>(iterations, dst_index_in, dst_index_out);
     }
 }
 

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_relu.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_relu.h
@@ -52,11 +52,12 @@ sfpi_inline sfpi::vFloat _relu_max_body_(sfpi::vFloat val, sfpi::vFloat threshol
 }
 
 template <typename VecType, bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _relu_max_impl_(const int iterations, VecType threshold)
+inline void _relu_max_impl_(const int iterations, VecType threshold, const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
     for (int d = 0; d < iterations; d++)
     {
-        VecType result = sfpi::dst_reg[0];
+        VecType result = sfpi::dst_reg[dst_index_in * dst_tile_size_sfpi];
         v_if (result > threshold)
         {
             result = threshold;
@@ -67,7 +68,7 @@ inline void _relu_max_impl_(const int iterations, VecType threshold)
             result = 0;
         }
         v_endif;
-        sfpi::dst_reg[0] = result;
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = result;
         sfpi::dst_reg++;
     }
 }

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_rounding_ops.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_rounding_ops.h
@@ -7,6 +7,7 @@
 
 #include <array>
 #include <climits>
+#include <cstdint>
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
@@ -147,8 +148,10 @@ inline sfpi::vFloat _round_even_(sfpi::vFloat v)
 }
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
-void _calculate_round_(const int decimals)
+void _calculate_round_(const int decimals, const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
+
     const auto exp10i = [](int n)
     {
         if (n > 38) // 38 is max decimal places float32 can store for positive values
@@ -169,9 +172,9 @@ void _calculate_round_(const int decimals)
 
     for (int d = 0; d < ITERATIONS; ++d)
     {
-        sfpi::vFloat v      = sfpi::dst_reg[0];
-        sfpi::vFloat result = inverse * _round_even_(v * coeff);
-        sfpi::dst_reg[0]    = result;
+        sfpi::vFloat v                                    = sfpi::dst_reg[dst_index_in * dst_tile_size_sfpi];
+        sfpi::vFloat result                               = inverse * _round_even_(v * coeff);
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = result;
         sfpi::dst_reg++;
     }
 }

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_rsqrt.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_rsqrt.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "ckernel_sfpu_rsqrt_compat.h"
 #include "ckernel_sfpu_sqrt.h"
 #include "sfpi.h"
@@ -14,7 +16,7 @@ namespace sfpu
 {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS, bool fp32_dest_acc_en, bool FAST_APPROX, bool legacy_compat = false>
-inline void _calculate_rsqrt_(int iterations)
+inline void _calculate_rsqrt_(int iterations, const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
     if constexpr (legacy_compat)
     {
@@ -22,7 +24,7 @@ inline void _calculate_rsqrt_(int iterations)
     }
     else
     {
-        return _calculate_sqrt_internal_<APPROXIMATION_MODE, ITERATIONS, fp32_dest_acc_en, true, FAST_APPROX>(iterations);
+        return _calculate_sqrt_internal_<APPROXIMATION_MODE, ITERATIONS, fp32_dest_acc_en, true, FAST_APPROX>(iterations, dst_index_in, dst_index_out);
     }
 }
 

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_rsqrt_compat.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_rsqrt_compat.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "sfpi.h"
 
 namespace ckernel
@@ -97,13 +99,52 @@ sfpi_inline sfpi::vFloat _reciprocal_compat_(const sfpi::vFloat in)
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS, bool fp32_dest_acc_en>
-inline void _calculate_rsqrt_compat_(const int iterations)
+inline void _calculate_rsqrt_compat_(const int iterations, const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
     {
-        sfpi::dst_reg[0] = _sqrt_compat_<APPROXIMATION_MODE, 2>(sfpi::dst_reg[0]);
-        sfpi::vFloat in  = sfpi::dst_reg[0];
+        sfpi::dst_reg[dst_index_in * dst_tile_size_sfpi] = _sqrt_compat_<APPROXIMATION_MODE, 2>(sfpi::dst_reg[dst_index_in * dst_tile_size_sfpi]);
+        sfpi::vFloat in                                  = sfpi::dst_reg[dst_index_in * dst_tile_size_sfpi];
+        sfpi::vFloat out                                 = _reciprocal_compat_<APPROXIMATION_MODE ? 2 : 3>(in);
+        v_if (in < 0.0)
+        {
+            out = -out;
+        }
+        v_endif;
+        if constexpr (fp32_dest_acc_en || APPROXIMATION_MODE)
+        {
+            sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = out;
+        }
+        else
+        {
+            sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = sfpi::reinterpret<sfpi::vFloat>(float_to_fp16b(out, 0));
+        }
+        sfpi::dst_reg++;
+    }
+}
+
+template <bool APPROXIMATION_MODE, int ITERATIONS, bool fp32_dest_acc_en>
+inline void _calculate_sqrt_compat_(const int iterations, const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
+{
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
+#pragma GCC unroll 8
+    for (int d = 0; d < iterations; d++)
+    {
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = _sqrt_compat_<APPROXIMATION_MODE, 2>(sfpi::dst_reg[dst_index_in * dst_tile_size_sfpi]);
+        sfpi::dst_reg++;
+    }
+}
+
+template <bool APPROXIMATION_MODE, int ITERATIONS, bool fp32_dest_acc_en>
+inline void _calculate_reciprocal_compat_(const int iterations, const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
+{
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
+#pragma GCC unroll 8
+    for (int d = 0; d < iterations; d++)
+    {
+        sfpi::vFloat in  = sfpi::dst_reg[dst_index_in * dst_tile_size_sfpi];
         sfpi::vFloat out = _reciprocal_compat_<APPROXIMATION_MODE ? 2 : 3>(in);
         v_if (in < 0.0)
         {
@@ -112,47 +153,11 @@ inline void _calculate_rsqrt_compat_(const int iterations)
         v_endif;
         if constexpr (fp32_dest_acc_en || APPROXIMATION_MODE)
         {
-            sfpi::dst_reg[0] = out;
+            sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = out;
         }
         else
         {
-            sfpi::dst_reg[0] = sfpi::reinterpret<sfpi::vFloat>(float_to_fp16b(out, 0));
-        }
-        sfpi::dst_reg++;
-    }
-}
-
-template <bool APPROXIMATION_MODE, int ITERATIONS, bool fp32_dest_acc_en>
-inline void _calculate_sqrt_compat_(const int iterations)
-{
-#pragma GCC unroll 8
-    for (int d = 0; d < iterations; d++)
-    {
-        sfpi::dst_reg[0] = _sqrt_compat_<APPROXIMATION_MODE, 2>(sfpi::dst_reg[0]);
-        sfpi::dst_reg++;
-    }
-}
-
-template <bool APPROXIMATION_MODE, int ITERATIONS, bool fp32_dest_acc_en>
-inline void _calculate_reciprocal_compat_(const int iterations)
-{
-#pragma GCC unroll 8
-    for (int d = 0; d < iterations; d++)
-    {
-        sfpi::vFloat in  = sfpi::dst_reg[0];
-        sfpi::vFloat out = _reciprocal_compat_<APPROXIMATION_MODE ? 2 : 3>(in);
-        v_if (in < 0.0)
-        {
-            out = -out;
-        }
-        v_endif;
-        if constexpr (fp32_dest_acc_en || APPROXIMATION_MODE)
-        {
-            sfpi::dst_reg[0] = out;
-        }
-        else
-        {
-            sfpi::dst_reg[0] = sfpi::reinterpret<sfpi::vFloat>(float_to_fp16b(out, 0));
+            sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = sfpi::reinterpret<sfpi::vFloat>(float_to_fp16b(out, 0));
         }
         sfpi::dst_reg++;
     }

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_sigmoid.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_sigmoid.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "ckernel_sfpu_load_config.h"
 #include "sfpi.h"
 
@@ -13,22 +15,23 @@ namespace sfpu
 {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_sigmoid_(const int iterations)
+inline void _calculate_sigmoid_(const int iterations, const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
-    constexpr int lut_mode = 0; // SFPLUTFP32_MOD0_FP16_6ENTRY_TABLE1
-    sfpi::vUInt l0         = sfpi::l_reg[sfpi::LRegs::LReg0];
-    sfpi::vUInt l1         = sfpi::l_reg[sfpi::LRegs::LReg1];
-    sfpi::vUInt l2         = sfpi::l_reg[sfpi::LRegs::LReg2];
-    sfpi::vUInt l4         = sfpi::l_reg[sfpi::LRegs::LReg4];
-    sfpi::vUInt l5         = sfpi::l_reg[sfpi::LRegs::LReg5];
-    sfpi::vUInt l6         = sfpi::l_reg[sfpi::LRegs::LReg6];
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
+    constexpr int lut_mode                     = 0; // SFPLUTFP32_MOD0_FP16_6ENTRY_TABLE1
+    sfpi::vUInt l0                             = sfpi::l_reg[sfpi::LRegs::LReg0];
+    sfpi::vUInt l1                             = sfpi::l_reg[sfpi::LRegs::LReg1];
+    sfpi::vUInt l2                             = sfpi::l_reg[sfpi::LRegs::LReg2];
+    sfpi::vUInt l4                             = sfpi::l_reg[sfpi::LRegs::LReg4];
+    sfpi::vUInt l5                             = sfpi::l_reg[sfpi::LRegs::LReg5];
+    sfpi::vUInt l6                             = sfpi::l_reg[sfpi::LRegs::LReg6];
 
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
     {
-        sfpi::vFloat val = sfpi::dst_reg[0];
+        sfpi::vFloat val = sfpi::dst_reg[dst_index_in * dst_tile_size_sfpi];
 
-        sfpi::dst_reg[0] = lut2(val, l0, l1, l2, l4, l5, l6, lut_mode) + 0.5f;
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = lut2(val, l0, l1, l2, l4, l5, l6, lut_mode) + 0.5f;
 
         sfpi::dst_reg++;
     }

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_sign.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_sign.h
@@ -15,18 +15,19 @@ namespace sfpu
 {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_sign_(const int iterations, std::uint32_t exponent_size_8)
+inline void _calculate_sign_(const int iterations, std::uint32_t exponent_size_8, const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
 // All params are in FP16 format
 // uint format = 1;
 #pragma GCC unroll 0
     for (int d = 0; d < iterations; d++)
     {
-        sfpi::vFloat v   = sfpi::dst_reg[0];
-        sfpi::dst_reg[0] = sfpi::vConst1;
+        sfpi::vFloat v                                    = sfpi::dst_reg[dst_index_in * dst_tile_size_sfpi];
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = sfpi::vConst1;
         v_if (v < 0.0F)
         {
-            sfpi::dst_reg[0] = sfpi::vConstNeg1;
+            sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = sfpi::vConstNeg1;
         }
         v_endif;
 
@@ -34,7 +35,7 @@ inline void _calculate_sign_(const int iterations, std::uint32_t exponent_size_8
         // param0 != 0 is Float16 format and exp bias needs to be removed for zero check.
         v_if (_sfpu_is_fp16_zero_(v, exponent_size_8))
         {
-            sfpi::dst_reg[0] = sfpi::vConst0;
+            sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = sfpi::vConst0;
         }
         v_endif;
 

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_silu.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_silu.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "ckernel_sfpu_polyval.h"
 #include "sfpi.h"
 
@@ -26,12 +28,13 @@ inline sfpi::vFloat _sigmoid_piecewise_linear_positive_(sfpi::vFloat val)
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_silu_()
+inline void _calculate_silu_(const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++)
     {
-        sfpi::vFloat val    = sfpi::dst_reg[0];
+        sfpi::vFloat val    = sfpi::dst_reg[dst_index_in * dst_tile_size_sfpi];
         sfpi::vFloat result = sfpi::abs(val);
         result              = _sigmoid_piecewise_linear_positive_(result);
         v_if (val < 0.0f)
@@ -39,7 +42,7 @@ inline void _calculate_silu_()
             result = 1.0f - result;
         }
         v_endif;
-        sfpi::dst_reg[0] = val * result;
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = val * result;
         sfpi::dst_reg++;
     }
 }

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_sqrt.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_sqrt.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "ckernel_sfpu_rsqrt_compat.h"
 #include "sfpi.h"
 
@@ -113,26 +115,27 @@ sfpi_inline sfpi::vFloat _calculate_sqrt_body_(const sfpi::vFloat x)
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS, bool fp32_dest_acc_en, bool RECIPROCAL, bool FAST_APPROX>
-inline void _calculate_sqrt_internal_(const int iterations)
+inline void _calculate_sqrt_internal_(const int iterations, const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
     {
-        sfpi::vFloat tmp = _calculate_sqrt_body_<APPROXIMATION_MODE, RECIPROCAL, FAST_APPROX>(sfpi::dst_reg[0]);
+        sfpi::vFloat tmp = _calculate_sqrt_body_<APPROXIMATION_MODE, RECIPROCAL, FAST_APPROX>(sfpi::dst_reg[dst_index_in * dst_tile_size_sfpi]);
         if constexpr (fp32_dest_acc_en)
         {
-            sfpi::dst_reg[0] = tmp;
+            sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = tmp;
         }
         else
         {
-            sfpi::dst_reg[0] = sfpi::reinterpret<sfpi::vFloat>(float_to_fp16b(tmp, 0));
+            sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = sfpi::reinterpret<sfpi::vFloat>(float_to_fp16b(tmp, 0));
         }
         sfpi::dst_reg++;
     }
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS, bool fp32_dest_acc_en, bool FAST_APPROX, bool legacy_compat = false>
-inline void _calculate_sqrt_(int iterations)
+inline void _calculate_sqrt_(int iterations, const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
     if constexpr (legacy_compat)
     {
@@ -140,7 +143,7 @@ inline void _calculate_sqrt_(int iterations)
     }
     else
     {
-        return _calculate_sqrt_internal_<APPROXIMATION_MODE, ITERATIONS, fp32_dest_acc_en, false, FAST_APPROX>(iterations);
+        return _calculate_sqrt_internal_<APPROXIMATION_MODE, ITERATIONS, fp32_dest_acc_en, false, FAST_APPROX>(iterations, dst_index_in, dst_index_out);
     }
 }
 

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_tanh.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_tanh.h
@@ -15,8 +15,9 @@ namespace sfpu
 {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_tanh_(const int iterations)
+inline void _calculate_tanh_(const int iterations, const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
     // SFPU microcode
     sfpi::vUInt l0 = sfpi::l_reg[sfpi::LRegs::LReg0];
     sfpi::vUInt l1 = sfpi::l_reg[sfpi::LRegs::LReg1];
@@ -25,9 +26,9 @@ inline void _calculate_tanh_(const int iterations)
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
     {
-        sfpi::vFloat val = sfpi::dst_reg[0];
-        val              = lut(val, l0, l1, l2);
-        sfpi::dst_reg[0] = val;
+        sfpi::vFloat val                                  = sfpi::dst_reg[dst_index_in * dst_tile_size_sfpi];
+        val                                               = lut(val, l0, l1, l2);
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = val;
 
         sfpi::dst_reg++;
     }

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_tanh_derivative.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_tanh_derivative.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "sfpi.h"
 
 namespace ckernel
@@ -12,24 +14,25 @@ namespace sfpu
 {
 
 template <bool APPROXIMATION_MODE, int WITH_PRECOMPUTED_TANH, int ITERATIONS>
-inline void _calculate_tanh_derivative_(const int iterations)
+inline void _calculate_tanh_derivative_(const int iterations, const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
-    sfpi::vUInt l0 = sfpi::l_reg[sfpi::LRegs::LReg0];
-    sfpi::vUInt l1 = sfpi::l_reg[sfpi::LRegs::LReg1];
-    sfpi::vUInt l2 = sfpi::l_reg[sfpi::LRegs::LReg2];
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
+    sfpi::vUInt l0                             = sfpi::l_reg[sfpi::LRegs::LReg0];
+    sfpi::vUInt l1                             = sfpi::l_reg[sfpi::LRegs::LReg1];
+    sfpi::vUInt l2                             = sfpi::l_reg[sfpi::LRegs::LReg2];
 
     // tanh'(x) = 1 - (tanh(x))^2
     for (int d = 0; d < iterations; d++)
     {
-        sfpi::vFloat val = sfpi::dst_reg[0];
+        sfpi::vFloat val = sfpi::dst_reg[dst_index_in * dst_tile_size_sfpi];
 
         if constexpr (!WITH_PRECOMPUTED_TANH)
         {
             val = lut(val, l0, l1, l2);
         }
 
-        val              = val * (-val) + sfpi::vConst1;
-        sfpi::dst_reg[0] = val;
+        val                                               = val * (-val) + sfpi::vConst1;
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = val;
 
         sfpi::dst_reg++;
     }

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_threshold.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_threshold.h
@@ -18,8 +18,9 @@ template <typename T>
 constexpr bool is_supported_threshold_type_v = std::is_same_v<T, float> || std::is_same_v<T, std::uint32_t>;
 
 template <bool APPROXIMATION_MODE, int ITERATIONS, typename T>
-inline void _calculate_threshold_(T threshold, T value)
+inline void _calculate_threshold_(T threshold, T value, const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
     static_assert(is_supported_threshold_type_v<T>, "Type T must be either float or uint32_t");
 
     sfpi::vFloat v_threshold;
@@ -37,10 +38,10 @@ inline void _calculate_threshold_(T threshold, T value)
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++)
     {
-        sfpi::vFloat in = sfpi::dst_reg[0];
+        sfpi::vFloat in = sfpi::dst_reg[dst_index_in * dst_tile_size_sfpi];
         v_if (in <= v_threshold)
         {
-            sfpi::dst_reg[0] = v_value;
+            sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = v_value;
         }
         v_endif;
 

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_trigonometry.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_trigonometry.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <limits>
 
 #include "ckernel_sfpu_log.h"
@@ -80,12 +81,14 @@ sfpi_inline sfpi::vFloat _sfpu_cosine_maclaurin_series_(sfpi::vFloat val)
 // Legacy implementation.
 // Candidate for removal in future versions. See https://github.com/tenstorrent/tt-llk/issues/225 for more details.
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_sine_(const int iterations)
+inline void _calculate_sine_(const int iterations, const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
+
     // SFPU microcode
     for (int d = 0; d < iterations; d++)
     {
-        sfpi::vFloat v             = sfpi::dst_reg[0];
+        sfpi::vFloat v             = sfpi::dst_reg[dst_index_in * dst_tile_size_sfpi];
         v                          = 0.318309886183791f * v; // *1/pi to get number of pi rads.
         sfpi::vInt whole_v         = float_to_int16(v, 0);
         sfpi::vFloat whole_v_float = int32_to_float(whole_v, 0);
@@ -99,7 +102,7 @@ inline void _calculate_sine_(const int iterations)
             v *= -1;
         }
         v_endif;
-        sfpi::dst_reg[0] = v;
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = v;
         sfpi::dst_reg++;
     }
 }
@@ -107,12 +110,14 @@ inline void _calculate_sine_(const int iterations)
 // Legacy implementation.
 // Candidate for removal in future versions. See https://github.com/tenstorrent/tt-llk/issues/225 for more details.
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_cosine_(const int iterations)
+inline void _calculate_cosine_(const int iterations, const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
+
     // SFPU microcode
     for (int d = 0; d < iterations; d++)
     {
-        sfpi::vFloat v             = sfpi::dst_reg[0];
+        sfpi::vFloat v             = sfpi::dst_reg[dst_index_in * dst_tile_size_sfpi];
         v                          = 0.318309886183791f * v; // *1/pi to get number of pi rads.
         sfpi::vInt whole_v         = float_to_int16(v, 0);
         sfpi::vFloat whole_v_float = int32_to_float(whole_v, 0);
@@ -126,7 +131,7 @@ inline void _calculate_cosine_(const int iterations)
             v *= -1;
         }
         v_endif;
-        sfpi::dst_reg[0] = v;
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = v;
         sfpi::dst_reg++;
     }
 }
@@ -134,27 +139,29 @@ inline void _calculate_cosine_(const int iterations)
 // https://en.wikipedia.org/wiki/Inverse_hyperbolic_functions#Definitions_in_terms_of_logarithms
 // acosh(x) = log(x + sqrt(x^2 - 1))
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_acosh_()
+inline void _calculate_acosh_(const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
+
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++)
     {
-        sfpi::vFloat inp = sfpi::dst_reg[0];
+        sfpi::vFloat inp = sfpi::dst_reg[dst_index_in * dst_tile_size_sfpi];
         v_if (inp < sfpi::vConst1)
         {
-            sfpi::dst_reg[0] = std::numeric_limits<float>::quiet_NaN();
+            sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = std::numeric_limits<float>::quiet_NaN();
         }
         v_elseif (inp == sfpi::vConst1)
         {
-            sfpi::dst_reg[0] = sfpi::vConst0;
+            sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = sfpi::vConst0;
         }
         v_else
         {
-            sfpi::vFloat tmp = inp * inp;
-            tmp              = tmp - sfpi::vConst1;
-            tmp              = _calculate_sqrt_body_<APPROXIMATION_MODE>(tmp);
-            tmp              = tmp + inp;
-            sfpi::dst_reg[0] = _calculate_log_body_no_init_(tmp);
+            sfpi::vFloat tmp                                  = inp * inp;
+            tmp                                               = tmp - sfpi::vConst1;
+            tmp                                               = _calculate_sqrt_body_<APPROXIMATION_MODE>(tmp);
+            tmp                                               = tmp + inp;
+            sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = _calculate_log_body_no_init_(tmp);
         }
         v_endif;
         sfpi::dst_reg++;
@@ -163,19 +170,21 @@ inline void _calculate_acosh_()
 
 // asinh(x) = log(x + sqrt(x^2 + 1))
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_asinh_()
+inline void _calculate_asinh_(const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
+
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++)
     {
-        sfpi::vFloat inp = sfpi::dst_reg[0];
-        sfpi::vFloat tmp = inp * inp + sfpi::vConst1;
-        tmp              = _calculate_sqrt_body_<APPROXIMATION_MODE>(tmp);
-        tmp              = tmp + sfpi::abs(inp);
-        sfpi::dst_reg[0] = _calculate_log_body_no_init_(tmp);
+        sfpi::vFloat inp                                  = sfpi::dst_reg[dst_index_in * dst_tile_size_sfpi];
+        sfpi::vFloat tmp                                  = inp * inp + sfpi::vConst1;
+        tmp                                               = _calculate_sqrt_body_<APPROXIMATION_MODE>(tmp);
+        tmp                                               = tmp + sfpi::abs(inp);
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = _calculate_log_body_no_init_(tmp);
         v_if (inp < sfpi::vConst0)
         {
-            sfpi::dst_reg[0] = -sfpi::dst_reg[0];
+            sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = -sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi];
         }
         v_endif;
         sfpi::dst_reg++;
@@ -184,21 +193,23 @@ inline void _calculate_asinh_()
 
 // atanh[x] = 0.5 * ln((1 + x) / (1 - x))
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
-inline void _calculate_atanh_()
+inline void _calculate_atanh_(const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
+
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++)
     {
-        sfpi::vFloat inp     = sfpi::dst_reg[0];
+        sfpi::vFloat inp     = sfpi::dst_reg[dst_index_in * dst_tile_size_sfpi];
         sfpi::vFloat abs_inp = sfpi::abs(inp);
         v_if (abs_inp > sfpi::vConst1)
         {
-            sfpi::dst_reg[0] = std::numeric_limits<float>::quiet_NaN();
+            sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = std::numeric_limits<float>::quiet_NaN();
         }
         v_elseif (abs_inp == sfpi::vConst1)
         {
-            sfpi::vFloat inf = std::numeric_limits<float>::infinity();
-            sfpi::dst_reg[0] = sfpi::setsgn(inf, inp);
+            sfpi::vFloat inf                                  = std::numeric_limits<float>::infinity();
+            sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = sfpi::setsgn(inf, inp);
         }
         v_else
         {
@@ -214,9 +225,9 @@ inline void _calculate_atanh_()
             {
                 den = sfpi::reinterpret<sfpi::vFloat>(float_to_fp16b(tmp, 0));
             }
-            num              = num * den;
-            den              = _calculate_log_body_no_init_(num);
-            sfpi::dst_reg[0] = 0.5f * den;
+            num                                               = num * den;
+            den                                               = _calculate_log_body_no_init_(num);
+            sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = 0.5f * den;
         }
         v_endif;
         sfpi::dst_reg++;

--- a/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_unary_sfpu_params.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_unary_sfpu_params.h
@@ -71,3 +71,67 @@ inline void _llk_math_eltwise_unary_sfpu_params_(
     TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::WAIT_SFPU);
     math::clear_addr_mod_base();
 }
+
+// Variant that supports writing to a different output tile than the input tile.
+// Uses absolute addressing (base=0) and appends tile indices after the callable's
+// normal args. The callable must accept (...args, dst_index_in, dst_index_out)
+// as its last two parameters (with defaults of 0 for backward compatibility).
+template <bool APPROXIMATE, typename Callable, typename... Args>
+inline void _llk_math_eltwise_unary_sfpu_params_with_output_(
+    Callable&& sfpu_func, std::uint32_t dst_index_in, std::uint32_t dst_index_out, int vector_mode = static_cast<int>(VectorMode::RC), Args&&... args)
+{
+    LLK_ASSERT((dst_index_in < get_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE, DstTileShape::Tile32x32>()), "dst_index_in exceeds max dest tiles");
+    LLK_ASSERT((dst_index_out < get_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE, DstTileShape::Tile32x32>()), "dst_index_out exceeds max dest tiles");
+
+    // Start from base 0 for absolute tile addressing (same as binary SFPU)
+    math::set_dst_write_addr<DstTileShape::Tile32x32, UnpackDestination::SrcRegs>(0);
+    math::set_addr_mod_base();
+    TTI_STALLWAIT(p_stall::STALL_SFPU, p_stall::MATH);
+
+    VectorMode mode = static_cast<VectorMode>(vector_mode);
+
+    if (mode == VectorMode::R)
+    {
+#pragma GCC unroll 0
+        for (int face = 0; face < 2; face++)
+        {
+            std::forward<Callable>(sfpu_func)(std::forward<Args>(args)..., dst_index_in, dst_index_out);
+            TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_D, 8, 0, 0, p_setrwc::SET_D);
+            TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_D, 8, 0, 0, p_setrwc::SET_D);
+        }
+        TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_D, 8, 0, 0, p_setrwc::SET_D);
+        TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_D, 8, 0, 0, p_setrwc::SET_D);
+        TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_D, 8, 0, 0, p_setrwc::SET_D);
+        TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_D, 8, 0, 0, p_setrwc::SET_D);
+    }
+    else if (mode == VectorMode::C)
+    {
+#pragma GCC unroll 0
+        for (int face = 0; face < 2; face++)
+        {
+            std::forward<Callable>(sfpu_func)(std::forward<Args>(args)..., dst_index_in, dst_index_out);
+            TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_D, 8, 0, 0, p_setrwc::SET_D);
+            TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_D, 8, 0, 0, p_setrwc::SET_D);
+            TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_D, 8, 0, 0, p_setrwc::SET_D);
+            TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_D, 8, 0, 0, p_setrwc::SET_D);
+        }
+    }
+    else if (mode == VectorMode::RC)
+    {
+#pragma GCC unroll 0
+        for (int face = 0; face < 4; face++)
+        {
+            std::forward<Callable>(sfpu_func)(std::forward<Args>(args)..., dst_index_in, dst_index_out);
+            TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_D, 8, 0, 0, p_setrwc::SET_D);
+            TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_D, 8, 0, 0, p_setrwc::SET_D);
+        }
+    }
+    else
+    {
+        std::forward<Callable>(sfpu_func)(std::forward<Args>(args)..., dst_index_in, dst_index_out);
+    }
+
+    math::clear_dst_reg_addr();
+    TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::WAIT_SFPU);
+    math::clear_addr_mod_base();
+}


### PR DESCRIPTION
### Ticket
[Link to Github Issue ](https://github.com/tenstorrent/tt-metal/issues/30298)

### Problem description
<!-- Provide context for the problem. -->
Unary SFPU ops previously always wrote back to the same tile they read from in dest. Binary and ternary ops already supported separate input/output tiles. This adds the same capability to unary ops, enabling the D2M compiler path to specify different output tiles for forks and joins in fusion.

### What's changed

  - Added `_llk_math_eltwise_unary_sfpu_params_with_output_()` to all three targets (Wormhole B0, Blackhole, Quasar). Sets base=0 for absolute tile addressing and appends `(dst_index_in, dst_index_out)` after the callable's normal args.
  - Modified all individual SFPU operations (~50 files across WH/BH, 14 on Quasar) to accept `dst_index_in = 0, dst_index_out = 0` as optional last parameters. Operations use `dst_reg[idx * 32]` (WH/BH) or `TT_SFPLOAD`/`TT_SFPSTORE` with tile offsets (Quasar) for direct indexed addressing. Default values of 0 preserve existing behavior for all current callers.
  - Added BH test.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Assert validation](https://github.com/tenstorrent/tt-llk/blob/main/docs/Introduction_to_asserts.md) Complied with assert doc (if applicable)
