### PR TITLE
Use explicit s2vFloat[ab]

### DIFF
--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_clamp.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_clamp.h
@@ -21,11 +21,10 @@ inline void _calculate_clamp_(const int iterations, std::uint32_t param0, std::u
     // param1 = max
 
     // uint format = (param0 >> 16)&0x1;
-    sfpi::s2vFloat16::Format format = sfpi::s2vFloat16::fp16a;
 
     // SFPU microcode
-    sfpi::vFloat min    = sfpi::s2vFloat16(param0, format);
-    sfpi::vFloat max    = sfpi::s2vFloat16(param1, format);
+    sfpi::vFloat min    = sfpi::s2vFloat16a(param0);
+    sfpi::vFloat max    = sfpi::s2vFloat16a(param1);
     sfpi::vFloat offset = sfpi::s2vFloat16b(param2); // 12 bits
 #pragma GCC unroll 0
     for (int d = 0; d < iterations; d++)

--- a/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_hardtanh.h
+++ b/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_hardtanh.h
@@ -21,9 +21,9 @@ inline void _calculate_hardtanh_(const int iterations, std::uint32_t param0, std
     // param1 = -(pos_threshold - neg_threshold)
     // param2 = -(pos_threshold)
 
-    sfpi::vFloat p0 = sfpi::s2vFloat16(param0);
-    sfpi::vFloat p1 = sfpi::s2vFloat16(param1);
-    sfpi::vFloat p2 = sfpi::s2vFloat16(param2);
+    sfpi::vFloat p0 = sfpi::s2vFloat16b(param0);
+    sfpi::vFloat p1 = sfpi::s2vFloat16b(param1);
+    sfpi::vFloat p2 = sfpi::s2vFloat16b(param2);
 // SFPU microcode
 #pragma GCC unroll 0
     for (int d = 0; d < iterations; d++)

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_clamp.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_clamp.h
@@ -21,11 +21,10 @@ inline void _calculate_clamp_(const int iterations, std::uint32_t param0, std::u
     // param1 = max
 
     // uint format = (param0 >> 16)&0x1;
-    sfpi::s2vFloat16::Format format = sfpi::s2vFloat16::fp16a;
 
     // SFPU microcode
-    sfpi::vFloat min    = sfpi::s2vFloat16(param0, format);
-    sfpi::vFloat max    = sfpi::s2vFloat16(param1, format);
+    sfpi::vFloat min    = sfpi::s2vFloat16a(param0);
+    sfpi::vFloat max    = sfpi::s2vFloat16a(param1);
     sfpi::vFloat offset = sfpi::s2vFloat16b(param2); // 12 bits
 #pragma GCC unroll 0
     for (int d = 0; d < iterations; d++)

--- a/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_hardtanh.h
+++ b/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_hardtanh.h
@@ -21,9 +21,9 @@ inline void _calculate_hardtanh_(const int iterations, std::uint32_t param0, std
     // param1 = -(pos_threshold - neg_threshold)
     // param2 = -(pos_threshold)
 
-    sfpi::vFloat p0 = sfpi::s2vFloat16(param0);
-    sfpi::vFloat p1 = sfpi::s2vFloat16(param1);
-    sfpi::vFloat p2 = sfpi::s2vFloat16(param2);
+    sfpi::vFloat p0 = sfpi::s2vFloat16b(param0);
+    sfpi::vFloat p1 = sfpi::s2vFloat16b(param1);
+    sfpi::vFloat p2 = sfpi::s2vFloat16b(param2);
 // SFPU microcode
 #pragma GCC unroll 0
     for (int d = 0; d < iterations; d++)


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/40182

### Problem description
We should not use dynamic typing

### What's changed
Do not use the s2vFloat16 base type -- always select a or b.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Assert validation](https://github.com/tenstorrent/tt-llk/blob/main/docs/Introduction_to_asserts.md) Complied with assert doc (if applicable)
