### PR TITLE
Set ADDR_MOD_6 autoincrement for signbit.

### DIFF
--- a/tt_llk_blackhole/llk_lib/llk_math_eltwise_unary_sfpu.h
+++ b/tt_llk_blackhole/llk_lib/llk_math_eltwise_unary_sfpu.h
@@ -45,7 +45,7 @@ inline void eltwise_unary_sfpu_configure_addrmod()
     if constexpr (
         sfpu_op == SfpuType::reciprocal || sfpu_op == SfpuType::typecast || sfpu_op == SfpuType::unary_max || sfpu_op == SfpuType::unary_min ||
         sfpu_op == SfpuType::unary_max_int32 || sfpu_op == SfpuType::unary_min_int32 || sfpu_op == SfpuType::unary_max_uint32 ||
-        sfpu_op == SfpuType::unary_min_uint32)
+        sfpu_op == SfpuType::unary_min_uint32 || sfpu_op == SfpuType::signbit)
     {
         addr_mod_t {
             .srca = {.incr = 0},

--- a/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_unary_sfpu.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_unary_sfpu.h
@@ -44,7 +44,7 @@ inline void eltwise_unary_sfpu_configure_addrmod()
 
     if constexpr (
         sfpu_op == SfpuType::typecast || sfpu_op == SfpuType::unary_max || sfpu_op == SfpuType::unary_min || sfpu_op == SfpuType::unary_max_int32 ||
-        sfpu_op == SfpuType::unary_min_int32 || sfpu_op == SfpuType::unary_max_uint32 || sfpu_op == SfpuType::unary_min_uint32)
+        sfpu_op == SfpuType::unary_min_int32 || sfpu_op == SfpuType::unary_max_uint32 || sfpu_op == SfpuType::unary_min_uint32 || sfpu_op == SfpuType::signbit)
     {
         addr_mod_t {
             .srca = {.incr = 0},


### PR DESCRIPTION
### Ticket

https://github.com/tenstorrent/tt-metal/issues/41030

### Problem description

`ADDR_MOD_6` (autoincrement) needs to be configured for future signbit optimisations.

### What's changed

For unary signbit, configure `ADDR_MOD_6` with `Dst += 2`.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Assert validation](https://github.com/tenstorrent/tt-llk/blob/main/docs/Introduction_to_asserts.md) Complied with assert doc (if applicable)
