### PR TITLE
Extending test infra: add is_int32_dest_en constexpr flag 

### DIFF
--- a/tests/python_tests/helpers/test_config.py
+++ b/tests/python_tests/helpers/test_config.py
@@ -412,6 +412,7 @@ class TestConfig:
         unpack_to_dest: bool = False,
         disable_format_inference: bool = False,
         dest_acc: DestAccumulation = DestAccumulation.No,
+        int32_dest: bool = False,
         l1_acc: L1Accumulation = L1Accumulation.No,
         skip_build_header: bool = False,
         compile_time_formats: bool = False,
@@ -443,6 +444,7 @@ class TestConfig:
         self.skip_build_header = skip_build_header
         self.compile_time_formats = compile_time_formats
         self.dest_acc = dest_acc
+        self.int32_dest = int32_dest
 
         TILE_SIZES = {
             DataFormat.Bfp8_b: 68,
@@ -875,6 +877,9 @@ class TestConfig:
             header_content.append(
                 f"constexpr bool is_fp32_dest_acc_en = {self.dest_acc.cpp_enum_value};"
             )
+        header_content.append(
+            f"constexpr bool is_int32_dest_en = {str(self.int32_dest).lower()};"
+        )
 
         if TestConfig.SPEED_OF_LIGHT:
             header_content.extend(

--- a/tests/python_tests/quasar/test_pack_untilize_quasar.py
+++ b/tests/python_tests/quasar/test_pack_untilize_quasar.py
@@ -132,6 +132,8 @@ def test_pack_untilize_quasar(formats_dest_acc_dimensions):
             formats.input_format.is_32_bit() and dest_acc == DestAccumulation.Yes
         ),
         dest_acc=dest_acc,
+        int32_dest=formats.input_format.is_integer()
+        and formats.input_format.is_32_bit(),
     )
 
     res_from_L1 = configuration.run().result

--- a/tests/python_tests/quasar/test_unpack_tilize_quasar.py
+++ b/tests/python_tests/quasar/test_unpack_tilize_quasar.py
@@ -162,6 +162,8 @@ def test_unpack_tilize_quasar(
             formats.input_format.is_32_bit() and dest_acc == DestAccumulation.Yes
         ),
         dest_acc=dest_acc,
+        int32_dest=formats.input_format.is_integer()
+        and formats.input_format.is_32_bit(),
         boot_mode=boot_mode,
     )
 

--- a/tests/sources/quasar/pack_untilize_quasar_test.cpp
+++ b/tests/sources/quasar/pack_untilize_quasar_test.cpp
@@ -33,19 +33,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     {
         set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::UNPACK, dest_dvalid_client::PACK});
 
