### PR TITLE
Add git-lfs to Dockerfile dependencies

### DIFF
--- a/.github/Dockerfile.ird
+++ b/.github/Dockerfile.ird
@@ -8,6 +8,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -qq && apt-get install -qq -y --no-install-recommends \
     clangd \
     fzf \
+    git-lfs \
     lcov \
     nano \
     python3-dev \


### PR DESCRIPTION
### Ticket
None

### Problem description
Some people have experienced problems when using LLK image trying to compile other repos, since these are depending on git-lfs and we don't have it in our image at the moment.

### What's changed
Added `git-lfs` to the LLK docker image.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Assert validation](https://github.com/tenstorrent/tt-llk/blob/main/docs/Introduction_to_asserts.md) Complied with assert doc (if applicable)
