### PR TITLE
[skip uplift] Migrate Exp2 to tt-llk

### DIFF
--- a/tests/helpers/include/sfpu_operations.h
+++ b/tests/helpers/include/sfpu_operations.h
@@ -66,7 +66,7 @@ void call_sfpu_operation(SfpuType operation, std::uint32_t math_format = 0, floa
             break;
         case SfpuType::exp2:
             _init_exp2_<APPROX_MODE>();
-            _calculate_exp2_<APPROX_MODE, ITERATIONS>();
+            _calculate_exp2_<APPROX_MODE, is_fp32_dest_acc_en, ITERATIONS>();
             break;
         case SfpuType::exponential:
             _init_exponential_<APPROX_MODE, FAST_MODE, 0x3F800000 /* exp_base_scale_factor */, CLAMP_NEGATIVE>();

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_exp2.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_exp2.h
@@ -12,31 +12,36 @@
 namespace ckernel::sfpu
 {
 
-template <bool APPROXIMATION_MODE, int ITERATIONS>
+template <bool APPROXIMATION_MODE /*unused*/, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
 inline void _calculate_exp2_()
 {
-    const bool SCALE_EN                       = false; // Exp2 does not use scale.
-    const bool SKIP_POSITIVE_CHECK            = false; // Exp2 does not skip positive check.
-    const std::uint16_t exp_base_scale_factor = p_sfpu::kCONST_1_FP16B;
-
+    // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++)
     {
         sfpi::vFloat v = sfpi::dst_reg[0];
-        // log(2) = 0.6931471805;
-        v = v * 0.6931471805f;
-        // exp = e^(v)
-        sfpi::vFloat exp = _calculate_exponential_piecewise_<APPROXIMATION_MODE, SCALE_EN, SKIP_POSITIVE_CHECK>(v, exp_base_scale_factor);
-        sfpi::dst_reg[0] = exp;
+
+        v = v * sfpi::vConstFloatPrgm0;
+        sfpi::vFloat result;
+
+        if constexpr (is_fp32_dest_acc_en)
+        {
+            result = _sfpu_exp_fp32_accurate_(v);
+        }
+        else
+        {
+            result = _sfpu_exp_21f_bf16_<true>(v);
+            result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
+        }
+
+        sfpi::dst_reg[0] = result;
         sfpi::dst_reg++;
     }
 }
 
-template <bool APPROXIMATION_MODE>
+template <bool APPROXIMATION_MODE /*unused*/>
 inline void _init_exp2_()
 {
-    const std::uint32_t EXP_BASE_SCALE_FACTOR = 0x3F800000;
-    const bool FAST_APPROX                    = false; // Exp2 does not use fast approximation.
-    _init_exponential_<APPROXIMATION_MODE, FAST_APPROX, EXP_BASE_SCALE_FACTOR>();
+    sfpi::vConstFloatPrgm0 = 0.6931471805f;
 }
 
 } // namespace ckernel::sfpu

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_exp2.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_exp2.h
@@ -12,31 +12,36 @@
 namespace ckernel::sfpu
 {
 
-template <bool APPROXIMATION_MODE, int ITERATIONS>
+template <bool APPROXIMATION_MODE /*unused*/, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
 inline void _calculate_exp2_()
 {
-    const bool SCALE_EN                       = false; // Exp2 does not use scale.
-    const bool SKIP_POSITIVE_CHECK            = false; // Exp2 does not skip positive check.
-    const std::uint16_t exp_base_scale_factor = p_sfpu::kCONST_1_FP16B;
-
+    // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++)
     {
         sfpi::vFloat v = sfpi::dst_reg[0];
-        // log(2) = 0.6931471805;
-        v = v * 0.6931471805f;
-        // exp = e^(v)
-        sfpi::vFloat exp = _calculate_exponential_piecewise_<APPROXIMATION_MODE, SCALE_EN, SKIP_POSITIVE_CHECK>(v, exp_base_scale_factor);
-        sfpi::dst_reg[0] = exp;
+
+        v = v * sfpi::vConstFloatPrgm0;
+        sfpi::vFloat result;
+
+        if constexpr (is_fp32_dest_acc_en)
+        {
+            result = _sfpu_exp_fp32_accurate_(v);
+        }
+        else
+        {
+            result = _sfpu_exp_21f_bf16_<true>(v);
+            result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
+        }
+
+        sfpi::dst_reg[0] = result;
         sfpi::dst_reg++;
     }
 }
 
-template <bool APPROXIMATION_MODE>
+template <bool APPROXIMATION_MODE /*unused*/>
 inline void _init_exp2_()
 {
-    const std::uint32_t EXP_BASE_SCALE_FACTOR = 0x3F800000;
-    const bool FAST_APPROX                    = false; // Exp2 does not use fast approximation.
-    _init_exponential_<APPROXIMATION_MODE, FAST_APPROX, EXP_BASE_SCALE_FACTOR>();
+    sfpi::vConstFloatPrgm0 = 0.6931471805f;
 }
 
 } // namespace ckernel::sfpu


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/40952

### Problem description
Metal implementation and tt-llk implementation differ. Metal side has the updated code , and tt-llk uses exp-approx appraoch. Hence exp2 requires to be migrated to tt-llk as part of exp-approx task.

### What's changed
Migrated Metal EXP2 implemengtation to tt-llk

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Assert validation](https://github.com/tenstorrent/tt-llk/blob/main/docs/Introduction_to_asserts.md) Complied with assert doc (if applicable)
