### PR TITLE
[Quasar AI codegen] Add generated abs SFPU kernel for Quasar (Opus)

### DIFF
--- a/tests/python_tests/quasar/test_sfpu_abs_quasar.py
+++ b/tests/python_tests/quasar/test_sfpu_abs_quasar.py
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 # SPDX-License-Identifier: Apache-2.0
-# AI-generated — run_id: 2026-04-01_abs_quasar_779f878d
+# AI-generated — run_id: 2026-04-08_abs_quasar_2f52d870
 
 from typing import List
 
@@ -41,11 +41,11 @@ def prepare_abs_inputs(
     output_format: DataFormat,
 ) -> torch.Tensor:
     """
-    Prepare input tensor for abs operation with safe value ranges.
+    Prepare input tensor for absolute value operation with safe value ranges.
 
-    Applies log-uniform distribution across orders of magnitude with random signs.
-    For abs, all input values are safe since |x| has the same magnitude as x,
-    so we only need to ensure values fit in both the input and output formats.
+    Generates a mix of positive and negative values across the representable
+    range. Abs does not change magnitude, so the only constraint is that values
+    fit in the input/output format.
 
     Args:
         src_A: Source tensor A (used for magnitude distribution)
@@ -54,17 +54,19 @@ def prepare_abs_inputs(
         output_format: Output data format
 
     Returns:
-        Prepared tensor with safe values for abs operation
+        Prepared tensor with safe values for abs
     """
     input_torch_format = format_dict[input_format]
     output_torch_format = format_dict[output_format]
     input_finfo = torch.finfo(input_torch_format)
     output_finfo = torch.finfo(output_torch_format)
 
-    # For abs, output magnitude = input magnitude, so safe range is min of both formats
+    # For abs, output magnitude equals input magnitude, so we need values that
+    # fit in BOTH input and output formats
     max_safe_value = min(input_finfo.max, output_finfo.max) * 0.9
 
-    # For bfloat16, limit to reasonable bounds for precision
+    # Special handling for bfloat16: limit to reasonable bounds to avoid
+    # precision issues at extreme values
     if input_torch_format == torch.bfloat16:
         max_safe_value = min(max_safe_value, 1e4)
     else:
@@ -140,6 +142,10 @@ def _is_invalid_quasar_combination(
     ):
         return True
 
+    # Integer and float formats cannot be mixed in input/output
+    if in_fmt.is_integer() != out_fmt.is_integer():
+        return True
+
     return False
 
 
@@ -169,6 +175,13 @@ def generate_sfpu_abs_combinations(
                 continue
 
             for implied_math_format in [ImpliedMathFormat.No, ImpliedMathFormat.Yes]:
+                # MX formats require implied_math_format=Yes
+                if (
+                    in_fmt.is_mx_format()
+                    and implied_math_format == ImpliedMathFormat.No
+                ):
+                    continue
+
                 for input_dimensions in [[32, 32], [64, 64], [32, 64]]:
                     combinations.append(
                         (fmt, dest_acc, implied_math_format, input_dimensions)
@@ -194,10 +207,10 @@ SFPU_ABS_FORMATS = input_output_formats(
 )
 def test_sfpu_abs_quasar(formats_dest_acc_implied_math_input_dims):
     """
-    Test abs operation on Quasar architecture.
+    Test absolute value operation on Quasar architecture.
 
-    Uses PyTorch's abs as the golden reference and generates input stimuli
-    covering the full representable range with both positive and negative values.
+    Uses Python's abs() as the golden reference. Abs is an exact operation
+    (sign bit clear for float), so results should match bitwise.
     """
     (formats, dest_acc, implied_math_format, input_dimensions) = (
         formats_dest_acc_implied_math_input_dims[0]
@@ -214,7 +227,7 @@ def test_sfpu_abs_quasar(formats_dest_acc_implied_math_input_dims):
         sfpu=True,
     )
 
-    # Prepare inputs with safe ranges for abs operation
+    # Prepare inputs with a mix of positive and negative values for abs testing
     src_A = prepare_abs_inputs(
         src_A, src_B, formats.input_format, formats.output_format
     )
@@ -263,9 +276,7 @@ def test_sfpu_abs_quasar(formats_dest_acc_implied_math_input_dims):
             tile_count_res=tile_cnt_A,
             num_faces=num_faces,
         ),
-        unpack_to_dest=(
-            formats.input_format.is_32_bit() and dest_acc == DestAccumulation.Yes
-        ),
+        unpack_to_dest=unpack_to_dest,
         dest_acc=dest_acc,
     )
 

