### PR TITLE
[Test Infra] [QSR] Reset Qsr mailboxes early 

### DIFF
--- a/tests/python_tests/helpers/device.py
+++ b/tests/python_tests/helpers/device.py
@@ -292,11 +292,22 @@ def handle_if_assert_hit(elfs: list[str], core_loc="0,0", device_id=0):
 
 
 def reset_mailboxes(location: str = "0,0"):
-    """Reset all core mailboxes (Unpacker, Math, Packer, Sfpu) before each test."""
+    """Reset all core mailboxes (Unpacker, Math, Packer, Sfpu for Quasar, Unpacker, Math, Packer for Wormhole/Blackhole) before each test."""
 
-    write_words_to_device(
-        location=location, addr=Mailbox.Unpacker.value, data=[0xA3, 0xA3, 0xA3]
-    )
+    # Use 0xA3, because it's a non-zero value that we don't use anywhere else - it's good for triaging hangs.
+    MAILBOX_START_BLOCK = Mailbox.Unpacker.value
+    if get_chip_architecture() == ChipArchitecture.QUASAR:
+        write_words_to_device(
+            location=location,
+            addr=MAILBOX_START_BLOCK,
+            data=[0xA3] * len(Mailbox),  # All 4 TRISC mailboxes on Quasar
+        )
+    else:
+        write_words_to_device(
+            location=location,
+            addr=MAILBOX_START_BLOCK,
+            data=[0xA3, 0xA3, 0xA3],  # All 3 TRISC mailboxes on Wormhole/Blackhole
+        )
 
 
 def pull_coverage_stream_from_tensix(

--- a/tests/python_tests/helpers/test_config.py
+++ b/tests/python_tests/helpers/test_config.py
@@ -41,6 +41,7 @@ from .device import (
     commit_brisc_command,
     exalens_device_setup,
     handle_if_assert_hit,
+    reset_mailboxes,
     set_tensix_soft_reset,
 )
 from .format_config import (
@@ -1122,14 +1123,8 @@ class TestConfig:
             case BootMode.BRISC:
                 commit_brisc_command(location, BriscCmd.START_TRISCS)
             case BootMode.TRISC:
-                # Reset mailboxes here to ensure that emu/sim see correct test completion state
-                if TestConfig.CHIP_ARCH == ChipArchitecture.QUASAR:
-                    MAILBOX_START_BLOCK = device_module.Mailbox.Unpacker.value
-                    write_words_to_device(
-                        location,
-                        MAILBOX_START_BLOCK,
-                        [0x0] * len(device_module.Mailbox),
-                    )
+                # Reset all mailboxes here to ensure that emu/sim see correct test completion state
+                reset_mailboxes(location)
                 set_tensix_soft_reset(0, [RiscCore.TRISC0], location)
             case BootMode.EXALENS:
                 exalens_device_setup(TestConfig.CHIP_ARCH, location)


### PR DESCRIPTION
### Ticket
<!-- Link to Github Issue -->

### Problem description
When running multiple tests one after the other on emulator with waves enabled, only the first one passes, and the following ones fail. This is because at the end of the first test there is a mailbox_complete written to the mailbox. This value gets read, instead of the mailbox reset value set by trisc.cpp. This results in the second test getting interpreted as already finished, when it has not even started yet.

### What's changed
Instead of trisc.cpp resetting the qsr mailboxes, it is now done inside of test_config.py.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Assert validation](https://github.com/tenstorrent/tt-llk/blob/main/docs/Introduction_to_asserts.md) Complied with assert doc (if applicable)
