### PR TITLE
Added runtime acc_to_dest param for Quasar eltwise binary

### DIFF
--- a/tests/python_tests/helpers/golden_generators.py
+++ b/tests/python_tests/helpers/golden_generators.py
@@ -1893,6 +1893,32 @@ class EltwiseBinaryGolden(FidelityMasking):
             return quantize_mx_tensor_chunked(operand, fmt)
         return to_tensor(operand, data_format)
 
+    def _compute_eltwise(self, op, t1, t2, math_format_for_fidelity, math_fidelity):
+        """Compute a single eltwise operation with fidelity masking."""
+        MATH_FIDELITY_TO_ITER_COUNT = {
+            MathFidelity.LoFi: 0,
+            MathFidelity.HiFi2: 1,
+            MathFidelity.HiFi3: 2,
+            MathFidelity.HiFi4: 3,
+        }
+        fidelity_iter_count = MATH_FIDELITY_TO_ITER_COUNT[math_fidelity]
+
+        if op == MathOperation.Elwmul:
+            result = None
+            for fidelity_iter in range(fidelity_iter_count + 1):
+                t1, t2 = self._apply_fidelity_masking(
+                    math_format_for_fidelity, t1, t2, fidelity_iter
+                )
+                phase_result = self.ops[op](t1, t2)
+                if fidelity_iter == 0:
+                    result = phase_result
+                else:
+                    result += phase_result
+        else:
+            result = self.ops[op](t1, t2)
+
+        return result
+
     def __call__(
         self,
         op,
@@ -1902,7 +1928,13 @@ class EltwiseBinaryGolden(FidelityMasking):
         math_fidelity,
         input_format=None,
         input_format_B=None,
+        acc_to_dest=False,
+        tile_shape=None,
+        num_tiles_per_accumulation=1,
     ):
+        if tile_shape is None:
+            tile_shape = construct_tile_shape()
+
         if op not in self.ops:
             raise ValueError(f"Unsupported Eltwise operation: {op}")
 
@@ -1927,28 +1959,43 @@ class EltwiseBinaryGolden(FidelityMasking):
 
         t1, t2 = operand1, operand2
 
-        # Step 2: Compute the operation (with fidelity masking for Elwmul).
-        MATH_FIDELITY_TO_ITER_COUNT = {
-            MathFidelity.LoFi: 0,
-            MathFidelity.HiFi2: 1,
-            MathFidelity.HiFi3: 2,
-            MathFidelity.HiFi4: 3,
-        }
-        fidelity_iter_count = MATH_FIDELITY_TO_ITER_COUNT[math_fidelity]
+        # Step 2: Calculate the eltwise result
+        if acc_to_dest:
+            # The concept of tile should only be used when we have accumulation, otherwise we can use the entire tensor.
+            tile_size = tile_shape.total_tile_size()
+            num_total_tiles = t1.numel() // tile_size
+            num_blocks = num_total_tiles // num_tiles_per_accumulation
 
-        if op == MathOperation.Elwmul:
-            result = None
-            for fidelity_iter in range(fidelity_iter_count + 1):
-                t1, t2 = self._apply_fidelity_masking(
-                    math_format_for_fidelity, t1, t2, fidelity_iter
-                )
-                phase_result = self.ops[op](t1, t2)
-                if fidelity_iter == 0:
-                    result = phase_result
-                else:
-                    result += phase_result
+            t1_tiles = t1.view(num_total_tiles, tile_size)
+            t2_tiles = t2.view(num_total_tiles, tile_size)
+
+            accumulated = []
+            for block in range(num_blocks):
+                block_acc = None
+                for tile in range(num_tiles_per_accumulation):
+                    idx = block * num_tiles_per_accumulation + tile
+                    tile_result = self._compute_eltwise(
+                        op,
+                        t1_tiles[idx],
+                        t2_tiles[idx],
+                        math_format_for_fidelity,
+                        math_fidelity,
+                    )
+                    if block_acc is None:
+                        block_acc = tile_result
+                    else:
+                        block_acc = block_acc + tile_result
+                accumulated.append(block_acc)
+
+            result = torch.cat(accumulated)
         else:
