### PR TITLE
Add more 32-bit data types to cmath and cunpack

### DIFF
--- a/tt_llk_blackhole/common/inc/cmath_common.h
+++ b/tt_llk_blackhole/common/inc/cmath_common.h
@@ -202,12 +202,16 @@ inline void set_dest_section_base()
     }
 }
 
+// Matches cunpack_common is_32bit_input: true for 32-bit-wide formats only (Tf32 excluded; see unpack helpers).
 inline constexpr bool is_32bit_input(const std::uint32_t src_format, const std::uint32_t dst_format)
 {
     const std::uint32_t input_df  = masked_data_format(src_format);
     const std::uint32_t output_df = masked_data_format(dst_format);
-    return ((input_df == to_underlying(DataFormat::Int32)) || (input_df == to_underlying(DataFormat::Float32))) &&
-           ((output_df == to_underlying(DataFormat::Int32)) || (output_df == to_underlying(DataFormat::Float32)));
+    const bool src_32b =
+        (input_df == to_underlying(DataFormat::Int32)) || (input_df == to_underlying(DataFormat::UInt32)) || (input_df == to_underlying(DataFormat::Float32));
+    const bool dst_32b = (output_df == to_underlying(DataFormat::Int32)) || (output_df == to_underlying(DataFormat::UInt32)) ||
+                         (output_df == to_underlying(DataFormat::Float32));
+    return src_32b && dst_32b;
 }
 
 inline constexpr bool is_high_fidelity(const MathFidelity math_fidelity_desc)

--- a/tt_llk_blackhole/common/inc/cunpack_common.h
+++ b/tt_llk_blackhole/common/inc/cunpack_common.h
@@ -204,20 +204,31 @@ inline void enable_int8_fpu_math()
 }
 
 /**
- * \brief Returns true if unpacker I/O uses 32-bit formats (Int32 or Float32).
+ * \brief Returns true if unpacker I/O uses 32-bit-wide L1/register formats (Int32, UInt32, Float32).
  *
  * Used to determine unpack-to-dest mode and related configuration when both
  * input and output are 32-bit. Masks low nibble of format codes for comparison.
  *
  * \param unpack_src_format Unpacker input (L1) data format.
  * \param unpack_dst_format Unpacker output (register) data format.
- * \return true if both formats are Int32 or Float32; false otherwise.
+ * \return true if both formats are 32-bit encodings above; false otherwise.
+ *
+ * Tf32 (~19b in dest) is excluded here; Float32 L1 -> Tf32 dest uses \ref llk_unpack_needs_dest_register_unpacr.
  */
 inline constexpr bool is_32bit_input(const std::uint32_t unpack_src_format, const std::uint32_t unpack_dst_format)
 {
     const DataFormat input_df  = static_cast<DataFormat>(masked_data_format(unpack_src_format));
     const DataFormat output_df = static_cast<DataFormat>(masked_data_format(unpack_dst_format));
-    return (input_df == DataFormat::Int32 || input_df == DataFormat::Float32) && (output_df == DataFormat::Int32 || output_df == DataFormat::Float32);
+    const auto is_32b          = [](DataFormat f) { return f == DataFormat::Int32 || f == DataFormat::UInt32 || f == DataFormat::Float32; };
+    return is_32b(input_df) && is_32b(output_df);
+}
+
+/// Selects unpack_srca_to_dest / dest-register UNPACR (not SrcA register path). Includes
+/// Float32 L1 -> Tf32 register (fp32_dest_acc_en / JIT); Tf32 is not part of \ref is_32bit_input.
+inline constexpr bool llk_unpack_needs_dest_register_unpacr(const std::uint32_t unpack_src_format, const std::uint32_t unpack_dst_format)
+{
+    return is_32bit_input(unpack_src_format, unpack_dst_format) || (masked_data_format(unpack_src_format) == to_underlying(DataFormat::Float32) &&
+                                                                    masked_data_format(unpack_dst_format) == to_underlying(DataFormat::Tf32));
 }
 
 /**

--- a/tt_llk_blackhole/llk_lib/llk_unpack_A.h
+++ b/tt_llk_blackhole/llk_lib/llk_unpack_A.h
@@ -51,7 +51,7 @@ inline void _llk_unpack_A_mop_config_(
     static constexpr std::uint32_t srcb_set_z_2           = TT_OP_SETADCZW(p_setadc::UNP_B, 0, 0, 0, 2, 0b0001); // set srcB ch0_z = 2
     static constexpr std::uint32_t srcb_clear_z           = TT_OP_SETADCZW(p_setadc::UNP_B, 0, 0, 0, 0, 0b0001); // set srcB ch0_z = 0
 
-    if (unpack_to_dest && is_32bit_input(unpack_src_format, unpack_dst_format))
+    if (unpack_to_dest && llk_unpack_needs_dest_register_unpacr(unpack_src_format, unpack_dst_format))
     {
         if (transpose_of_faces && num_faces == 4)
         {
@@ -277,7 +277,7 @@ inline void _llk_unpack_A_(const std::uint32_t address, const std::uint32_t unpa
 
     if constexpr (unpack_to_dest)
     {
-        if (is_32bit_input(unpack_src_format, unpack_dst_format))
+        if (llk_unpack_needs_dest_register_unpacr(unpack_src_format, unpack_dst_format))
         {
             set_dst_write_addr(unp_cfg_context, unpack_dst_format);
             wait_for_dest_available();
@@ -293,9 +293,9 @@ inline void _llk_unpack_A_(const std::uint32_t address, const std::uint32_t unpa
     // T6::SEMGET for context release
     t6_semaphore_get(semaphore::UNPACK_SYNC);
 
-    if (unpack_to_dest)
+    if constexpr (unpack_to_dest)
     {
-        if (is_32bit_input(unpack_src_format, unpack_dst_format))
+        if (llk_unpack_needs_dest_register_unpacr(unpack_src_format, unpack_dst_format))
         {
             unpack_to_dest_tile_done(unp_cfg_context);
         }

--- a/tt_llk_wormhole_b0/common/inc/cmath_common.h
+++ b/tt_llk_wormhole_b0/common/inc/cmath_common.h
@@ -222,9 +222,11 @@ inline constexpr bool is_32bit_input(const std::uint32_t src_format, const std::
 {
     const std::uint32_t input_df  = masked_data_format(src_format);
     const std::uint32_t output_df = masked_data_format(dst_format);
-
-    return ((input_df == to_underlying(DataFormat::Int32)) || (input_df == to_underlying(DataFormat::Float32))) &&
-           ((output_df == to_underlying(DataFormat::Int32)) || (output_df == to_underlying(DataFormat::Float32)));
+    const bool src_32b =
+        (input_df == to_underlying(DataFormat::Int32)) || (input_df == to_underlying(DataFormat::UInt32)) || (input_df == to_underlying(DataFormat::Float32));
+    const bool dst_32b = (output_df == to_underlying(DataFormat::Int32)) || (output_df == to_underlying(DataFormat::UInt32)) ||
+                         (output_df == to_underlying(DataFormat::Float32));
+    return src_32b && dst_32b;
 }
 
 inline constexpr int get_math_num_fidelity_phases(const int math_fidelity_desc)

--- a/tt_llk_wormhole_b0/common/inc/cunpack_common.h
+++ b/tt_llk_wormhole_b0/common/inc/cunpack_common.h
@@ -205,20 +205,29 @@ inline void enable_int8_fpu_math()
 }
 
 /**
- * \brief Returns true if unpacker I/O uses 32-bit formats (Int32 or Float32).
+ * \brief Returns true if unpacker I/O uses 32-bit-wide L1/register formats (Int32, UInt32, Float32).
  *
  * Used to determine unpack-to-dest mode and related configuration when both
  * input and output are 32-bit. Masks low nibble of format codes for comparison.
  *
  * \param unpack_src_format Unpacker input (L1) data format.
  * \param unpack_dst_format Unpacker output (register) data format.
- * \return true if both formats are Int32 or Float32; false otherwise.
+ * \return true if both formats are 32-bit encodings above; false otherwise.
  */
 inline constexpr bool is_32bit_input(const std::uint32_t unpack_src_format, const std::uint32_t unpack_dst_format)
 {
     const DataFormat input_df  = static_cast<DataFormat>(masked_data_format(unpack_src_format));
     const DataFormat output_df = static_cast<DataFormat>(masked_data_format(unpack_dst_format));
-    return (input_df == DataFormat::Int32 || input_df == DataFormat::Float32) && (output_df == DataFormat::Int32 || output_df == DataFormat::Float32);
+    const auto is_32b          = [](DataFormat f) { return f == DataFormat::Int32 || f == DataFormat::UInt32 || f == DataFormat::Float32; };
+    return is_32b(input_df) && is_32b(output_df);
+}
+
+/// Selects unpack_srca_to_dest / dest-register UNPACR (not SrcA register path). Includes
+/// Float32 L1 -> Tf32 register (fp32_dest_acc_en / JIT); Tf32 is not part of \ref is_32bit_input.
+inline constexpr bool llk_unpack_needs_dest_register_unpacr(const std::uint32_t unpack_src_format, const std::uint32_t unpack_dst_format)
+{
+    return is_32bit_input(unpack_src_format, unpack_dst_format) || (masked_data_format(unpack_src_format) == to_underlying(DataFormat::Float32) &&
+                                                                    masked_data_format(unpack_dst_format) == to_underlying(DataFormat::Tf32));
 }
 
 /**

--- a/tt_llk_wormhole_b0/llk_lib/llk_unpack_A.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_unpack_A.h
@@ -62,7 +62,7 @@ inline void _llk_unpack_A_mop_config_(
     static constexpr std::uint32_t unpack_srca_zerosrc_set_dvalid = lltt::replay_insn(0, 2);
     static constexpr std::uint32_t unpack_srcb_unpack_srcb        = lltt::replay_insn(2, 2);
 
-    if (unpack_to_dest && is_32bit_input(unpack_src_format, unpack_dst_format))
+    if (unpack_to_dest && llk_unpack_needs_dest_register_unpacr(unpack_src_format, unpack_dst_format))
     {
         if (transpose_of_faces && num_faces == 4)
         {
@@ -266,7 +266,7 @@ inline void _llk_unpack_A_(const std::uint32_t address, const std::uint32_t unpa
 
     if constexpr (unpack_to_dest)
     {
-        if (is_32bit_input(unpack_src_format, unpack_dst_format))
+        if (llk_unpack_needs_dest_register_unpacr(unpack_src_format, unpack_dst_format))
         {
             set_dst_write_addr(unp_cfg_context, unpack_dst_format);
             wait_for_dest_available();
@@ -285,9 +285,9 @@ inline void _llk_unpack_A_(const std::uint32_t address, const std::uint32_t unpa
     // T6::SEMGET for context release
     t6_semaphore_get(semaphore::UNPACK_SYNC);
 
-    if (unpack_to_dest)
+    if constexpr (unpack_to_dest)
     {
-        if (is_32bit_input(unpack_src_format, unpack_dst_format))
+        if (llk_unpack_needs_dest_register_unpacr(unpack_src_format, unpack_dst_format))
         {
             unpack_to_dest_tile_done(unp_cfg_context);
         }


### PR DESCRIPTION
### Ticket
None

### Problem description
1. Uint32 data type is not treated as 32-bit by `is_32bit_input`.
2. Float32→Tf32 dest-register unpack path is incorrect and causes error in simulator:
`ERROR: UndefinedBehavior: tensix_execute_unpacr: unpack_to_dst=0 in_data_format=0 out_data_format=0`
https://github.com/tenstorrent/tt-metal/actions/runs/23943052037/job/69837149774

### What's changed
Add `Uint32` data type to `is_32bit_input`.
Add a new llk_unpack_needs_dest_register_unpacr function which explicitly checks input Fp32 && output Tf32 flow.

### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Assert validation](https://github.com/tenstorrent/tt-llk/blob/main/docs/Introduction_to_asserts.md) Complied with assert doc (if applicable)
