### PR TITLE
fix: remove unneeded init from Quasar etlwise binary dest reuse test

### DIFF
--- a/tests/sources/quasar/eltwise_binary_reuse_dest_quasar_test.cpp
+++ b/tests/sources/quasar/eltwise_binary_reuse_dest_quasar_test.cpp
@@ -124,11 +124,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
     {
         for (int n = 0; n < num_tiles_accum; n++)
         {
-            if (n == 1)
-            {
-                _llk_math_eltwise_binary_init_<ELTWISE_BINARY_OP, MATH_FIDELITY, false /*EN_DI*/, REUSE_DEST_TYPE>(
-                    ckernel::DEFAULT_TENSOR_SHAPE); // tiny-tile testing not yet supported
-            }
             for (int tile = 0; tile < tiles_in_block; tile++)
             {
                 const int global_tile_idx = block * tiles_in_block + tile;


### PR DESCRIPTION
### Ticket
None

### Problem description
We have an init call inside the loop that looks superfluous.

### What's changed
Removed nested init call. Retested, all tests were passing.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Assert validation](https://github.com/tenstorrent/tt-llk/blob/main/docs/Introduction_to_asserts.md) Complied with assert doc (if applicable)