-            result = self.ops[op](t1, t2)
+            result = self._compute_eltwise(
+                op,
+                t1,
+                t2,
+                math_format_for_fidelity,
+                math_fidelity,
+            )
 
         # Step 3: Quantize output to match what hardware packs back into L1.
         if data_format == DataFormat.Bfp4_b:

--- a/tests/python_tests/quasar/test_eltwise_binary_quasar.py
+++ b/tests/python_tests/quasar/test_eltwise_binary_quasar.py
@@ -25,13 +25,16 @@ from helpers.stimuli_config import StimuliConfig
 from helpers.stimuli_generator import generate_stimuli
 from helpers.test_config import BootMode, TestConfig
 from helpers.test_variant_parameters import (
+    ACC_TO_DEST,
     DEST_SYNC,
     IMPLIED_MATH_FORMAT,
+    INPUT_TILE_CNT,
     MATH_FIDELITY,
     MATH_OP,
     NUM_FACES,
+    NUM_TILES_IN_BLOCK,
+    OUTPUT_TILE_CNT,
     TEST_FACE_DIMS,
-    TILE_COUNT,
 )
 from helpers.utils import passed_test
 
@@ -40,6 +43,12 @@ ELTWISE_DIMENSIONS = [
     for dest_sync in (DestSync.Half, DestSync.Full)
     for dims in generate_unary_input_dimensions(DestAccumulation.No, dest_sync)
 ]
+from helpers.tile_shape import construct_tile_shape
+
+
+# For acc_to_dest setting, accumulate two result tiles into dest. Can be extended.
+def get_num_tiles_per_accumulation(acc_to_dest: bool) -> int:
+    return 2 if acc_to_dest else 1
 
 
 @pytest.mark.quasar
@@ -68,6 +77,7 @@ ELTWISE_DIMENSIONS = [
         ImpliedMathFormat.Yes,
     ],
     dest_sync_dims_dest_acc=ELTWISE_DIMENSIONS,
+    acc_to_dest=[False, True],
     num_faces=[4],
 )
 def test_eltwise_binary(
@@ -76,11 +86,12 @@ def test_eltwise_binary(
     math_fidelity,
     implied_math_format,
     dest_sync_dims_dest_acc,
+    acc_to_dest,
     num_faces,
     boot_mode=BootMode.DEFAULT,
 ):
-
     dest_sync_mode, input_dimensions, dest_acc = dest_sync_dims_dest_acc
+    tile_shape = construct_tile_shape()
 
     # Math fidelity only affects multiplication operations
     if (
@@ -96,12 +107,26 @@ def test_eltwise_binary(
     ):
         pytest.skip("MX formats require implied_math_format=Yes on Quasar")
 
+    num_tiles_per_accumulation = get_num_tiles_per_accumulation(acc_to_dest)
+    total_tiles = (
+        input_dimensions[0] * input_dimensions[1]
+    ) // tile_shape.total_tile_size()
+
+    if (
+        acc_to_dest and total_tiles < num_tiles_per_accumulation
+    ) or total_tiles % num_tiles_per_accumulation != 0:
+        pytest.skip("Not enough tiles for dest accumulation")
+
     src_A, tile_cnt_A, src_B, _ = generate_stimuli(
         stimuli_format_A=formats.input_format,
         input_dimensions_A=input_dimensions,
         stimuli_format_B=formats.input_format,
         input_dimensions_B=input_dimensions,
         output_format=formats.output_format,
+    )
+
+    tile_cnt_res = src_A.numel() // (
+        tile_shape.total_tile_size() * num_tiles_per_accumulation
     )
 
     generate_golden = get_golden_generator(EltwiseBinaryGolden)
@@ -112,6 +137,9 @@ def test_eltwise_binary(
         formats.output_format,
         math_fidelity,
         input_format=formats.input_format,
+        acc_to_dest=acc_to_dest,
+        tile_shape=tile_shape,
+        num_tiles_per_accumulation=num_tiles_per_accumulation,
     )
 
     configuration = TestConfig(
@@ -122,11 +150,14 @@ def test_eltwise_binary(
             MATH_OP(mathop=mathop),
             IMPLIED_MATH_FORMAT(implied_math_format),
             DEST_SYNC(dest_sync_mode),
+            ACC_TO_DEST(acc_to_dest),
         ],
         runtimes=[
-            TILE_COUNT(tile_cnt_A),
+            INPUT_TILE_CNT(tile_cnt_A),
+            OUTPUT_TILE_CNT(tile_cnt_res),
             NUM_FACES(num_faces),
             TEST_FACE_DIMS(),
+            NUM_TILES_IN_BLOCK(num_tiles_per_accumulation),
         ],
         variant_stimuli=StimuliConfig(
             src_A,
@@ -136,7 +167,7 @@ def test_eltwise_binary(
             formats.output_format,
             tile_count_A=tile_cnt_A,
             tile_count_B=tile_cnt_A,
-            tile_count_res=tile_cnt_A,
+            tile_count_res=tile_cnt_res,
             num_faces=num_faces,
         ),
         # Determine unpack_to_dest based on format and accumulation mode

--- a/tests/sources/quasar/eltwise_binary_test.cpp
+++ b/tests/sources/quasar/eltwise_binary_test.cpp
@@ -65,8 +65,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     // Initialize binary operands unpacker - unpack 1 tile per MOP run
     _llk_unpack_binary_operands_init_(buf_desc_id_a, buf_desc_id_b, 1);
 
-    // Unpack all tiles for both operands
-    for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
+    for (int i = 0; i < params.INPUT_TILE_CNT; ++i)
     {
         _llk_unpack_binary_operands_(i, i);
     }
@@ -102,12 +101,20 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en, is_int_fpu_en>(src_format, src_format);
 
     // Initialize eltwise binary operation with default 32x32 tensor shape
-    _llk_math_eltwise_binary_init_<ELTWISE_BINARY_OP, MATH_FIDELITY>(ckernel::DEFAULT_TENSOR_SHAPE); // tiny-tile testing not yet supported
+    _llk_math_eltwise_binary_init_<ELTWISE_BINARY_OP, MATH_FIDELITY>(ckernel::DEFAULT_TENSOR_SHAPE, ACC_TO_DEST); // tiny-tile testing not yet supported
 
     // Perform eltwise binary operation for each tile
-    for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
+    int tile_idx        = 0;
+    int remaining_tiles = params.INPUT_TILE_CNT;
+
+    while (remaining_tiles)
     {
-        _llk_math_eltwise_binary_(i);
+        for (std::uint32_t tile = 0; tile < params.NUM_TILES_IN_BLOCK; ++tile) // number of result tiles to accumulate
+        {
+            _llk_math_eltwise_binary_(tile_idx);
+        }
+        tile_idx++;
+        remaining_tiles -= params.NUM_TILES_IN_BLOCK;
     }
 
     // Signal math completion
@@ -153,7 +160,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_pack_init_(buf_desc_id, 1);
 
     // Pack all result tiles
-    for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
+    for (int i = 0; i < params.OUTPUT_TILE_CNT; ++i)
     {
         _llk_pack_(i, i);
     }

--- a/tt_llk_quasar/llk_lib/llk_math_eltwise_binary.h
+++ b/tt_llk_quasar/llk_lib/llk_math_eltwise_binary.h
@@ -12,20 +12,20 @@ using namespace ckernel;
 using namespace ckernel::trisc;
 using namespace ckernel::math;
 
-template <EltwiseBinaryType ELTWISE_BINARY_TYPE, std::uint8_t CLR_SRC, std::uint8_t EN_DST_ACCUM, std::uint8_t SRCB_BROADCAST_TYPE, std::uint8_t ADDR_MOD>
-constexpr std::uint32_t eltwise_binary_func()
+template <EltwiseBinaryType ELTWISE_BINARY_TYPE, std::uint8_t CLR_SRC, std::uint8_t SRCB_BROADCAST_TYPE, std::uint8_t ADDR_MOD>
+constexpr std::uint32_t eltwise_binary_func(std::uint8_t EN_DST_ACC)
 {
     if constexpr (ELTWISE_BINARY_TYPE == EltwiseBinaryType::ELWADD)
     {
-        return TT_OP_ELWADD(CLR_SRC, EN_DST_ACCUM, SRCB_BROADCAST_TYPE, ADDR_MOD, 0);
+        return TT_OP_ELWADD(CLR_SRC, EN_DST_ACC, SRCB_BROADCAST_TYPE, ADDR_MOD, 0);
     }
     else if constexpr (ELTWISE_BINARY_TYPE == EltwiseBinaryType::ELWSUB)
     {
-        return TT_OP_ELWSUB(CLR_SRC, EN_DST_ACCUM, SRCB_BROADCAST_TYPE, ADDR_MOD, 0);
+        return TT_OP_ELWSUB(CLR_SRC, EN_DST_ACC, SRCB_BROADCAST_TYPE, ADDR_MOD, 0);
     }
     else
     {
-        return TT_OP_ELWMUL(CLR_SRC, EN_DST_ACCUM, SRCB_BROADCAST_TYPE, ADDR_MOD, 0);
+        return TT_OP_ELWMUL(CLR_SRC, EN_DST_ACC, SRCB_BROADCAST_TYPE, ADDR_MOD, 0);
     }
 }
 
@@ -68,19 +68,19 @@ template <
     EltwiseBinaryType ELTWISE_BINARY_TYPE,
     ckernel::MathFidelity MATH_FIDELITY_TYPE,
     EltwiseBinaryReuseDestType reuse_dest = EltwiseBinaryReuseDestType::NONE>
-inline void _llk_math_eltwise_binary_mop_config_(const ckernel::TensorShape& tensor_shape)
+inline void _llk_math_eltwise_binary_mop_config_(const ckernel::TensorShape& tensor_shape, bool acc_to_dest = false)
 {
     const std::uint32_t rows_per_mop_run =
         (reuse_dest != EltwiseBinaryReuseDestType::NONE) ? tensor_shape.face_r_dim : (tensor_shape.total_num_faces() * tensor_shape.face_r_dim);
     constexpr bool high_fidelity = MATH_FIDELITY_TYPE != ckernel::MathFidelity::LoFi;
     static_assert(!(high_fidelity && ELTWISE_BINARY_TYPE != EltwiseBinaryType::ELWMUL), "Math fidelity larger than LoFi only works with Eltwise MUL");
-    // For reuse_dest + Elwmul we need dest accumulation (dest = old_dest + srcA*srcB) ; LoFi alone sets EN_DST_ACC_EN=0.
-    constexpr std::uint32_t EN_DST_ACC_EN =
-        (reuse_dest != EltwiseBinaryReuseDestType::NONE && ELTWISE_BINARY_TYPE == EltwiseBinaryType::ELWMUL) ? 1u : (high_fidelity ? 1u : 0u);
+    // For reuse_dest + Elwmul we need dest accumulation (dest = old_dest + srcA*srcB) ; LoFi alone sets EN_DST_ACC=0.
+    const std::uint32_t EN_DST_ACC =
+        acc_to_dest ? 1u
+                    : ((reuse_dest != EltwiseBinaryReuseDestType::NONE && ELTWISE_BINARY_TYPE == EltwiseBinaryType::ELWMUL) ? 1u : (high_fidelity ? 1u : 0u));
 
-    constexpr std::uint8_t addrmod_fid = high_fidelity ? ADDR_MOD_2 : ADDR_MOD_0;
-    constexpr static std::uint32_t eltwise_binary_op =
-        eltwise_binary_func<ELTWISE_BINARY_TYPE, p_elwise::CLR_NONE, EN_DST_ACC_EN, p_elwise::SRCB_NO_BCAST, addrmod_fid>();
+    constexpr std::uint8_t addrmod_fid    = high_fidelity ? ADDR_MOD_2 : ADDR_MOD_0;
+    const std::uint32_t eltwise_binary_op = eltwise_binary_func<ELTWISE_BINARY_TYPE, p_elwise::CLR_NONE, p_elwise::SRCB_NO_BCAST, addrmod_fid>(EN_DST_ACC);
 
     if constexpr (reuse_dest != EltwiseBinaryReuseDestType::NONE)
     {
@@ -98,15 +98,15 @@ inline void _llk_math_eltwise_binary_mop_config_(const ckernel::TensorShape& ten
         const std::uint32_t MOP_OUTER_LOOP     = (rows_per_mop_run >> math_rows_log2(ELTWISE_MATH_ROWS));
         constexpr std::uint32_t MOP_INNER_LOOP = MATH_FIDELITY_TYPE == ckernel::MathFidelity::LoFi ? 1 : to_underlying(MATH_FIDELITY_TYPE);
 
-        constexpr static std::uint32_t eltwise_binary_op_clr_valid =
-            eltwise_binary_func<ELTWISE_BINARY_TYPE, p_setrwc::CLR_AB, EN_DST_ACC_EN, p_elwise::SRCB_NO_BCAST, ADDR_MOD_1>();
+        const std::uint32_t eltwise_binary_op_clr_valid =
+            eltwise_binary_func<ELTWISE_BINARY_TYPE, p_setrwc::CLR_AB, p_elwise::SRCB_NO_BCAST, ADDR_MOD_1>(EN_DST_ACC);
         ckernel_template temp(MOP_OUTER_LOOP, MOP_INNER_LOOP, eltwise_binary_op);
         temp.set_last_outer_loop_instr(eltwise_binary_op_clr_valid);
 
         if (high_fidelity)
         {
-            constexpr static std::uint32_t eltwise_binary_op_clr_fidelity =
-                eltwise_binary_func<ELTWISE_BINARY_TYPE, p_elwise::CLR_NONE, EN_DST_ACC_EN, p_elwise::SRCB_NO_BCAST, ADDR_MOD_0>();
+            const std::uint32_t eltwise_binary_op_clr_fidelity =
+                eltwise_binary_func<ELTWISE_BINARY_TYPE, p_elwise::CLR_NONE, p_elwise::SRCB_NO_BCAST, ADDR_MOD_0>(EN_DST_ACC);
             temp.set_last_inner_loop_instr(eltwise_binary_op_clr_fidelity); // clear math fidelity
         }
 
@@ -118,14 +118,14 @@ inline void _llk_math_eltwise_binary_mop_config_(const ckernel::TensorShape& ten
 // Direct Indexing Method
 //----------------------
 template <EltwiseBinaryType ELTWISE_BINARY_TYPE, ckernel::MathFidelity MATH_FIDELITY_TYPE>
-inline void _llk_math_eltwise_di_binary_mop_config_(const ckernel::TensorShape& tensor_shape)
+inline void _llk_math_eltwise_di_binary_mop_config_(const ckernel::TensorShape& tensor_shape, bool acc_to_dest = false)
 {
     const std::uint32_t total_num_rows_per_tile = tensor_shape.total_num_faces() * tensor_shape.face_r_dim;
     const std::uint32_t REPLAY_BUF_LEN          = (total_num_rows_per_tile >> math_rows_log2(ELTWISE_MATH_ROWS));
     const std::uint32_t MOP_INNER_LOOP          = to_underlying(MATH_FIDELITY_TYPE) + 1;
     constexpr bool high_fidelity                = MATH_FIDELITY_TYPE != ckernel::MathFidelity::LoFi;
     static_assert(!(high_fidelity && ELTWISE_BINARY_TYPE != EltwiseBinaryType::ELWMUL), "Math fidelity larger than LoFi only works with Eltwise MUL");
-    const std::uint32_t EN_DST_ACC_EN = high_fidelity;
+    const std::uint32_t EN_DST_ACC = acc_to_dest ? 1u : static_cast<std::uint32_t>(high_fidelity);
 
     load_replay_buf(
         0u,
@@ -139,7 +139,7 @@ inline void _llk_math_eltwise_di_binary_mop_config_(const ckernel::TensorShape& 
             {
                 eltwise_di_binary_func<ELTWISE_BINARY_TYPE>(
                     p_elwise::CLR_NONE,
-                    EN_DST_ACC_EN,
+                    EN_DST_ACC,
                     p_elwise::SRCB_NO_BCAST,
                     (i * ELTWISE_MATH_ROWS) >> 2, // Srcb addr
                     (i * ELTWISE_MATH_ROWS) >> 2, // Srca addr
@@ -151,7 +151,7 @@ inline void _llk_math_eltwise_di_binary_mop_config_(const ckernel::TensorShape& 
             {
                 eltwise_di_binary_func<ELTWISE_BINARY_TYPE>(
                     p_elwise::CLR_NONE,
-                    EN_DST_ACC_EN,
+                    EN_DST_ACC,
                     p_elwise::SRCB_NO_BCAST,
                     ((REPLAY_BUF_LEN - 1) * ELTWISE_MATH_ROWS) >> 2,  // Srcb addr
                     ((REPLAY_BUF_LEN - 1) * ELTWISE_MATH_ROWS) >> 2,  // Srca addr
@@ -162,7 +162,7 @@ inline void _llk_math_eltwise_di_binary_mop_config_(const ckernel::TensorShape& 
             {
                 eltwise_di_binary_func<ELTWISE_BINARY_TYPE>(
                     p_setrwc::CLR_AB,
-                    EN_DST_ACC_EN,
+                    EN_DST_ACC,
                     p_elwise::SRCB_NO_BCAST,
                     ((REPLAY_BUF_LEN - 1) * ELTWISE_MATH_ROWS) >> 2,  // Srcb addr
                     ((REPLAY_BUF_LEN - 1) * ELTWISE_MATH_ROWS) >> 2,  // Srca addr
@@ -240,17 +240,17 @@ template <
     ckernel::MathFidelity MATH_FIDELITY_TYPE,
     bool EN_DI                            = false,
     EltwiseBinaryReuseDestType reuse_dest = EltwiseBinaryReuseDestType::NONE>
-inline void _llk_math_eltwise_binary_init_(const ckernel::TensorShape& tensor_shape)
+inline void _llk_math_eltwise_binary_init_(const ckernel::TensorShape& tensor_shape, bool acc_to_dest = false)
 {
     if constexpr (EN_DI)
     {
         _llk_math_eltwise_di_binary_addrmod_<MATH_FIDELITY_TYPE>();
-        _llk_math_eltwise_di_binary_mop_config_<ELTWISE_BINARY_TYPE, MATH_FIDELITY_TYPE>(tensor_shape);
+        _llk_math_eltwise_di_binary_mop_config_<ELTWISE_BINARY_TYPE, MATH_FIDELITY_TYPE>(tensor_shape, acc_to_dest);
     }
     else
     {
         _llk_math_eltwise_binary_addrmod_<MATH_FIDELITY_TYPE>();
-        _llk_math_eltwise_binary_mop_config_<ELTWISE_BINARY_TYPE, MATH_FIDELITY_TYPE, reuse_dest>(tensor_shape);
+        _llk_math_eltwise_binary_mop_config_<ELTWISE_BINARY_TYPE, MATH_FIDELITY_TYPE, reuse_dest>(tensor_shape, acc_to_dest);
     }
 
     if constexpr (reuse_dest != EltwiseBinaryReuseDestType::NONE)

--- a/tt_llk_quasar/llk_lib/llk_math_eltwise_binary_broadcast.h
+++ b/tt_llk_quasar/llk_lib/llk_math_eltwise_binary_broadcast.h
@@ -31,20 +31,19 @@ inline void _llk_math_eltwise_binary_broadcast_mop_config_(const TileShape& tile
                                              ? p_elwise::SRCB_BCAST_COL
                                              : ((BROADCAST_TYPE == BroadcastType::ROW) ? p_elwise::SRCB_BCAST_ROW : p_elwise::SRCB_BCAST_ALL);
 
-    constexpr std::uint32_t EN_DST_ACC_EN = MATH_FIDELITY_TYPE != ckernel::MathFidelity::LoFi;
-    static_assert(!(EN_DST_ACC_EN && ELTWISE_BINARY_TYPE != EltwiseBinaryType::ELWMUL), "Math fidelity larger than LoFi only works with Eltwise MUL");
+    constexpr std::uint32_t EN_DST_ACC = MATH_FIDELITY_TYPE != ckernel::MathFidelity::LoFi;
+    static_assert(!(EN_DST_ACC && ELTWISE_BINARY_TYPE != EltwiseBinaryType::ELWMUL), "Math fidelity larger than LoFi only works with Eltwise MUL");
 
     const std::uint32_t MOP_OUTER_LOOP = tile_shape.num_faces;
     const std::uint32_t MOP_INNER_LOOP = num_eltwise_instrn_per_face;
 
-    constexpr static std::uint32_t eltwise_binary_op =
-        eltwise_binary_func<ELTWISE_BINARY_TYPE, p_elwise::CLR_NONE, EN_DST_ACC_EN, SRCB_BROADCAST_TYPE, ADDR_MOD_0>();
-    constexpr static std::uint32_t eltwise_binary_op_clr_srcAB_valid =
-        eltwise_binary_func<ELTWISE_BINARY_TYPE, p_elwise::CLR_SRCAB_VLD, EN_DST_ACC_EN, SRCB_BROADCAST_TYPE, ADDR_MOD_1>();
+    const std::uint32_t eltwise_binary_op = eltwise_binary_func<ELTWISE_BINARY_TYPE, p_elwise::CLR_NONE, SRCB_BROADCAST_TYPE, ADDR_MOD_0>(EN_DST_ACC);
+    const std::uint32_t eltwise_binary_op_clr_srcAB_valid =
+        eltwise_binary_func<ELTWISE_BINARY_TYPE, p_elwise::CLR_SRCAB_VLD, SRCB_BROADCAST_TYPE, ADDR_MOD_1>(EN_DST_ACC);
 
     constexpr std::uint32_t replay_buf_len = MATH_FIDELITY_TYPE == ckernel::MathFidelity::LoFi ? 0 : to_underlying(MATH_FIDELITY_TYPE) - 1;
 
-    if constexpr (EN_DST_ACC_EN)
+    if constexpr (EN_DST_ACC)
     {
         load_replay_buf<0, replay_buf_len>(
             // Lambda function to load reply buffer
@@ -62,15 +61,15 @@ inline void _llk_math_eltwise_binary_broadcast_mop_config_(const TileShape& tile
     ROW -> Unpacker unpacks 4 (default in 32x32 tile) faces: F0, F1, F0, F1, SrcB Inc = 0
     COL -> Unpacker unpacks 4 (default in 32x32 tile) faces: F0, F0, F2, F2, SrcB Inc += ELTWISE_MATH_ROWS
     */
-    ckernel_template temp = EN_DST_ACC_EN ? ckernel_template(MOP_OUTER_LOOP, MOP_INNER_LOOP, TT_OP_REPLAY(0, replay_buf_len, 0, 0, 0, 0), eltwise_binary_op)
-                                          : ckernel_template(MOP_OUTER_LOOP, MOP_INNER_LOOP, eltwise_binary_op);
+    ckernel_template temp = EN_DST_ACC ? ckernel_template(MOP_OUTER_LOOP, MOP_INNER_LOOP, TT_OP_REPLAY(0, replay_buf_len, 0, 0, 0, 0), eltwise_binary_op)
+                                       : ckernel_template(MOP_OUTER_LOOP, MOP_INNER_LOOP, eltwise_binary_op);
 
     // Only need to clear per face for ROW/COL, since SCALAR only has 1 face from the unpacker
     if constexpr (BROADCAST_TYPE != BroadcastType::SCALAR)
     {
         constexpr std::uint32_t ADDR_MOD = (BROADCAST_TYPE == BroadcastType::COL) ? ADDR_MOD_2 : ADDR_MOD_0;
-        constexpr static std::uint32_t eltwise_binary_op_clr_srcB =
-            eltwise_binary_func<ELTWISE_BINARY_TYPE, p_elwise::CLR_SRCB_VLD, EN_DST_ACC_EN, SRCB_BROADCAST_TYPE, ADDR_MOD>();
+        const std::uint32_t eltwise_binary_op_clr_srcB =
+            eltwise_binary_func<ELTWISE_BINARY_TYPE, p_elwise::CLR_SRCB_VLD, SRCB_BROADCAST_TYPE, ADDR_MOD>(EN_DST_ACC);
         temp.set_last_inner_loop_instr(eltwise_binary_op_clr_srcB);
     }
 


### PR DESCRIPTION
### Ticket
<!-- Link to Github Issue -->
https://github.com/tenstorrent/tt-metal/issues/39753

### Problem description
<!-- Provide context for the problem. -->
As part of bringing-up eltwise binary and dest-acc support for Quasar, it was noticed that a runtime acc_to_dest flag was not exposed up to metal.

### What's changed
<!-- Describe the approach used to solve the problem.
Summarize the changes made and its impact. -->
Added a runtime acc_to_dest flag to match metal use-cases.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Assert validation](https://github.com/tenstorrent/tt-llk/blob/main/docs/Introduction_to_asserts.md) Complied with assert doc (if applicable)
