### PR TITLE
Fix LLK_ASSERT for checking num faces when transposing

### DIFF
--- a/tt_llk_blackhole/llk_lib/llk_unpack_AB.h
+++ b/tt_llk_blackhole/llk_lib/llk_unpack_AB.h
@@ -41,9 +41,9 @@ inline void _llk_unpack_AB_mop_config_(const bool transpose_of_faces, const cker
     {
         LLK_ASSERT(num_faces_r_dim == num_faces_c_dim, "num_faces_r_dim must be equal to num_faces_c_dim when transpose_of_faces is true");
         LLK_ASSERT(
-            num_faces_c_dim == 2,
-            "num_faces_c_dim has to be 2 with transpose due to stride limitations in UNPACR instruction, this limitation can be removed when TensorShapes are "
-            "passed compile time");
+            num_faces_c_dim == 1 || num_faces_c_dim == 2,
+            "num_faces_c_dim has to be either 1 or 2 with transpose due to stride limitations in UNPACR instruction,"
+            "this limitation can be removed when TensorShapes are passed at compile time");
     }
 
     // Transpose + Broadcast Scalar not supported

--- a/tt_llk_wormhole_b0/llk_lib/llk_unpack_AB.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_unpack_AB.h
@@ -42,9 +42,9 @@ inline void _llk_unpack_AB_mop_config_(const bool transpose_of_faces, const cker
     {
         LLK_ASSERT(num_faces_r_dim == num_faces_c_dim, "num_faces_r_dim must be equal to num_faces_c_dim when transpose_of_faces is true");
         LLK_ASSERT(
-            num_faces_c_dim == 2,
-            "num_faces_c_dim has to be 2 with transpose due to stride limitations in UNPACR instruction, this limitation can be removed when TensiorShapes are "
-            "passed compile time");
+            num_faces_c_dim == 1 || num_faces_c_dim == 2,
+            "num_faces_c_dim has to be either 1 or 2 with transpose due to stride limitations in UNPACR instruction,"
+            "this limitation can be removed when TensorShapes are passed at compile time");
     }
 
     static constexpr std::uint32_t unpack_srca = TT_OP_UNPACR(SrcA, 0b1, 0, 0, 0, 1, 1, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/39472

### Problem description
There is a test test_deepseek_moe_gate.py which hits assert due to num_faces_c_dim being 1 instead of 2. However, this is an ok scenario, therefore an assert should be relaxed.

### What's changed
Assert is changed for both BH and WH to allow either 1 or 2 for num_faces_c_dim for transposing faces scenario.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [x] [Assert validation](https://github.com/tenstorrent/tt-llk/blob/main/docs/Introduction_to_asserts.md) Complied with assert doc (if applicable)