-        DataFormat pack_src_format = static_cast<DataFormat>(formats.pack_src);
-        if (is_fp32_dest_acc_en && pack_src_format == DataFormat::Float32)
-        {
-            _llk_math_upk_to_dest_hw_configure_<IMPLIED_MATH_FORMAT, true /*fp32_dest*/, false /*int32_dest*/>();
-        }
-        else if (is_fp32_dest_acc_en && pack_src_format == DataFormat::Int32)
-        {
-            _llk_math_upk_to_dest_hw_configure_<IMPLIED_MATH_FORMAT, false /*fp32_dest*/, true /*int32_dest*/>();
-        }
-        else
-        {
-            _llk_math_upk_to_dest_hw_configure_<IMPLIED_MATH_FORMAT, false /*fp32_dest*/, false /*int32_dest*/>();
-        }
+        _llk_math_upk_to_dest_hw_configure_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en && !is_int32_dest_en, is_int32_dest_en>();
     }
     else
     {
@@ -109,16 +97,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
-#ifdef FORMAT_INT32
-    const bool is_int_fpu_en = true;
-#else
-    const bool is_int_fpu_en = false;
-#endif
     // Setup data valid scheme
     set_up_dest_dvalid_per_thread<dest_dvalid_client::FPU>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
 
     DataFormat src_format = static_cast<DataFormat>(formats.math);
-    _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en, is_int_fpu_en>(src_format, src_format);
+    _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en && !is_int32_dest_en, is_int32_dest_en>(src_format, src_format);
 
     _llk_math_eltwise_unary_datacopy_init_<DataCopyType::A2D, is_fp32_dest_acc_en>(num_faces * TEST_FACE_R_DIM /*num_rows_per_matrix*/, 1 /*num_matrices*/);
     for (std::uint32_t block_rt = 0; block_rt < BLOCK_RT_DIM; block_rt++)

--- a/tests/sources/quasar/unpack_tilize_quasar_test.cpp
+++ b/tests/sources/quasar/unpack_tilize_quasar_test.cpp
@@ -31,23 +31,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     if constexpr (unpack_to_dest)
     {
-        if constexpr (is_fp32_dest_acc_en)
-        {
-            // dest is in 32b mode (and we unpack directly to dest)determine whether it's Float32 or Int32 from the unpack source format.
-            const bool int32_dest = static_cast<DataFormat>(formats.unpack_A_src) == DataFormat::Int32;
-            if (int32_dest)
-            {
-                _llk_math_upk_to_dest_hw_configure_<IMPLIED_MATH_FORMAT, false, true>();
-            }
-            else
-            {
-                _llk_math_upk_to_dest_hw_configure_<IMPLIED_MATH_FORMAT, true, false>();
-            }
-        }
-        else
-        {
-            _llk_math_upk_to_dest_hw_configure_<IMPLIED_MATH_FORMAT, false, false>();
-        }
+        _llk_math_upk_to_dest_hw_configure_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en && !is_int32_dest_en, is_int32_dest_en>();
     }
 
     buffer_descriptor_u bd_val = {0};
@@ -117,12 +101,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
 #ifdef LLK_TRISC_MATH
 
-#ifdef FORMAT_INT32
-const bool is_int_fpu_en = true;
-#else
-const bool is_int_fpu_en = false;
-#endif
-
 #include "llk_math_common.h"
 #include "llk_math_eltwise_unary_datacopy.h"
 #include "params.h"
@@ -139,7 +117,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         set_up_dest_dvalid_per_thread<dest_dvalid_client::FPU>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
 
         DataFormat src_format = static_cast<DataFormat>(formats.math);
-        _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en, is_int_fpu_en>(src_format, src_format);
+        _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en && !is_int32_dest_en, is_int32_dest_en>(src_format, src_format);
 
         _llk_math_eltwise_unary_datacopy_init_<DATA_COPY_TYPE, is_fp32_dest_acc_en>(num_faces * TEST_FACE_R_DIM /*num_rows_per_matrix*/, 1 /*num_matrices*/);
         for (std::uint32_t i = 0; i < TILE_CNT; ++i)


### PR DESCRIPTION
### Ticket
<!-- Link to Github Issue -->
https://github.com/tenstorrent/tt-llk/pull/1521/#discussion_r2989562833
### Problem description
<!-- Provide context for the problem. -->
#ifdef FORMAT_INT32 was never defined in the build system, so is_int_fpu_en was always false — even for Int32 format tests. Runtime if branches in  _llk_math_upk_to_dest_hw_configure_ calls also distinguished Float32 vs Int32 unnecessarily.
### What's changed
<!-- Describe the approach used to solve the problem.
Summarize the changes made and its impact. -->
- test_config.py: Add int32_dest: bool parameter to TestConfig, emitted as constexpr bool is_int32_dest_en in the build header (mirrors
  dest_acc/is_fp32_dest_acc_en).                                                                                                                               
- test_unpack_tilize_quasar.py, test_pack_untilize_quasar.py: Pass int32_dest=formats.input_format.is_integer() and formats.input_format.is_32_bit().
- unpack_tilize_quasar_test.cpp, pack_untilize_quasar_test.cpp: Remove #ifdef FORMAT_INT32 blocks and runtime format checks. Use is_int32_dest_en directly in
   template args (is_fp32_dest_acc_en && !is_int32_dest_en for fp32, is_int32_dest_en for int32).                 
### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring