### PR TITLE
[test infra.] Blackhole simulator fix

### DIFF
--- a/tests/helpers/src/brisc.cpp
+++ b/tests/helpers/src/brisc.cpp
@@ -7,7 +7,7 @@
 #include "boot.h"
 
 // BRISC firmware
-#ifdef LLK_BOOT_MODE_BRISC && !defined(ARCH_BLACKHOLE_SIMULATOR)
+#if defined(LLK_BOOT_MODE_BRISC) && !defined(ARCH_BLACKHOLE_SIMULATOR)
 
 // Mailbox addresses
 #ifdef COVERAGE
@@ -134,10 +134,6 @@ int main()
 
 int main(void)
 {
-    commit_store(mailbox_math, ckernel::RESET_VAL);
-    commit_store(mailbox_unpack, ckernel::RESET_VAL);
-    commit_store(mailbox_pack, ckernel::RESET_VAL);
-
     commit_store(profiler_barrier, 0U);
     commit_store(profiler_barrier + 1, 0U);
     commit_store(profiler_barrier + 2, 0U);

--- a/tests/helpers/src/brisc.cpp
+++ b/tests/helpers/src/brisc.cpp
@@ -132,14 +132,19 @@ int main()
 // end of LLK_BOOT_MODE_BRISC and not ARCH_BLACKHOLE_SIMULATOR
 #elif defined(ARCH_BLACKHOLE_SIMULATOR)
 
+// We have different BRISC firmware version for simulator because we don't have to work around UMD issue
+// https://github.com/tenstorrent/tt-umd/issues/1265
+// We can just have BRISC release TRISC[0-2] from reset, and that's it, host does all the rest.
+
 int main(void)
 {
-    commit_store(profiler_barrier, 0U);
-    commit_store(profiler_barrier + 1, 0U);
-    commit_store(profiler_barrier + 2, 0U);
-
     device_setup();
-    clear_trisc_soft_reset();
+
+    // Clear reset without polling, because simulator doesn't require it,
+    // and it only degrades simulation performance
+    std::uint32_t soft_reset = ckernel::reg_read(RISCV_DEBUG_REG_SOFT_RESET_0);
+    soft_reset &= ~TRISC_SOFT_RESET_MASK;
+    ckernel::reg_write(RISCV_DEBUG_REG_SOFT_RESET_0, soft_reset);
 }
 
 #else // ARCH_BLACKHOLE_SIMULATOR

--- a/tests/helpers/src/brisc.cpp
+++ b/tests/helpers/src/brisc.cpp
@@ -6,7 +6,8 @@
 
 #include "boot.h"
 
-#ifdef LLK_BOOT_MODE_BRISC
+// BRISC firmware
+#ifdef LLK_BOOT_MODE_BRISC && !defined(ARCH_BLACKHOLE_SIMULATOR)
 
 // Mailbox addresses
 #ifdef COVERAGE
@@ -45,6 +46,7 @@ enum class BriscCommandState : std::uint32_t
 void reset_state(std::uint32_t& counter)
 {
     counter++;
+    // Clear current buffer to zero: First if counter is even; Second buffer if counter is odd.
     ckernel::store_blocking(brisc_command_buffer + (counter & 1), static_cast<std::uint32_t>(BriscCommandState::IDLE_STATE));
     commit_store(brisc_counter, counter);
 }
@@ -70,6 +72,7 @@ int main()
     {
         ckernel::invalidate_data_cache();
 
+        // Poll current command buffer: First if counter is even; Second buffer if counter is odd.
         switch (static_cast<BriscCommandState>(ckernel::load_blocking(brisc_command_buffer + (counter & 1))))
         {
             // Wormhole specific, on Blackhole this command has same behaviour as BriscCommandState::START_TRISCS
@@ -126,9 +129,26 @@ int main()
     }
 }
 
-#else
+// end of LLK_BOOT_MODE_BRISC and not ARCH_BLACKHOLE_SIMULATOR
+#elif defined(ARCH_BLACKHOLE_SIMULATOR)
 
-int main()
+int main(void)
+{
+    commit_store(mailbox_math, ckernel::RESET_VAL);
+    commit_store(mailbox_unpack, ckernel::RESET_VAL);
+    commit_store(mailbox_pack, ckernel::RESET_VAL);
+
+    commit_store(profiler_barrier, 0U);
+    commit_store(profiler_barrier + 1, 0U);
+    commit_store(profiler_barrier + 2, 0U);
+
+    device_setup();
+    clear_trisc_soft_reset();
+}
+
+#else // ARCH_BLACKHOLE_SIMULATOR
+
+int main(void)
 {
 }
 

--- a/tests/python_tests/conftest.py
+++ b/tests/python_tests/conftest.py
@@ -269,16 +269,6 @@ def pytest_configure(config):
         config.option.log_cli = True
 
     config.coverage_enabled = config.getoption("--coverage", default=False)
-    compile_producer = config.getoption("--compile-producer", default=False)
-    compile_consumer = config.getoption("--compile-consumer", default=False)
-    initialize_test_target_from_pytest(config)
-    TestConfig.setup_mode(TestTargetConfig(), compile_consumer, compile_producer)
-
-    with_coverage = config.getoption("--coverage", default=False)
-    detailed_artefacts = config.getoption("--detailed-artefacts", default=False)
-    no_debug_symbols = config.getoption("--no-debug-symbols", default=False)
-    speed_of_light = config.getoption("--speed-of-light", default=False)
-
     TestConfig.setup_build(
         Path(os.environ["LLK_HOME"]),
         config.getoption("--coverage", default=False),
@@ -287,7 +277,10 @@ def pytest_configure(config):
         config.getoption("--speed-of-light", default=False),
     )
 
+    initialize_test_target_from_pytest(config)
+
     TestConfig.setup_mode(
+        TestTargetConfig(),
         # Pass worker id here, so TestConfig can calculate Tensix tile it will run on
         getattr(config, "workerinput", {}).get("workerid", "master"),
         config.getoption("--compile-consumer", default=False),
@@ -313,7 +306,9 @@ def pytest_configure(config):
         _RECORD_TEST_ORDER = True
         utils_module._RECORD_TEST_ORDER = True
 
-    overrirde_gprs_used_by_tensix_dump()
+    # We don't need to override tensix dump on simulator
+    if not TestConfig.TEST_TARGET.run_simulator:
+        overrirde_gprs_used_by_tensix_dump()
 
     log_file = "pytest_errors.log"
     if not hasattr(config, "workerinput"):  # executed only by master pytest runner

--- a/tests/python_tests/conftest.py
+++ b/tests/python_tests/conftest.py
@@ -269,6 +269,15 @@ def pytest_configure(config):
         config.option.log_cli = True
 
     config.coverage_enabled = config.getoption("--coverage", default=False)
+    compile_producer = config.getoption("--compile-producer", default=False)
+    compile_consumer = config.getoption("--compile-consumer", default=False)
+    initialize_test_target_from_pytest(config)
+    TestConfig.setup_mode(TestTargetConfig(), compile_consumer, compile_producer)
+
+    with_coverage = config.getoption("--coverage", default=False)
+    detailed_artefacts = config.getoption("--detailed-artefacts", default=False)
+    no_debug_symbols = config.getoption("--no-debug-symbols", default=False)
+    speed_of_light = config.getoption("--speed-of-light", default=False)
 
     TestConfig.setup_build(
         Path(os.environ["LLK_HOME"]),
@@ -324,11 +333,8 @@ def pytest_configure(config):
         format="%(asctime)s - %(levelname)s - %(message)s",
     )
 
-    initialize_test_target_from_pytest(config)
-    test_target = TestTargetConfig()
-
     if TestConfig.BUILD_MODE != BuildMode.PRODUCE:
-        if test_target.run_simulator:
+        if TestConfig.TEST_TARGET.run_simulator:
             simulator_path = os.environ.get("TT_UMD_SIMULATOR_PATH")
 
             if simulator_path is None:
@@ -344,7 +350,7 @@ def pytest_configure(config):
                 global _exalens_server
                 _exalens_server = ExalensServer(
                     simulator_path=simulator_path,
-                    port=test_target.simulator_port,
+                    port=TestConfig.TEST_TARGET.simulator_port,
                 )
         else:
             tt_exalens_init.init_ttexalens(use_4B_mode=False)

--- a/tests/python_tests/helpers/test_config.py
+++ b/tests/python_tests/helpers/test_config.py
@@ -809,7 +809,7 @@ class TestConfig:
                 compile_command = (  # brisc.elf : brisc.cpp
                     f"{TestConfig.GXX} {TestConfig.ARCH_NON_COMPUTE} {TestConfig.OPTIONS_ALL} {TestConfig.OPTIONS_LINK} {local_non_coverage} "
                     f'{"-DCOVERAGE " if TestConfig.WITH_COVERAGE else ""}'
-                    f'{"-DARCH_BLACKHOLE_SIMULATOR " if TestConfig.TEST_TARGET.run_simulator else ""}'
+                    f'{"-DARCH_BLACKHOLE_SIMULATOR " if TestConfig.TEST_TARGET.run_simulator and TestConfig.CHIP_ARCH == ChipArchitecture.BLACKHOLE else ""}'
                     f'-T{local_memory_layout_ld} -T{TestConfig.LINKER_SCRIPTS / "brisc.ld"} -T{TestConfig.LINKER_SCRIPTS / "sections.ld"} '
                     f'-o {shared_elf_dir / "brisc.elf"} {TestConfig.RISCV_SOURCES / "brisc.cpp"}'
                 )

--- a/tests/python_tests/helpers/test_config.py
+++ b/tests/python_tests/helpers/test_config.py
@@ -809,6 +809,7 @@ class TestConfig:
                 compile_command = (  # brisc.elf : brisc.cpp
                     f"{TestConfig.GXX} {TestConfig.ARCH_NON_COMPUTE} {TestConfig.OPTIONS_ALL} {TestConfig.OPTIONS_LINK} {local_non_coverage} "
                     f'{"-DCOVERAGE " if TestConfig.WITH_COVERAGE else ""}'
+                    f'{"-DARCH_BLACKHOLE_SIMULATOR " if TestConfig.TEST_TARGET.run_simulator else ""}'
                     f'-T{local_memory_layout_ld} -T{TestConfig.LINKER_SCRIPTS / "brisc.ld"} -T{TestConfig.LINKER_SCRIPTS / "sections.ld"} '
                     f'-o {shared_elf_dir / "brisc.elf"} {TestConfig.RISCV_SOURCES / "brisc.cpp"}'
                 )
@@ -1162,11 +1163,21 @@ class TestConfig:
 
                 # Start BRISC firmware only if we're using real device
                 if not TestConfig.TEST_TARGET.run_simulator:
-                    set_tensix_soft_reset(0, [RiscCore.BRISC], TestConfig.TENSIX_LOCATION)
+                    set_tensix_soft_reset(
+                        0, [RiscCore.BRISC], TestConfig.TENSIX_LOCATION
+                    )
 
             # if we're using simulator, we need to put all cores to reset every time
             if TestConfig.TEST_TARGET.run_simulator:
                 set_tensix_soft_reset(1, location=TestConfig.TENSIX_LOCATION)
+
+                # Reset profiler barrier, 3 zeros for 3 TRISCs
+                write_words_to_device(
+                    TestConfig.TENSIX_LOCATION,
+                    TestConfig.TRISC_PROFILER_BARRIER_ADDRESS,
+                    3 * [0],
+                )
+
                 reset_mailboxes(TestConfig.TENSIX_LOCATION)
             else:
                 # otherwise just command BRISC firmware to put T[0-2] to reset
@@ -1228,10 +1239,14 @@ class TestConfig:
             case BootMode.BRISC:
                 if TestConfig.TEST_TARGET.run_simulator:
                     # if we're in a simulator, just release BRSIC from reset, it will release other cores automatically
-                    set_tensix_soft_reset(0, [RiscCore.BRISC], TestConfig.TENSIX_LOCATION)
+                    set_tensix_soft_reset(
+                        0, [RiscCore.BRISC], TestConfig.TENSIX_LOCATION
+                    )
                 else:
                     # otherwise just command BRISC firmware to release T[0-2] from reset
-                    commit_brisc_command(TestConfig.TENSIX_LOCATION, BriscCmd.START_TRISCS)
+                    commit_brisc_command(
+                        TestConfig.TENSIX_LOCATION, BriscCmd.START_TRISCS
+                    )
 
             case BootMode.TRISC:
                 reset_mailboxes(TestConfig.TENSIX_LOCATION)
@@ -1273,6 +1288,11 @@ class TestConfig:
 
             if completed == mailboxes:
                 return
+
+            if TestConfig.TEST_TARGET.run_simulator:
+                time.sleep(
+                    0.01
+                )  # Poll every 10ms in simulator, because it takes a lot longer to execute the kernel
 
         handle_if_assert_hit(
             self.temp_elfs,

--- a/tests/python_tests/helpers/test_config.py
+++ b/tests/python_tests/helpers/test_config.py
@@ -173,6 +173,8 @@ class TestConfig:
         False  # Should everything be converted to compile-time arguments?
     )
 
+    TEST_TARGET: ClassVar[TestTargetConfig] = None
+
     WORKER_ID: ClassVar[str] = "master"
     TENSIX_LOCATION: ClassVar[str] = "0,0"
     STIMULI_ADDRESS_MAP: ClassVar[dict[str, int]] = {}
@@ -387,6 +389,7 @@ class TestConfig:
 
     @staticmethod
     def setup_mode(
+        test_target: TestTargetConfig,
         worker_id: str,
         compile_consumer: bool,
         compile_producer: bool,
@@ -394,6 +397,7 @@ class TestConfig:
         use_stimuli: str = None,
     ):
 
+        TestConfig.TEST_TARGET = test_target
         TestConfig.WORKER_ID = worker_id
 
         if worker_id != "master":
@@ -1155,8 +1159,16 @@ class TestConfig:
                     risc_name="brisc",
                     verify_write=False,
                 )
-                set_tensix_soft_reset(0, [RiscCore.BRISC], TestConfig.TENSIX_LOCATION)
-            if get_chip_architecture() != ChipArchitecture.QUASAR:
+
+                # Start BRISC firmware only if we're using real device
+                if not TestConfig.TEST_TARGET.run_simulator:
+                    set_tensix_soft_reset(0, [RiscCore.BRISC], TestConfig.TENSIX_LOCATION)
+
+            # if we're using simulator, we need to put all cores to reset every time
+            if TestConfig.TEST_TARGET.run_simulator:
+                set_tensix_soft_reset(1, location=TestConfig.TENSIX_LOCATION)
+            else:
+                # otherwise just command BRISC firmware to put T[0-2] to reset
                 commit_brisc_command(TestConfig.TENSIX_LOCATION, BriscCmd.RESET_TRISCS)
         else:
             set_tensix_soft_reset(1, location=TestConfig.TENSIX_LOCATION)
@@ -1213,7 +1225,13 @@ class TestConfig:
 
         match boot_mode:
             case BootMode.BRISC:
-                commit_brisc_command(TestConfig.TENSIX_LOCATION, BriscCmd.START_TRISCS)
+                if TestConfig.TEST_TARGET.run_simulator:
+                    # if we're in a simulator, just release BRSIC from reset, it will release other cores automatically
+                    set_tensix_soft_reset(0, [RiscCore.BRISC], TestConfig.TENSIX_LOCATION)
+                else:
+                    # otherwise just command BRISC firmware to release T[0-2] from reset
+                    commit_brisc_command(TestConfig.TENSIX_LOCATION, BriscCmd.START_TRISCS)
+
             case BootMode.TRISC:
                 reset_mailboxes(TestConfig.TENSIX_LOCATION)
                 set_tensix_soft_reset(0, [RiscCore.TRISC0], TestConfig.TENSIX_LOCATION)
@@ -1240,8 +1258,7 @@ class TestConfig:
                 device_module.Mailboxes.BriscBread0,
                 device_module.Mailboxes.BriscBread1,
             }
-        test_target = TestTargetConfig()
-        timeout = 600 if test_target.run_simulator else timeout
+        timeout = 600 if TestConfig.TEST_TARGET.run_simulator else timeout
 
         completed = set()
         end_time = time.time() + timeout

--- a/tests/python_tests/helpers/test_config.py
+++ b/tests/python_tests/helpers/test_config.py
@@ -1167,6 +1167,7 @@ class TestConfig:
             # if we're using simulator, we need to put all cores to reset every time
             if TestConfig.TEST_TARGET.run_simulator:
                 set_tensix_soft_reset(1, location=TestConfig.TENSIX_LOCATION)
+                reset_mailboxes(TestConfig.TENSIX_LOCATION)
             else:
                 # otherwise just command BRISC firmware to put T[0-2] to reset
                 commit_brisc_command(TestConfig.TENSIX_LOCATION, BriscCmd.RESET_TRISCS)


### PR DESCRIPTION
### Problem description
Blackhole simulator wasn't working at all. This is a fix for it.

### What's changed
We needed to have a version of BRISC firmware, which only sets Tensix coprocessor up, and releases TRISC[0-2] from reset. This is nessesary because current BRISC BH firmware  is taking too much time to respond to commands issued by the host, because simulater runs _much_ slower than the device. This fix adds define to `brisc.cpp` which gets triggered only when simulator for blackhole is used.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Assert validation](https://github.com/tenstorrent/tt-llk/blob/main/docs/Introduction_to_asserts.md) Complied with assert doc (if applicable)