--- a/tests/python_tests/quasar/test_sfpu_abs_quasar.py
+++ b/tests/python_tests/quasar/test_sfpu_abs_quasar.py
@@ -1,0 +1,283 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import List
+
+import pytest
+import torch
+from helpers.format_config import DataFormat, FormatConfig
+from helpers.golden_generators import UnarySFPUGolden, get_golden_generator
+from helpers.llk_params import (
+    DataCopyType,
+    DestAccumulation,
+    ImpliedMathFormat,
+    MathOperation,
+    UnpackerEngine,
+    format_dict,
+)
+from helpers.param_config import input_output_formats, parametrize
+from helpers.stimuli_config import StimuliConfig
+from helpers.stimuli_generator import generate_stimuli
+from helpers.test_config import TestConfig
+from helpers.test_variant_parameters import (
+    DATA_COPY_TYPE,
+    DEST_INDEX,
+    DEST_SYNC,
+    IMPLIED_MATH_FORMAT,
+    MATH_OP,
+    NUM_FACES,
+    TEST_FACE_DIMS,
+    TILE_COUNT,
+    UNPACKER_ENGINE_SEL,
+)
+from helpers.utils import passed_test
+
+
+def prepare_abs_inputs(
+    src_A: torch.Tensor,
+    src_B: torch.Tensor,
+    input_format: DataFormat,
+    output_format: DataFormat,
+) -> torch.Tensor:
+    """
+    Prepare input tensor for abs operation with safe value ranges.
+
+    Applies log-uniform distribution across orders of magnitude with random signs.
+    For abs, all input values are safe since |x| has the same magnitude as x,
+    so we only need to ensure values fit in both the input and output formats.
+
+    Args:
+        src_A: Source tensor A (used for magnitude distribution)
+        src_B: Source tensor B (used for sign distribution)
+        input_format: Input data format
+        output_format: Output data format
+
+    Returns:
+        Prepared tensor with safe values for abs operation
+    """
+    input_torch_format = format_dict[input_format]
+    output_torch_format = format_dict[output_format]
+    input_finfo = torch.finfo(input_torch_format)
+    output_finfo = torch.finfo(output_torch_format)
+
+    # For abs, output magnitude = input magnitude, so safe range is min of both formats
+    max_safe_value = min(input_finfo.max, output_finfo.max) * 0.9
+
+    # For bfloat16, limit to reasonable bounds for precision
+    if input_torch_format == torch.bfloat16:
+        max_safe_value = min(max_safe_value, 1e4)
+    else:
+        max_safe_value = min(max_safe_value, input_finfo.max * 0.9)
+
+    min_magnitude = max(1e-6, input_finfo.tiny * 100)  # Avoid denormals
+
+    # Ensure src_A and src_B don't contain inf/nan before normalization
+    src_A_float = src_A.to(torch.float32)
+    src_B_float = src_B.to(torch.float32)
+
+    # Normalize src_A to [0, 1] range for log-uniform distribution
+    src_A_min = src_A_float.min()
+    src_A_max = src_A_float.max()
+    src_A_normalized = (
+        (src_A_float - src_A_min) / (src_A_max - src_A_min)
+        if src_A_max > src_A_min
+        else torch.zeros_like(src_A_float)
+    )
+
+    # Use log-uniform distribution for magnitudes to test across orders of magnitude
+    log_min = torch.log(torch.tensor(min_magnitude, dtype=torch.float32))
+    log_max = torch.log(torch.tensor(max_safe_value, dtype=torch.float32))
+    magnitudes = torch.exp(log_min + src_A_normalized * (log_max - log_min))
+
+    # Randomly assign signs to get both positive and negative values
+    src_B_min = src_B_float.min()
+    src_B_max = src_B_float.max()
+    src_B_normalized = (
+        (src_B_float - src_B_min) / (src_B_max - src_B_min)
+        if src_B_max > src_B_min
+        else torch.zeros_like(src_B_float)
+    )
+    signs = torch.where(src_B_normalized < 0.5, -1.0, 1.0)
+
+    # Apply signs and clamp to safe range BEFORE converting to input format
+    src_A_values = signs * magnitudes
+    src_A_values = torch.clamp(src_A_values, -max_safe_value, max_safe_value)
+    result = src_A_values.to(input_torch_format)
+
+    return result
+
+
+def _is_invalid_quasar_combination(
+    fmt: FormatConfig, dest_acc: DestAccumulation
+) -> bool:
+    """
+    Check if format combination is invalid for Quasar.
+
+    Args:
+        fmt: Format configuration with input and output formats
+        dest_acc: Destination accumulation mode
+
+    Returns:
+        True if the combination is invalid, False otherwise
+    """
+    in_fmt = fmt.input_format
+    out_fmt = fmt.output_format
+
+    # Quasar packer does not support non-Float32 to Float32 conversion when dest_acc=No
+    if (
+        in_fmt != DataFormat.Float32
+        and out_fmt == DataFormat.Float32
+        and dest_acc == DestAccumulation.No
+    ):
+        return True
+
+    # Quasar SFPU with Float32 input and Float16 output requires dest_acc=Yes
+    if (
+        in_fmt == DataFormat.Float32
+        and out_fmt == DataFormat.Float16
+        and dest_acc == DestAccumulation.No
+    ):
+        return True
+
+    return False
+
+
+def generate_sfpu_abs_combinations(
+    formats_list: List[FormatConfig],
+):
+    """
+    Generate SFPU abs test combinations.
+
+    Args: Input-output format pairs
+
+    Returns: List of (format, dest_acc, implied_math_format, input_dimensions) tuples
+    """
+    combinations = []
+
+    for fmt in formats_list:
+        in_fmt = fmt.input_format
+
+        dest_acc_modes = (
+            (DestAccumulation.Yes,)
+            if in_fmt.is_32_bit()
+            else (DestAccumulation.No, DestAccumulation.Yes)
+        )
+        for dest_acc in dest_acc_modes:
+            # Skip invalid format combinations for Quasar
+            if _is_invalid_quasar_combination(fmt, dest_acc):
+                continue
+
+            for implied_math_format in [ImpliedMathFormat.No, ImpliedMathFormat.Yes]:
+                for input_dimensions in [[32, 32], [64, 64], [32, 64]]:
+                    combinations.append(
+                        (fmt, dest_acc, implied_math_format, input_dimensions)
+                    )
+
+    return combinations
+
+
+SFPU_ABS_FORMATS = input_output_formats(
+    [
+        DataFormat.Float16,
+        DataFormat.Float32,
+        DataFormat.Float16_b,
+    ]
+)
+
+
+@pytest.mark.quasar
+@parametrize(
+    formats_dest_acc_implied_math_input_dims=generate_sfpu_abs_combinations(
+        SFPU_ABS_FORMATS
+    ),
+)
+def test_sfpu_abs_quasar(formats_dest_acc_implied_math_input_dims):
+    """
+    Test abs operation on Quasar architecture.
+
+    Uses PyTorch's abs as the golden reference and generates input stimuli
+    covering the full representable range with both positive and negative values.
+    """
+    (formats, dest_acc, implied_math_format, input_dimensions) = (
+        formats_dest_acc_implied_math_input_dims[0]
+    )
+
+    # Set seed for reproducibility
+    torch.manual_seed(42)
+
+    src_A, tile_cnt_A, src_B, _ = generate_stimuli(
+        stimuli_format_A=formats.input_format,
+        input_dimensions_A=input_dimensions,
+        stimuli_format_B=formats.input_format,
+        input_dimensions_B=input_dimensions,
+        sfpu=True,
+    )
+
+    # Prepare inputs with safe ranges for abs operation
+    src_A = prepare_abs_inputs(
+        src_A, src_B, formats.input_format, formats.output_format
+    )
+
+    num_faces = 4
+
+    generate_golden = get_golden_generator(UnarySFPUGolden)
+    golden_tensor = generate_golden(
+        MathOperation.Abs,
+        src_A,
+        formats.output_format,
+        dest_acc,
+        formats.input_format,
+        input_dimensions,
+    )
+
+    unpack_to_dest = (
+        formats.input_format.is_32_bit() and dest_acc == DestAccumulation.Yes
+    )
+    configuration = TestConfig(
+        "sources/quasar/sfpu_abs_quasar_test.cpp",
+        formats,
+        templates=[
+            MATH_OP(mathop=MathOperation.Abs),
+            IMPLIED_MATH_FORMAT(implied_math_format),
+            DATA_COPY_TYPE(DataCopyType.A2D),
+            UNPACKER_ENGINE_SEL(
+                UnpackerEngine.UnpDest if unpack_to_dest else UnpackerEngine.UnpA
+            ),
+            DEST_SYNC(),
+        ],
+        runtimes=[
+            TILE_COUNT(tile_cnt_A),
+            NUM_FACES(num_faces),
+            TEST_FACE_DIMS(),
+            DEST_INDEX(0),
+        ],
+        variant_stimuli=StimuliConfig(
+            src_A,
+            formats.input_format,
+            src_B,
+            formats.input_format,
+            formats.output_format,
+            tile_count_A=tile_cnt_A,
+            tile_count_B=tile_cnt_A,
+            tile_count_res=tile_cnt_A,
+            num_faces=num_faces,
+        ),
+        unpack_to_dest=(
+            formats.input_format.is_32_bit() and dest_acc == DestAccumulation.Yes
+        ),
+        dest_acc=dest_acc,
+    )
+
+    res_from_L1 = configuration.run().result
+
+    # Verify results match golden
+    assert len(res_from_L1) == len(
+        golden_tensor
+    ), "Result tensor and golden tensor are not of the same length"
+
+    torch_format = format_dict[formats.output_format]
+    res_tensor = torch.tensor(res_from_L1, dtype=torch_format)
+
+    assert passed_test(
+        golden_tensor, res_tensor, formats.output_format
+    ), "Assert against golden failed"

--- a/tests/python_tests/quasar/test_sfpu_abs_quasar.py
+++ b/tests/python_tests/quasar/test_sfpu_abs_quasar.py
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 # SPDX-License-Identifier: Apache-2.0
+# AI-generated — run_id: 2026-04-01_abs_quasar_779f878d
 
 from typing import List
 

--- a/tests/sources/quasar/sfpu_abs_quasar_test.cpp
+++ b/tests/sources/quasar/sfpu_abs_quasar_test.cpp
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
-// AI-generated — run_id: 2026-04-01_abs_quasar_779f878d
+// AI-generated — run_id: 2026-04-08_abs_quasar_2f52d870
 
 #include <cstdint>
 
@@ -27,12 +27,18 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     if (unpack_to_dest)
     {
-        // Unpacking to DEST directly
+        // Direct path: UNPACK writes data straight into Dest — no FPU datacopy needed.
+        // Requires format bit-width to match Dest mode (e.g., 16-bit input with 16-bit Dest).
+        // dvalid clients: UNPACK (writes Dest), SFPU (reads/writes Dest), PACK (reads Dest).
         set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::UNPACK, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
+        // When unpacking directly to Dest (bypassing FPU), MATH HW still needs format configuration
+        // so the SFPU reads Dest data in the correct format.
         _llk_math_upk_to_dest_hw_configure_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en, false /*is_int_fpu_en*/>();
     }
     else
     {
+        // FPU path: UNPACK -> SrcA -> FPU datacopy (MOVA2D) -> Dest.
+        // Needed when input format bit-width differs from Dest mode (format conversion required).
         set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::FPU, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
     }
 
