### PR TITLE
[Test Infra] Skip math when unpacking to dest in QSR pack untilize tests, add Fp16<->Fp16b test combos

### DIFF
--- a/tests/python_tests/quasar/test_pack_quasar.py
+++ b/tests/python_tests/quasar/test_pack_quasar.py
@@ -64,9 +64,10 @@ def generate_qsr_pack_combinations(
 
     def get_dest_acc_modes(in_fmt):
         """Determine valid dest register modes depending on the input format."""
-        # Having Int16 in src registers and Int32 in the dest register is not supported
+        # Int16 requires 16bit mode dest register
         if in_fmt == DataFormat.Int16:
             return (DestAccumulation.No,)
+        # Int32, Float32 (unpack_to_dest) requires 32bit mode dest register
         if in_fmt.is_32_bit():
             return (DestAccumulation.Yes,)
         return (DestAccumulation.No, DestAccumulation.Yes)

--- a/tests/python_tests/quasar/test_pack_untilize_quasar.py
+++ b/tests/python_tests/quasar/test_pack_untilize_quasar.py
@@ -44,34 +44,45 @@ def generate_pack_untilize_combinations(
 
     Returns: List of (format, dest_acc, dest_sync, input_dimensions) tuples
     """
-    dest_sync_modes = (DestSync.Half, DestSync.Full)
+
+    def is_supported_format_conversion(in_fmt, out_fmt):
+        # Skip if mixing integer and non-integer formats
+        if in_fmt.is_integer() ^ out_fmt.is_integer():
+            return False
+        # If input format is Int16, output format must also be Int16, and vice versa
+        if (in_fmt == DataFormat.Int16) ^ (out_fmt == DataFormat.Int16):
+            return False
+        return True
+
+    def get_dest_acc_modes(in_fmt):
+        # Int16 requires 16bit mode dest register
+        if in_fmt == DataFormat.Int16:
+            return (DestAccumulation.No,)
+        # Int32, Float32 (unpack_to_dest) requires 32bit mode dest register
+        if in_fmt.is_32_bit():
+            return (DestAccumulation.Yes,)
+        return (DestAccumulation.No, DestAccumulation.Yes)
+
     dimensions_cache = {
         (dest_acc, dest_sync): tuple(
             generate_unary_input_dimensions(dest_acc, dest_sync)
         )
         for dest_acc in (DestAccumulation.No, DestAccumulation.Yes)
-        for dest_sync in dest_sync_modes
+        for dest_sync in (DestSync.Half, DestSync.Full)
     }
 
+    dest_sync_modes = (DestSync.Half, DestSync.Full)
     combinations = []
-
     for fmt in formats_list:
-        in_fmt = fmt.input_format
+        in_fmt, out_fmt = fmt.input_format, fmt.output_format
 
-        dest_acc_modes = (
-            (DestAccumulation.Yes,)
-            if in_fmt.is_32_bit()
-            else (
-                (DestAccumulation.No,)
-                if in_fmt in [DataFormat.Int16, DataFormat.Float16]
-                else (DestAccumulation.No, DestAccumulation.Yes)
-            )
-        )
+        if not is_supported_format_conversion(in_fmt, out_fmt):
+            continue
 
-        for dest_acc in dest_acc_modes:
-            for sync in dest_sync_modes:
-                for dimensions in dimensions_cache[(dest_acc, sync)]:
-                    combinations.append((fmt, dest_acc, sync, dimensions))
+        for dest_acc in get_dest_acc_modes(in_fmt):
+            for dest_sync in dest_sync_modes:
+                for dimensions in dimensions_cache[(dest_acc, dest_sync)]:
+                    combinations.append((fmt, dest_acc, dest_sync, dimensions))
 
     return combinations
 
@@ -83,7 +94,6 @@ PACK_UNTILIZE_FORMATS = input_output_formats(
         DataFormat.Int16,
         DataFormat.Int32,
     ],
-    same=True,
 )
 ALL_PACK_UNTILIZE_COMBINATIONS = generate_pack_untilize_combinations(
     PACK_UNTILIZE_FORMATS

--- a/tests/sources/quasar/pack_untilize_quasar_test.cpp
+++ b/tests/sources/quasar/pack_untilize_quasar_test.cpp
@@ -109,25 +109,35 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
-#ifdef FORMAT_INT32
-    const bool is_int_fpu_en = true;
-#else
-    const bool is_int_fpu_en = false;
-#endif
-    // Setup data valid scheme
-    set_up_dest_dvalid_per_thread<dest_dvalid_client::FPU>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
-
-    DataFormat src_format = static_cast<DataFormat>(formats.math);
-    _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en, is_int_fpu_en>(src_format, src_format);
-
-    _llk_math_eltwise_unary_datacopy_init_<DataCopyType::A2D, is_fp32_dest_acc_en>(num_faces * TEST_FACE_R_DIM /*num_rows_per_matrix*/, 1 /*num_matrices*/);
-    for (std::uint32_t block_rt = 0; block_rt < BLOCK_RT_DIM; block_rt++)
+    if constexpr (!unpack_to_dest)
     {
-        for (std::uint32_t block_ct = 0; block_ct < BLOCK_CT_DIM; block_ct++)
+        // Setup data valid scheme
+        set_up_dest_dvalid_per_thread<dest_dvalid_client::FPU>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
+
+        DataFormat math_format     = static_cast<DataFormat>(formats.math);
+        DataFormat pack_src_format = static_cast<DataFormat>(formats.pack_src);
+        if (is_fp32_dest_acc_en && pack_src_format == DataFormat::Float32)
         {
-            _llk_math_eltwise_unary_datacopy_(num_faces * TEST_FACE_R_DIM /*num_rows_per_tile*/, block_ct);
+            _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, true /*fp32_dest*/, false /*int32_dest*/>(math_format, math_format);
         }
-        _llk_math_set_dvalid_<p_cleardvalid::FPU, dest_sync>();
+        else if (is_fp32_dest_acc_en && pack_src_format == DataFormat::Int32)
+        {
+            _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, false /*fp32_dest*/, true /*int32_dest*/>(math_format, math_format);
+        }
+        else
+        {
+            _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, false /*fp32_dest*/, false /*int32_dest*/>(math_format, math_format);
+        }
+
+        _llk_math_eltwise_unary_datacopy_init_<DataCopyType::A2D, is_fp32_dest_acc_en>(num_faces * TEST_FACE_R_DIM /*num_rows_per_matrix*/, 1 /*num_matrices*/);
+        for (std::uint32_t block_rt = 0; block_rt < BLOCK_RT_DIM; block_rt++)
+        {
+            for (std::uint32_t block_ct = 0; block_ct < BLOCK_CT_DIM; block_ct++)
+            {
+                _llk_math_eltwise_unary_datacopy_(num_faces * TEST_FACE_R_DIM /*num_rows_per_tile*/, block_ct);
+            }
+            _llk_math_set_dvalid_<p_cleardvalid::FPU, dest_sync>();
+        }
     }
 }
 


### PR DESCRIPTION
### Ticket
<!-- Link to Github Issue -->

### Problem description

### What's changed
Bringing back the input_fmt=Fp16, output_fmt=Fp16b and vice versa test combos.
When using the dest dvalid scheme we should skip math completely.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Assert validation](https://github.com/tenstorrent/tt-llk/blob/main/docs/Introduction_to_asserts.md) Complied with assert doc (if applicable)
