### PR TITLE
Update are_packers_configured_correctly to verify Fp8_e4m3

### DIFF
--- a/tt_llk_blackhole/common/inc/cpack_common.h
+++ b/tt_llk_blackhole/common/inc/cpack_common.h
@@ -717,8 +717,7 @@ __attribute__((noinline)) bool are_packers_configured_correctly(
     const std::uint32_t pack_hw_src_format =
         ((pack_dst_format & 0x1F) == to_underlying(DataFormat::Fp8_e4m3)) ? to_underlying(DataFormat::Float16) : pack_output_src_format;
 
-    const bool isDataFormatCorrect =
-        (config.in_data_format == pack_hw_src_format) && (config.out_data_format == pack_output_dst_format);
+    const bool isDataFormatCorrect = (config.in_data_format == pack_hw_src_format) && (config.out_data_format == pack_output_dst_format);
 
     const bool isFaceRDimCorrect = (program_type == PackerProgramType::ProgramByTile) ? true : (counters.pack_reads_per_xy_plane == face_r_dim);
     return isDataFormatCorrect && isFaceRDimCorrect;


### PR DESCRIPTION
### Ticket

### Problem description
There are LLK unit tests in metal repo which leverage newly added Fp8_e4m3. However, this format is not handled properly for BH version of are_packers_configured_correctly.

### What's changed
Fix BH version of are_packers_configured_correctly so that LLK unit tests test_fp8_typecast.cpp can work with LLK_ASSERTS enabled.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Assert validation](https://github.com/tenstorrent/tt-llk/blob/main/docs/Introduction_to_asserts.md) Complied with assert doc (if applicable)