@@ -40,9 +46,10 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     bd_val.f.l1_addr_16B = L1_ADDRESS(params.buffer_A[0]);
     bd_val.f.format      = static_cast<std::uint8_t>(formats.unpack_A_src);
-    bd_val.f.x_dim       = params.TEST_FACE_C_DIM;
-    bd_val.f.y_dim       = params.TEST_FACE_R_DIM;
-    bd_val.f.z_dim       = params.num_faces;
+    // Buffer descriptor: x_dim = columns per face, y_dim = rows per face, z_dim = number of faces
+    bd_val.f.x_dim = params.TEST_FACE_C_DIM;
+    bd_val.f.y_dim = params.TEST_FACE_R_DIM;
+    bd_val.f.z_dim = params.num_faces;
 
     tdma_descriptor_t td_val;
     td_val.buf_desc        = bd_val;
@@ -52,7 +59,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     if (is_fp32_dest_acc_en && !unpack_to_dest)
     {
-        // If Dst fmt is 32b and operation is Mov2D, we need both SrcA/B fmts to be configured since Mov2D will be implemented via ELWADD
+        // When Dest is 32-bit (fp32_dest_acc) and data goes through the FPU path,
+        // MOVA2D/MOVB2D requires both SrcA and SrcB format registers configured,
+        // so use binary unpack configuration.
         _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(td_val, td_val);
     }
     else
