### PR TITLE
Ldjurovic/fix bfp4 b packer

### DIFF
--- a/tests/python_tests/helpers/bfp_format_utils.py
+++ b/tests/python_tests/helpers/bfp_format_utils.py
@@ -48,6 +48,11 @@ def _finalize_bfp_quantized(
     dimensions,
 ) -> torch.Tensor:
     values = torch.where(signs_blocks.bool(), -values, values)
+    # Hardware runs with FTZ: flush near-zero values that arise from BFP
+    # scale arithmetic with very small shared exponents (shared_exp <= 1).
+    # The smallest meaningful BFP value has shared_exp=2, giving ~2.35e-38.
+    FTZ_THRESHOLD = 1e-37
+    values = torch.where(values.abs() < FTZ_THRESHOLD, torch.zeros_like(values), values)
     out = values.flatten()[:n].to(torch.bfloat16)
     if dimensions is not None:
         out = untilize_block(

--- a/tests/python_tests/helpers/bfp_format_utils.py
+++ b/tests/python_tests/helpers/bfp_format_utils.py
@@ -15,6 +15,48 @@ import torch
 from .format_config import DataFormat
 from .tilize_untilize import untilize_block
 
+BFP_BLOCK = 16
+
+
+def _bf16_sign_exp_mantissa(flat: torch.Tensor):
+    """Extract sign, exponent, and implicit 7-bit mantissa from BF16 (as uint16)."""
+    bf16_bits = (flat.view(torch.int32) >> 16) & 0xFFFF
+    signs = (bf16_bits >> 15) & 1
+    exps = (bf16_bits >> 7) & 0xFF
+    mants = ((bf16_bits & 0x7F) >> 1) | 0x40
+    return signs, exps, mants
+
+
+def _bfp8_mantissas_per_block(mants_blocks: torch.Tensor, exps_blocks: torch.Tensor):
+    """
+    Round to shared block exponent per ISA BFP8 packing: round-to-nearest,
+    ties away from zero; guard bit when delta > 0.
+    """
+    shared_exps = exps_blocks.max(dim=1, keepdim=True).values
+    deltas = shared_exps - exps_blocks
+    guard = torch.where(
+        deltas > 0, (mants_blocks >> (deltas - 1)) & 1, torch.zeros_like(mants_blocks)
+    )
+    bfp8 = ((mants_blocks >> deltas) + guard) & 0x7F
+    return shared_exps, bfp8
+
+
+def _finalize_bfp_quantized(
+    values: torch.Tensor,
+    signs_blocks: torch.Tensor,
+    n: int,
+    dimensions,
+) -> torch.Tensor:
+    values = torch.where(signs_blocks.bool(), -values, values)
+    out = values.flatten()[:n].to(torch.bfloat16)
+    if dimensions is not None:
+        out = untilize_block(
+            out,
+            stimuli_format=DataFormat.Float16_b,
+            dimensions=dimensions,
+        ).flatten()
+    return out
+
 
 def bfp8b_to_float16b(operand: torch.Tensor, dimensions=None) -> torch.Tensor:
     """
@@ -32,46 +74,18 @@ def bfp8b_to_float16b(operand: torch.Tensor, dimensions=None) -> torch.Tensor:
     Returns:
         Quantized bfloat16 tensor (same number of elements as input).
     """
-    BFP8_BLOCK = 16
     flat = operand.flatten().to(torch.float32)
     n = flat.numel()
+    signs, exps, mants = _bf16_sign_exp_mantissa(flat)
 
-    u32 = flat.view(torch.int32)
-    bf16_bits = (u32 >> 16) & 0xFFFF
-
-    signs = (bf16_bits >> 15) & 1
-    exps = (bf16_bits >> 7) & 0xFF
-    mants = ((bf16_bits & 0x7F) >> 1) | 0x40
-
-    exps_blocks = exps.view(-1, BFP8_BLOCK)
-    mants_blocks = mants.view(-1, BFP8_BLOCK)
-    signs_blocks = signs.view(-1, BFP8_BLOCK)
-
-    shared_exps = exps_blocks.max(dim=1, keepdim=True).values
-
-    deltas = shared_exps - exps_blocks
-
-    # Round-to-nearest, ties away from zero (per ISA spec for BFP8 packing).
-    # When delta > 0, check the highest bit being shifted out (guard bit).
-    guard = torch.where(
-        deltas > 0, (mants_blocks >> (deltas - 1)) & 1, torch.zeros_like(mants_blocks)
+    signs_blocks = signs.view(-1, BFP_BLOCK)
+    shared_exps, bfp8_mants = _bfp8_mantissas_per_block(
+        mants.view(-1, BFP_BLOCK),
+        exps.view(-1, BFP_BLOCK),
     )
-    shifted = (mants_blocks >> deltas) + guard
-    shifted = shifted & 0x7F
 
-    values = shifted.float() * torch.exp2((shared_exps - 133).float())
-    values = torch.where(signs_blocks.bool(), -values, values)
-
-    quantized = values.flatten()[:n].to(torch.bfloat16)
-
-    if dimensions is not None:
-        quantized = untilize_block(
-            quantized,
-            stimuli_format=DataFormat.Float16_b,
-            dimensions=dimensions,
-        ).flatten()
-
-    return quantized
+    values = bfp8_mants.float() * torch.exp2((shared_exps - 133).float())
+    return _finalize_bfp_quantized(values, signs_blocks, n, dimensions)
 
 
 def bfp4b_to_float16b(operand: torch.Tensor, dimensions=None) -> torch.Tensor:
@@ -89,48 +103,20 @@ def bfp4b_to_float16b(operand: torch.Tensor, dimensions=None) -> torch.Tensor:
     Returns:
         Quantized bfloat16 tensor (same number of elements as input).
     """
-    BFP4_BLOCK = 16
     flat = operand.flatten().to(torch.float32)
     n = flat.numel()
+    signs, exps, mants = _bf16_sign_exp_mantissa(flat)
 
-    u32 = flat.view(torch.int32)
-    bf16_bits = (u32 >> 16) & 0xFFFF
-
-    signs = (bf16_bits >> 15) & 1
-    exps = (bf16_bits >> 7) & 0xFF
-    # BFP8 mantissa: 7 bits = 1 implicit + 6 explicit (same as bfp8b_to_float16b)
-    mants = ((bf16_bits & 0x7F) >> 1) | 0x40
-
-    exps_blocks = exps.view(-1, BFP4_BLOCK)
-    mants_blocks = mants.view(-1, BFP4_BLOCK)
-    signs_blocks = signs.view(-1, BFP4_BLOCK)
-
-    shared_exps = exps_blocks.max(dim=1, keepdim=True).values
-
-    # Stage 1: BF16 -> BFP8 with rounding (round-to-nearest, ties away from zero)
-    deltas = shared_exps - exps_blocks
-    guard = torch.where(
-        deltas > 0, (mants_blocks >> (deltas - 1)) & 1, torch.zeros_like(mants_blocks)
+    signs_blocks = signs.view(-1, BFP_BLOCK)
+    shared_exps, bfp8_mants = _bfp8_mantissas_per_block(
+        mants.view(-1, BFP_BLOCK),
+        exps.view(-1, BFP_BLOCK),
     )
-    bfp8_mants = (mants_blocks >> deltas) + guard
-    bfp8_mants = bfp8_mants & 0x7F
 
     # Stage 2: BFP8 -> BFP4 by truncating (drop the 4 LSBs of the 7-bit mantissa)
     bfp4_mants = bfp8_mants >> 4
-
     # Scale: 2^(shared_exp - 127 - 2) = 2^(shared_exp - 129)
     # BFP4 mantissa is 3 bits with implicit leading 1 worth 4 (0x4),
     # so divide by 4 -> exponent offset is 129
     values = bfp4_mants.float() * torch.exp2((shared_exps - 129).float())
-    values = torch.where(signs_blocks.bool(), -values, values)
-
-    quantized = values.flatten()[:n].to(torch.bfloat16)
-
-    if dimensions is not None:
-        quantized = untilize_block(
-            quantized,
-            stimuli_format=DataFormat.Float16_b,
-            dimensions=dimensions,
-        ).flatten()
-
-    return quantized
+    return _finalize_bfp_quantized(values, signs_blocks, n, dimensions)

--- a/tests/python_tests/helpers/bfp_format_utils.py
+++ b/tests/python_tests/helpers/bfp_format_utils.py
@@ -50,7 +50,14 @@ def bfp8b_to_float16b(operand: torch.Tensor, dimensions=None) -> torch.Tensor:
     shared_exps = exps_blocks.max(dim=1, keepdim=True).values
 
     deltas = shared_exps - exps_blocks
-    shifted = mants_blocks >> deltas
+
+    # Round-to-nearest, ties away from zero (per ISA spec for BFP8 packing).
+    # When delta > 0, check the highest bit being shifted out (guard bit).
+    guard = torch.where(
+        deltas > 0, (mants_blocks >> (deltas - 1)) & 1, torch.zeros_like(mants_blocks)
+    )
+    shifted = (mants_blocks >> deltas) + guard
+    shifted = shifted & 0x7F
 
     values = shifted.float() * torch.exp2((shared_exps - 133).float())
     values = torch.where(signs_blocks.bool(), -values, values)
@@ -71,10 +78,9 @@ def bfp4b_to_float16b(operand: torch.Tensor, dimensions=None) -> torch.Tensor:
     """
     Simulate BFP4_b pack/unpack round-trip quantization.
 
-    Processes values in blocks of 16, determines a shared exponent per block
-    (the maximum element exponent), and right-shifts each element's 3-bit
-    mantissa (1 implicit + 2 explicit bits) by the per-element delta, matching
-    the hardware packer/unpacker behaviour.
+    Per the ISA spec, BFP4 packing is a two-stage process:
+      1. Convert to BFP8 with rounding (round-to-nearest, ties away from zero)
+      2. Truncate BFP8 mantissa (7 bits) down to BFP4 mantissa (3 bits)
 
     Args:
         operand: Input tensor (any shape).
@@ -88,12 +94,12 @@ def bfp4b_to_float16b(operand: torch.Tensor, dimensions=None) -> torch.Tensor:
     n = flat.numel()
 
     u32 = flat.view(torch.int32)
+    bf16_bits = (u32 >> 16) & 0xFFFF
 
-    signs = (u32 >> 31) & 1
-    exps = (u32 >> 23) & 0xFF
-    # bfp4_b has 3 mantissa bits: 1 implicit leading bit + 2 explicit bits.
-    # Hardware takes bits 23:21 of the 24-bit mantissa (with implicit leading 1).
-    mants = ((u32 & 0x7FFFFF) >> 21) | 0x4
+    signs = (bf16_bits >> 15) & 1
+    exps = (bf16_bits >> 7) & 0xFF
+    # BFP8 mantissa: 7 bits = 1 implicit + 6 explicit (same as bfp8b_to_float16b)
+    mants = ((bf16_bits & 0x7F) >> 1) | 0x40
 
     exps_blocks = exps.view(-1, BFP4_BLOCK)
     mants_blocks = mants.view(-1, BFP4_BLOCK)
@@ -101,11 +107,21 @@ def bfp4b_to_float16b(operand: torch.Tensor, dimensions=None) -> torch.Tensor:
 
     shared_exps = exps_blocks.max(dim=1, keepdim=True).values
 
+    # Stage 1: BF16 -> BFP8 with rounding (round-to-nearest, ties away from zero)
     deltas = shared_exps - exps_blocks
-    shifted = mants_blocks >> deltas
+    guard = torch.where(
+        deltas > 0, (mants_blocks >> (deltas - 1)) & 1, torch.zeros_like(mants_blocks)
+    )
+    bfp8_mants = (mants_blocks >> deltas) + guard
+    bfp8_mants = bfp8_mants & 0x7F
+
+    # Stage 2: BFP8 -> BFP4 by truncating (drop the 4 LSBs of the 7-bit mantissa)
+    bfp4_mants = bfp8_mants >> 4
 
     # Scale: 2^(shared_exp - 127 - 2) = 2^(shared_exp - 129)
-    values = shifted.float() * torch.exp2((shared_exps - 129).float())
+    # BFP4 mantissa is 3 bits with implicit leading 1 worth 4 (0x4),
+    # so divide by 4 -> exponent offset is 129
+    values = bfp4_mants.float() * torch.exp2((shared_exps - 129).float())
     values = torch.where(signs_blocks.bool(), -values, values)
 
     quantized = values.flatten()[:n].to(torch.bfloat16)

--- a/tests/python_tests/helpers/golden_generators.py
+++ b/tests/python_tests/helpers/golden_generators.py
@@ -1845,6 +1845,11 @@ class EltwiseBinaryGolden(FidelityMasking):
             result = self.ops[op](t1, t2)
 
         # Step 3: Quantize output to match what hardware packs back into L1.
+        # For Bfp4_b output: use round-half-up packing only when the input was
+        # Float16_b (full-precision), matching the hardware gasket behaviour.
+        # When inputs were already BFP-quantized (Bfp4_b, Bfp8_b), the sums
+        # land on exact BFP4 grid points and hardware truncates, so use the
+        # plain truncating path to avoid introducing errors there.
         if data_format == DataFormat.Bfp4_b:
             result = _bfp4b_to_float16b(result.to(torch.bfloat16))
         elif data_format == DataFormat.Bfp8_b:

--- a/tests/python_tests/helpers/golden_generators.py
+++ b/tests/python_tests/helpers/golden_generators.py
@@ -1844,12 +1844,7 @@ class EltwiseBinaryGolden(FidelityMasking):
         else:
             result = self.ops[op](t1, t2)
 
-        # Step 3: Quantize output to match what hardware packs back into L1.
-        # For Bfp4_b output: use round-half-up packing only when the input was
-        # Float16_b (full-precision), matching the hardware gasket behaviour.
-        # When inputs were already BFP-quantized (Bfp4_b, Bfp8_b), the sums
-        # land on exact BFP4 grid points and hardware truncates, so use the
-        # plain truncating path to avoid introducing errors there.
+        # Quantize output to match what hardware packs back into L1.
         if data_format == DataFormat.Bfp4_b:
             result = _bfp4b_to_float16b(result.to(torch.bfloat16))
         elif data_format == DataFormat.Bfp8_b:

--- a/tests/python_tests/helpers/golden_generators.py
+++ b/tests/python_tests/helpers/golden_generators.py
@@ -1836,6 +1836,8 @@ class EltwiseBinaryGolden(FidelityMasking):
             result = None
             orig_t1, orig_t2 = t1, t2
             for fidelity_iter in range(fidelity_iter_count + 1):
+                if fidelity_iter > 0:
+                    t1, t2 = operand1, operand2
                 masked_t1, masked_t2 = self._apply_fidelity_masking(
                     math_format_for_fidelity, orig_t1, orig_t2, fidelity_iter
                 )

--- a/tests/python_tests/helpers/golden_generators.py
+++ b/tests/python_tests/helpers/golden_generators.py
@@ -1834,11 +1834,12 @@ class EltwiseBinaryGolden(FidelityMasking):
 
         if op == MathOperation.Elwmul:
             result = None
+            orig_t1, orig_t2 = t1, t2
             for fidelity_iter in range(fidelity_iter_count + 1):
-                t1, t2 = self._apply_fidelity_masking(
-                    math_format_for_fidelity, t1, t2, fidelity_iter
+                masked_t1, masked_t2 = self._apply_fidelity_masking(
+                    math_format_for_fidelity, orig_t1, orig_t2, fidelity_iter
                 )
-                phase_result = self.ops[op](t1, t2)
+                phase_result = self.ops[op](masked_t1, masked_t2)
                 if fidelity_iter == 0:
                     result = phase_result
                 else:

--- a/tests/python_tests/helpers/golden_generators.py
+++ b/tests/python_tests/helpers/golden_generators.py
@@ -1806,8 +1806,8 @@ class EltwiseBinaryGolden(FidelityMasking):
 
         # Step 1: Quantize each input independently to match what hardware sees
         # after unpacking from L1. Each operand uses its own format.
-        operand1 = self._quantize_input(operand1, input_format, data_format)
-        operand2 = self._quantize_input(operand2, input_format_B, data_format)
+        operand1 = self._quantize_input(operand1, input_format, input_format)
+        operand2 = self._quantize_input(operand2, input_format_B, input_format_B)
 
         # Use bfloat16 for fidelity masking when any input is a block-float format.
         uses_block_float = any(
@@ -1858,13 +1858,12 @@ class EltwiseBinaryGolden(FidelityMasking):
 
     # Operation methods
     def _add(self, t1, t2):
-        return t1 + t2
+        return (t1.to(torch.float32) + t2.to(torch.float32)).to(t1.dtype)
 
     def _sub(self, t1, t2):
-        return t1 - t2
+        return (t1.to(torch.float32) - t2.to(torch.float32)).to(t1.dtype)
 
     def _mul(self, t1, t2):
-        # Compute in float32 for better fidelity, then cast back to original dtype.
         return (t1.to(torch.float32) * t2.to(torch.float32)).to(t1.dtype)
 
 

--- a/tests/python_tests/helpers/golden_generators.py
+++ b/tests/python_tests/helpers/golden_generators.py
@@ -1806,8 +1806,8 @@ class EltwiseBinaryGolden(FidelityMasking):
 
         # Step 1: Quantize each input independently to match what hardware sees
         # after unpacking from L1. Each operand uses its own format.
-        operand1 = self._quantize_input(operand1, input_format, input_format)
-        operand2 = self._quantize_input(operand2, input_format_B, input_format_B)
+        # operand1 = self._quantize_input(operand1, input_format, input_format)
+        # operand2 = self._quantize_input(operand2, input_format_B, input_format_B)
 
         # Use bfloat16 for fidelity masking when any input is a block-float format.
         uses_block_float = any(
@@ -1853,6 +1853,16 @@ class EltwiseBinaryGolden(FidelityMasking):
             result = quantize_mx_tensor_chunked(result.to(torch.bfloat16), data_format)
         else:
             result = to_tensor(result, data_format)
+
+        # Final FTZ pass: hardware always flushes subnormals to zero.
+        # Do this after all quantization so it covers every output format.
+        FTZ_THRESHOLD = 1e-37
+        result_f32 = result.float()
+        result = torch.where(
+            result_f32.abs() < FTZ_THRESHOLD,
+            torch.zeros_like(result_f32),
+            result_f32,
+        ).to(result.dtype)
 
         return result
 

--- a/tests/python_tests/helpers/golden_generators.py
+++ b/tests/python_tests/helpers/golden_generators.py
@@ -1809,15 +1809,17 @@ class EltwiseBinaryGolden(FidelityMasking):
         # operand1 = self._quantize_input(operand1, input_format, input_format)
         # operand2 = self._quantize_input(operand2, input_format_B, input_format_B)
 
-        # Use bfloat16 for fidelity masking when any input is a block-float format.
-        uses_block_float = any(
-            fmt is not None
-            and (fmt in (DataFormat.Bfp4_b, DataFormat.Bfp8_b) or fmt.is_mx_format())
-            for fmt in (input_format, input_format_B)
-        )
-        math_format_for_fidelity = (
-            DataFormat.Float16_b if uses_block_float else data_format
-        )
+        # Fidelity masking models the source register decomposition, so use
+        # the *input* format, not the output format.  Block-float / MX formats
+        # are unpacked to Float16_b in the source registers.
+        def _src_reg_format(fmt):
+            if fmt is None:
+                return None
+            if fmt in (DataFormat.Bfp4_b, DataFormat.Bfp8_b) or fmt.is_mx_format():
+                return DataFormat.Float16_b
+            return fmt
+
+        math_format_for_fidelity = _src_reg_format(input_format) or data_format
 
         t1, t2 = operand1, operand2
 

--- a/tests/python_tests/helpers/golden_generators.py
+++ b/tests/python_tests/helpers/golden_generators.py
@@ -515,6 +515,18 @@ class TransposeGolden:
     def __init__(self):
         pass
 
+    def _quantize_transpose_input(self, operand, data_format):
+        """Quantize input before transposing to match hardware unpack behavior.
+
+        Hardware unpacks BFP data using the original (pre-transpose) block structure,
+        then transposes. So quantization must happen before the transpose.
+        """
+        if data_format == DataFormat.Bfp4_b:
+            return _bfp4b_to_float16b(operand)
+        elif data_format == DataFormat.Bfp8_b:
+            return _bfp8b_to_float16b(operand)
+        return operand
+
     def transpose_within_faces(
         self,
         operand,
@@ -537,6 +549,7 @@ class TransposeGolden:
             raise ValueError(f"num_faces must be 1, 2, or 4, got {num_faces}")
 
         tensor = to_tensor(operand, data_format)
+        tensor = self._quantize_transpose_input(tensor, data_format)
         torch_format = format_dict[data_format]
 
         # Each face is always 16x16 = 256 elements
@@ -587,6 +600,7 @@ class TransposeGolden:
 
         torch_format = format_dict[data_format]
         tensor = to_tensor(operand, data_format)
+        tensor = self._quantize_transpose_input(tensor, data_format)
 
         total_elements = ELEMENTS_PER_FACE * num_faces
         tensor = tensor[:total_elements]
@@ -1069,9 +1083,11 @@ class DataCopyGolden:
     ):
         torch_format = format_dict[data_format]
 
-        # Quantize input to match what hardware actually unpacks from bfp4_b L1 memory
+        # Quantize input to match what hardware actually unpacks from BFP L1 memory
         if input_format == DataFormat.Bfp4_b:
             operand1 = _bfp4b_to_float16b(operand1)
+        elif input_format == DataFormat.Bfp8_b:
+            operand1 = _bfp8b_to_float16b(operand1)
 
         height, width = input_dimensions[0], input_dimensions[1]
 
@@ -1134,8 +1150,8 @@ class DataCopyGolden:
 
             result = result.to(torch_format)
 
-        # Apply bfp4_b output quantization round-trip to match hardware behaviour
-        if data_format == DataFormat.Bfp4_b:
+        # Apply BFP output quantization round-trip to match hardware behaviour
+        if data_format in (DataFormat.Bfp4_b, DataFormat.Bfp8_b):
             result_t = (
                 result.float()
                 if isinstance(result, torch.Tensor)
@@ -1150,7 +1166,10 @@ class DataCopyGolden:
             else:
                 data = flat
                 dims = None
-            result = _bfp4b_to_float16b(data, dims)
+            if data_format == DataFormat.Bfp4_b:
+                result = _bfp4b_to_float16b(data, dims)
+            else:
+                result = _bfp8b_to_float16b(data, dims)
 
         return result
 
@@ -1787,6 +1806,8 @@ class EltwiseBinaryGolden(FidelityMasking):
             return quantize_mx_tensor_chunked(operand, fmt)
         return to_tensor(operand, data_format)
 
+    _UNSET = object()
+
     def __call__(
         self,
         op,
@@ -1795,19 +1816,20 @@ class EltwiseBinaryGolden(FidelityMasking):
         data_format,
         math_fidelity,
         input_format=None,
-        input_format_B=None,
+        input_format_B=_UNSET,
     ):
         if op not in self.ops:
             raise ValueError(f"Unsupported Eltwise operation: {op}")
 
-        # If input_format_B is not provided, it defaults to input_format.
-        if input_format_B is None:
+        # If input_format_B is not provided at all, default to input_format.
+        # If explicitly passed as None, it means "already quantized, skip".
+        if input_format_B is EltwiseBinaryGolden._UNSET:
             input_format_B = input_format
 
         # Step 1: Quantize each input independently to match what hardware sees
         # after unpacking from L1. Each operand uses its own format.
-        # operand1 = self._quantize_input(operand1, input_format, input_format)
-        # operand2 = self._quantize_input(operand2, input_format_B, input_format_B)
+        operand1 = self._quantize_input(operand1, input_format, data_format)
+        operand2 = self._quantize_input(operand2, input_format_B, data_format)
 
         # Fidelity masking models the source register decomposition, so use
         # the *input* format, not the output format.  Block-float / MX formats

--- a/tests/python_tests/helpers/golden_generators.py
+++ b/tests/python_tests/helpers/golden_generators.py
@@ -2070,6 +2070,18 @@ class ReduceGolden:
             ReduceDimension.Scalar: self._reduce_scalar,
         }
 
+    def _quantize_reduce_input(self, operand, fmt, data_format):
+        """Quantize input to match what hardware sees after unpack (same as EltwiseBinaryGolden)."""
+        if fmt is None:
+            return to_tensor(operand, data_format)
+        if fmt == DataFormat.Bfp4_b:
+            return _bfp4b_to_float16b(operand)
+        if fmt == DataFormat.Bfp8_b:
+            return _bfp8b_to_float16b(operand)
+        if fmt.is_mx_format():
+            return quantize_mx_tensor_chunked(operand, fmt)
+        return to_tensor(operand, data_format)
+
     def __call__(
         self,
         operand,
@@ -2087,11 +2099,10 @@ class ReduceGolden:
         if reduce_dim not in self.dim_handlers:
             raise ValueError(f"Unsupported reduce dimension: {reduce_dim}")
 
-        # Quantize input to match what hardware actually unpacks from BFP L1 memory
-        if input_format == DataFormat.Bfp4_b:
-            operand = _bfp4b_to_float16b(operand)
-        elif input_format == DataFormat.Bfp8_b:
-            operand = _bfp8b_to_float16b(operand)
+        # Same convention as EltwiseBinaryGolden: plain cast uses input format when set,
+        # else output format (callers that omit input_format typically use matching I/O).
+        fmt_for_plain = input_format if input_format is not None else data_format
+        operand = self._quantize_reduce_input(operand, input_format, fmt_for_plain)
 
         if reduce_to_one:
             # Accumulate all tiles into a single result
@@ -2099,15 +2110,34 @@ class ReduceGolden:
                 operand, reduce_dim, pool_type, data_format, tile_cnt, tile_shape
             )
         else:
-            # Process each tile independently
+            # Process each tile independently; quantize output like eltwise binary
             return torch.cat(
                 [
-                    self._process_tile(
-                        operand, reduce_dim, pool_type, data_format, tile, tile_shape
+                    self._quantize_reduce_output(
+                        self._process_tile(
+                            operand,
+                            reduce_dim,
+                            pool_type,
+                            data_format,
+                            tile,
+                            tile_shape,
+                        ),
+                        data_format,
                     )
                     for tile in range(tile_cnt)
                 ]
             )
+
+    def _quantize_reduce_output(self, tensor: torch.Tensor, data_format: DataFormat):
+        """Quantize output to match what hardware packs into L1 (same as EltwiseBinaryGolden)."""
+        if data_format == DataFormat.Bfp4_b:
+            return _bfp4b_to_float16b(tensor.to(torch.bfloat16))
+        elif data_format == DataFormat.Bfp8_b:
+            return _bfp8b_to_float16b(tensor.to(torch.bfloat16))
+        elif data_format.is_mx_format():
+            return quantize_mx_tensor_chunked(tensor.to(torch.bfloat16), data_format)
+        else:
+            return to_tensor(tensor, data_format)
 
     def _reduce_all_tiles(
         self, operand, reduce_dim, pool_type, data_format, tile_cnt, tile_shape
@@ -2137,9 +2167,8 @@ class ReduceGolden:
                 else:
                     raise ValueError(f"Unsupported pool type: {pool_type}")
 
-        # Convert back to target data format at the end
-        target_dtype = format_dict[data_format]
-        return accumulated.to(target_dtype)
+        # Convert back to target data format at the end (same as eltwise output path)
+        return self._quantize_reduce_output(accumulated, data_format)
 
     def _process_tile(
         self, operand, reduce_dim, pool_type, data_format, tile_idx, tile_shape

--- a/tests/python_tests/helpers/pack.py
+++ b/tests/python_tests/helpers/pack.py
@@ -111,7 +111,13 @@ def float_to_bfp8_block(block):
     bfp8_mantissas = []
     for i in range(len(block)):
         exponent_delta = shared_exponent - exponents[i]
-        mantissa = mantissas_explicit[i] >> exponent_delta
+        if exponent_delta > 0:
+            # Round-to-nearest, ties away from zero (per ISA spec for BFP8 packing)
+            guard_bit = (mantissas_explicit[i] >> (exponent_delta - 1)) & 1
+            mantissa = (mantissas_explicit[i] >> exponent_delta) + guard_bit
+        else:
+            mantissa = mantissas_explicit[i]
+        mantissa = mantissa & 0x7F
         mantissa = (signs[i] << 7) | mantissa
         bfp8_mantissas.append(mantissa)
 

--- a/tests/python_tests/helpers/pack.py
+++ b/tests/python_tests/helpers/pack.py
@@ -171,6 +171,7 @@ def truncate_bfp8_to_bfp4(bfp8_mantissas):
     BFP4 mantissas are 4 bits: 1 sign bit + 3 magnitude bits.
 
     Truncation: keep the top 3 magnitude bits, drop the last 4 bits.
+    This matches hardware behavior which uses simple truncation.
 
     Args:
         bfp8_mantissas: List of 8-bit BFP8 mantissa values

--- a/tests/python_tests/helpers/pack.py
+++ b/tests/python_tests/helpers/pack.py
@@ -164,47 +164,44 @@ def pack_bfp8_b(tensor, block_size=16, num_faces=4, face_r_dim=16):
     return exponents + mantissas
 
 
+def truncate_bfp8_to_bfp4(bfp8_mantissas):
+    """Truncate BFP8 mantissas to BFP4 format.
+
+    BFP8 mantissas are 8 bits: 1 sign bit + 7 magnitude bits.
+    BFP4 mantissas are 4 bits: 1 sign bit + 3 magnitude bits.
+
+    Truncation: keep the top 3 magnitude bits, drop the last 4 bits.
+
+    Args:
+        bfp8_mantissas: List of 8-bit BFP8 mantissa values
+
+    Returns:
+        List of 4-bit BFP4 mantissa values (as integers 0-15)
+    """
+    bfp4_mantissas = []
+    for bfp8 in bfp8_mantissas:
+        sign = (bfp8 >> 7) & 0x1
+        # Extract 7-bit magnitude and truncate to top 3 bits
+        magnitude = (bfp8 >> 4) & 0x7
+        bfp4 = (sign << 3) | magnitude
+        bfp4_mantissas.append(bfp4)
+    return bfp4_mantissas
+
+
 def float_to_bfp4_block(block):
     """Pack a 16-element block to BFP4_b format.
 
     Per hardware spec (WormholeB0 Packers/FormatConversion.md):
-      Step 1: Round FP32/BF16 → BFP8 (round-to-nearest, ties away from zero,
+      Step 1: Convert to BFP8 using float_to_bfp8_block (round-to-nearest,
               one shared 8-bit exponent per 16 datums).
               BFP8 has 1 sign bit + 7 magnitude bits.
-              The 7-bit magnitude comes from bits [23:17] of the aligned 24-bit
-              mantissa, rounded using bit 16 as the round bit.
       Step 2: Truncate BFP8 → BFP4 (keep top 3 of the 7 magnitude bits).
     """
-    n = len(block)
+    # Step 1: Convert to BFP8 first
+    shared_exponent, bfp8_mantissas = float_to_bfp8_block(block)
 
-    raw_bytes = struct.pack(f"<{n}f", *(float(v) for v in block))
-    all_bits = struct.unpack(f"<{n}I", raw_bytes)
-
-    signs = [0] * n
-    exponents = [0] * n
-    mantissas = [0] * n
-    shared_exponent = 0
-
-    for i, bits in enumerate(all_bits):
-        if bits & 0x7FFFFFFF:  # nonzero magnitude (handles -0.0 too)
-            signs[i] = bits >> 31
-            exp = (bits >> 23) & 0xFF
-            exponents[i] = exp
-            mantissas[i] = 0x800000 | (bits & 0x7FFFFF)
-            if exp > shared_exponent:
-                shared_exponent = exp
-
-    bfp4_mantissas = [0] * n
-    for i in range(n):
-        if mantissas[i]:
-            # Align mantissa to shared exponent (24-bit value, bit 23 = implicit 1)
-            shifted = mantissas[i] >> (shared_exponent - exponents[i])
-            # Step 1: Round to BFP8 (7 magnitude bits = bits [23:17] of shifted).
-            # Round-to-nearest, ties away from zero: add round bit (bit 16).
-            bfp8_mag = ((shifted >> 17) + ((shifted >> 16) & 1)) & 0x7F
-            # Step 2: Truncate BFP8 → BFP4 (keep top 3 of the 7 magnitude bits).
-            bfp4_mag = (bfp8_mag >> 4) & 0x7
-            bfp4_mantissas[i] = (signs[i] << 3) | bfp4_mag
+    # Step 2: Truncate BFP8 mantissas to BFP4
+    bfp4_mantissas = truncate_bfp8_to_bfp4(bfp8_mantissas)
 
     return shared_exponent, bfp4_mantissas
 

--- a/tests/python_tests/helpers/pack.py
+++ b/tests/python_tests/helpers/pack.py
@@ -165,6 +165,16 @@ def pack_bfp8_b(tensor, block_size=16, num_faces=4, face_r_dim=16):
 
 
 def float_to_bfp4_block(block):
+    """Pack a 16-element block to BFP4_b format.
+
+    Per hardware spec (WormholeB0 Packers/FormatConversion.md):
+      Step 1: Round FP32/BF16 → BFP8 (round-to-nearest, ties away from zero,
+              one shared 8-bit exponent per 16 datums).
+              BFP8 has 1 sign bit + 7 magnitude bits.
+              The 7-bit magnitude comes from bits [23:17] of the aligned 24-bit
+              mantissa, rounded using bit 16 as the round bit.
+      Step 2: Truncate BFP8 → BFP4 (keep top 3 of the 7 magnitude bits).
+    """
     n = len(block)
 
     raw_bytes = struct.pack(f"<{n}f", *(float(v) for v in block))
@@ -187,8 +197,14 @@ def float_to_bfp4_block(block):
     bfp4_mantissas = [0] * n
     for i in range(n):
         if mantissas[i]:
+            # Align mantissa to shared exponent (24-bit value, bit 23 = implicit 1)
             shifted = mantissas[i] >> (shared_exponent - exponents[i])
-            bfp4_mantissas[i] = (signs[i] << 3) | ((shifted >> 21) & 0x7)
+            # Step 1: Round to BFP8 (7 magnitude bits = bits [23:17] of shifted).
+            # Round-to-nearest, ties away from zero: add round bit (bit 16).
+            bfp8_mag = ((shifted >> 17) + ((shifted >> 16) & 1)) & 0x7F
+            # Step 2: Truncate BFP8 → BFP4 (keep top 3 of the 7 magnitude bits).
+            bfp4_mag = (bfp8_mag >> 4) & 0x7
+            bfp4_mantissas[i] = (signs[i] << 3) | bfp4_mag
 
     return shared_exponent, bfp4_mantissas
 

--- a/tests/python_tests/helpers/stimuli_generator.py
+++ b/tests/python_tests/helpers/stimuli_generator.py
@@ -368,14 +368,6 @@ def _generate_source_tensor(
 
     tensor = torch.tensor(src[:num_elements], dtype=dtype)
 
-    # Simulate the hardware pack/unpack round-trip for BFP4_b so that the stimuli
-    # already reflect the precision loss introduced by the format.  Golden generators
-    # can then operate directly on these values without needing a separate step.
-    #
-    # NOTE: BFP8_b is intentionally excluded here.  For operations like matmul the
-    # data reaches the hardware in tilized order, so quantization must be performed
-    # in tilized order (face-row blocks of 16).  Those golden generators handle
-    # BFP8_b quantization themselves, using the correct tilized layout.
     if stimuli_format == DataFormat.Bfp4_b:
         tensor = bfp4b_to_float16b(tensor)
 

--- a/tests/python_tests/helpers/test_config.py
+++ b/tests/python_tests/helpers/test_config.py
@@ -454,6 +454,7 @@ class TestConfig:
 
         TILE_SIZES = {
             DataFormat.Bfp8_b: 68,
+            DataFormat.Bfp4_b: 36,
             DataFormat.Float32: 256,
         }
 

--- a/tests/python_tests/helpers/unpack.py
+++ b/tests/python_tests/helpers/unpack.py
@@ -71,13 +71,6 @@ def unpack_uint8(packed_list):
 
 
 def bfp8_to_float_block(exponent, bfp8_mantissas, unpacked_bfp8):
-    # Bug fix and improvement:
-    # 1. Caching: If the (exponent, mantissa) pair is already processed, the precomputed value is reused.
-    # 2. Sign and Fractional Calculation: The sign bit is extracted, and the fractional part is calculated by iterating
-    #    over the mantissa bits, adding `1 / (2 ** i)` for each '1' bit.
-    # 3. Exponent Scaling: The final value is scaled by `2^exponent` and adjusted by the sign bit.
-    # 4. Efficient Storage: The computed value is stored in `unpacked_bfp8` for future use.
-
     bfloat16_values = []
     exponent = exponent - 127
 
@@ -87,22 +80,22 @@ def bfp8_to_float_block(exponent, bfp8_mantissas, unpacked_bfp8):
             continue
 
         sign_mantissa = str(format(mantissa, "08b"))
-        # Extract the sign bit (most significant bit)
         sign = int(sign_mantissa[0], 2)
-        # Get the remaining bits which represent the fractional part of the mantissa
         mantissa_value = sign_mantissa[1:]
-        # Changed computation of mantissa to fix , accumulate fractional value
+
         fract_value = 0.0
         for i in range(len(mantissa_value)):
-            # If the bit is '1', add the corresponding fractional value to fract_value
             if mantissa_value[i] == "1":
                 fract_value += 1 / (2 ** (i))
 
-        bfloat16_values.append(((-1.0) ** sign) * (2**exponent) * (fract_value))
+        # ISA spec: sign=1, mag=0 → -Inf (BF16 0xff80); sign=0, mag=0 → +0
+        if fract_value == 0.0:
+            value = -float("inf") if sign == 1 else 0.0
+        else:
+            value = ((-1.0) ** sign) * (2**exponent) * fract_value
 
-        unpacked_bfp8[(exponent, mantissa)] = (
-            ((-1.0) ** sign) * (2**exponent) * (fract_value)
-        )
+        bfloat16_values.append(value)
+        unpacked_bfp8[(exponent, mantissa)] = value
 
     return bfloat16_values
 
@@ -147,8 +140,13 @@ def bfp4_to_float_block(exponent, bfp4_mantissas, unpacked_bfp4):
     for mantissa in bfp4_mantissas:
         mag = mantissa & 0x7
         if mag == 0:
-            bfloat16_values.append(0.0)
-            unpacked_bfp4[(exp_adj, mantissa)] = 0.0
+            # ISA spec: sign=1, mag=0 → -Inf (BF16 0xff80); sign=0, mag=0 → +0
+            if mantissa & 0x8:
+                value = -float("inf")
+            else:
+                value = 0.0
+            bfloat16_values.append(value)
+            unpacked_bfp4[(exp_adj, mantissa)] = value
             continue
 
         key = (exp_adj, mantissa)

--- a/tests/python_tests/helpers/utils.py
+++ b/tests/python_tests/helpers/utils.py
@@ -300,14 +300,11 @@ def passed_test(
     golden_tensor = golden_tensor.type(format_dict[output_data_format])
     res_tensor = res_tensor.type(format_dict[output_data_format])
 
-    if output_data_format == DataFormat.Bfp4_b:
-        is_valid = _bfp4_block_aware_compare(golden_tensor, res_tensor)
-    else:
-        is_close = torch.isclose(
-            golden_tensor, res_tensor, rtol=tolerance.rtol, atol=tolerance.atol
-        )
-        is_nan = torch.isnan(golden_tensor) & torch.isnan(res_tensor)
-        is_valid = is_close | is_nan
+    is_close = torch.isclose(
+        golden_tensor, res_tensor, rtol=tolerance.rtol, atol=tolerance.atol
+    )
+    is_nan = torch.isnan(golden_tensor) & torch.isnan(res_tensor)
+    is_valid = is_close | is_nan
 
     is_within_tolerance = torch.all(is_valid)
 

--- a/tests/python_tests/helpers/utils.py
+++ b/tests/python_tests/helpers/utils.py
@@ -34,7 +34,7 @@ tolerances = {
     DataFormat.Int8: Tolerance(atol=0, rtol=0),
     DataFormat.UInt8: Tolerance(atol=0, rtol=0),
     DataFormat.Bfp8_b: Tolerance(atol=0.1, rtol=0.2),
-    DataFormat.Bfp4_b: Tolerance(atol=0.25, rtol=0.3),
+    DataFormat.Bfp4_b: Tolerance(atol=0.125, rtol=0.3),
     DataFormat.MxFp8R: Tolerance(atol=0.2, rtol=0.3),
     DataFormat.MxFp8P: Tolerance(atol=0.2, rtol=0.3),
     DataFormat.Fp8_e4m3: Tolerance(atol=0.2, rtol=0.2),
@@ -229,14 +229,26 @@ def _bfp4_block_aware_compare(
 
         block_max = finite_vals.max().item()
         if block_max == 0:
-            is_valid[blk_start:blk_end] = (g_blk == r_blk) | both_nan
+            is_valid[blk_start:blk_end] = (
+                torch.isclose(g_blk, r_blk, atol=1e-5, rtol=0.0, equal_nan=True)
+                | both_nan
+            )
             continue
 
         block_exp = math.floor(math.log2(block_max))
         one_ulp = 2.0 ** (block_exp - BFP4_MANTISSA_BITS + 1)
 
         diff = (g_blk - r_blk).abs()
-        is_valid[blk_start:blk_end] = (diff <= max_ulp_diff * one_ulp) | both_nan
+        ulp_ok = diff <= max_ulp_diff * one_ulp
+        # Padding / zero lanes can disagree slightly after pack-unpack while still
+        # printing as 0.00; ULP sizing from a large value elsewhere in the block
+        # can make those tiny residuals look like multi-ULP failures. Accept when
+        # both sides are negligible magnitude and close in absolute terms.
+        max_abs = torch.maximum(g_blk.abs(), r_blk.abs())
+        tiny_ok = (max_abs < 1e-4) & torch.isclose(
+            g_blk, r_blk, atol=1e-5, rtol=0.0, equal_nan=True
+        )
+        is_valid[blk_start:blk_end] = ulp_ok | both_nan | tiny_ok
 
     return is_valid
 
@@ -246,6 +258,7 @@ def passed_test(
     res_tensor,
     output_data_format: DataFormat = DataFormat.Float16_b,
     L1_to_L1_iterations: int = 1,
+    custom_bfp4_max_ulp_diff=None,
     print_errors: bool = True,
     print_pcc: bool = False,
     custom_atol=None,
@@ -277,7 +290,10 @@ def passed_test(
     res_tensor = res_tensor.type(format_dict[output_data_format])
 
     if output_data_format == DataFormat.Bfp4_b:
-        is_valid = _bfp4_block_aware_compare(golden_tensor, res_tensor)
+        ulp = custom_bfp4_max_ulp_diff if custom_bfp4_max_ulp_diff is not None else 1
+        is_valid = _bfp4_block_aware_compare(
+            golden_tensor, res_tensor, max_ulp_diff=ulp
+        )
     else:
         is_close = torch.isclose(
             golden_tensor, res_tensor, rtol=tolerance.rtol, atol=tolerance.atol

--- a/tests/python_tests/helpers/utils.py
+++ b/tests/python_tests/helpers/utils.py
@@ -34,7 +34,7 @@ tolerances = {
     DataFormat.Int8: Tolerance(atol=0, rtol=0),
     DataFormat.UInt8: Tolerance(atol=0, rtol=0),
     DataFormat.Bfp8_b: Tolerance(atol=0.1, rtol=0.2),
-    DataFormat.Bfp4_b: Tolerance(atol=0.25, rtol=0.5),
+    DataFormat.Bfp4_b: Tolerance(atol=0.25, rtol=0.3),
     DataFormat.MxFp8R: Tolerance(atol=0.2, rtol=0.3),
     DataFormat.MxFp8P: Tolerance(atol=0.2, rtol=0.3),
     DataFormat.Fp8_e4m3: Tolerance(atol=0.2, rtol=0.2),
@@ -187,46 +187,33 @@ def calculate_pcc(golden, input):
 
 
 def _bfp4_block_aware_compare(
-    golden: torch.Tensor, result: torch.Tensor, max_ulp_diff: int = 2
+    golden: torch.Tensor, result: torch.Tensor, max_ulp_diff: int = 1
 ) -> torch.Tensor:
     """Compare two BFP4_b tensors allowing small ULP differences per 16-element block.
 
     BFP4_b shares an exponent across each 16-element block, so the ULP size
-    depends on the block's max magnitude.  The SFPU hardware computes in FP32
-    with internal approximations (e.g. Newton-Raphson for rsqrt) that can
-    differ slightly from the golden model.  After Bfp4 quantization (3-bit
-    mantissa), these small intermediate differences can shift a value by up
-    to ``max_ulp_diff`` quantization steps.
+    depends on the block's max magnitude.  Hardware and the Python golden can
+    disagree at BFP8→BFP4 truncation boundaries (e.g. 0.0 vs 0.5 printed as bf16).
+    After Bfp4 quantization (3-bit mantissa), treat differences up to
+    ``max_ulp_diff`` steps as acceptable.
 
-    For full tiles (n a multiple of 1024), we tilize before block-wise check and
-    untilize the validity mask. For partial tiles (num_faces 1 or 2: 256/512
-    elements), we compare block-by-block on flat data without tilize/untilize.
+    Golden and result must already be in the same flat buffer order (tilized
+    layout as produced by the tests).  We do not re-tilize here: inputs are
+    already ordered in 16-element BFP blocks for the device.
     """
-    from helpers.tilize_untilize import tilize_block, untilize_block
-
     BLOCK = 16
     BFP4_MANTISSA_BITS = 3
-    TILE_SIZE = 1024
 
     g_flat = golden.float().flatten()
     r_flat = result.float().flatten()
     n = g_flat.numel()
 
-    if n % TILE_SIZE == 0 and n > 0:
-        num_tiles = n // TILE_SIZE
-        tile_dim = (32 * num_tiles, 32)
-        g_til = tilize_block(g_flat, tile_dim, DataFormat.Float32).flatten()
-        r_til = tilize_block(r_flat, tile_dim, DataFormat.Float32).flatten()
-    else:
-        g_til = g_flat
-        r_til = r_flat
-
-    is_valid_til = torch.ones(n, dtype=torch.bool)
+    is_valid = torch.ones(n, dtype=torch.bool)
 
     for blk_start in range(0, n, BLOCK):
         blk_end = min(blk_start + BLOCK, n)
-        g_blk = g_til[blk_start:blk_end]
-        r_blk = r_til[blk_start:blk_end]
+        g_blk = g_flat[blk_start:blk_end]
+        r_blk = r_flat[blk_start:blk_end]
 
         both_nan = torch.isnan(g_blk) & torch.isnan(r_blk)
 
@@ -237,30 +224,19 @@ def _bfp4_block_aware_compare(
             ]
         )
         if finite_vals.numel() == 0:
-            is_valid_til[blk_start:blk_end] = True
+            is_valid[blk_start:blk_end] = True
             continue
 
         block_max = finite_vals.max().item()
         if block_max == 0:
-            is_valid_til[blk_start:blk_end] = (g_blk == r_blk) | both_nan
+            is_valid[blk_start:blk_end] = (g_blk == r_blk) | both_nan
             continue
 
         block_exp = math.floor(math.log2(block_max))
         one_ulp = 2.0 ** (block_exp - BFP4_MANTISSA_BITS + 1)
 
         diff = (g_blk - r_blk).abs()
-        is_valid_til[blk_start:blk_end] = (diff <= max_ulp_diff * one_ulp) | both_nan
-
-    if n % TILE_SIZE == 0 and n > 0:
-        num_tiles = n // TILE_SIZE
-        tile_dim = (32 * num_tiles, 32)
-        is_valid = (
-            untilize_block(is_valid_til.float(), DataFormat.Float32, tile_dim)
-            .flatten()
-            .bool()
-        )
-    else:
-        is_valid = is_valid_til
+        is_valid[blk_start:blk_end] = (diff <= max_ulp_diff * one_ulp) | both_nan
 
     return is_valid
 
@@ -300,11 +276,14 @@ def passed_test(
     golden_tensor = golden_tensor.type(format_dict[output_data_format])
     res_tensor = res_tensor.type(format_dict[output_data_format])
 
-    is_close = torch.isclose(
-        golden_tensor, res_tensor, rtol=tolerance.rtol, atol=tolerance.atol
-    )
-    is_nan = torch.isnan(golden_tensor) & torch.isnan(res_tensor)
-    is_valid = is_close | is_nan
+    if output_data_format == DataFormat.Bfp4_b:
+        is_valid = _bfp4_block_aware_compare(golden_tensor, res_tensor)
+    else:
+        is_close = torch.isclose(
+            golden_tensor, res_tensor, rtol=tolerance.rtol, atol=tolerance.atol
+        )
+        is_nan = torch.isnan(golden_tensor) & torch.isnan(res_tensor)
+        is_valid = is_close | is_nan
 
     is_within_tolerance = torch.all(is_valid)
 

--- a/tests/python_tests/helpers/utils.py
+++ b/tests/python_tests/helpers/utils.py
@@ -34,7 +34,7 @@ tolerances = {
     DataFormat.Int8: Tolerance(atol=0, rtol=0),
     DataFormat.UInt8: Tolerance(atol=0, rtol=0),
     DataFormat.Bfp8_b: Tolerance(atol=0.1, rtol=0.2),
-    DataFormat.Bfp4_b: Tolerance(atol=0.25, rtol=0.3),
+    DataFormat.Bfp4_b: Tolerance(atol=0.25, rtol=0.5),
     DataFormat.MxFp8R: Tolerance(atol=0.2, rtol=0.3),
     DataFormat.MxFp8P: Tolerance(atol=0.2, rtol=0.3),
     DataFormat.Fp8_e4m3: Tolerance(atol=0.2, rtol=0.2),
@@ -407,7 +407,7 @@ def passed_test(
     if output_data_format == DataFormat.Bfp8_b:
         target_pcc = pow(0.99, L1_to_L1_iterations)
     elif output_data_format == DataFormat.Bfp4_b:
-        target_pcc = 0.98
+        target_pcc = 0.97
 
     if custom_pcc_threshold is not None:
         logger.info(

--- a/tests/python_tests/test_reduce.py
+++ b/tests/python_tests/test_reduce.py
@@ -126,6 +126,7 @@ def test_reduce(
         tile_cnt_A,
         reduce_to_one=is_reduce_to_one,
         tile_shape=tile_shape,
+        input_format=formats.input_format,
     )
 
     dest_acc = (

--- a/tests/python_tests/test_zzz_eltwise_binary.py
+++ b/tests/python_tests/test_zzz_eltwise_binary.py
@@ -352,13 +352,12 @@ def test_eltwise_binary(
         or fmt.output_format == DataFormat.Bfp4_b
     ],
     broadcast_type=[
-        # BroadcastType.None_,
-        # BroadcastType.Row,
-        # BroadcastType.Column,
+        BroadcastType.None_,
+        BroadcastType.Row,
+        BroadcastType.Column,
         BroadcastType.Scalar,
     ],
-    # math_op=[MathOperation.Elwadd, MathOperation.Elwsub, MathOperation.Elwmul],
-    math_op=[MathOperation.Elwmul],
+    math_op=[MathOperation.Elwmul, MathOperation.Elwadd, MathOperation.Elwsub],
     math_fidelity=lambda formats, math_op: _get_valid_math_fidelity(formats, math_op),
     transpose_srca=Transpose.No,
     input_dimensions=[[32, 32], [64, 32], [32, 64], [256, 32]],
@@ -546,17 +545,29 @@ def test_eltwise_binary_bfp4_b(
             f"  formats={formats.input_format}->{formats.output_format}  tile_dimensions={tile_dimensions}"
         )
         print(f"  input_dimensions={input_dimensions}  dest_acc={dest_acc}")
-        torch.set_printoptions(linewidth=200, precision=4, sci_mode=False)
-        print(f"\n--- src_B_tilized_flat (raw before broadcast, first 32 elements) ---")
+        torch.set_printoptions(linewidth=200, precision=9, sci_mode=True)
+        print(f"\n--- src_A_tilized_flat (first input, first 32 elements) ---")
+        print(src_A_tilized_flat[:32])
+        if transpose_srca == Transpose.Yes:
+            print(f"\n--- golden_src_A (after transpose, first 32 elements) ---")
+            print(golden_src_A[:32])
+        print(
+            f"\n--- src_B_tilized_flat (second input, raw before broadcast, first 32 elements) ---"
+        )
         print(src_B_tilized_flat[:32])
-        print(f"\n--- golden_src_B (after broadcast, first 32 elements) ---")
-        print(golden_src_B[:32])
+        if broadcast_type != BroadcastType.None_:
+            print(f"\n--- golden_src_B (after broadcast, first 32 elements) ---")
+            print(golden_src_B[:32])
         print(f"\n--- golden_tensor (expected output, first 32 elements) ---")
         print(golden_tensor[:32])
         print(f"\n--- res_tensor (device output, first 32 elements) ---")
         print(res_tensor[:32])
         diff = (golden_tensor.float() - res_tensor.float()).abs()
+        rel_diff = diff / (golden_tensor.float().abs() + 1e-10)
         print(f"\n--- abs diff (max={diff.max():.6f}, mean={diff.mean():.6f}) ---")
+        print(
+            f"--- rel diff (max={rel_diff.max():.6f}, mean={rel_diff.mean():.6f}) ---"
+        )
         # Show first differing block
         nonzero_idx = diff.nonzero(as_tuple=True)[0]
         if len(nonzero_idx) > 0:

--- a/tests/python_tests/test_zzz_eltwise_binary.py
+++ b/tests/python_tests/test_zzz_eltwise_binary.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 # SPDX-License-Identifier: Apache-2.0
 
+import pytest
 import torch
 from helpers.format_config import DataFormat, InputOutputFormat
 from helpers.golden_generators import (
@@ -238,22 +239,29 @@ def test_eltwise_binary(
     golden_src_A = src_A_tilized_flat
     if transpose_srca == Transpose.Yes:
         transpose_golden = get_golden_generator(TransposeGolden)
-        # Apply face transpose (f0,f1,f2,f3 -> f0,f2,f1,f3)
+        # Apply face transpose — also quantizes BFP formats to float16_b
         golden_src_A = transpose_golden.transpose_faces_multi_tile(
             src_A,
             formats.input_format,
             num_tiles=tile_cnt_A,
             tilize=True,
-            untilize=False,  # Keep tilized
+            untilize=False,
             input_dimensions=tuple(input_dimensions),
         )
-        # Apply within-face transpose (transpose each 16x16 face)
+        # Apply within-face transpose on already-quantized data.
+        # Use Float32 to match hardware source register precision (TF32)
+        # and avoid double-quantization — hardware only quantizes once
+        # during unpack, then transposes at full precision.
         golden_src_A = transpose_golden.transpose_within_faces_multi_tile(
             golden_src_A,
-            formats.input_format,
+            (
+                DataFormat.Float16_b
+                if formats.input_format in [DataFormat.Bfp4_b, DataFormat.Bfp8_b]
+                else formats.input_format
+            ),
             num_tiles=tile_cnt_A,
-            tilize=False,  # Already tilized
-            untilize=False,  # Keep tilized for golden comparison
+            tilize=False,
+            untilize=False,
             input_dimensions=tuple(input_dimensions),
         )
 
@@ -270,9 +278,11 @@ def test_eltwise_binary(
             face_r_dim=face_r_dim,
         )
 
-    # Compute golden on tilized data
-    # When broadcast is applied, BroadcastGolden already quantized golden_src_B
-    # (Bfp4_b/Bfp8_b -> float16_b), so we must not re-quantize it here.
+    # When transpose/broadcast already quantized an operand (BFP -> float16_b),
+    # pass None to skip re-quantization in EltwiseBinaryGolden.
+    golden_input_format_A = (
+        None if transpose_srca == Transpose.Yes else formats.input_format
+    )
     golden_input_format_B = (
         None if broadcast_type != BroadcastType.None_ else formats.input_format
     )
@@ -282,7 +292,7 @@ def test_eltwise_binary(
         golden_src_B,
         formats.output_format,
         math_fidelity,
-        input_format=formats.input_format,
+        input_format=golden_input_format_A,
         input_format_B=golden_input_format_B,
     )
 
@@ -359,7 +369,7 @@ def test_eltwise_binary(
     ],
     math_op=[MathOperation.Elwmul, MathOperation.Elwadd, MathOperation.Elwsub],
     math_fidelity=lambda formats, math_op: _get_valid_math_fidelity(formats, math_op),
-    transpose_srca=Transpose.No,
+    transpose_srca=[Transpose.Yes, Transpose.No],
     input_dimensions=[[32, 32], [64, 32], [32, 64], [256, 32]],
     tile_dimensions=lambda transpose_srca, broadcast_type: _get_valid_tile_dimensions(
         transpose_srca, broadcast_type
@@ -376,6 +386,8 @@ def test_eltwise_binary_bfp4_b(
     tile_dimensions,
     workers_tensix_coordinates,
 ):
+    if transpose_srca == Transpose.Yes and broadcast_type == BroadcastType.Scalar:
+        pytest.skip("SrcA transpose is not supported with scalar broadcast")
 
     face_r_dim, num_faces_r_dim, num_faces_c_dim = get_tile_params(tile_dimensions)
     num_faces = num_faces_r_dim * num_faces_c_dim
@@ -443,22 +455,29 @@ def test_eltwise_binary_bfp4_b(
     golden_src_A = src_A_tilized_flat
     if transpose_srca == Transpose.Yes:
         transpose_golden = get_golden_generator(TransposeGolden)
-        # Apply face transpose (f0,f1,f2,f3 -> f0,f2,f1,f3)
+        # Apply face transpose — also quantizes BFP formats to float16_b
         golden_src_A = transpose_golden.transpose_faces_multi_tile(
             src_A,
             formats.input_format,
             num_tiles=tile_cnt_A,
             tilize=True,
-            untilize=False,  # Keep tilized
+            untilize=False,
             input_dimensions=tuple(input_dimensions),
         )
-        # Apply within-face transpose (transpose each 16x16 face)
+        # Apply within-face transpose on already-quantized data.
+        # Use Float32 to match hardware source register precision (TF32)
+        # and avoid double-quantization — hardware only quantizes once
+        # during unpack, then transposes at full precision.
         golden_src_A = transpose_golden.transpose_within_faces_multi_tile(
             golden_src_A,
-            formats.input_format,
+            (
+                DataFormat.Float16_b
+                if formats.input_format in [DataFormat.Bfp4_b, DataFormat.Bfp8_b]
+                else formats.input_format
+            ),
             num_tiles=tile_cnt_A,
-            tilize=False,  # Already tilized
-            untilize=False,  # Keep tilized for golden comparison
+            tilize=False,
+            untilize=False,
             input_dimensions=tuple(input_dimensions),
         )
 
@@ -475,8 +494,11 @@ def test_eltwise_binary_bfp4_b(
             face_r_dim=face_r_dim,
         )
 
-    # When broadcast is applied, BroadcastGolden already converts Bfp4_b/Bfp8_b to
-    # float16_b, so we must not re-quantize golden_src_B inside binary_golden.
+    # When transpose/broadcast already quantized an operand (BFP -> float16_b),
+    # pass None to skip re-quantization in EltwiseBinaryGolden.
+    golden_input_format_A = (
+        None if transpose_srca == Transpose.Yes else formats.input_format
+    )
     golden_input_format_B = (
         None if broadcast_type != BroadcastType.None_ else formats.input_format
     )
@@ -486,7 +508,7 @@ def test_eltwise_binary_bfp4_b(
         golden_src_B,
         formats.output_format,
         math_fidelity,
-        input_format=formats.input_format,
+        input_format=golden_input_format_A,
         input_format_B=golden_input_format_B,
     )
 

--- a/tests/python_tests/test_zzz_eltwise_binary.py
+++ b/tests/python_tests/test_zzz_eltwise_binary.py
@@ -352,12 +352,13 @@ def test_eltwise_binary(
         or fmt.output_format == DataFormat.Bfp4_b
     ],
     broadcast_type=[
-        BroadcastType.None_,
-        BroadcastType.Row,
-        BroadcastType.Column,
+        # BroadcastType.None_,
+        # BroadcastType.Row,
+        # BroadcastType.Column,
         BroadcastType.Scalar,
     ],
-    math_op=[MathOperation.Elwadd, MathOperation.Elwsub],
+    # math_op=[MathOperation.Elwadd, MathOperation.Elwsub, MathOperation.Elwmul],
+    math_op=[MathOperation.Elwmul],
     math_fidelity=lambda formats, math_op: _get_valid_math_fidelity(formats, math_op),
     transpose_srca=Transpose.No,
     input_dimensions=[[32, 32], [64, 32], [32, 64], [256, 32]],
@@ -475,6 +476,11 @@ def test_eltwise_binary_bfp4_b(
             face_r_dim=face_r_dim,
         )
 
+    # When broadcast is applied, BroadcastGolden already converts Bfp4_b/Bfp8_b to
+    # float16_b, so we must not re-quantize golden_src_B inside binary_golden.
+    golden_input_format_B = (
+        None if broadcast_type != BroadcastType.None_ else formats.input_format
+    )
     golden_tensor = binary_golden(
         math_op,
         golden_src_A,
@@ -482,7 +488,7 @@ def test_eltwise_binary_bfp4_b(
         formats.output_format,
         math_fidelity,
         input_format=formats.input_format,
-        input_format_B=formats.input_format,
+        input_format_B=golden_input_format_B,
     )
 
     configuration = TestConfig(
@@ -531,6 +537,66 @@ def test_eltwise_binary_bfp4_b(
     res_tensor = torch.tensor(res_from_L1, dtype=torch_format)
 
     test_passed = passed_test(golden_tensor, res_tensor, formats.output_format)
+    if not test_passed:
+        print("\n=== DEBUG: test_eltwise_binary_bfp4_b FAILED ===")
+        print(
+            f"  broadcast_type={broadcast_type}  math_op={math_op}  math_fidelity={math_fidelity}"
+        )
+        print(
+            f"  formats={formats.input_format}->{formats.output_format}  tile_dimensions={tile_dimensions}"
+        )
+        print(f"  input_dimensions={input_dimensions}  dest_acc={dest_acc}")
+        torch.set_printoptions(linewidth=200, precision=4, sci_mode=False)
+        print(f"\n--- src_B_tilized_flat (raw before broadcast, first 32 elements) ---")
+        print(src_B_tilized_flat[:32])
+        print(f"\n--- golden_src_B (after broadcast, first 32 elements) ---")
+        print(golden_src_B[:32])
+        print(f"\n--- golden_tensor (expected output, first 32 elements) ---")
+        print(golden_tensor[:32])
+        print(f"\n--- res_tensor (device output, first 32 elements) ---")
+        print(res_tensor[:32])
+        diff = (golden_tensor.float() - res_tensor.float()).abs()
+        print(f"\n--- abs diff (max={diff.max():.6f}, mean={diff.mean():.6f}) ---")
+        # Show first differing block
+        nonzero_idx = diff.nonzero(as_tuple=True)[0]
+        if len(nonzero_idx) > 0:
+            print(
+                f"  first {len(nonzero_idx)} nonzero diffs at indices: {nonzero_idx[:20].tolist()}"
+            )
+            print(f"  golden at those: {golden_tensor[nonzero_idx[:20]].tolist()}")
+            print(f"  result at those: {res_tensor[nonzero_idx[:20]].tolist()}")
+        else:
+            print(
+                "  all diffs are zero -- failure is in _bfp4_block_aware_compare ULP logic"
+            )
+            # Rerun compare with verbose block-level output
+            import math as _math
+
+            g = golden_tensor.float().flatten()
+            r = res_tensor.float().flatten()
+            BLOCK = 16
+            for blk in range(0, len(g), BLOCK):
+                g_blk = g[blk : blk + BLOCK]
+                r_blk = r[blk : blk + BLOCK]
+                diff_blk = (g_blk - r_blk).abs()
+                block_max = max(g_blk.abs().max().item(), r_blk.abs().max().item())
+                if block_max == 0:
+                    ok = torch.isclose(g_blk, r_blk, atol=1e-5, rtol=0.0).all().item()
+                    if not ok:
+                        print(
+                            f"  FAIL block {blk//BLOCK} (block_max=0): g={g_blk.tolist()} r={r_blk.tolist()}"
+                        )
+                else:
+                    block_exp = _math.floor(_math.log2(block_max))
+                    one_ulp = 2.0 ** (block_exp - 3 + 1)
+                    ulp_ok = (diff_blk <= one_ulp).all().item()
+                    if not ulp_ok:
+                        print(
+                            f"  FAIL block {blk//BLOCK} (block_max={block_max:.4f}, 1ulp={one_ulp:.6f}): max_diff={diff_blk.max():.6f}"
+                        )
+                        print(f"    g={g_blk.tolist()}")
+                        print(f"    r={r_blk.tolist()}")
+        torch.set_printoptions(profile="default")
     assert test_passed, "Assert against golden failed"
 
 

--- a/tests/python_tests/test_zzz_eltwise_binary.py
+++ b/tests/python_tests/test_zzz_eltwise_binary.py
@@ -58,24 +58,6 @@ def _get_valid_formats(dest_acc):
     """
     all_formats = input_output_formats(
         [
-            DataFormat.Bfp8_b,
-            DataFormat.Float16_b,
-            DataFormat.Float32,
-        ],
-        same=False,
-    )
-    if dest_acc == DestAccumulation.Yes:
-        return [f for f in all_formats if f.input_format == DataFormat.Float32]
-    return all_formats
-
-
-def _get_valid_formats_include_bfp4_b(dest_acc):
-    """
-    Filter formats based on dest accumulation:
-    - If dest accumulation is enabled, input must be Float32
-    """
-    all_formats = input_output_formats(
-        [
             DataFormat.Bfp4_b,
             DataFormat.Bfp8_b,
             DataFormat.Float16_b,
@@ -115,20 +97,6 @@ def _get_valid_math_fidelity(formats, math_op=None):
     ]
 
 
-def _get_valid_math_ops(math_fidelity):
-    """High fidelity operations are only supported for Elwmul."""
-    if math_fidelity != MathFidelity.LoFi:
-        return [MathOperation.Elwmul]
-    return [MathOperation.Elwadd, MathOperation.Elwsub, MathOperation.Elwmul]
-
-
-def _get_valid_transpose(broadcast_type):
-    """Transpose does not work for Scalar broadcast."""
-    if broadcast_type == BroadcastType.Scalar:
-        return [Transpose.No]
-    return [Transpose.No, Transpose.Yes]
-
-
 def _get_valid_tile_dimensions(transpose_srca, broadcast_type):
     """
     Filter tile dimensions based on transpose and broadcast constraints:
@@ -153,229 +121,15 @@ def _get_valid_tile_dimensions(transpose_srca, broadcast_type):
         BroadcastType.Column,
         BroadcastType.Scalar,
     ],
-    math_fidelity=lambda formats: _get_valid_math_fidelity(formats),
-    transpose_srca=lambda broadcast_type: _get_valid_transpose(broadcast_type),
-    math_op=lambda math_fidelity: _get_valid_math_ops(math_fidelity),
+    math_op=[MathOperation.Elwmul, MathOperation.Elwadd, MathOperation.Elwsub],
+    math_fidelity=lambda formats, math_op: _get_valid_math_fidelity(formats, math_op),
+    transpose_srca=[Transpose.Yes, Transpose.No],
     input_dimensions=[[256, 32]],
     tile_dimensions=lambda transpose_srca, broadcast_type: _get_valid_tile_dimensions(
         transpose_srca, broadcast_type
     ),
 )
 def test_eltwise_binary(
-    dest_acc,
-    formats,
-    broadcast_type,
-    math_fidelity,
-    transpose_srca,
-    math_op,
-    input_dimensions,
-    tile_dimensions,
-    workers_tensix_coordinates,
-):
-
-    face_r_dim, num_faces_r_dim, num_faces_c_dim = get_tile_params(tile_dimensions)
-    num_faces = num_faces_r_dim * num_faces_c_dim
-
-    # Calculate tile count based on tile_dimensions (not hardcoded 32x32)
-    tile_rows, tile_cols = tile_dimensions
-    tile_cnt_A = (input_dimensions[0] // tile_rows) * (input_dimensions[1] // tile_cols)
-    tile_cnt_B = tile_cnt_A
-
-    # Generate stimuli with correct face dimensions for smaller tiles
-    # Uses generate_stimuli_w_tile_dimensions which computes face_r_dim and num_faces from tile_dimensions
-    src_A, _, src_B, _ = generate_stimuli_w_tile_dimensions(
-        stimuli_format_A=formats.input_format,
-        input_dimensions_A=input_dimensions,
-        stimuli_format_B=formats.input_format_B,  # Use different format for src_B
-        input_dimensions_B=input_dimensions,
-        tile_dimensions=tile_dimensions,
-    )
-
-    effective_dest_acc = (
-        DestAccumulation.Yes
-        if formats.output_format == DataFormat.Float32
-        else dest_acc
-    )
-    num_blocks, num_tiles_in_block = get_num_blocks_and_num_tiles_in_block(
-        DestSync.Half,
-        effective_dest_acc,
-        formats,
-        input_dimensions,
-        tile_dimensions,
-        BlocksCalculationAlgorithm.Standard,
-    )
-
-    # Compute element-wise subtraction in tilized format
-    binary_golden = get_golden_generator(EltwiseBinaryGolden)
-
-    # Tilize inputs for device and golden calculation
-    src_A_tilized = tilize_block(
-        src_A,
-        dimensions=input_dimensions,
-        stimuli_format=formats.input_format,
-        num_faces=num_faces,
-        tile_dimensions=tile_dimensions,
-        face_r_dim=face_r_dim,
-    )
-    src_B_tilized = tilize_block(
-        src_B,
-        dimensions=input_dimensions,
-        stimuli_format=formats.input_format,
-        num_faces=num_faces,
-        tile_dimensions=tile_dimensions,
-        face_r_dim=face_r_dim,
-    )
-
-    # Flatten tilized tensors
-    src_A_tilized_flat = src_A_tilized.flatten()
-    src_B_tilized_flat = src_B_tilized.flatten()
-
-    # Send tilized data to device (device handles transpose during unpack)
-    stimuli_A = src_A_tilized_flat
-    stimuli_B = src_B_tilized_flat
-
-    # Prepare golden src_A: apply tile-level transpose if enabled
-    # Hardware does transpose_faces then transpose_within_faces during unpack
-    golden_src_A = src_A_tilized_flat
-    if transpose_srca == Transpose.Yes:
-        transpose_golden = get_golden_generator(TransposeGolden)
-        # Apply face transpose — also quantizes BFP formats to float16_b
-        golden_src_A = transpose_golden.transpose_faces_multi_tile(
-            src_A,
-            formats.input_format,
-            num_tiles=tile_cnt_A,
-            tilize=True,
-            untilize=False,
-            input_dimensions=tuple(input_dimensions),
-        )
-        # Apply within-face transpose on already-quantized data.
-        # Use Float32 to match hardware source register precision (TF32)
-        # and avoid double-quantization — hardware only quantizes once
-        # during unpack, then transposes at full precision.
-        golden_src_A = transpose_golden.transpose_within_faces_multi_tile(
-            golden_src_A,
-            (
-                DataFormat.Float16_b
-                if formats.input_format in [DataFormat.Bfp4_b, DataFormat.Bfp8_b]
-                else formats.input_format
-            ),
-            num_tiles=tile_cnt_A,
-            tilize=False,
-            untilize=False,
-            input_dimensions=tuple(input_dimensions),
-        )
-
-    # Prepare golden src_B: apply broadcast if enabled
-    golden_src_B = src_B_tilized_flat
-    if broadcast_type != BroadcastType.None_:
-        broadcast_golden = get_golden_generator(BroadcastGolden)
-        golden_src_B = broadcast_golden(
-            broadcast_type,
-            src_B_tilized_flat,
-            formats.input_format,
-            num_faces=num_faces,
-            tile_cnt=tile_cnt_A,
-            face_r_dim=face_r_dim,
-        )
-
-    # When transpose/broadcast already quantized an operand (BFP -> float16_b),
-    # pass None to skip re-quantization in EltwiseBinaryGolden.
-    golden_input_format_A = (
-        None if transpose_srca == Transpose.Yes else formats.input_format
-    )
-    golden_input_format_B = (
-        None if broadcast_type != BroadcastType.None_ else formats.input_format
-    )
-    golden_tensor = binary_golden(
-        math_op,
-        golden_src_A,
-        golden_src_B,
-        formats.output_format,
-        math_fidelity,
-        input_format=golden_input_format_A,
-        input_format_B=golden_input_format_B,
-    )
-
-    configuration = TestConfig(
-        "sources/eltwise_binary_test.cpp",
-        formats,
-        templates=[
-            MATH_FIDELITY(math_fidelity),
-            BROADCAST_TYPE(broadcast_type),
-            MATH_OP(mathop=math_op),
-            DEST_SYNC(),
-        ],
-        runtimes=[
-            UNPACK_TRANS_FACES(transpose_srca),
-            UNPACK_TRANS_WITHIN_FACE(transpose_srca),
-            NUM_TILES_IN_BLOCK(num_tiles_in_block),
-            NUM_BLOCKS(num_blocks),
-            NUM_FACES_R_DIM(num_faces_r_dim),
-            NUM_FACES_C_DIM(num_faces_c_dim),
-            TEST_FACE_DIMS(face_r_dim=face_r_dim),
-        ],
-        variant_stimuli=StimuliConfig(
-            stimuli_A,
-            formats.input_format,
-            stimuli_B,
-            formats.input_format,
-            formats.output_format,
-            tile_count_A=tile_cnt_A,
-            tile_count_B=tile_cnt_B,
-            tile_count_res=tile_cnt_A,
-            num_faces=num_faces,
-            face_r_dim=face_r_dim,
-            tile_dimensions=tile_dimensions,
-            use_dense_tile_dimensions=True,
-        ),
-        dest_acc=dest_acc,
-        unpack_to_dest=False,
-    )
-
-    res_from_L1 = configuration.run(workers_tensix_coordinates).result
-
-    assert len(res_from_L1) == len(
-        golden_tensor
-    ), "Result tensor and golden tensor are not of the same length"
-
-    torch_format = format_dict[formats.output_format]
-    res_tensor = torch.tensor(res_from_L1, dtype=torch_format)
-
-    # Compare in tilized format
-    test_passed = passed_test(golden_tensor, res_tensor, formats.output_format)
-    assert test_passed, "Assert against golden failed"
-
-
-@parametrize(
-    dest_acc=[DestAccumulation.No, DestAccumulation.Yes],
-    formats=[
-        fmt
-        for fmt in input_output_formats(
-            [
-                DataFormat.Bfp4_b,
-                DataFormat.Bfp8_b,
-                DataFormat.Float16_b,
-                DataFormat.Float32,
-            ]
-        )
-        if fmt.input_format == DataFormat.Bfp4_b
-        or fmt.output_format == DataFormat.Bfp4_b
-    ],
-    broadcast_type=[
-        BroadcastType.None_,
-        BroadcastType.Row,
-        BroadcastType.Column,
-        BroadcastType.Scalar,
-    ],
-    math_op=[MathOperation.Elwmul, MathOperation.Elwadd, MathOperation.Elwsub],
-    math_fidelity=lambda formats, math_op: _get_valid_math_fidelity(formats, math_op),
-    transpose_srca=[Transpose.Yes, Transpose.No],
-    input_dimensions=[[32, 32], [64, 32], [32, 64], [256, 32]],
-    tile_dimensions=lambda transpose_srca, broadcast_type: _get_valid_tile_dimensions(
-        transpose_srca, broadcast_type
-    ),
-)
-def test_eltwise_binary_bfp4_b(
     dest_acc,
     formats,
     broadcast_type,
@@ -392,17 +146,14 @@ def test_eltwise_binary_bfp4_b(
     face_r_dim, num_faces_r_dim, num_faces_c_dim = get_tile_params(tile_dimensions)
     num_faces = num_faces_r_dim * num_faces_c_dim
 
-    # Calculate tile count based on tile_dimensions (not hardcoded 32x32)
     tile_rows, tile_cols = tile_dimensions
     tile_cnt_A = (input_dimensions[0] // tile_rows) * (input_dimensions[1] // tile_cols)
     tile_cnt_B = tile_cnt_A
 
-    # Generate stimuli with correct face dimensions for smaller tiles
-    # Uses generate_stimuli_w_tile_dimensions which computes face_r_dim and num_faces from tile_dimensions
     src_A, _, src_B, _ = generate_stimuli_w_tile_dimensions(
         stimuli_format_A=formats.input_format,
         input_dimensions_A=input_dimensions,
-        stimuli_format_B=formats.input_format_B,  # Use different format for src_B
+        stimuli_format_B=formats.input_format_B,
         input_dimensions_B=input_dimensions,
         tile_dimensions=tile_dimensions,
     )
@@ -421,10 +172,8 @@ def test_eltwise_binary_bfp4_b(
         BlocksCalculationAlgorithm.Standard,
     )
 
-    # Compute element-wise subtraction in tilized format
     binary_golden = get_golden_generator(EltwiseBinaryGolden)
 
-    # Tilize inputs for device and golden calculation
     src_A_tilized = tilize_block(
         src_A,
         dimensions=input_dimensions,
@@ -442,11 +191,9 @@ def test_eltwise_binary_bfp4_b(
         face_r_dim=face_r_dim,
     )
 
-    # Flatten tilized tensors
     src_A_tilized_flat = src_A_tilized.flatten()
     src_B_tilized_flat = src_B_tilized.flatten()
 
-    # Send tilized data to device (device handles transpose during unpack)
     stimuli_A = src_A_tilized_flat
     stimuli_B = src_B_tilized_flat
 
@@ -559,7 +306,7 @@ def test_eltwise_binary_bfp4_b(
 
     test_passed = passed_test(golden_tensor, res_tensor, formats.output_format)
     if not test_passed:
-        print("\n=== DEBUG: test_eltwise_binary_bfp4_b FAILED ===")
+        print("\n=== DEBUG: test_eltwise_binary FAILED ===")
         print(
             f"  broadcast_type={broadcast_type}  math_op={math_op}  math_fidelity={math_fidelity}"
         )
@@ -590,7 +337,6 @@ def test_eltwise_binary_bfp4_b(
         print(
             f"--- rel diff (max={rel_diff.max():.6f}, mean={rel_diff.mean():.6f}) ---"
         )
-        # Show first differing block
         nonzero_idx = diff.nonzero(as_tuple=True)[0]
         if len(nonzero_idx) > 0:
             print(
@@ -602,7 +348,6 @@ def test_eltwise_binary_bfp4_b(
             print(
                 "  all diffs are zero -- failure is in _bfp4_block_aware_compare ULP logic"
             )
-            # Rerun compare with verbose block-level output
             import math as _math
 
             g = golden_tensor.float().flatten()

--- a/tests/python_tests/test_zzz_eltwise_binary.py
+++ b/tests/python_tests/test_zzz_eltwise_binary.py
@@ -345,7 +345,7 @@ def test_eltwise_binary(
                 DataFormat.Bfp4_b,
                 DataFormat.Bfp8_b,
                 DataFormat.Float16_b,
-                # DataFormat.Float32,
+                DataFormat.Float32,
             ]
         )
         if fmt.input_format == DataFormat.Bfp4_b

--- a/tests/python_tests/test_zzz_eltwise_binary.py
+++ b/tests/python_tests/test_zzz_eltwise_binary.py
@@ -52,93 +52,6 @@ ALL_TILE_DIMENSIONS = [list(td) for td in SUPPORTED_TILE_SIZES]
 BFP_BLOCK_SIZE = 16
 
 
-def _print_bfp_mismatch_blocks(
-    golden_tensor: "torch.Tensor",
-    res_tensor: "torch.Tensor",
-    src_a: "torch.Tensor | None" = None,
-    golden_src_b: "torch.Tensor | None" = None,
-):
-    """Print BFP blocks (shared exponent + mantissas in binary) for every block
-    that contains at least one mismatch between golden and result.
-
-    Optionally also shows src_A, golden_src_B and their sum alongside each element.
-    """
-    import struct
-
-    g_flat = golden_tensor.float().flatten()
-    r_flat = res_tensor.float().flatten()
-    n = g_flat.numel()
-
-    a_flat = src_a.float().flatten() if src_a is not None else None
-    b_flat = golden_src_b.float().flatten() if golden_src_b is not None else None
-    has_inputs = a_flat is not None and b_flat is not None
-
-    def float_to_bfp_parts(val: float):
-        """Return (sign, exponent, mantissa_bits) from a float32 value."""
-        packed = struct.pack(">f", val)
-        bits = int.from_bytes(packed, "big")
-        sign = (bits >> 31) & 1
-        exp = (bits >> 23) & 0xFF
-        mant = bits & 0x7FFFFF
-        return sign, exp, mant
-
-    mismatch_found = False
-    for blk_start in range(0, n, BFP_BLOCK_SIZE):
-        blk_end = min(blk_start + BFP_BLOCK_SIZE, n)
-        g_blk = g_flat[blk_start:blk_end]
-        r_blk = r_flat[blk_start:blk_end]
-
-        if torch.equal(g_blk, r_blk):
-            continue
-
-        if not mismatch_found:
-            print("\n" + "=" * 120)
-            print("BFP MISMATCH BLOCKS (shared exponent + mantissas in binary)")
-            print("=" * 120)
-            mismatch_found = True
-
-        # Compute shared exponent for golden and result blocks independently
-        g_exps = [float_to_bfp_parts(v)[1] for v in g_blk.tolist()]
-        r_exps = [float_to_bfp_parts(v)[1] for v in r_blk.tolist()]
-        g_shared_exp = max(g_exps)
-        r_shared_exp = max(r_exps)
-
-        print(f"\nBlock [{blk_start}:{blk_end}]")
-        print(f"  Golden shared exp : {g_shared_exp} (0b{g_shared_exp:08b})")
-        print(f"  Result shared exp : {r_shared_exp} (0b{r_shared_exp:08b})")
-
-        header = (
-            f"  {'Idx':>4}  {'Golden value':>14}  {'Golden bits (s exp mant)':>34}  "
-            f"{'Result value':>14}  {'Result bits (s exp mant)':>34}  {'Match':>8}"
-        )
-        if has_inputs:
-            header += f"  {'src_A':>14}  {'golden_src_B':>14}  {'A+B':>14}"
-        print(header)
-        print("  " + "-" * (115 + (50 if has_inputs else 0)))
-
-        a_blk = a_flat[blk_start:blk_end] if has_inputs else None
-        b_blk = b_flat[blk_start:blk_end] if has_inputs else None
-
-        for i, (gv, rv) in enumerate(zip(g_blk.tolist(), r_blk.tolist())):
-            g_sign, g_exp, g_mant = float_to_bfp_parts(gv)
-            r_sign, r_exp, r_mant = float_to_bfp_parts(rv)
-            match = "OK" if gv == rv else "MISMATCH"
-            g_bits = f"{'1' if g_sign else '0'} {g_exp:08b} {g_mant:023b}"
-            r_bits = f"{'1' if r_sign else '0'} {r_exp:08b} {r_mant:023b}"
-            line = (
-                f"  [{blk_start + i:4d}]  {gv:>14.6f}  {g_bits}  "
-                f"{rv:>14.6f}  {r_bits}  {match:>8}"
-            )
-            if has_inputs:
-                av = a_blk[i].item()
-                bv = b_blk[i].item()
-                line += f"  {av:>14.6f}  {bv:>14.6f}  {av + bv:>14.6f}"
-            print(line)
-
-    if mismatch_found:
-        print("=" * 120 + "\n")
-
-
 def _get_valid_formats(dest_acc):
     """
     Filter formats based on dest accumulation:
@@ -454,7 +367,6 @@ def test_eltwise_binary(
     math_fidelity=lambda formats, math_op: _get_valid_math_fidelity(formats, math_op),
     transpose_srca=Transpose.No,
     input_dimensions=[[32, 32], [64, 32], [32, 64], [256, 32]],
-    # input_dimensions=[[32, 32]],
     tile_dimensions=lambda transpose_srca, broadcast_type: _get_valid_tile_dimensions(
         transpose_srca, broadcast_type
     ),
@@ -470,30 +382,6 @@ def test_eltwise_binary_bfp4_b(
     tile_dimensions,
     workers_tensix_coordinates,
 ):
-    # import os
-    # from io import StringIO
-
-    # DEBUG_BFP4 = os.environ.get("DEBUG_BFP4", "1") == "1"
-    # debug_buffer = StringIO()
-
-    # def debug_print(title, data=None, tensor=None, max_items=64):
-    # output = f"\n{'='*80}\n"
-    # output += f"DEBUG: {title}\n"
-    # output += f"{'='*80}\n"
-    # if data is not None:
-    #     output += f"{data}\n"
-    # if tensor is not None:
-    #     if isinstance(tensor, torch.Tensor):
-    #         flat = tensor.flatten()
-    #         output += f"  Shape: {tensor.shape}, Dtype: {tensor.dtype}\n"
-    #         output += f"  Min: {flat.min():.4f}, Max: {flat.max():.4f}, Mean: {flat.mean():.4f}\n"
-    #         output += f"  First {min(max_items, len(flat))} values: {flat[:max_items].tolist()}\n"
-    #     else:
-    #         output += f"  Data: {tensor}\n"
-    # output += f"{'='*80}\n"
-    # debug_buffer.write(output)
-    # if DEBUG_BFP4:
-    #     print(output, end="")
 
     face_r_dim, num_faces_r_dim, num_faces_c_dim = get_tile_params(tile_dimensions)
     num_faces = num_faces_r_dim * num_faces_c_dim
@@ -502,14 +390,6 @@ def test_eltwise_binary_bfp4_b(
     tile_rows, tile_cols = tile_dimensions
     tile_cnt_A = (input_dimensions[0] // tile_rows) * (input_dimensions[1] // tile_cols)
     tile_cnt_B = tile_cnt_A
-
-    # debug_print(
-    #     "TEST CONFIGURATION",
-    #     f"formats: {formats}, broadcast_type: {broadcast_type}, math_op: {math_op}\n"
-    #     f"math_fidelity: {math_fidelity}, transpose_srca: {transpose_srca}\n"
-    #     f"input_dimensions: {input_dimensions}, tile_dimensions: {tile_dimensions}\n"
-    #     f"face_r_dim: {face_r_dim}, num_faces: {num_faces}, tile_cnt: {tile_cnt_A}",
-    # )
 
     # Generate stimuli with correct face dimensions for smaller tiles
     # Uses generate_stimuli_w_tile_dimensions which computes face_r_dim and num_faces from tile_dimensions
@@ -520,18 +400,6 @@ def test_eltwise_binary_bfp4_b(
         input_dimensions_B=input_dimensions,
         tile_dimensions=tile_dimensions,
     )
-
-    # debug_print("GENERATED STIMULI - src_A", tensor=src_A, max_items=128)
-    # debug_print("GENERATED STIMULI - src_B", tensor=src_B, max_items=128)
-
-    # Print some sample values from src_B for scalar broadcast debugging
-    # if broadcast_type == BroadcastType.Scalar:
-    #     print(
-    #         f"\n>>> SCALAR BROADCAST CHECK: src_B first 16 values: {src_B[:16].tolist()}"
-    #     )
-    #     print(
-    #         f">>> SCALAR BROADCAST CHECK: src_B tilized first 16 values will be computed next..."
-    #     )
 
     effective_dest_acc = (
         DestAccumulation.Yes
@@ -568,20 +436,9 @@ def test_eltwise_binary_bfp4_b(
         face_r_dim=face_r_dim,
     )
 
-    # debug_print("TILIZED src_A", tensor=src_A_tilized, max_items=128)
-    # debug_print("TILIZED src_B", tensor=src_B_tilized, max_items=128)
-
     # Flatten tilized tensors
     src_A_tilized_flat = src_A_tilized.flatten()
     src_B_tilized_flat = src_B_tilized.flatten()
-
-    # debug_print("TILIZED FLAT src_A", tensor=src_A_tilized_flat, max_items=128)
-    # debug_print("TILIZED FLAT src_B", tensor=src_B_tilized_flat, max_items=128)
-
-    # if broadcast_type == BroadcastType.Scalar:
-    #     print(
-    #         f">>> SCALAR BROADCAST CHECK: src_B_tilized_flat first 16 values: {src_B_tilized_flat[:16].tolist()}"
-    #     )
 
     # Send tilized data to device (device handles transpose during unpack)
     stimuli_A = src_A_tilized_flat
@@ -624,18 +481,6 @@ def test_eltwise_binary_bfp4_b(
             face_r_dim=face_r_dim,
         )
 
-    # debug_print(
-    #     "GOLDEN src_A (after transpose if any)", tensor=golden_src_A, max_items=128
-    # )
-    # debug_print(
-    #     "GOLDEN src_B (after broadcast if any)", tensor=golden_src_B, max_items=128
-    # )
-    # debug_print("BROADCAST TYPE", data=f"{broadcast_type}")
-
-    # Compute golden on tilized data
-    # When broadcast is applied, BroadcastGolden already quantized golden_src_B
-    # (Bfp4_b/Bfp8_b -> float16_b), so we must not re-quantize it here.
-    # golden_input_format_B = None if broadcast_type != BroadcastType.None_ else formats.input_format
     golden_tensor = binary_golden(
         math_op,
         golden_src_A,
@@ -645,10 +490,6 @@ def test_eltwise_binary_bfp4_b(
         input_format=formats.input_format,
         input_format_B=formats.input_format,
     )
-
-    # debug_print(
-    #     "GOLDEN TENSOR (result of binary op)", tensor=golden_tensor, max_items=256
-    # )
 
     configuration = TestConfig(
         "sources/eltwise_binary_test.cpp",
@@ -688,16 +529,6 @@ def test_eltwise_binary_bfp4_b(
 
     res_from_L1 = configuration.run(workers_tensix_coordinates).result
 
-    # debug_print(
-    #     "RESULT FROM L1 (raw)",
-    #     data=f"Type: {type(res_from_L1)}, Length: {len(res_from_L1)}",
-    # )
-    # debug_print(
-    #     "RESULT FROM L1 (first 256 values)",
-    #     tensor=torch.tensor(res_from_L1),
-    #     max_items=256,
-    # )
-
     assert len(res_from_L1) == len(
         golden_tensor
     ), f"Result tensor ({len(res_from_L1)}) and golden tensor ({len(golden_tensor)}) are not of the same length"
@@ -705,46 +536,12 @@ def test_eltwise_binary_bfp4_b(
     torch_format = format_dict[formats.output_format]
     res_tensor = torch.tensor(res_from_L1, dtype=torch_format)
 
-    # debug_print("RESULT TENSOR (converted to torch)", tensor=res_tensor, max_items=256)
-
-    # Compare in tilized format - print debug output only if test fails
-    try:
-        is_valid = passed_test(
-            golden_tensor,
-            res_tensor,
-            formats.output_format,
-            print_pcc=True,
-        )
-        assert is_valid, "Assert against golden failed"
-    except AssertionError as e:
-        # print("\n")
-        # print("src_B")
-        # print(src_B.view(32, 32))
-        # print("\n")
-        # print("src_A")
-        # print(src_A.view(32, 32))
-        # print("\n")
-        # print("-" * 200)
-        # print("golden_src_B")
-        # print(golden_src_B.view(32, 32))
-        # print("golden_src_A + golden_src_B (emulated addition)")
-        # golden_added = (
-        #     golden_src_A.to(torch.float32) + golden_src_B.to(torch.float32)
-        # ).to(golden_src_A.dtype)
-        # print(golden_added.view(32, 32))
-        # print("\n")
-        # print("golden_tensor")
-        # print(golden_tensor.view(32, 32))
-        # print("\n")
-        # print("res_tensor")
-        # print(res_tensor.view(32, 32))
-        # print("\n")
-        # print("-" * 200)
-
+    test_passed = passed_test(golden_tensor, res_tensor, formats.output_format)
+    if not test_passed:
         _print_bfp_mismatch_blocks(
             golden_tensor, res_tensor, src_a=golden_src_A, golden_src_b=golden_src_B
         )
-        raise
+    assert test_passed, "Assert against golden failed"
 
 
 @parametrize(

--- a/tests/python_tests/test_zzz_eltwise_binary.py
+++ b/tests/python_tests/test_zzz_eltwise_binary.py
@@ -304,78 +304,9 @@ def test_eltwise_binary(
     torch_format = format_dict[formats.output_format]
     res_tensor = torch.tensor(res_from_L1, dtype=torch_format)
 
-    test_passed = passed_test(golden_tensor, res_tensor, formats.output_format)
-    if not test_passed:
-        print("\n=== DEBUG: test_eltwise_binary FAILED ===")
-        print(
-            f"  broadcast_type={broadcast_type}  math_op={math_op}  math_fidelity={math_fidelity}"
-        )
-        print(
-            f"  formats={formats.input_format}->{formats.output_format}  tile_dimensions={tile_dimensions}"
-        )
-        print(f"  input_dimensions={input_dimensions}  dest_acc={dest_acc}")
-        torch.set_printoptions(linewidth=200, precision=9, sci_mode=True)
-        print(f"\n--- src_A_tilized_flat (first input, first 32 elements) ---")
-        print(src_A_tilized_flat[:32])
-        if transpose_srca == Transpose.Yes:
-            print(f"\n--- golden_src_A (after transpose, first 32 elements) ---")
-            print(golden_src_A[:32])
-        print(
-            f"\n--- src_B_tilized_flat (second input, raw before broadcast, first 32 elements) ---"
-        )
-        print(src_B_tilized_flat[:32])
-        if broadcast_type != BroadcastType.None_:
-            print(f"\n--- golden_src_B (after broadcast, first 32 elements) ---")
-            print(golden_src_B[:32])
-        print(f"\n--- golden_tensor (expected output, first 32 elements) ---")
-        print(golden_tensor[:32])
-        print(f"\n--- res_tensor (device output, first 32 elements) ---")
-        print(res_tensor[:32])
-        diff = (golden_tensor.float() - res_tensor.float()).abs()
-        rel_diff = diff / (golden_tensor.float().abs() + 1e-10)
-        print(f"\n--- abs diff (max={diff.max():.6f}, mean={diff.mean():.6f}) ---")
-        print(
-            f"--- rel diff (max={rel_diff.max():.6f}, mean={rel_diff.mean():.6f}) ---"
-        )
-        nonzero_idx = diff.nonzero(as_tuple=True)[0]
-        if len(nonzero_idx) > 0:
-            print(
-                f"  first {len(nonzero_idx)} nonzero diffs at indices: {nonzero_idx[:20].tolist()}"
-            )
-            print(f"  golden at those: {golden_tensor[nonzero_idx[:20]].tolist()}")
-            print(f"  result at those: {res_tensor[nonzero_idx[:20]].tolist()}")
-        else:
-            print(
-                "  all diffs are zero -- failure is in _bfp4_block_aware_compare ULP logic"
-            )
-            import math as _math
-
-            g = golden_tensor.float().flatten()
-            r = res_tensor.float().flatten()
-            BLOCK = 16
-            for blk in range(0, len(g), BLOCK):
-                g_blk = g[blk : blk + BLOCK]
-                r_blk = r[blk : blk + BLOCK]
-                diff_blk = (g_blk - r_blk).abs()
-                block_max = max(g_blk.abs().max().item(), r_blk.abs().max().item())
-                if block_max == 0:
-                    ok = torch.isclose(g_blk, r_blk, atol=1e-5, rtol=0.0).all().item()
-                    if not ok:
-                        print(
-                            f"  FAIL block {blk//BLOCK} (block_max=0): g={g_blk.tolist()} r={r_blk.tolist()}"
-                        )
-                else:
-                    block_exp = _math.floor(_math.log2(block_max))
-                    one_ulp = 2.0 ** (block_exp - 3 + 1)
-                    ulp_ok = (diff_blk <= one_ulp).all().item()
-                    if not ulp_ok:
-                        print(
-                            f"  FAIL block {blk//BLOCK} (block_max={block_max:.4f}, 1ulp={one_ulp:.6f}): max_diff={diff_blk.max():.6f}"
-                        )
-                        print(f"    g={g_blk.tolist()}")
-                        print(f"    r={r_blk.tolist()}")
-        torch.set_printoptions(profile="default")
-    assert test_passed, "Assert against golden failed"
+    assert passed_test(
+        golden_tensor, res_tensor, formats.output_format
+    ), "Assert against golden failed"
 
 
 @parametrize(

--- a/tests/python_tests/test_zzz_eltwise_binary.py
+++ b/tests/python_tests/test_zzz_eltwise_binary.py
@@ -49,6 +49,95 @@ from helpers.utils import passed_test
 
 ALL_TILE_DIMENSIONS = [list(td) for td in SUPPORTED_TILE_SIZES]
 
+BFP_BLOCK_SIZE = 16
+
+
+def _print_bfp_mismatch_blocks(
+    golden_tensor: "torch.Tensor",
+    res_tensor: "torch.Tensor",
+    src_a: "torch.Tensor | None" = None,
+    golden_src_b: "torch.Tensor | None" = None,
+):
+    """Print BFP blocks (shared exponent + mantissas in binary) for every block
+    that contains at least one mismatch between golden and result.
+
+    Optionally also shows src_A, golden_src_B and their sum alongside each element.
+    """
+    import struct
+
+    g_flat = golden_tensor.float().flatten()
+    r_flat = res_tensor.float().flatten()
+    n = g_flat.numel()
+
+    a_flat = src_a.float().flatten() if src_a is not None else None
+    b_flat = golden_src_b.float().flatten() if golden_src_b is not None else None
+    has_inputs = a_flat is not None and b_flat is not None
+
+    def float_to_bfp_parts(val: float):
+        """Return (sign, exponent, mantissa_bits) from a float32 value."""
+        packed = struct.pack(">f", val)
+        bits = int.from_bytes(packed, "big")
+        sign = (bits >> 31) & 1
+        exp = (bits >> 23) & 0xFF
+        mant = bits & 0x7FFFFF
+        return sign, exp, mant
+
+    mismatch_found = False
+    for blk_start in range(0, n, BFP_BLOCK_SIZE):
+        blk_end = min(blk_start + BFP_BLOCK_SIZE, n)
+        g_blk = g_flat[blk_start:blk_end]
+        r_blk = r_flat[blk_start:blk_end]
+
+        if torch.equal(g_blk, r_blk):
+            continue
+
+        if not mismatch_found:
+            print("\n" + "=" * 120)
+            print("BFP MISMATCH BLOCKS (shared exponent + mantissas in binary)")
+            print("=" * 120)
+            mismatch_found = True
+
+        # Compute shared exponent for golden and result blocks independently
+        g_exps = [float_to_bfp_parts(v)[1] for v in g_blk.tolist()]
+        r_exps = [float_to_bfp_parts(v)[1] for v in r_blk.tolist()]
+        g_shared_exp = max(g_exps)
+        r_shared_exp = max(r_exps)
+
+        print(f"\nBlock [{blk_start}:{blk_end}]")
+        print(f"  Golden shared exp : {g_shared_exp} (0b{g_shared_exp:08b})")
+        print(f"  Result shared exp : {r_shared_exp} (0b{r_shared_exp:08b})")
+
+        header = (
+            f"  {'Idx':>4}  {'Golden value':>14}  {'Golden bits (s exp mant)':>34}  "
+            f"{'Result value':>14}  {'Result bits (s exp mant)':>34}  {'Match':>8}"
+        )
+        if has_inputs:
+            header += f"  {'src_A':>14}  {'golden_src_B':>14}  {'A+B':>14}"
+        print(header)
+        print("  " + "-" * (115 + (50 if has_inputs else 0)))
+
+        a_blk = a_flat[blk_start:blk_end] if has_inputs else None
+        b_blk = b_flat[blk_start:blk_end] if has_inputs else None
+
+        for i, (gv, rv) in enumerate(zip(g_blk.tolist(), r_blk.tolist())):
+            g_sign, g_exp, g_mant = float_to_bfp_parts(gv)
+            r_sign, r_exp, r_mant = float_to_bfp_parts(rv)
+            match = "OK" if gv == rv else "MISMATCH"
+            g_bits = f"{'1' if g_sign else '0'} {g_exp:08b} {g_mant:023b}"
+            r_bits = f"{'1' if r_sign else '0'} {r_exp:08b} {r_mant:023b}"
+            line = (
+                f"  [{blk_start + i:4d}]  {gv:>14.6f}  {g_bits}  "
+                f"{rv:>14.6f}  {r_bits}  {match:>8}"
+            )
+            if has_inputs:
+                av = a_blk[i].item()
+                bv = b_blk[i].item()
+                line += f"  {av:>14.6f}  {bv:>14.6f}  {av + bv:>14.6f}"
+            print(line)
+
+    if mismatch_found:
+        print("=" * 120 + "\n")
+
 
 def _get_valid_formats(dest_acc):
     """
@@ -271,6 +360,11 @@ def test_eltwise_binary(
         )
 
     # Compute golden on tilized data
+    # When broadcast is applied, BroadcastGolden already quantized golden_src_B
+    # (Bfp4_b/Bfp8_b -> float16_b), so we must not re-quantize it here.
+    golden_input_format_B = (
+        None if broadcast_type != BroadcastType.None_ else formats.input_format
+    )
     golden_tensor = binary_golden(
         math_op,
         golden_src_A,
@@ -278,6 +372,7 @@ def test_eltwise_binary(
         formats.output_format,
         math_fidelity,
         input_format=formats.input_format,
+        input_format_B=golden_input_format_B,
     )
 
     configuration = TestConfig(
@@ -326,9 +421,12 @@ def test_eltwise_binary(
     res_tensor = torch.tensor(res_from_L1, dtype=torch_format)
 
     # Compare in tilized format
-    assert passed_test(
-        golden_tensor, res_tensor, formats.output_format
-    ), "Assert against golden failed"
+    test_passed = passed_test(golden_tensor, res_tensor, formats.output_format)
+    if not test_passed:
+        _print_bfp_mismatch_blocks(
+            golden_tensor, res_tensor, src_a=golden_src_A, golden_src_b=golden_src_B
+        )
+    assert test_passed, "Assert against golden failed"
 
 
 @parametrize(
@@ -338,9 +436,9 @@ def test_eltwise_binary(
         for fmt in input_output_formats(
             [
                 DataFormat.Bfp4_b,
-                DataFormat.Float16_b,
                 DataFormat.Bfp8_b,
-                DataFormat.Float32,
+                DataFormat.Float16_b,
+                # DataFormat.Float32,
             ]
         )
         if fmt.input_format == DataFormat.Bfp4_b
@@ -378,24 +476,24 @@ def test_eltwise_binary_bfp4_b(
     DEBUG_BFP4 = os.environ.get("DEBUG_BFP4", "1") == "1"
     debug_buffer = StringIO()
 
-    def debug_print(title, data=None, tensor=None, max_items=64):
-        output = f"\n{'='*80}\n"
-        output += f"DEBUG: {title}\n"
-        output += f"{'='*80}\n"
-        if data is not None:
-            output += f"{data}\n"
-        if tensor is not None:
-            if isinstance(tensor, torch.Tensor):
-                flat = tensor.flatten()
-                output += f"  Shape: {tensor.shape}, Dtype: {tensor.dtype}\n"
-                output += f"  Min: {flat.min():.4f}, Max: {flat.max():.4f}, Mean: {flat.mean():.4f}\n"
-                output += f"  First {min(max_items, len(flat))} values: {flat[:max_items].tolist()}\n"
-            else:
-                output += f"  Data: {tensor}\n"
-        output += f"{'='*80}\n"
-        debug_buffer.write(output)
-        if DEBUG_BFP4:
-            print(output, end="")
+    # def debug_print(title, data=None, tensor=None, max_items=64):
+    # output = f"\n{'='*80}\n"
+    # output += f"DEBUG: {title}\n"
+    # output += f"{'='*80}\n"
+    # if data is not None:
+    #     output += f"{data}\n"
+    # if tensor is not None:
+    #     if isinstance(tensor, torch.Tensor):
+    #         flat = tensor.flatten()
+    #         output += f"  Shape: {tensor.shape}, Dtype: {tensor.dtype}\n"
+    #         output += f"  Min: {flat.min():.4f}, Max: {flat.max():.4f}, Mean: {flat.mean():.4f}\n"
+    #         output += f"  First {min(max_items, len(flat))} values: {flat[:max_items].tolist()}\n"
+    #     else:
+    #         output += f"  Data: {tensor}\n"
+    # output += f"{'='*80}\n"
+    # debug_buffer.write(output)
+    # if DEBUG_BFP4:
+    #     print(output, end="")
 
     face_r_dim, num_faces_r_dim, num_faces_c_dim = get_tile_params(tile_dimensions)
     num_faces = num_faces_r_dim * num_faces_c_dim
@@ -405,13 +503,13 @@ def test_eltwise_binary_bfp4_b(
     tile_cnt_A = (input_dimensions[0] // tile_rows) * (input_dimensions[1] // tile_cols)
     tile_cnt_B = tile_cnt_A
 
-    debug_print(
-        "TEST CONFIGURATION",
-        f"formats: {formats}, broadcast_type: {broadcast_type}, math_op: {math_op}\n"
-        f"math_fidelity: {math_fidelity}, transpose_srca: {transpose_srca}\n"
-        f"input_dimensions: {input_dimensions}, tile_dimensions: {tile_dimensions}\n"
-        f"face_r_dim: {face_r_dim}, num_faces: {num_faces}, tile_cnt: {tile_cnt_A}",
-    )
+    # debug_print(
+    #     "TEST CONFIGURATION",
+    #     f"formats: {formats}, broadcast_type: {broadcast_type}, math_op: {math_op}\n"
+    #     f"math_fidelity: {math_fidelity}, transpose_srca: {transpose_srca}\n"
+    #     f"input_dimensions: {input_dimensions}, tile_dimensions: {tile_dimensions}\n"
+    #     f"face_r_dim: {face_r_dim}, num_faces: {num_faces}, tile_cnt: {tile_cnt_A}",
+    # )
 
     # Generate stimuli with correct face dimensions for smaller tiles
     # Uses generate_stimuli_w_tile_dimensions which computes face_r_dim and num_faces from tile_dimensions
@@ -423,17 +521,17 @@ def test_eltwise_binary_bfp4_b(
         tile_dimensions=tile_dimensions,
     )
 
-    debug_print("GENERATED STIMULI - src_A", tensor=src_A, max_items=128)
-    debug_print("GENERATED STIMULI - src_B", tensor=src_B, max_items=128)
+    # debug_print("GENERATED STIMULI - src_A", tensor=src_A, max_items=128)
+    # debug_print("GENERATED STIMULI - src_B", tensor=src_B, max_items=128)
 
     # Print some sample values from src_B for scalar broadcast debugging
-    if broadcast_type == BroadcastType.Scalar:
-        print(
-            f"\n>>> SCALAR BROADCAST CHECK: src_B first 16 values: {src_B[:16].tolist()}"
-        )
-        print(
-            f">>> SCALAR BROADCAST CHECK: src_B tilized first 16 values will be computed next..."
-        )
+    # if broadcast_type == BroadcastType.Scalar:
+    #     print(
+    #         f"\n>>> SCALAR BROADCAST CHECK: src_B first 16 values: {src_B[:16].tolist()}"
+    #     )
+    #     print(
+    #         f">>> SCALAR BROADCAST CHECK: src_B tilized first 16 values will be computed next..."
+    #     )
 
     effective_dest_acc = (
         DestAccumulation.Yes
@@ -470,20 +568,20 @@ def test_eltwise_binary_bfp4_b(
         face_r_dim=face_r_dim,
     )
 
-    debug_print("TILIZED src_A", tensor=src_A_tilized, max_items=128)
-    debug_print("TILIZED src_B", tensor=src_B_tilized, max_items=128)
+    # debug_print("TILIZED src_A", tensor=src_A_tilized, max_items=128)
+    # debug_print("TILIZED src_B", tensor=src_B_tilized, max_items=128)
 
     # Flatten tilized tensors
     src_A_tilized_flat = src_A_tilized.flatten()
     src_B_tilized_flat = src_B_tilized.flatten()
 
-    debug_print("TILIZED FLAT src_A", tensor=src_A_tilized_flat, max_items=128)
-    debug_print("TILIZED FLAT src_B", tensor=src_B_tilized_flat, max_items=128)
+    # debug_print("TILIZED FLAT src_A", tensor=src_A_tilized_flat, max_items=128)
+    # debug_print("TILIZED FLAT src_B", tensor=src_B_tilized_flat, max_items=128)
 
-    if broadcast_type == BroadcastType.Scalar:
-        print(
-            f">>> SCALAR BROADCAST CHECK: src_B_tilized_flat first 16 values: {src_B_tilized_flat[:16].tolist()}"
-        )
+    # if broadcast_type == BroadcastType.Scalar:
+    #     print(
+    #         f">>> SCALAR BROADCAST CHECK: src_B_tilized_flat first 16 values: {src_B_tilized_flat[:16].tolist()}"
+    #     )
 
     # Send tilized data to device (device handles transpose during unpack)
     stimuli_A = src_A_tilized_flat
@@ -526,15 +624,18 @@ def test_eltwise_binary_bfp4_b(
             face_r_dim=face_r_dim,
         )
 
-    debug_print(
-        "GOLDEN src_A (after transpose if any)", tensor=golden_src_A, max_items=128
-    )
-    debug_print(
-        "GOLDEN src_B (after broadcast if any)", tensor=golden_src_B, max_items=128
-    )
-    debug_print("BROADCAST TYPE", data=f"{broadcast_type}")
+    # debug_print(
+    #     "GOLDEN src_A (after transpose if any)", tensor=golden_src_A, max_items=128
+    # )
+    # debug_print(
+    #     "GOLDEN src_B (after broadcast if any)", tensor=golden_src_B, max_items=128
+    # )
+    # debug_print("BROADCAST TYPE", data=f"{broadcast_type}")
 
     # Compute golden on tilized data
+    # When broadcast is applied, BroadcastGolden already quantized golden_src_B
+    # (Bfp4_b/Bfp8_b -> float16_b), so we must not re-quantize it here.
+    # golden_input_format_B = None if broadcast_type != BroadcastType.None_ else formats.input_format
     golden_tensor = binary_golden(
         math_op,
         golden_src_A,
@@ -542,11 +643,12 @@ def test_eltwise_binary_bfp4_b(
         formats.output_format,
         math_fidelity,
         input_format=formats.input_format,
+        input_format_B=formats.input_format,
     )
 
-    debug_print(
-        "GOLDEN TENSOR (result of binary op)", tensor=golden_tensor, max_items=256
-    )
+    # debug_print(
+    #     "GOLDEN TENSOR (result of binary op)", tensor=golden_tensor, max_items=256
+    # )
 
     configuration = TestConfig(
         "sources/eltwise_binary_test.cpp",
@@ -586,15 +688,15 @@ def test_eltwise_binary_bfp4_b(
 
     res_from_L1 = configuration.run(workers_tensix_coordinates).result
 
-    debug_print(
-        "RESULT FROM L1 (raw)",
-        data=f"Type: {type(res_from_L1)}, Length: {len(res_from_L1)}",
-    )
-    debug_print(
-        "RESULT FROM L1 (first 256 values)",
-        tensor=torch.tensor(res_from_L1),
-        max_items=256,
-    )
+    # debug_print(
+    #     "RESULT FROM L1 (raw)",
+    #     data=f"Type: {type(res_from_L1)}, Length: {len(res_from_L1)}",
+    # )
+    # debug_print(
+    #     "RESULT FROM L1 (first 256 values)",
+    #     tensor=torch.tensor(res_from_L1),
+    #     max_items=256,
+    # )
 
     assert len(res_from_L1) == len(
         golden_tensor
@@ -603,25 +705,7 @@ def test_eltwise_binary_bfp4_b(
     torch_format = format_dict[formats.output_format]
     res_tensor = torch.tensor(res_from_L1, dtype=torch_format)
 
-    debug_print("RESULT TENSOR (converted to torch)", tensor=res_tensor, max_items=256)
-
-    # Detailed element-wise comparison for debugging
-    comparison_output = f"\n{'='*80}\n"
-    comparison_output += f"DETAILED COMPARISON (all {len(golden_tensor)} elements):\n"
-    comparison_output += f"{'='*80}\n"
-    for i in range(len(golden_tensor)):
-        g_val = golden_tensor[i].item()
-        r_val = res_tensor[i].item()
-        match = (
-            "MATCH"
-            if torch.isclose(golden_tensor[i], res_tensor[i], atol=0.3, rtol=0.3)
-            else "DIFF"
-        )
-        comparison_output += (
-            f"  [{i:4d}] Golden: {g_val:8.4f} | Result: {r_val:8.4f} | {match}\n"
-        )
-    comparison_output += f"{'='*80}\n"
-    debug_buffer.write(comparison_output)
+    # debug_print("RESULT TENSOR (converted to torch)", tensor=res_tensor, max_items=256)
 
     # Compare in tilized format - print debug output only if test fails
     try:
@@ -629,15 +713,37 @@ def test_eltwise_binary_bfp4_b(
             golden_tensor,
             res_tensor,
             formats.output_format,
-            custom_atol=0.3,
-            custom_rtol=0.3,
+            print_pcc=True,
         )
         assert is_valid, "Assert against golden failed"
     except AssertionError as e:
-        # Print all debug output when test fails
-        print(debug_buffer.getvalue())
-        if DEBUG_BFP4:
-            print(comparison_output)
+        print("\n")
+        print("src_B")
+        print(src_B.view(32, 32))
+        print("\n")
+        print("src_A")
+        print(src_A.view(32, 32))
+        print("\n")
+        print("-" * 200)
+        print("golden_src_B")
+        print(golden_src_B.view(32, 32))
+        print("golden_src_A + golden_src_B (emulated addition)")
+        golden_added = (
+            golden_src_A.to(torch.float32) + golden_src_B.to(torch.float32)
+        ).to(golden_src_A.dtype)
+        print(golden_added.view(32, 32))
+        print("\n")
+        print("golden_tensor")
+        print(golden_tensor.view(32, 32))
+        print("\n")
+        print("res_tensor")
+        print(res_tensor.view(32, 32))
+        print("\n")
+        print("-" * 200)
+
+        _print_bfp_mismatch_blocks(
+            golden_tensor, res_tensor, src_a=golden_src_A, golden_src_b=golden_src_B
+        )
         raise
 
 
@@ -828,9 +934,10 @@ def test_eltwise_binary_dest_reuse(
 
     res_tensor = torch.tensor(res_from_L1, dtype=torch_format)
 
-    assert passed_test(
-        golden_tensor, res_tensor, formats.output_format
-    ), "Assert against golden failed"
+    test_passed = passed_test(golden_tensor, res_tensor, formats.output_format)
+    if not test_passed:
+        _print_bfp_mismatch_blocks(golden_tensor, res_tensor)
+    assert test_passed, "Assert against golden failed"
 
 
 @parametrize(
@@ -991,4 +1098,6 @@ def test_eltwise_binary_int8_format(
         golden_tensor, res_tensor, formats.output_format, print_errors=False
     )
 
+    if not test_passed:
+        _print_bfp_mismatch_blocks(golden_tensor, res_tensor)
     assert test_passed, "Assert against golden failed"

--- a/tests/python_tests/test_zzz_eltwise_binary.py
+++ b/tests/python_tests/test_zzz_eltwise_binary.py
@@ -344,13 +344,13 @@ def test_eltwise_binary(
             ]
         )
         if fmt.input_format == DataFormat.Bfp4_b
-        # or fmt.output_format == DataFormat.Bfp4_b
+        or fmt.output_format == DataFormat.Bfp4_b
     ],
     broadcast_type=[
         BroadcastType.None_,
         BroadcastType.Row,
         BroadcastType.Column,
-        BroadcastType.Scalar,
+        # BroadcastType.Scalar,
     ],
     math_op=[MathOperation.Elwadd, MathOperation.Elwsub],
     math_fidelity=lambda formats, math_op: _get_valid_math_fidelity(formats, math_op),

--- a/tests/python_tests/test_zzz_eltwise_binary.py
+++ b/tests/python_tests/test_zzz_eltwise_binary.py
@@ -347,9 +347,9 @@ def test_eltwise_binary(
         or fmt.output_format == DataFormat.Bfp4_b
     ],
     broadcast_type=[
-        BroadcastType.None_,
-        BroadcastType.Row,
-        BroadcastType.Column,
+        # BroadcastType.None_,
+        # BroadcastType.Row,
+        # BroadcastType.Column,
         BroadcastType.Scalar,
     ],
     math_op=[MathOperation.Elwadd, MathOperation.Elwsub],
@@ -373,30 +373,29 @@ def test_eltwise_binary_bfp4_b(
     workers_tensix_coordinates,
 ):
     import os
+    from io import StringIO
 
     DEBUG_BFP4 = os.environ.get("DEBUG_BFP4", "1") == "1"
+    debug_buffer = StringIO()
 
     def debug_print(title, data=None, tensor=None, max_items=64):
-        if not DEBUG_BFP4:
-            return
-        print(f"\n{'='*80}")
-        print(f"DEBUG: {title}")
-        print(f"{'='*80}")
+        output = f"\n{'='*80}\n"
+        output += f"DEBUG: {title}\n"
+        output += f"{'='*80}\n"
         if data is not None:
-            print(f"{data}")
+            output += f"{data}\n"
         if tensor is not None:
             if isinstance(tensor, torch.Tensor):
                 flat = tensor.flatten()
-                print(f"  Shape: {tensor.shape}, Dtype: {tensor.dtype}")
-                print(
-                    f"  Min: {flat.min():.4f}, Max: {flat.max():.4f}, Mean: {flat.mean():.4f}"
-                )
-                print(
-                    f"  First {min(max_items, len(flat))} values: {flat[:max_items].tolist()}"
-                )
+                output += f"  Shape: {tensor.shape}, Dtype: {tensor.dtype}\n"
+                output += f"  Min: {flat.min():.4f}, Max: {flat.max():.4f}, Mean: {flat.mean():.4f}\n"
+                output += f"  First {min(max_items, len(flat))} values: {flat[:max_items].tolist()}\n"
             else:
-                print(f"  Data: {tensor}")
-        print(f"{'='*80}\n")
+                output += f"  Data: {tensor}\n"
+        output += f"{'='*80}\n"
+        debug_buffer.write(output)
+        if DEBUG_BFP4:
+            print(output, end="")
 
     face_r_dim, num_faces_r_dim, num_faces_c_dim = get_tile_params(tile_dimensions)
     num_faces = num_faces_r_dim * num_faces_c_dim
@@ -607,25 +606,39 @@ def test_eltwise_binary_bfp4_b(
     debug_print("RESULT TENSOR (converted to torch)", tensor=res_tensor, max_items=256)
 
     # Detailed element-wise comparison for debugging
-    if DEBUG_BFP4:
-        print(f"\n{'='*80}")
-        print(f"DETAILED COMPARISON (all {len(golden_tensor)} elements):")
-        print(f"{'='*80}")
-        for i in range(len(golden_tensor)):
-            g_val = golden_tensor[i].item()
-            r_val = res_tensor[i].item()
-            match = (
-                "MATCH"
-                if torch.isclose(golden_tensor[i], res_tensor[i], atol=0.3, rtol=0.3)
-                else "DIFF"
-            )
-            print(f"  [{i:4d}] Golden: {g_val:8.4f} | Result: {r_val:8.4f} | {match}")
-        print(f"{'='*80}\n")
+    comparison_output = f"\n{'='*80}\n"
+    comparison_output += f"DETAILED COMPARISON (all {len(golden_tensor)} elements):\n"
+    comparison_output += f"{'='*80}\n"
+    for i in range(len(golden_tensor)):
+        g_val = golden_tensor[i].item()
+        r_val = res_tensor[i].item()
+        match = (
+            "MATCH"
+            if torch.isclose(golden_tensor[i], res_tensor[i], atol=0.3, rtol=0.3)
+            else "DIFF"
+        )
+        comparison_output += (
+            f"  [{i:4d}] Golden: {g_val:8.4f} | Result: {r_val:8.4f} | {match}\n"
+        )
+    comparison_output += f"{'='*80}\n"
+    debug_buffer.write(comparison_output)
 
-    # Compare in tilized format
-    assert passed_test(
-        golden_tensor, res_tensor, formats.output_format
-    ), "Assert against golden failed"
+    # Compare in tilized format - print debug output only if test fails
+    try:
+        is_valid = passed_test(
+            golden_tensor,
+            res_tensor,
+            formats.output_format,
+            custom_atol=0.3,
+            custom_rtol=0.3,
+        )
+        assert is_valid, "Assert against golden failed"
+    except AssertionError as e:
+        # Print all debug output when test fails
+        print(debug_buffer.getvalue())
+        if DEBUG_BFP4:
+            print(comparison_output)
+        raise
 
 
 @parametrize(

--- a/tests/python_tests/test_zzz_eltwise_binary.py
+++ b/tests/python_tests/test_zzz_eltwise_binary.py
@@ -87,13 +87,18 @@ def _get_valid_formats_include_bfp4_b(dest_acc):
     return all_formats
 
 
-def _get_valid_math_fidelity(formats):
+def _get_valid_math_fidelity(formats, math_op=None):
     """
     Filter math fidelity based on input data format:
     - Bfp8_b: LoFi only
     - Float16_b: LoFi or HiFi2
     - Float32: HiFi3 and HiFi4
+
+    Math fidelity > LoFi is only supported for Elwmul (hardware constraint),
+    so non-multiply ops are restricted to LoFi regardless of format.
     """
+    if math_op is not None and math_op != MathOperation.Elwmul:
+        return [MathFidelity.LoFi]
     input_format = formats.input_format
     if input_format in [DataFormat.Bfp8_b, DataFormat.Bfp4_b]:
         return [MathFidelity.LoFi]
@@ -198,15 +203,6 @@ def test_eltwise_binary(
         tile_dimensions,
         BlocksCalculationAlgorithm.Standard,
     )
-
-    # src_A = torch.ones(input_dimensions[0], input_dimensions[1], dtype=torch.bfloat16) * 2.5
-    # src_B = torch.ones(input_dimensions[0], input_dimensions[1], dtype=torch.bfloat16) * 1.25
-
-    # print("src_A:")
-    # print(src_A.view(input_dimensions[0], input_dimensions[1]))
-    # print("src_B:")
-    # print(src_B.view(input_dimensions[0], input_dimensions[1]))
-    # print("--------------------------------" * 5)
 
     # Compute element-wise subtraction in tilized format
     binary_golden = get_golden_generator(EltwiseBinaryGolden)
@@ -356,11 +352,10 @@ def test_eltwise_binary(
         BroadcastType.Column,
         BroadcastType.Scalar,
     ],
-    math_fidelity=lambda formats: _get_valid_math_fidelity(formats),
-    transpose_srca=Transpose.No,
     math_op=[MathOperation.Elwadd, MathOperation.Elwsub],
+    math_fidelity=lambda formats, math_op: _get_valid_math_fidelity(formats, math_op),
+    transpose_srca=Transpose.No,
     input_dimensions=[[32, 32], [64, 32], [32, 64], [256, 32]],
-    # tile_dimensions=[[32, 32], [16,32]],
     tile_dimensions=lambda transpose_srca, broadcast_type: _get_valid_tile_dimensions(
         transpose_srca, broadcast_type
     ),
@@ -369,9 +364,9 @@ def test_eltwise_binary_bfp4_b(
     dest_acc,
     formats,
     broadcast_type,
+    math_op,
     math_fidelity,
     transpose_srca,
-    math_op,
     input_dimensions,
     tile_dimensions,
     workers_tensix_coordinates,

--- a/tests/python_tests/test_zzz_eltwise_binary.py
+++ b/tests/python_tests/test_zzz_eltwise_binary.py
@@ -445,16 +445,16 @@ def test_eltwise_binary(
         or fmt.output_format == DataFormat.Bfp4_b
     ],
     broadcast_type=[
-        # BroadcastType.None_,
-        # BroadcastType.Row,
-        # BroadcastType.Column,
+        BroadcastType.None_,
+        BroadcastType.Row,
+        BroadcastType.Column,
         BroadcastType.Scalar,
     ],
     math_op=[MathOperation.Elwadd, MathOperation.Elwsub],
     math_fidelity=lambda formats, math_op: _get_valid_math_fidelity(formats, math_op),
     transpose_srca=Transpose.No,
-    # input_dimensions=[[32, 32], [64, 32], [32, 64], [256, 32]],
-    input_dimensions=[[32, 32]],
+    input_dimensions=[[32, 32], [64, 32], [32, 64], [256, 32]],
+    # input_dimensions=[[32, 32]],
     tile_dimensions=lambda transpose_srca, broadcast_type: _get_valid_tile_dimensions(
         transpose_srca, broadcast_type
     ),
@@ -470,11 +470,11 @@ def test_eltwise_binary_bfp4_b(
     tile_dimensions,
     workers_tensix_coordinates,
 ):
-    import os
-    from io import StringIO
+    # import os
+    # from io import StringIO
 
-    DEBUG_BFP4 = os.environ.get("DEBUG_BFP4", "1") == "1"
-    debug_buffer = StringIO()
+    # DEBUG_BFP4 = os.environ.get("DEBUG_BFP4", "1") == "1"
+    # debug_buffer = StringIO()
 
     # def debug_print(title, data=None, tensor=None, max_items=64):
     # output = f"\n{'='*80}\n"
@@ -717,29 +717,29 @@ def test_eltwise_binary_bfp4_b(
         )
         assert is_valid, "Assert against golden failed"
     except AssertionError as e:
-        print("\n")
-        print("src_B")
-        print(src_B.view(32, 32))
-        print("\n")
-        print("src_A")
-        print(src_A.view(32, 32))
-        print("\n")
-        print("-" * 200)
-        print("golden_src_B")
-        print(golden_src_B.view(32, 32))
-        print("golden_src_A + golden_src_B (emulated addition)")
-        golden_added = (
-            golden_src_A.to(torch.float32) + golden_src_B.to(torch.float32)
-        ).to(golden_src_A.dtype)
-        print(golden_added.view(32, 32))
-        print("\n")
-        print("golden_tensor")
-        print(golden_tensor.view(32, 32))
-        print("\n")
-        print("res_tensor")
-        print(res_tensor.view(32, 32))
-        print("\n")
-        print("-" * 200)
+        # print("\n")
+        # print("src_B")
+        # print(src_B.view(32, 32))
+        # print("\n")
+        # print("src_A")
+        # print(src_A.view(32, 32))
+        # print("\n")
+        # print("-" * 200)
+        # print("golden_src_B")
+        # print(golden_src_B.view(32, 32))
+        # print("golden_src_A + golden_src_B (emulated addition)")
+        # golden_added = (
+        #     golden_src_A.to(torch.float32) + golden_src_B.to(torch.float32)
+        # ).to(golden_src_A.dtype)
+        # print(golden_added.view(32, 32))
+        # print("\n")
+        # print("golden_tensor")
+        # print(golden_tensor.view(32, 32))
+        # print("\n")
+        # print("res_tensor")
+        # print(res_tensor.view(32, 32))
+        # print("\n")
+        # print("-" * 200)
 
         _print_bfp_mismatch_blocks(
             golden_tensor, res_tensor, src_a=golden_src_A, golden_src_b=golden_src_B

--- a/tests/python_tests/test_zzz_eltwise_binary.py
+++ b/tests/python_tests/test_zzz_eltwise_binary.py
@@ -350,12 +350,13 @@ def test_eltwise_binary(
         BroadcastType.None_,
         BroadcastType.Row,
         BroadcastType.Column,
-        # BroadcastType.Scalar,
+        BroadcastType.Scalar,
     ],
     math_op=[MathOperation.Elwadd, MathOperation.Elwsub],
     math_fidelity=lambda formats, math_op: _get_valid_math_fidelity(formats, math_op),
     transpose_srca=Transpose.No,
-    input_dimensions=[[32, 32], [64, 32], [32, 64], [256, 32]],
+    # input_dimensions=[[32, 32], [64, 32], [32, 64], [256, 32]],
+    input_dimensions=[[32, 32]],
     tile_dimensions=lambda transpose_srca, broadcast_type: _get_valid_tile_dimensions(
         transpose_srca, broadcast_type
     ),
@@ -371,6 +372,31 @@ def test_eltwise_binary_bfp4_b(
     tile_dimensions,
     workers_tensix_coordinates,
 ):
+    import os
+
+    DEBUG_BFP4 = os.environ.get("DEBUG_BFP4", "1") == "1"
+
+    def debug_print(title, data=None, tensor=None, max_items=64):
+        if not DEBUG_BFP4:
+            return
+        print(f"\n{'='*80}")
+        print(f"DEBUG: {title}")
+        print(f"{'='*80}")
+        if data is not None:
+            print(f"{data}")
+        if tensor is not None:
+            if isinstance(tensor, torch.Tensor):
+                flat = tensor.flatten()
+                print(f"  Shape: {tensor.shape}, Dtype: {tensor.dtype}")
+                print(
+                    f"  Min: {flat.min():.4f}, Max: {flat.max():.4f}, Mean: {flat.mean():.4f}"
+                )
+                print(
+                    f"  First {min(max_items, len(flat))} values: {flat[:max_items].tolist()}"
+                )
+            else:
+                print(f"  Data: {tensor}")
+        print(f"{'='*80}\n")
 
     face_r_dim, num_faces_r_dim, num_faces_c_dim = get_tile_params(tile_dimensions)
     num_faces = num_faces_r_dim * num_faces_c_dim
@@ -379,6 +405,14 @@ def test_eltwise_binary_bfp4_b(
     tile_rows, tile_cols = tile_dimensions
     tile_cnt_A = (input_dimensions[0] // tile_rows) * (input_dimensions[1] // tile_cols)
     tile_cnt_B = tile_cnt_A
+
+    debug_print(
+        "TEST CONFIGURATION",
+        f"formats: {formats}, broadcast_type: {broadcast_type}, math_op: {math_op}\n"
+        f"math_fidelity: {math_fidelity}, transpose_srca: {transpose_srca}\n"
+        f"input_dimensions: {input_dimensions}, tile_dimensions: {tile_dimensions}\n"
+        f"face_r_dim: {face_r_dim}, num_faces: {num_faces}, tile_cnt: {tile_cnt_A}",
+    )
 
     # Generate stimuli with correct face dimensions for smaller tiles
     # Uses generate_stimuli_w_tile_dimensions which computes face_r_dim and num_faces from tile_dimensions
@@ -389,6 +423,18 @@ def test_eltwise_binary_bfp4_b(
         input_dimensions_B=input_dimensions,
         tile_dimensions=tile_dimensions,
     )
+
+    debug_print("GENERATED STIMULI - src_A", tensor=src_A, max_items=128)
+    debug_print("GENERATED STIMULI - src_B", tensor=src_B, max_items=128)
+
+    # Print some sample values from src_B for scalar broadcast debugging
+    if broadcast_type == BroadcastType.Scalar:
+        print(
+            f"\n>>> SCALAR BROADCAST CHECK: src_B first 16 values: {src_B[:16].tolist()}"
+        )
+        print(
+            f">>> SCALAR BROADCAST CHECK: src_B tilized first 16 values will be computed next..."
+        )
 
     effective_dest_acc = (
         DestAccumulation.Yes
@@ -425,9 +471,20 @@ def test_eltwise_binary_bfp4_b(
         face_r_dim=face_r_dim,
     )
 
+    debug_print("TILIZED src_A", tensor=src_A_tilized, max_items=128)
+    debug_print("TILIZED src_B", tensor=src_B_tilized, max_items=128)
+
     # Flatten tilized tensors
     src_A_tilized_flat = src_A_tilized.flatten()
     src_B_tilized_flat = src_B_tilized.flatten()
+
+    debug_print("TILIZED FLAT src_A", tensor=src_A_tilized_flat, max_items=128)
+    debug_print("TILIZED FLAT src_B", tensor=src_B_tilized_flat, max_items=128)
+
+    if broadcast_type == BroadcastType.Scalar:
+        print(
+            f">>> SCALAR BROADCAST CHECK: src_B_tilized_flat first 16 values: {src_B_tilized_flat[:16].tolist()}"
+        )
 
     # Send tilized data to device (device handles transpose during unpack)
     stimuli_A = src_A_tilized_flat
@@ -470,6 +527,14 @@ def test_eltwise_binary_bfp4_b(
             face_r_dim=face_r_dim,
         )
 
+    debug_print(
+        "GOLDEN src_A (after transpose if any)", tensor=golden_src_A, max_items=128
+    )
+    debug_print(
+        "GOLDEN src_B (after broadcast if any)", tensor=golden_src_B, max_items=128
+    )
+    debug_print("BROADCAST TYPE", data=f"{broadcast_type}")
+
     # Compute golden on tilized data
     golden_tensor = binary_golden(
         math_op,
@@ -478,6 +543,10 @@ def test_eltwise_binary_bfp4_b(
         formats.output_format,
         math_fidelity,
         input_format=formats.input_format,
+    )
+
+    debug_print(
+        "GOLDEN TENSOR (result of binary op)", tensor=golden_tensor, max_items=256
     )
 
     configuration = TestConfig(
@@ -518,12 +587,40 @@ def test_eltwise_binary_bfp4_b(
 
     res_from_L1 = configuration.run(workers_tensix_coordinates).result
 
+    debug_print(
+        "RESULT FROM L1 (raw)",
+        data=f"Type: {type(res_from_L1)}, Length: {len(res_from_L1)}",
+    )
+    debug_print(
+        "RESULT FROM L1 (first 256 values)",
+        tensor=torch.tensor(res_from_L1),
+        max_items=256,
+    )
+
     assert len(res_from_L1) == len(
         golden_tensor
-    ), "Result tensor and golden tensor are not of the same length"
+    ), f"Result tensor ({len(res_from_L1)}) and golden tensor ({len(golden_tensor)}) are not of the same length"
 
     torch_format = format_dict[formats.output_format]
     res_tensor = torch.tensor(res_from_L1, dtype=torch_format)
+
+    debug_print("RESULT TENSOR (converted to torch)", tensor=res_tensor, max_items=256)
+
+    # Detailed element-wise comparison for debugging
+    if DEBUG_BFP4:
+        print(f"\n{'='*80}")
+        print(f"DETAILED COMPARISON (all {len(golden_tensor)} elements):")
+        print(f"{'='*80}")
+        for i in range(len(golden_tensor)):
+            g_val = golden_tensor[i].item()
+            r_val = res_tensor[i].item()
+            match = (
+                "MATCH"
+                if torch.isclose(golden_tensor[i], res_tensor[i], atol=0.3, rtol=0.3)
+                else "DIFF"
+            )
+            print(f"  [{i:4d}] Golden: {g_val:8.4f} | Result: {r_val:8.4f} | {match}")
+        print(f"{'='*80}\n")
 
     # Compare in tilized format
     assert passed_test(

--- a/tests/python_tests/test_zzz_eltwise_binary.py
+++ b/tests/python_tests/test_zzz_eltwise_binary.py
@@ -49,8 +49,6 @@ from helpers.utils import passed_test
 
 ALL_TILE_DIMENSIONS = [list(td) for td in SUPPORTED_TILE_SIZES]
 
-BFP_BLOCK_SIZE = 16
-
 
 def _get_valid_formats(dest_acc):
     """
@@ -335,10 +333,6 @@ def test_eltwise_binary(
 
     # Compare in tilized format
     test_passed = passed_test(golden_tensor, res_tensor, formats.output_format)
-    if not test_passed:
-        _print_bfp_mismatch_blocks(
-            golden_tensor, res_tensor, src_a=golden_src_A, golden_src_b=golden_src_B
-        )
     assert test_passed, "Assert against golden failed"
 
 
@@ -537,10 +531,6 @@ def test_eltwise_binary_bfp4_b(
     res_tensor = torch.tensor(res_from_L1, dtype=torch_format)
 
     test_passed = passed_test(golden_tensor, res_tensor, formats.output_format)
-    if not test_passed:
-        _print_bfp_mismatch_blocks(
-            golden_tensor, res_tensor, src_a=golden_src_A, golden_src_b=golden_src_B
-        )
     assert test_passed, "Assert against golden failed"
 
 
@@ -732,8 +722,6 @@ def test_eltwise_binary_dest_reuse(
     res_tensor = torch.tensor(res_from_L1, dtype=torch_format)
 
     test_passed = passed_test(golden_tensor, res_tensor, formats.output_format)
-    if not test_passed:
-        _print_bfp_mismatch_blocks(golden_tensor, res_tensor)
     assert test_passed, "Assert against golden failed"
 
 
@@ -894,7 +882,4 @@ def test_eltwise_binary_int8_format(
     test_passed = passed_test(
         golden_tensor, res_tensor, formats.output_format, print_errors=False
     )
-
-    if not test_passed:
-        _print_bfp_mismatch_blocks(golden_tensor, res_tensor)
     assert test_passed, "Assert against golden failed"

--- a/tests/sources/eltwise_binary_test.cpp
+++ b/tests/sources/eltwise_binary_test.cpp
@@ -150,8 +150,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const std::uint32_t num_faces = tensor_shape.total_num_faces();
     const bool partial_face       = tensor_shape.face_r_dim < FACE_R_DIM;
 
-    cfg_reg_rmw_tensix<PCK_DEST_RD_CTRL_Round_10b_mant_RMW>(0);
-
 #ifdef ARCH_WORMHOLE
     const bool narrow_tile = (tensor_shape.num_faces_c_dim == 1);
 #endif

--- a/tests/sources/eltwise_binary_test.cpp
+++ b/tests/sources/eltwise_binary_test.cpp
@@ -150,6 +150,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const std::uint32_t num_faces = tensor_shape.total_num_faces();
     const bool partial_face       = tensor_shape.face_r_dim < FACE_R_DIM;
 
+    cfg_reg_rmw_tensix<PCK_DEST_RD_CTRL_Round_10b_mant_RMW>(0);
+
 #ifdef ARCH_WORMHOLE
     const bool narrow_tile = (tensor_shape.num_faces_c_dim == 1);
 #endif

--- a/tests/sources/eltwise_binary_test.cpp
+++ b/tests/sources/eltwise_binary_test.cpp
@@ -37,6 +37,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const ckernel::TensorShape tensor_shape = {face_r_dim, face_c_dim, num_faces_r_dim, num_faces_c_dim};
     const std::uint32_t transpose           = params.UNPACK_TRANSPOSE_FACES;
 
+    _llk_unpack_configure_stoch_rnd_<StochRndType::None>();
+
     // Configure hardware for unpacking, no broadcast, no transpose
     _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
         formats.unpack_A_src,


### PR DESCRIPTION
### Ticket
#1493 

### Problem description
Enable bfp4_b to be output format in eltwise binary test

### What's changed
Apply to data what hw packer does that is fp16-B -> bfp8_b -> bfp4_b
Utilize bfp4_b aware comparison

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring
