### PR TITLE
Reuse dest :remove semaphores from cpp implementation

### DIFF
--- a/tests/sources/quasar/eltwise_binary_reuse_dest_quasar_test.cpp
+++ b/tests/sources/quasar/eltwise_binary_reuse_dest_quasar_test.cpp
@@ -120,11 +120,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_math_eltwise_binary_init_<ELTWISE_BINARY_OP, MATH_FIDELITY, false /*EN_DI*/, REUSE_DEST_TYPE>(
         ckernel::DEFAULT_TENSOR_SHAPE); // tiny-tile testing not yet supported
 
-    _llk_math_pack_sync_init_<dest_sync>();
-
     for (int block = 0; block < num_blocks; block++)
     {
-        _llk_math_wait_for_dest_available_();
         for (int n = 0; n < num_tiles_accum; n++)
         {
             if (n == 1)
@@ -138,7 +135,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
                 _llk_math_eltwise_binary_<REUSE_DEST_TYPE>(global_tile_idx, params.num_faces);
             }
         }
-        _llk_math_dest_section_done_<dest_sync>();
         _llk_math_set_dvalid_<p_cleardvalid::FPU>();
     }
 }
@@ -181,7 +177,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     for (int block = 0; block < output_num_blocks; block++)
     {
-        _llk_packer_wait_for_math_done_();
         for (int tile = 0; tile < output_tiles_in_block; tile++)
         {
             int res_tile_idx = (block * output_tiles_in_block) + tile;
@@ -189,7 +184,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
         }
         _llk_pack_dest_dvalid_section_done_<dest_sync, is_fp32_dest_acc_en>();
     }
-    _llk_packer_set_math_semaphore_();
 }
 
 #endif


### PR DESCRIPTION
### Ticket
<!-- Link to Github Issue -->

### Problem description
<!-- Semaphores used together with dvalid scheme for reuse dest. -->

### What's changed
<!-- Remove semaphore from reuse dest cpp implementation. Only dvalid scheme remains -->

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Assert validation](https://github.com/tenstorrent/tt-llk/blob/main/docs/Introduction_to_asserts.md) Complied with assert doc (if applicable)