@@ -95,11 +104,13 @@ void run_kernel(RUNTIME_PARAMETERS params)
     // Setup dvalid for MATH kernel
     if (unpack_to_dest)
     {
+        // Data flows directly from UNPACK -> Dest -> SFPU -> PACK, bypassing the FPU pipeline.
         // Chain must match UNPACK's chain: {UNPACK, SFPU, PACK}
         set_up_dest_dvalid_per_thread<dest_dvalid_client::SFPU>({dest_dvalid_client::UNPACK, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
     }
     else
     {
+        // FPU path: data goes UNPACK -> SrcA -> FPU (MOVA2D) -> Dest -> SFPU -> PACK
         set_up_dest_dvalid_per_thread<dest_dvalid_client::FPU>({dest_dvalid_client::FPU, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
         set_up_dest_dvalid_per_thread<dest_dvalid_client::SFPU>({dest_dvalid_client::FPU, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
     }
@@ -111,6 +122,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     if (!unpack_to_dest)
     {
+        // FPU path: datacopy tiles from SrcA to Dest via MOVA2D before SFPU can operate on them.
         const std::uint32_t num_rows = params.num_faces * params.TEST_FACE_R_DIM;
         _llk_math_eltwise_unary_datacopy_init_<DATA_COPY_TYPE, is_fp32_dest_acc_en>(num_rows, 1);
 
@@ -125,7 +137,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     _llk_math_eltwise_unary_sfpu_init_();
 
-    // Apply SFPU abs to all tiles
+    // Apply SFPU absolute value (SFPABS instruction) to all tiles
     for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
     {
         _llk_math_eltwise_unary_sfpu_params_<false>(ckernel::sfpu::_calculate_abs_, i, num_sfpu_iterations);
@@ -133,7 +145,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     _llk_math_set_dvalid_<p_cleardvalid::SFPU>();
 
-    // Wait for all operations to complete
+    // Wait for SFPU, FPU, and MOP to finish their Dest sections.
+    // No REPLAY wait needed because this kernel uses straight-line SFPU execution (no replay buffer).
     wait_sfpu_idle();
     wait_fpu_idle();
     wait_mop_idle();
@@ -169,9 +182,10 @@ void run_kernel(RUNTIME_PARAMETERS params)
     buffer_descriptor_u bd_val = {0};
     bd_val.f.l1_addr_16B       = params.buffer_Res[0] / 16;
     bd_val.f.format            = static_cast<std::uint8_t>(formats.pack_dst);
-    bd_val.f.x_dim             = params.TEST_FACE_C_DIM;
-    bd_val.f.y_dim             = params.TEST_FACE_R_DIM;
-    bd_val.f.z_dim             = params.num_faces;
+    // Buffer descriptor: x_dim = columns per face, y_dim = rows per face, z_dim = number of faces
+    bd_val.f.x_dim = params.TEST_FACE_C_DIM;
+    bd_val.f.y_dim = params.TEST_FACE_R_DIM;
+    bd_val.f.z_dim = params.num_faces;
 
     tdma_descriptor_t tdma_desc;
     tdma_desc.buf_desc        = bd_val;

--- a/tests/sources/quasar/sfpu_abs_quasar_test.cpp
+++ b/tests/sources/quasar/sfpu_abs_quasar_test.cpp
@@ -1,0 +1,186 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "ckernel.h"
+#include "llk_defs.h"
+#include "llk_memory_checks.h"
+#include "sfpu_stub.h"
+
+#ifdef LLK_TRISC_UNPACK
+
+#include "llk_math_common.h"
+#include "llk_unpack_common.h"
+#include "llk_unpack_unary_operand.h"
+#include "params.h"
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+#if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
+    const FormatConfig& formats = params.formats;
+#endif
+    const std::uint32_t buf_desc_id = 0;
+    const std::uint32_t num_tiles   = params.TILE_CNT;
+
+    if (unpack_to_dest)
+    {
+        // Unpacking to DEST directly
+        set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::UNPACK, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
+        _llk_math_upk_to_dest_hw_configure_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en, false /*is_int_fpu_en*/>();
+    }
+    else
+    {
+        set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::FPU, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
+    }
+
+    buffer_descriptor_u bd_val = {0};
+
+    bd_val.f.l1_addr_16B = L1_ADDRESS(params.buffer_A[0]);
+    bd_val.f.format      = static_cast<std::uint8_t>(formats.unpack_A_src);
+    bd_val.f.x_dim       = params.TEST_FACE_C_DIM;
+    bd_val.f.y_dim       = params.TEST_FACE_R_DIM;
+    bd_val.f.z_dim       = params.num_faces;
+
+    tdma_descriptor_t td_val;
+    td_val.buf_desc        = bd_val;
+    td_val.buf_desc_id     = buf_desc_id;
+    td_val.reg_data_format = static_cast<std::uint8_t>(formats.unpack_A_dst);
+    _configure_buf_desc_table_(td_val.buf_desc_id, td_val.buf_desc);
+
+    if (is_fp32_dest_acc_en && !unpack_to_dest)
+    {
+        // If Dst fmt is 32b and operation is Mov2D, we need both SrcA/B fmts to be configured since Mov2D will be implemented via ELWADD
+        _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(td_val, td_val);
+    }
+    else
+    {
+        _llk_unpack_configure_unary_<UNPACKER_ENGINE_SEL>(td_val);
+    }
+
+    _llk_unpack_unary_operand_init_<UNPACKER_ENGINE_SEL, false /*transpose*/, is_fp32_dest_acc_en>(buf_desc_id, num_tiles);
+    _llk_unpack_unary_operand_<UNPACKER_ENGINE_SEL>(0);
+
+    if (unpack_to_dest)
+    {
+        _llk_unpack_dest_dvalid_section_done_();
+    }
+}
+
+#endif
+
+#ifdef LLK_TRISC_MATH
+
+const bool is_int_fpu_en = false;
+
+#include "cfg_defines.h"
+#include "cmath_common.h"
+#include "llk_math_common.h"
+#include "llk_math_eltwise_unary_datacopy.h"
+#include "llk_math_eltwise_unary_sfpu_common.h"
+#include "params.h"
+#include "sfpu/ckernel_sfpu_abs.h"
+
+using namespace ckernel;
+using namespace ckernel::math;
+using namespace ckernel::sfpu;
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+#if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
+    const FormatConfig& formats = params.formats;
+#endif
+    // Setup dvalid for MATH kernel
+    if (unpack_to_dest)
+    {
+        // Chain must match UNPACK's chain: {UNPACK, SFPU, PACK}
+        set_up_dest_dvalid_per_thread<dest_dvalid_client::SFPU>({dest_dvalid_client::UNPACK, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
+    }
+    else
+    {
+        set_up_dest_dvalid_per_thread<dest_dvalid_client::FPU>({dest_dvalid_client::FPU, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
+        set_up_dest_dvalid_per_thread<dest_dvalid_client::SFPU>({dest_dvalid_client::FPU, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
+    }
+
+    DataFormat src_format = static_cast<DataFormat>(formats.math);
+    _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en, is_int_fpu_en>(src_format, src_format);
+
+    const std::uint32_t num_sfpu_iterations = params.TEST_FACE_R_DIM / ckernel::math::SFP_ROWS;
+
+    if (!unpack_to_dest)
+    {
+        const std::uint32_t num_rows = params.num_faces * params.TEST_FACE_R_DIM;
+        _llk_math_eltwise_unary_datacopy_init_<DATA_COPY_TYPE, is_fp32_dest_acc_en>(num_rows, 1);
+
+        // Datacopy all tiles from SRC to DEST
+        for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
+        {
+            _llk_math_eltwise_unary_datacopy_(num_rows, i);
+        }
+
+        _llk_math_set_dvalid_<p_cleardvalid::FPU>();
+    }
+
+    _llk_math_eltwise_unary_sfpu_init_();
+
+    // Apply SFPU abs to all tiles
+    for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
+    {
+        _llk_math_eltwise_unary_sfpu_params_<false>(ckernel::sfpu::_calculate_abs_, i, num_sfpu_iterations);
+    }
+
+    _llk_math_set_dvalid_<p_cleardvalid::SFPU>();
+
+    // Wait for all operations to complete
+    wait_sfpu_idle();
+    wait_fpu_idle();
+    wait_mop_idle();
+}
+
+#endif
+
+#ifdef LLK_TRISC_PACK
+
+#include "cfg_defines.h"
+#include "llk_pack.h"
+#include "llk_pack_common.h"
+#include "params.h"
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+#if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
+    const FormatConfig& formats = params.formats;
+#endif
+    std::uint32_t const buf_desc_id        = 8;
+    const std::uint32_t num_tiles_per_pack = params.TILE_CNT;
+
+    // Setup dvalid for PACK
+    if (unpack_to_dest)
+    {
+        set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::UNPACK, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
+    }
+    else
+    {
+        set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::FPU, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
+    }
+
+    buffer_descriptor_u bd_val = {0};
+    bd_val.f.l1_addr_16B       = params.buffer_Res[0] / 16;
+    bd_val.f.format            = static_cast<std::uint8_t>(formats.pack_dst);
+    bd_val.f.x_dim             = params.TEST_FACE_C_DIM;
+    bd_val.f.y_dim             = params.TEST_FACE_R_DIM;
+    bd_val.f.z_dim             = params.num_faces;
+
+    tdma_descriptor_t tdma_desc;
+    tdma_desc.buf_desc        = bd_val;
+    tdma_desc.buf_desc_id     = buf_desc_id;
+    tdma_desc.reg_data_format = static_cast<std::uint8_t>(formats.pack_src);
+    _configure_buf_desc_table_(tdma_desc.buf_desc_id, tdma_desc.buf_desc);
+
+    _llk_pack_hw_configure_<p_pacr::PACK0>(tdma_desc);
+    _llk_pack_init_<p_pacr::PACK0>(buf_desc_id, num_tiles_per_pack);
+    _llk_pack_<p_pacr::PACK0>(params.DST_INDEX, 0);
+    _llk_pack_dest_dvalid_section_done_<dest_sync, is_fp32_dest_acc_en>();
+}
+#endif

--- a/tests/sources/quasar/sfpu_abs_quasar_test.cpp
+++ b/tests/sources/quasar/sfpu_abs_quasar_test.cpp
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
+// AI-generated — run_id: 2026-04-01_abs_quasar_779f878d
 
 #include <cstdint>
 
@@ -76,11 +77,11 @@ const bool is_int_fpu_en = false;
 
 #include "cfg_defines.h"
 #include "cmath_common.h"
+#include "experimental/ckernel_sfpu_abs.h"
 #include "llk_math_common.h"
 #include "llk_math_eltwise_unary_datacopy.h"
 #include "llk_math_eltwise_unary_sfpu_common.h"
 #include "params.h"
-#include "sfpu/ckernel_sfpu_abs.h"
 
 using namespace ckernel;
 using namespace ckernel::math;
@@ -179,8 +180,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _configure_buf_desc_table_(tdma_desc.buf_desc_id, tdma_desc.buf_desc);
 
     _llk_pack_hw_configure_<p_pacr::PACK0>(tdma_desc);
-    _llk_pack_init_<p_pacr::PACK0>(buf_desc_id, num_tiles_per_pack);
-    _llk_pack_<p_pacr::PACK0>(params.DST_INDEX, 0);
+    _llk_pack_init_(buf_desc_id, num_tiles_per_pack);
+    _llk_pack_(params.DST_INDEX, 0);
     _llk_pack_dest_dvalid_section_done_<dest_sync, is_fp32_dest_acc_en>();
 }
 #endif

--- a/tt_llk_quasar/common/inc/experimental/ckernel_sfpu_abs.h
+++ b/tt_llk_quasar/common/inc/experimental/ckernel_sfpu_abs.h
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+// AI-generated — run_id: 2026-04-08_abs_quasar_2f52d870
+#pragma once
+
+#include "ckernel_trisc_common.h"
+#include "cmath_common.h"
+
+namespace ckernel
+{
+namespace sfpu
+{
+// Calculates ABS for number of rows of output SFPU ops (Quasar = 2 rows)
+inline void _calculate_abs_sfp_rows_()
+{
+    TTI_SFPLOAD(p_sfpu::LREG0, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0, 0); // load from dest into lreg[0]
+
+    // SFPABS with instr_mod1=1 selects float absolute value (clears sign bit).
+    // instr_mod1=0 would be integer abs (2's complement), which is wrong for float data.
+    // See sfpi_constants.h: SFPABS_MOD1_FLOAT=1, SFPABS_MOD1_INT=0.
+    TTI_SFPABS(p_sfpu::LREG0, p_sfpu::LREG0, 1);
+
+    // Store result back to destination
+    TTI_SFPSTORE(p_sfpu::LREG0, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0, 0);
+}
+
+// Implements element-wise absolute value: abs(x)
+inline void _calculate_abs_(const int iterations)
+{
+#pragma GCC unroll 8
+    for (int d = 0; d < iterations; d++)
+    {
+        _calculate_abs_sfp_rows_();
+        ckernel::math::_incr_counters_<0x0, 0x0, ckernel::math::SFP_ROWS, 0x0>(); // does the dest_reg++ (increments by 2 rows)
+    }
+}
+
+} // namespace sfpu
+} // namespace ckernel

--- a/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_abs.h
+++ b/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_abs.h
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ckernel_ops.h"
+#include "ckernel_trisc_common.h"
+#include "cmath_common.h"
+
+namespace ckernel
+{
+namespace sfpu
+{
+// Calculates ABS for number of rows of output SFPU ops (Quasar = 2 rows)
+inline void _calculate_abs_sfp_rows_()
+{
+    TTI_SFPLOAD(p_sfpu::LREG0, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0, 0); // load from dest into lreg[0]
+    // Apply absolute value: clear sign bit for FP32 (instr_mod1=1)
+    TTI_SFPABS(p_sfpu::LREG0, p_sfpu::LREG0, 1);
+    // Store result back to destination
+    TTI_SFPSTORE(p_sfpu::LREG0, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0, 0);
+}
+
+inline void _calculate_abs_(const int iterations)
+{
+#pragma GCC unroll 8
+    for (int d = 0; d < iterations; d++)
+    {
+        _calculate_abs_sfp_rows_();
+        ckernel::math::_incr_counters_<0x0, 0x0, ckernel::math::SFP_ROWS, 0x0>(); // does the dest_reg++ (increments by 2 rows)
+    }
+}
+
+} // namespace sfpu
+} // namespace ckernel

--- a/tt_llk_quasar/llk_lib/experimental/ckernel_sfpu_abs.h
+++ b/tt_llk_quasar/llk_lib/experimental/ckernel_sfpu_abs.h
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
+// AI-generated — run_id: 2026-04-01_abs_quasar_779f878d
 
 #pragma once
 

--- a/tt_llk_quasar/llk_lib/llk_defs.h
+++ b/tt_llk_quasar/llk_lib/llk_defs.h
@@ -69,7 +69,8 @@ enum class SfpuType : std::uint32_t
     add,
     square,
     sigmoid,
-    silu
+    silu,
+    abs
 };
 
 enum class DstSync : std::uint8_t


### PR DESCRIPTION
Generated via LLK codegen (Opus). Includes kernel implementation, SfpuType enum entry, and test files.

### Ticket
<!-- Link to Github Issue -->

### Problem description
Quasar is missing an SFPU `abs` (absolute value) kernel. The Blackhole architecture already has this implementation, but it has not been ported to Quasar.

### What's changed
- Added `tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_abs.h` — Quasar SFPU absolute value kernel using SFPABS instruction
- Added `tt_llk_quasar/llk_lib/llk_defs.h` — `abs` entry in SfpuType enum
- Added `tests/sources/quasar/sfpu_abs_quasar_test.cpp` — C++ test source for abs kernel
- Added `tests/python_tests/quasar/test_sfpu_abs_quasar.py` — Python test harness for abs on Quasar simulator

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Assert validation](https://github.com/tenstorrent/tt-llk/blob/main/docs/Introduction_to_asserts.md) Complied with assert doc (if applicable)