### PR TITLE
MXFP8 format support for isolate sfpu test

### DIFF
--- a/tests/python_tests/helpers/format_config.py
+++ b/tests/python_tests/helpers/format_config.py
@@ -9,6 +9,8 @@ from typing import List, Optional, Tuple
 import ml_dtypes
 import numpy as np
 
+from .tile_constants import SRCS_SLICE_32B_ELEMENT_COUNT, SRCS_SLICE_ELEMENT_COUNT
+
 # ============================================================================
 # MX (Microscaling) Format Constants - OCP Specification
 # ============================================================================
@@ -20,6 +22,39 @@ MXFP8_E5M2_MAX_NORMAL = float(
 MXFP8_E4M3_MAX_NORMAL = float(
     ml_dtypes.finfo(ml_dtypes.float8_e4m3fn).max
 )  # 448.0 from dtype
+
+# ============================================================================
+# MX SrcS Slice L1 Layout
+# ============================================================================
+# Each SrcS slice is 8×16 = 128 elements.  In L1 a slice is stored as
+# [scales padded to 16 B][elements padded to 16 B].
+
+
+def l1_align(size: int) -> int:
+    """Align *size* to the next 16B boundary."""
+    l1_alignment = 16
+    return (size + l1_alignment - 1) // l1_alignment * l1_alignment
+
+
+# Per SrcS slice (8×16 = 128 elements, each 8-bit in L1):
+#   scales:   128 / 32 = 4 bytes   → padded to 16 B
+#   elements: 128 × 1 = 128 bytes  → already 16 B-aligned
+#   total: 16 + 128 = 144 bytes per slice
+MXFP8_SLICE_SCALE_BYTES = SRCS_SLICE_ELEMENT_COUNT // MXFP8_BLOCK_SIZE  # 4
+MXFP8_SLICE_ELEMENT_BYTES = SRCS_SLICE_ELEMENT_COUNT  # 128
+MXFP8_SRCS_SLICE_PACKED_BYTE_LEN = l1_align(MXFP8_SLICE_SCALE_BYTES) + l1_align(
+    MXFP8_SLICE_ELEMENT_BYTES
+)
+
+# 32-bit SrcS mode (dest_acc): 4x16 = 64 elements per slice
+#   scales:   64 / 32 = 2 bytes   -> padded to 16 B
+#   elements: 64 x 1  = 64 bytes  -> already 16 B-aligned
+#   total: 16 + 64 = 80 bytes per slice
+MXFP8_SLICE_32B_SCALE_BYTES = SRCS_SLICE_32B_ELEMENT_COUNT // MXFP8_BLOCK_SIZE  # 2
+MXFP8_SLICE_32B_ELEMENT_BYTES = SRCS_SLICE_32B_ELEMENT_COUNT  # 64
+MXFP8_SRCS_SLICE_32B_PACKED_BYTE_LEN = l1_align(MXFP8_SLICE_32B_SCALE_BYTES) + l1_align(
+    MXFP8_SLICE_32B_ELEMENT_BYTES
+)  # 80
 
 
 # ============================================================================

--- a/tests/python_tests/helpers/format_config.py
+++ b/tests/python_tests/helpers/format_config.py
@@ -159,7 +159,8 @@ class DataFormat(Enum):
             return (num_datums // 2) + num_exponents
         elif self.is_mx_format():
             # MX formats: 1 scale (E8M0, 8 bits) per 32 elements
-            num_exponents = num_datums // 32
+            num_scales = num_datums // MXFP8_BLOCK_SIZE
+            return l1_align(num_scales) + l1_align(self.size * num_datums)
         return (self.size * num_datums) + num_exponents
 
     def is_float32(self) -> bool:

--- a/tests/python_tests/helpers/golden_generators.py
+++ b/tests/python_tests/helpers/golden_generators.py
@@ -98,7 +98,20 @@ def convert_nan_to_inf(operand):
     return [math.inf if math.isnan(x) else x for x in operand]
 
 
-def convert_inf_to_value(operand: list, inf_value: float) -> list:
+def convert_inf_to_value(operand, inf_value: float):
+    """Replace every +inf with *inf_value*, preserving the input type.
+
+    Accepts a torch.Tensor or a plain list of floats and returns the same
+    type so that downstream code (e.g. `result.to(...)`) does not break
+    when the caller passes a tensor.
+    """
+    if isinstance(operand, torch.Tensor):
+        return torch.where(
+            operand == math.inf,
+            torch.full_like(operand, inf_value),
+            operand,
+        )
+
     return [inf_value if x == math.inf else x for x in operand]
 
 
@@ -1664,7 +1677,12 @@ class UnarySFPUGolden:
             result = quantize_mx_tensor_chunked(result.to(torch.bfloat16), data_format)
 
         # depending on `data_format`, `inf` values may get converted when unpacked to L1.
+        # Cast to the target data_format dtype before replacing inf so that
+        # replacement values larger than float16-max (65504) don't overflow for torch tensors.
         if dst_format == DataFormat.Float16:
+            target_dtype = format_dict[data_format]
+            if isinstance(result, torch.Tensor) and result.dtype != target_dtype:
+                result = result.to(target_dtype)
             match data_format:
                 case DataFormat.Float16_b:
                     result = convert_inf_to_value(result, 130560.0)

--- a/tests/python_tests/helpers/golden_generators.py
+++ b/tests/python_tests/helpers/golden_generators.py
@@ -92,7 +92,7 @@ def convert_nan_to_inf(operand):
     if isinstance(operand, torch.Tensor):
         return torch.where(
             torch.isnan(operand),
-            torch.tensor(float("inf"), dtype=operand.dtype),
+            torch.full_like(operand, float("inf")),
             operand,
         )
     return [math.inf if math.isnan(x) else x for x in operand]

--- a/tests/python_tests/helpers/golden_generators.py
+++ b/tests/python_tests/helpers/golden_generators.py
@@ -82,7 +82,19 @@ def check_bfp4_b(operand: list) -> list:
     return operand
 
 
-def convert_nan_to_inf(operand: list) -> list:
+def convert_nan_to_inf(operand):
+    """Replace every NaN with +inf, preserving the input type.
+
+    Accepts a torch.Tensor or a plain list of floats and returns the same
+    type so that downstream code (e.g. `result.to(...)`) does not break
+    when the caller passes a tensor.
+    """
+    if isinstance(operand, torch.Tensor):
+        return torch.where(
+            torch.isnan(operand),
+            torch.tensor(float("inf"), dtype=operand.dtype),
+            operand,
+        )
     return [math.inf if math.isnan(x) else x for x in operand]
 
 
@@ -259,6 +271,9 @@ def quantize_mx_stimuli(
     This simulates the quantization that occurs when data is stored in MX format
     in L1 memory and then unpacked by hardware. The golden model should use
     quantized values to match what hardware actually sees.
+
+    The L1 layout (flat vs SrcS) does not affect quantization — the same
+    scales and FP8 elements are produced regardless of byte arrangement.
 
     Args:
         tensor: Input tensor (bfloat16 values)
@@ -1541,13 +1556,18 @@ class UnarySFPUGolden:
         # Quantize input to match what hardware actually unpacks from bfp4_b L1 memory
         if input_format == DataFormat.Bfp4_b:
             operand1 = _bfp4b_to_float16b(operand1)
+        if input_format.is_mx_format():
+            operand1 = quantize_mx_tensor_chunked(operand1, input_format)
 
         # Special handling for Column and Row reduction which needs to process the entire tensor
         if operation in [MathOperation.ReduceColumn, MathOperation.ReduceRow]:
             return self.ops[operation](operand1, reduce_pool)
 
         # determine the data format for dst
-        if self.dest_acc == DestAccumulation.Yes:
+        if input_format.is_mx_format():
+            # MX in L1 always unpacks to Float16_b even if dest_acc=Yes.
+            dst_format = DataFormat.Float16_b
+        elif self.dest_acc == DestAccumulation.Yes:
             dst_format = DataFormat.Float32
         elif DataFormat.Float16 in (input_format, data_format):
             dst_format = DataFormat.Float16
@@ -1639,6 +1659,9 @@ class UnarySFPUGolden:
                 result_t.flatten(), dimensions, DataFormat.Float16_b
             ).flatten()
             result = _bfp4b_to_float16b(tilized, dimensions)
+
+        if data_format.is_mx_format():
+            result = quantize_mx_tensor_chunked(result.to(torch.bfloat16), data_format)
 
         # depending on `data_format`, `inf` values may get converted when unpacked to L1.
         if dst_format == DataFormat.Float16:

--- a/tests/python_tests/helpers/pack.py
+++ b/tests/python_tests/helpers/pack.py
@@ -12,7 +12,13 @@ from .format_config import (
     MXFP8_E4M3_MAX_NORMAL,
     MXFP8_E5M2_MAX_NORMAL,
 )
-from .tile_constants import FACE_C_DIM, MIN_BFP_EXPONENTS
+from .tile_constants import (
+    FACE_C_DIM,
+    MAX_TILE_ELEMENTS,
+    MIN_BFP_EXPONENTS,
+    SRCS_SLICE_ELEMENT_COUNT,
+    SRCS_SLICE_ROW_DIM,
+)
 
 
 def pack_bfp16(torch_tensor):
@@ -247,18 +253,27 @@ def pack_bfp4_b(tensor, block_size=16, num_faces=4, face_r_dim=16):
 # ============================================================================
 
 
+def _pad16(data: list[int]) -> list[int]:
+    """Pad a byte list to the next 16-byte boundary."""
+    rem = len(data) % 16
+    return data if rem == 0 else data + [0] * (16 - rem)
+
+
 def _pack_mxfp8(tensor, fp8_dtype, element_max_normal, num_faces=4, face_r_dim=16):
     """
     Internal helper to pack MXFP8 formats with FULLY SEPARATED layout.
 
-    Layout (similar to BFP8_b): [all_scales][all_elements]
-    - BFP8_b: [64 exponents][1024 mantissas]
-    - MXFP8:  [32 scales][1024 elements]
+    Layout (similar to BFP8_b): [all_scales][all_elements], each section 16-byte aligned.
+    Padding bytes (zeros) are appended after scales and after FP8 payload as needed.
+    - Full tile: 32 scales (32 B, aligned) + 1024 FP8 (aligned) → 1056 B.
+    - SrcS slice (8×16): 4 scales + pad to 16 B + 128 FP8 (aligned) → 144 B per slice.
+
+    Element count must be a multiple of MXFP8_BLOCK_SIZE (32).
 
     Uses ml_dtypes for FP8 element conversion and E8M0 scale encoding.
 
     Args:
-        tensor: Input tensor (typically 1024 elements for full tile)
+        tensor: Input tensor (first face_r_dim * FACE_C_DIM * num_faces elements used)
         fp8_dtype: ml_dtypes dtype (float8_e5m2 or float8_e4m3fn)
         element_max_normal: Maximum normal value for element format
         num_faces: Number of faces to pack (1, 2, or 4). Defaults to 4.
@@ -316,13 +331,13 @@ def _pack_mxfp8(tensor, fp8_dtype, element_max_normal, num_faces=4, face_r_dim=1
     scaled_blocks = blocks / scale_factors[:, np.newaxis]
     fp8_blocks = scaled_blocks.astype(fp8_dtype)
 
-    # FULLY SEPARATED layout: all scales first, then all elements
+    # FULLY SEPARATED layout: all scales first, then all elements (both 16B-aligned)
     # Convert FP8 blocks to list of bytes (integers 0-255)
     fp8_bytes = list(fp8_blocks.tobytes())
-    return scales_e8m0 + fp8_bytes
+    return _pad16(scales_e8m0) + _pad16(fp8_bytes)
 
 
-def pack_mxfp8r(tensor, num_faces=4, face_r_dim=16):
+def pack_mxfp8r(tensor, num_faces=4, face_r_dim=16, use_srcs: bool = False):
     """
     Pack tensor into MXFP8R format (MXFP8 E5M2 variant).
 
@@ -336,20 +351,42 @@ def pack_mxfp8r(tensor, num_faces=4, face_r_dim=16):
     - Has Inf and NaN support
 
     Args:
-        tensor: Input tensor (typically 1024 elements for full tile)
+        tensor: Input tensor (at most one tile worth of elements).
         num_faces: Number of faces to pack (1, 2, or 4). Defaults to 4.
         face_r_dim: Number of rows per face (1, 2, 4, 8, or 16). Defaults to 16.
 
     Returns:
         List of packed bytes in FULLY SEPARATED layout: [all_scales][all_elements]
-        Layout: [32 scales (1 per block)][1024 FP8 elements]
+        Scale count = (face_r_dim * 16 * num_faces) // 32 (one per OCP 32-datum block).
+
+        If use_srcs is True: the tensor is split into 8×16 SrcS slices and each
+        slice is packed independently as [scales][elements] (per-slice blocks in L1).
     """
+    assert tensor.numel() <= MAX_TILE_ELEMENTS, (
+        f"pack_mxfp8r handles at most one tile ({MAX_TILE_ELEMENTS} elements), "
+        f"got {tensor.numel()}"
+    )
+    if use_srcs:
+        flat = tensor.flatten()
+        num_elements = flat.numel()
+        out: list[int] = []
+        for i in range(0, num_elements, SRCS_SLICE_ELEMENT_COUNT):
+            out.extend(
+                _pack_mxfp8(
+                    flat[i : i + SRCS_SLICE_ELEMENT_COUNT],
+                    ml_dtypes.float8_e5m2,
+                    MXFP8_E5M2_MAX_NORMAL,
+                    num_faces=1,
+                    face_r_dim=SRCS_SLICE_ROW_DIM,
+                )
+            )
+        return out
     return _pack_mxfp8(
         tensor, ml_dtypes.float8_e5m2, MXFP8_E5M2_MAX_NORMAL, num_faces, face_r_dim
     )
 
 
-def pack_mxfp8p(tensor, num_faces=4, face_r_dim=16):
+def pack_mxfp8p(tensor, num_faces=4, face_r_dim=16, use_srcs: bool = False):
     """
     Pack tensor into MXFP8P format (MXFP8 E4M3 variant).
 
@@ -363,14 +400,35 @@ def pack_mxfp8p(tensor, num_faces=4, face_r_dim=16):
     - No Inf support, NaN represented by 0bS1111111
 
     Args:
-        tensor: Input tensor (typically 1024 elements for full tile)
+        tensor: Input tensor (at most one tile worth of elements).
         num_faces: Number of faces to pack (1, 2, or 4). Defaults to 4.
         face_r_dim: Number of rows per face (1, 2, 4, 8, or 16). Defaults to 16.
 
     Returns:
         List of packed bytes in FULLY SEPARATED layout: [all_scales][all_elements]
-        Layout: [32 scales (1 per block)][1024 FP8 elements]
+        Scale count = (face_r_dim * 16 * num_faces) // 32 (one per OCP 32-datum block).
+
+        If use_srcs is True: same as pack_mxfp8r (per-slice blocks in L1).
     """
+    assert tensor.numel() <= MAX_TILE_ELEMENTS, (
+        f"pack_mxfp8p handles at most one tile ({MAX_TILE_ELEMENTS} elements), "
+        f"got {tensor.numel()}"
+    )
+    if use_srcs:
+        flat = tensor.flatten()
+        num_elements = flat.numel()
+        out: list[int] = []
+        for i in range(0, num_elements, SRCS_SLICE_ELEMENT_COUNT):
+            out.extend(
+                _pack_mxfp8(
+                    flat[i : i + SRCS_SLICE_ELEMENT_COUNT],
+                    ml_dtypes.float8_e4m3fn,
+                    MXFP8_E4M3_MAX_NORMAL,
+                    num_faces=1,
+                    face_r_dim=SRCS_SLICE_ROW_DIM,
+                )
+            )
+        return out
     return _pack_mxfp8(
         tensor, ml_dtypes.float8_e4m3fn, MXFP8_E4M3_MAX_NORMAL, num_faces, face_r_dim
     )

--- a/tests/python_tests/helpers/pack.py
+++ b/tests/python_tests/helpers/pack.py
@@ -11,6 +11,7 @@ from .format_config import (
     MXFP8_BLOCK_SIZE,
     MXFP8_E4M3_MAX_NORMAL,
     MXFP8_E5M2_MAX_NORMAL,
+    l1_align,
 )
 from .tile_constants import (
     FACE_C_DIM,
@@ -253,10 +254,11 @@ def pack_bfp4_b(tensor, block_size=16, num_faces=4, face_r_dim=16):
 # ============================================================================
 
 
-def _pad16(data: list[int]) -> list[int]:
-    """Pad a byte list to the next 16-byte boundary."""
-    rem = len(data) % 16
-    return data if rem == 0 else data + [0] * (16 - rem)
+def _pad_to_l1_alignment(data: list[int]) -> list[int]:
+    """Pad a byte list to the next L1-aligned (16-byte) boundary."""
+    aligned_len = l1_align(len(data))
+    pad = aligned_len - len(data)
+    return data if pad == 0 else data + [0] * pad
 
 
 def _pack_mxfp8(tensor, fp8_dtype, element_max_normal, num_faces=4, face_r_dim=16):
@@ -291,6 +293,10 @@ def _pack_mxfp8(tensor, fp8_dtype, element_max_normal, num_faces=4, face_r_dim=1
     assert (
         len(fp32_array) >= elements_to_pack
     ), f"Tensor has {len(fp32_array)} elements, need {elements_to_pack} for {num_faces} face(s)"
+    assert elements_to_pack % MXFP8_BLOCK_SIZE == 0, (
+        f"Element count ({elements_to_pack}) must be a multiple of "
+        f"MXFP8_BLOCK_SIZE ({MXFP8_BLOCK_SIZE})"
+    )
 
     fp32_array = fp32_array[:elements_to_pack]
 
@@ -334,10 +340,43 @@ def _pack_mxfp8(tensor, fp8_dtype, element_max_normal, num_faces=4, face_r_dim=1
     # FULLY SEPARATED layout: all scales first, then all elements (both 16B-aligned)
     # Convert FP8 blocks to list of bytes (integers 0-255)
     fp8_bytes = list(fp8_blocks.tobytes())
-    return _pad16(scales_e8m0) + _pad16(fp8_bytes)
+    return _pad_to_l1_alignment(scales_e8m0) + _pad_to_l1_alignment(fp8_bytes)
 
 
-def pack_mxfp8r(tensor, num_faces=4, face_r_dim=16, use_srcs: bool = False):
+def _pack_mxfp8_srcs(tensor, fp8_dtype, element_max_normal, dest_acc: bool = False):
+    """Pack a tensor into per-slice SrcS blocks for MX formats.
+
+    Splits the tensor into SrcS slices and packs each independently as
+    [scales][elements].  Slice geometry depends on *dest_acc*:
+      - 16-bit (dest_acc=False): 8×16 = 128 elements/slice, 144 bytes
+      - 32-bit (dest_acc=True):  4×16 =  64 elements/slice,  80 bytes
+    """
+    if dest_acc:
+        slice_elem_count = SRCS_SLICE_32B_ELEMENT_COUNT
+        slice_row_dim = SRCS_SLICE_32B_ROW_DIM
+    else:
+        slice_elem_count = SRCS_SLICE_ELEMENT_COUNT
+        slice_row_dim = SRCS_SLICE_ROW_DIM
+
+    flat = tensor.flatten()
+    num_elements = flat.numel()
+    out: list[int] = []
+    for i in range(0, num_elements, slice_elem_count):
+        out.extend(
+            _pack_mxfp8(
+                flat[i : i + slice_elem_count],
+                fp8_dtype,
+                element_max_normal,
+                num_faces=1,
+                face_r_dim=slice_row_dim,
+            )
+        )
+    return out
+
+
+def pack_mxfp8r(
+    tensor, num_faces=4, face_r_dim=16, use_srcs: bool = False, dest_acc: bool = False
+):
     """
     Pack tensor into MXFP8R format (MXFP8 E5M2 variant).
 
@@ -354,39 +393,30 @@ def pack_mxfp8r(tensor, num_faces=4, face_r_dim=16, use_srcs: bool = False):
         tensor: Input tensor (at most one tile worth of elements).
         num_faces: Number of faces to pack (1, 2, or 4). Defaults to 4.
         face_r_dim: Number of rows per face (1, 2, 4, 8, or 16). Defaults to 16.
+        use_srcs: If True, split into SrcS slices (per-slice blocks in L1).
+        dest_acc: If True (with use_srcs), use 32-bit SrcS slice geometry
+            (4×16, 80 bytes/slice) instead of 16-bit (8×16, 144 bytes/slice).
 
     Returns:
         List of packed bytes in FULLY SEPARATED layout: [all_scales][all_elements]
         Scale count = (face_r_dim * 16 * num_faces) // 32 (one per OCP 32-datum block).
-
-        If use_srcs is True: the tensor is split into 8×16 SrcS slices and each
-        slice is packed independently as [scales][elements] (per-slice blocks in L1).
     """
     assert tensor.numel() <= MAX_TILE_ELEMENTS, (
         f"pack_mxfp8r handles at most one tile ({MAX_TILE_ELEMENTS} elements), "
         f"got {tensor.numel()}"
     )
     if use_srcs:
-        flat = tensor.flatten()
-        num_elements = flat.numel()
-        out: list[int] = []
-        for i in range(0, num_elements, SRCS_SLICE_ELEMENT_COUNT):
-            out.extend(
-                _pack_mxfp8(
-                    flat[i : i + SRCS_SLICE_ELEMENT_COUNT],
-                    ml_dtypes.float8_e5m2,
-                    MXFP8_E5M2_MAX_NORMAL,
-                    num_faces=1,
-                    face_r_dim=SRCS_SLICE_ROW_DIM,
-                )
-            )
-        return out
+        return _pack_mxfp8_srcs(
+            tensor, ml_dtypes.float8_e5m2, MXFP8_E5M2_MAX_NORMAL, dest_acc
+        )
     return _pack_mxfp8(
         tensor, ml_dtypes.float8_e5m2, MXFP8_E5M2_MAX_NORMAL, num_faces, face_r_dim
     )
 
 
-def pack_mxfp8p(tensor, num_faces=4, face_r_dim=16, use_srcs: bool = False):
+def pack_mxfp8p(
+    tensor, num_faces=4, face_r_dim=16, use_srcs: bool = False, dest_acc: bool = False
+):
     """
     Pack tensor into MXFP8P format (MXFP8 E4M3 variant).
 
@@ -403,32 +433,22 @@ def pack_mxfp8p(tensor, num_faces=4, face_r_dim=16, use_srcs: bool = False):
         tensor: Input tensor (at most one tile worth of elements).
         num_faces: Number of faces to pack (1, 2, or 4). Defaults to 4.
         face_r_dim: Number of rows per face (1, 2, 4, 8, or 16). Defaults to 16.
+        use_srcs: If True, split into SrcS slices (per-slice blocks in L1).
+        dest_acc: If True (with use_srcs), use 32-bit SrcS slice geometry
+            (4×16, 80 bytes/slice) instead of 16-bit (8×16, 144 bytes/slice).
 
     Returns:
         List of packed bytes in FULLY SEPARATED layout: [all_scales][all_elements]
         Scale count = (face_r_dim * 16 * num_faces) // 32 (one per OCP 32-datum block).
-
-        If use_srcs is True: same as pack_mxfp8r (per-slice blocks in L1).
     """
     assert tensor.numel() <= MAX_TILE_ELEMENTS, (
         f"pack_mxfp8p handles at most one tile ({MAX_TILE_ELEMENTS} elements), "
         f"got {tensor.numel()}"
     )
     if use_srcs:
-        flat = tensor.flatten()
-        num_elements = flat.numel()
-        out: list[int] = []
-        for i in range(0, num_elements, SRCS_SLICE_ELEMENT_COUNT):
-            out.extend(
-                _pack_mxfp8(
-                    flat[i : i + SRCS_SLICE_ELEMENT_COUNT],
-                    ml_dtypes.float8_e4m3fn,
-                    MXFP8_E4M3_MAX_NORMAL,
-                    num_faces=1,
-                    face_r_dim=SRCS_SLICE_ROW_DIM,
-                )
-            )
-        return out
+        return _pack_mxfp8_srcs(
+            tensor, ml_dtypes.float8_e4m3fn, MXFP8_E4M3_MAX_NORMAL, dest_acc
+        )
     return _pack_mxfp8(
         tensor, ml_dtypes.float8_e4m3fn, MXFP8_E4M3_MAX_NORMAL, num_faces, face_r_dim
     )

--- a/tests/python_tests/helpers/stimuli_config.py
+++ b/tests/python_tests/helpers/stimuli_config.py
@@ -100,13 +100,25 @@ class StimuliConfig:
         self.use_dense_tile_dimensions = use_dense_tile_dimensions
         self.operand_res_tile_size = operand_res_tile_size
 
-        # Stimuli addresses calculation
-        # Use actual tile size based on tile_dimensions for memory-efficient allocation
+        # Hardware flags injected by TestConfig via set_use_srcs() / set_dest_acc()
+        self.use_srcs = False
+        self._dest_acc_32b = False
+
+        self._calculate_tile_sizes()
+
+    def _calculate_tile_sizes(self):
+        """Compute tile sizes and L1 buffer addresses from current flags."""
         self.tile_size_A_bytes = calculate_tile_size_bytes(
-            self.stimuli_A_format, self.tile_dimensions, format_tile_sizes
+            self.stimuli_A_format,
+            self.tile_dimensions,
+            format_tile_sizes,
+            use_srcs=self.use_srcs,
         )
         self.tile_size_B_bytes = calculate_tile_size_bytes(
-            self.stimuli_B_format, self.tile_dimensions, format_tile_sizes
+            self.stimuli_B_format,
+            self.tile_dimensions,
+            format_tile_sizes,
+            use_srcs=self.use_srcs,
         )
 
         self.buf_a_addr = 0
@@ -119,7 +131,10 @@ class StimuliConfig:
 
         if self.buffer_C is not None:
             self.tile_size_C_bytes = calculate_tile_size_bytes(
-                self.stimuli_C_format, self.tile_dimensions, format_tile_sizes
+                self.stimuli_C_format,
+                self.tile_dimensions,
+                format_tile_sizes,
+                use_srcs=self.use_srcs,
             )
             self.buf_c_addr = (
                 self.buf_b_addr + self.tile_size_B_bytes * self.tile_count_B
@@ -136,8 +151,24 @@ class StimuliConfig:
             self.buf_res_tile_size = self.operand_res_tile_size
         else:
             self.buf_res_tile_size = calculate_tile_size_bytes(
-                stimuli_res_format, self.tile_dimensions, format_tile_sizes
+                self.stimuli_res_format,
+                self.tile_dimensions,
+                format_tile_sizes,
+                use_srcs=self.use_srcs,
+                dest_acc=self._dest_acc_32b,
             )
+
+    def set_use_srcs(self, unpack_to_srcs: bool):
+        """Enable SrcS-interleaved L1 layout. Called by TestConfig."""
+        self.use_srcs = unpack_to_srcs
+        self._calculate_tile_sizes()
+
+    def set_dest_acc(self, dest_acc):
+        """Set 32-bit dest accumulation mode. Called by TestConfig."""
+        from .llk_params import DestAccumulation
+
+        self._dest_acc_32b = dest_acc == DestAccumulation.Yes
+        self._calculate_tile_sizes()
 
     def __str__(self) -> str:
         lines = (
@@ -159,6 +190,8 @@ class StimuliConfig:
             f"  sfpu: {self.sfpu}"
             f"  write_full_tiles: {self.write_full_tiles}"
             f"  use_dense_tile_dimensions: {self.use_dense_tile_dimensions}"
+            f"  use_srcs: {self.use_srcs}"
+            f"  dest_acc_32b: {self._dest_acc_32b}"
             f"  operand_res_tile_size: {self.operand_res_tile_size}"
             f"  buf_a_addr: 0x{self.buf_a_addr:08X}"
             f"  buf_b_addr: 0x{self.buf_b_addr:08X}"
@@ -242,6 +275,7 @@ class StimuliConfig:
         face_r_dim: int,
         location: str = "0,0",
         write_full_tiles: bool = False,
+        use_srcs: bool = False,
     ):
         """
         Original backward-compatible write_matrix.
@@ -259,17 +293,25 @@ class StimuliConfig:
         else:
             tile_elements = num_faces * face_r_dim * FACE_C_DIM
 
-        pack_function_lambda = lambda buffer_tile: (
-            pack_function(buffer_tile, num_faces=num_faces, face_r_dim=face_r_dim)
-            if pack_function in [pack_bfp8_b, pack_bfp4_b, pack_mxfp8r, pack_mxfp8p]
-            else pack_function(buffer_tile)
-        )
+        def _pack_tile(buffer_tile):
+            if pack_function in (pack_mxfp8r, pack_mxfp8p):
+                return pack_function(
+                    buffer_tile,
+                    num_faces=num_faces,
+                    face_r_dim=face_r_dim,
+                    use_srcs=use_srcs,
+                )
+            if pack_function in (pack_bfp8_b, pack_bfp4_b):
+                return pack_function(
+                    buffer_tile, num_faces=num_faces, face_r_dim=face_r_dim
+                )
+            return pack_function(buffer_tile)
 
         for ind in range(tile_count):
             # Always stride at MAX_TILE_ELEMENTS (1024) for backward compatibility
             start_idx = MAX_TILE_ELEMENTS * ind
             tile_data = buffer[start_idx : start_idx + tile_elements]
-            packed_data = pack_function_lambda(tile_data)
+            packed_data = _pack_tile(tile_data)
             addresses.append(base_address + ind * tile_size)
             packed_data_list.append(packed_data)
 
@@ -287,6 +329,7 @@ class StimuliConfig:
         face_r_dim: int,
         tile_dimensions: list[int],
         location: str = "0,0",
+        use_srcs: bool = False,
     ):
         """
         New write_matrix for variable tile dimensions with dense L1 data.
@@ -299,16 +342,24 @@ class StimuliConfig:
         tile_r, tile_c = tile_dimensions
         tile_elements = tile_r * tile_c  # Dense: use actual tile dimensions
 
-        pack_function_lambda = lambda buffer_tile: (
-            pack_function(buffer_tile, num_faces=num_faces, face_r_dim=face_r_dim)
-            if pack_function in [pack_bfp8_b, pack_bfp4_b, pack_mxfp8r, pack_mxfp8p]
-            else pack_function(buffer_tile)
-        )
+        def _pack_tile(buffer_tile):
+            if pack_function in (pack_mxfp8r, pack_mxfp8p):
+                return pack_function(
+                    buffer_tile,
+                    num_faces=num_faces,
+                    face_r_dim=face_r_dim,
+                    use_srcs=use_srcs,
+                )
+            if pack_function in (pack_bfp8_b, pack_bfp4_b):
+                return pack_function(
+                    buffer_tile, num_faces=num_faces, face_r_dim=face_r_dim
+                )
+            return pack_function(buffer_tile)
 
         for ind in range(tile_count):
             start_idx = tile_elements * ind
             tile_data = buffer[start_idx : start_idx + tile_elements]
-            packed_data = pack_function_lambda(tile_data)
+            packed_data = _pack_tile(tile_data)
             addresses.append(base_address + ind * tile_size)
             packed_data_list.append(packed_data)
 
@@ -379,6 +430,7 @@ class StimuliConfig:
             self.face_r_dim,
             location,
             self.write_full_tiles,
+            use_srcs=self.use_srcs,
         )
 
         StimuliConfig.write_matrix(
@@ -391,6 +443,7 @@ class StimuliConfig:
             self.face_r_dim,
             location,
             self.write_full_tiles,
+            use_srcs=self.use_srcs,
         )
 
         if self.buffer_C is not None:
@@ -409,6 +462,7 @@ class StimuliConfig:
                 self.face_r_dim,
                 location,
                 self.write_full_tiles,
+                use_srcs=self.use_srcs,
             )
 
     def _write_dense_tile_dimensions(self, location: str = "0,0"):
@@ -435,6 +489,7 @@ class StimuliConfig:
             self.face_r_dim,
             self.tile_dimensions,
             location,
+            use_srcs=self.use_srcs,
         )
         StimuliConfig.write_matrix_w_tile_dimensions(
             self.buffer_B,
@@ -446,6 +501,7 @@ class StimuliConfig:
             self.face_r_dim,
             self.tile_dimensions,
             location,
+            use_srcs=self.use_srcs,
         )
 
         if self.buffer_C is not None:
@@ -469,7 +525,11 @@ class StimuliConfig:
     def collect_results(self, location="0,0"):
         # Read tiles based on actual tile dimensions
         tile_size_res_bytes = calculate_tile_size_bytes(
-            self.stimuli_res_format, self.tile_dimensions, format_tile_sizes
+            self.stimuli_res_format,
+            self.tile_dimensions,
+            format_tile_sizes,
+            use_srcs=self.use_srcs,
+            dest_acc=self._dest_acc_32b,
         )
         read_bytes_cnt = tile_size_res_bytes * self.tile_count_res
 
@@ -488,11 +548,15 @@ class StimuliConfig:
             location, self.buf_res_addr, num_bytes=read_bytes_cnt
         )
 
-        # Only pass tile_stride_bytes for dense tile dimensions.
-        # For backward-compatible path (use_dense_tile_dimensions=False),
-        # let unpack_res_tiles default to format_tile_sizes which strides at
-        # full 32x32 tile size and extracts only the needed faces.
-        stride_bytes = tile_size_res_bytes if self.use_dense_tile_dimensions else None
+        # Pass explicit tile_stride_bytes when tiles are densely packed
+        # (use_dense_tile_dimensions or use_srcs).  For the backward-compatible
+        # path, pass None so unpack_res_tiles strides at the full 32×32 tile
+        # size and extracts only the needed faces.
+        stride_bytes = (
+            tile_size_res_bytes
+            if (self.use_dense_tile_dimensions or self.use_srcs)
+            else None
+        )
         res_from_L1 = unpack_res_tiles(
             read_data,
             self.stimuli_res_format,
@@ -501,6 +565,8 @@ class StimuliConfig:
             self.num_faces,
             self.face_r_dim,
             tile_stride_bytes=stride_bytes,
+            use_srcs=self.use_srcs,
+            dest_acc=self._dest_acc_32b,
         )
         return res_from_L1
 

--- a/tests/python_tests/helpers/stimuli_config.py
+++ b/tests/python_tests/helpers/stimuli_config.py
@@ -520,6 +520,7 @@ class StimuliConfig:
                 self.face_r_dim,
                 self.tile_dimensions,
                 location,
+                use_srcs=self.use_srcs,
             )
 
     def collect_results(self, location="0,0"):

--- a/tests/python_tests/helpers/test_config.py
+++ b/tests/python_tests/helpers/test_config.py
@@ -540,6 +540,11 @@ class TestConfig:
             self.formats_config = None
             self.pack_size, self.unpack_size_a, self.unpack_size_b = 128, 128, 128
 
+        # Inject use_srcs and dest_acc into StimuliConfig
+        if self.variant_stimuli:
+            self.variant_stimuli.set_use_srcs(self.unpack_to_srcs)
+            self.variant_stimuli.set_dest_acc(self.dest_acc)
+
         if (len(self.runtimes) > 0 or len(self.templates) > 0) and self.variant_stimuli:
             itd_param = next(
                 (

--- a/tests/python_tests/helpers/tile_constants.py
+++ b/tests/python_tests/helpers/tile_constants.py
@@ -63,6 +63,23 @@ MAX_FACE_ELEMENTS = MAX_FACE_R_DIM * FACE_C_DIM
 MAX_TILE_ELEMENTS = DEFAULT_TILE_R_DIM * DEFAULT_TILE_C_DIM
 
 # =============================================================================
+# SrcS / UNP_S TDMA slice
+# =============================================================================
+# Hardware delivers SrcS in 8×16 regions of 16-bit datums (e.g. UNP_S x_dim=16,
+# y_dim=8)
+
+SRCS_SLICE_DATUM_BITS = 16
+SRCS_SLICE_COL_DIM = FACE_C_DIM  # 16 columns of 16-bit datums
+SRCS_SLICE_ROW_DIM = 8
+SRCS_SLICE_ELEMENT_COUNT = (
+    SRCS_SLICE_ROW_DIM * SRCS_SLICE_COL_DIM
+)  # 128 elements per slice
+
+# 32-bit SrcS mode (dest_acc=Yes): register file holds 32-bit datums, halving rows
+SRCS_SLICE_32B_ROW_DIM = 4
+SRCS_SLICE_32B_ELEMENT_COUNT = SRCS_SLICE_32B_ROW_DIM * SRCS_SLICE_COL_DIM  # 64
+
+# =============================================================================
 # Supported Tile Sizes
 # =============================================================================
 
@@ -138,7 +155,13 @@ def get_tile_params(tile_dimensions):
     return face_r_dim, num_faces_r_dim, num_faces_c_dim
 
 
-def calculate_tile_size_bytes(data_format, tile_dimensions, format_tile_sizes):
+def calculate_tile_size_bytes(
+    data_format,
+    tile_dimensions,
+    format_tile_sizes,
+    use_srcs: bool = False,
+    dest_acc: bool = False,
+):
     """
     Calculate the actual tile size in bytes based on tile dimensions and data format.
 
@@ -152,14 +175,29 @@ def calculate_tile_size_bytes(data_format, tile_dimensions, format_tile_sizes):
         data_format: DataFormat enum value
         tile_dimensions: List or tuple of [rows, cols]
         format_tile_sizes: Dict mapping DataFormat to full tile size in bytes
+        use_srcs: If True and MX format, compute size using per-slice 16B-aligned
+            layout (SrcS blocks) instead of flat [scales][elements].
+        dest_acc: If True (with use_srcs), use 32-bit SrcS slice geometry
+            (4×16 = 64 elements/slice) instead of 16-bit (8×16 = 128).
 
     Returns:
         int: Tile size in bytes
     """
-    from .format_config import DataFormat
+    from .format_config import (
+        MXFP8_SRCS_SLICE_32B_PACKED_BYTE_LEN,
+        MXFP8_SRCS_SLICE_PACKED_BYTE_LEN,
+        DataFormat,
+    )
 
     tile_rows, tile_cols = tile_dimensions
     tile_elements = tile_rows * tile_cols
+
+    if use_srcs and data_format.is_mx_format():
+        if dest_acc:
+            num_slices = tile_elements // SRCS_SLICE_32B_ELEMENT_COUNT
+            return num_slices * MXFP8_SRCS_SLICE_32B_PACKED_BYTE_LEN
+        num_slices = tile_elements // SRCS_SLICE_ELEMENT_COUNT
+        return num_slices * MXFP8_SRCS_SLICE_PACKED_BYTE_LEN
 
     # For standard 32x32 tiles, use the predefined sizes (includes format overhead)
     if tile_elements == MAX_TILE_ELEMENTS:

--- a/tests/python_tests/helpers/tile_constants.py
+++ b/tests/python_tests/helpers/tile_constants.py
@@ -193,11 +193,16 @@ def calculate_tile_size_bytes(
     tile_elements = tile_rows * tile_cols
 
     if use_srcs and data_format.is_mx_format():
-        if dest_acc:
-            num_slices = tile_elements // SRCS_SLICE_32B_ELEMENT_COUNT
-            return num_slices * MXFP8_SRCS_SLICE_32B_PACKED_BYTE_LEN
-        num_slices = tile_elements // SRCS_SLICE_ELEMENT_COUNT
-        return num_slices * MXFP8_SRCS_SLICE_PACKED_BYTE_LEN
+        slice_elem_count = (
+            SRCS_SLICE_32B_ELEMENT_COUNT if dest_acc else SRCS_SLICE_ELEMENT_COUNT
+        )
+        slice_byte_len = (
+            MXFP8_SRCS_SLICE_32B_PACKED_BYTE_LEN
+            if dest_acc
+            else MXFP8_SRCS_SLICE_PACKED_BYTE_LEN
+        )
+        num_slices = (tile_elements + slice_elem_count - 1) // slice_elem_count
+        return num_slices * slice_byte_len
 
     # For standard 32x32 tiles, use the predefined sizes (includes format overhead)
     if tile_elements == MAX_TILE_ELEMENTS:

--- a/tests/python_tests/helpers/unpack.py
+++ b/tests/python_tests/helpers/unpack.py
@@ -297,6 +297,11 @@ def unpack_mxfp8r(
             slice_len = MXFP8_SRCS_SLICE_PACKED_BYTE_LEN
             slice_row_dim = SRCS_SLICE_ROW_DIM
         num_bytes = len(packed_bytes)
+        if num_bytes % slice_len != 0:
+            raise ValueError(
+                f"Invalid packed_bytes length for use_srcs=True: got {num_bytes} bytes, "
+                f"expected a multiple of {slice_len} bytes per SrcS slice."
+            )
         out = []
         for i in range(0, num_bytes, slice_len):
             out.append(
@@ -341,6 +346,11 @@ def unpack_mxfp8p(
             slice_len = MXFP8_SRCS_SLICE_PACKED_BYTE_LEN
             slice_row_dim = SRCS_SLICE_ROW_DIM
         num_bytes = len(packed_bytes)
+        if num_bytes % slice_len != 0:
+            raise ValueError(
+                f"Invalid packed_bytes length for use_srcs=True: got {num_bytes} bytes, "
+                f"expected a multiple of {slice_len} bytes per SrcS slice."
+            )
         out = []
         for i in range(0, num_bytes, slice_len):
             out.append(

--- a/tests/python_tests/helpers/unpack.py
+++ b/tests/python_tests/helpers/unpack.py
@@ -267,6 +267,40 @@ def _unpack_mxfp8(packed_bytes, fp8_dtype, num_faces=4, face_r_dim=MAX_FACE_R_DI
     return torch.tensor(scaled_blocks.flatten(), dtype=torch.bfloat16)
 
 
+def _unpack_mxfp8_srcs(packed_bytes, fp8_dtype, dest_acc: bool = False):
+    """Unpack sequential SrcS slices for MX formats.
+
+    Slice geometry depends on *dest_acc*:
+      - 16-bit (dest_acc=False): 8×16 = 128 elements/slice, 144 bytes
+      - 32-bit (dest_acc=True):  4×16 =  64 elements/slice,  80 bytes
+    """
+    if dest_acc:
+        slice_len = MXFP8_SRCS_SLICE_32B_PACKED_BYTE_LEN
+        slice_row_dim = SRCS_SLICE_32B_ROW_DIM
+    else:
+        slice_len = MXFP8_SRCS_SLICE_PACKED_BYTE_LEN
+        slice_row_dim = SRCS_SLICE_ROW_DIM
+
+    num_bytes = len(packed_bytes)
+    if num_bytes % slice_len != 0:
+        raise ValueError(
+            f"Invalid packed_bytes length for use_srcs=True: got {num_bytes} bytes, "
+            f"expected a multiple of {slice_len} bytes per SrcS slice."
+        )
+
+    out = []
+    for i in range(0, num_bytes, slice_len):
+        out.append(
+            _unpack_mxfp8(
+                packed_bytes[i : i + slice_len],
+                fp8_dtype,
+                num_faces=1,
+                face_r_dim=slice_row_dim,
+            )
+        )
+    return torch.cat(out)
+
+
 def unpack_mxfp8r(
     packed_bytes,
     num_faces=4,
@@ -290,29 +324,7 @@ def unpack_mxfp8r(
         torch.Tensor of bfloat16 values
     """
     if use_srcs:
-        if dest_acc:
-            slice_len = MXFP8_SRCS_SLICE_32B_PACKED_BYTE_LEN
-            slice_row_dim = SRCS_SLICE_32B_ROW_DIM
-        else:
-            slice_len = MXFP8_SRCS_SLICE_PACKED_BYTE_LEN
-            slice_row_dim = SRCS_SLICE_ROW_DIM
-        num_bytes = len(packed_bytes)
-        if num_bytes % slice_len != 0:
-            raise ValueError(
-                f"Invalid packed_bytes length for use_srcs=True: got {num_bytes} bytes, "
-                f"expected a multiple of {slice_len} bytes per SrcS slice."
-            )
-        out = []
-        for i in range(0, num_bytes, slice_len):
-            out.append(
-                _unpack_mxfp8(
-                    packed_bytes[i : i + slice_len],
-                    ml_dtypes.float8_e5m2,
-                    num_faces=1,
-                    face_r_dim=slice_row_dim,
-                )
-            )
-        return torch.cat(out)
+        return _unpack_mxfp8_srcs(packed_bytes, ml_dtypes.float8_e5m2, dest_acc)
     return _unpack_mxfp8(packed_bytes, ml_dtypes.float8_e5m2, num_faces, face_r_dim)
 
 
@@ -339,29 +351,7 @@ def unpack_mxfp8p(
         torch.Tensor of bfloat16 values
     """
     if use_srcs:
-        if dest_acc:
-            slice_len = MXFP8_SRCS_SLICE_32B_PACKED_BYTE_LEN
-            slice_row_dim = SRCS_SLICE_32B_ROW_DIM
-        else:
-            slice_len = MXFP8_SRCS_SLICE_PACKED_BYTE_LEN
-            slice_row_dim = SRCS_SLICE_ROW_DIM
-        num_bytes = len(packed_bytes)
-        if num_bytes % slice_len != 0:
-            raise ValueError(
-                f"Invalid packed_bytes length for use_srcs=True: got {num_bytes} bytes, "
-                f"expected a multiple of {slice_len} bytes per SrcS slice."
-            )
-        out = []
-        for i in range(0, num_bytes, slice_len):
-            out.append(
-                _unpack_mxfp8(
-                    packed_bytes[i : i + slice_len],
-                    ml_dtypes.float8_e4m3fn,
-                    num_faces=1,
-                    face_r_dim=slice_row_dim,
-                )
-            )
-        return torch.cat(out)
+        return _unpack_mxfp8_srcs(packed_bytes, ml_dtypes.float8_e4m3fn, dest_acc)
     return _unpack_mxfp8(packed_bytes, ml_dtypes.float8_e4m3fn, num_faces, face_r_dim)
 
 

--- a/tests/python_tests/helpers/unpack.py
+++ b/tests/python_tests/helpers/unpack.py
@@ -6,10 +6,22 @@
 import ml_dtypes
 import numpy as np
 import torch
-from helpers.format_config import MXFP8_BLOCK_SIZE, DataFormat
+from helpers.format_config import (
+    MXFP8_BLOCK_SIZE,
+    MXFP8_SRCS_SLICE_32B_PACKED_BYTE_LEN,
+    MXFP8_SRCS_SLICE_PACKED_BYTE_LEN,
+    DataFormat,
+)
 
 from .llk_params import format_dict, format_tile_sizes
-from .tile_constants import FACE_C_DIM, MAX_FACE_R_DIM, MAX_NUM_FACES, MIN_BFP_EXPONENTS
+from .tile_constants import (
+    FACE_C_DIM,
+    MAX_FACE_R_DIM,
+    MAX_NUM_FACES,
+    MIN_BFP_EXPONENTS,
+    SRCS_SLICE_32B_ROW_DIM,
+    SRCS_SLICE_ROW_DIM,
+)
 
 
 def unpack_fp16(packed_list):
@@ -208,41 +220,44 @@ def unpack_bfp4_b(bfp4_block, sfpu=False, num_faces=4, face_r_dim=16):
 # ============================================================================
 
 
-def _unpack_mxfp8(packed_bytes, fp8_dtype, num_faces=4):
+def _align16(n: int) -> int:
+    """Round *n* up to the next 16-byte boundary."""
+    return (n + 15) & ~15
+
+
+def _unpack_mxfp8(packed_bytes, fp8_dtype, num_faces=4, face_r_dim=MAX_FACE_R_DIM):
     """
-    Unpack MXFP8 format with layout: [all_scales][all_elements]
+    Unpack MXFP8 format with layout: [scales padded to 16B][elements padded to 16B].
+
+    One E8M0 scale byte per 32-element block.
 
     Args:
         packed_bytes: List of bytes in [all scales][all elements] format
         fp8_dtype: ml_dtypes dtype (float8_e5m2 or float8_e4m3fn)
         num_faces: Number of faces (1, 2, or 4). Defaults to 4.
+        face_r_dim: Rows per face (1, 2, 4, 8, or 16). Defaults to 16.
 
     Returns:
         torch.Tensor of bfloat16 values
     """
-    num_scales = num_faces * 8
-    num_blocks = num_faces * 8
+    num_elements = face_r_dim * FACE_C_DIM * num_faces
+    num_scales = num_elements // MXFP8_BLOCK_SIZE
+
+    scale_section_len = _align16(num_scales)
 
     scales_e8m0 = packed_bytes[:num_scales]
-    elements_bytes = packed_bytes[num_scales:]
+    elements_bytes = packed_bytes[scale_section_len : scale_section_len + num_elements]
 
-    # Convert all elements to FP8 array using ml_dtypes
-    fp8_array = np.frombuffer(bytes(elements_bytes), dtype=fp8_dtype)
-
-    # Reshape into blocks: (num_blocks, 32)
-    fp8_blocks = fp8_array[: num_blocks * MXFP8_BLOCK_SIZE].reshape(
-        num_blocks, MXFP8_BLOCK_SIZE
+    # Convert elements bytes to FP8 blocks and reshape to (num_scales, 32)
+    fp8_blocks = np.frombuffer(bytes(elements_bytes), dtype=fp8_dtype).reshape(
+        num_scales, MXFP8_BLOCK_SIZE
     )
 
     # Vectorized scale decoding - decode all E8M0 scales at once
     scales_array = np.frombuffer(bytes(scales_e8m0), dtype=np.uint8)
     # Handle NaN case (255) and compute 2^(exponent) where exponent = value - 127
     scale_factors = np.where(
-        scales_array == 255, np.nan, np.exp2(scales_array.astype(np.float32) - 127.0)
-    )
-    # Replace NaN and zero scales with 0
-    scale_factors = np.where(
-        np.isnan(scale_factors) | (scale_factors == 0), 0, scale_factors
+        scales_array == 255, 0.0, np.exp2(scales_array.astype(np.float32) - 127.0)
     )
 
     # Scale blocks back to float32
@@ -252,32 +267,92 @@ def _unpack_mxfp8(packed_bytes, fp8_dtype, num_faces=4):
     return torch.tensor(scaled_blocks.flatten(), dtype=torch.bfloat16)
 
 
-def unpack_mxfp8r(packed_bytes, num_faces=4):
+def unpack_mxfp8r(
+    packed_bytes,
+    num_faces=4,
+    face_r_dim=MAX_FACE_R_DIM,
+    use_srcs: bool = False,
+    dest_acc: bool = False,
+):
     """
     Unpack MXFP8R format (E5M2 variant) to bfloat16 tensor.
 
     Args:
         packed_bytes: Packed MX data in FULLY SEPARATED layout [all_scales][all_elements]
         num_faces: Number of faces to unpack (1, 2, or 4). Defaults to 4.
+        face_r_dim: Rows per face (1, 2, 4, 8, or 16). Defaults to 16.
+        use_srcs: If True, unpack sequential SrcS slices instead of a
+            single flat tile.  Supports sub-tile sizes (any multiple of one slice).
+        dest_acc: If True (with use_srcs), use 32-bit SrcS slice geometry
+            (4×16, 80 bytes/slice) instead of 16-bit (8×16, 144 bytes/slice).
 
     Returns:
         torch.Tensor of bfloat16 values
     """
-    return _unpack_mxfp8(packed_bytes, ml_dtypes.float8_e5m2, num_faces)
+    if use_srcs:
+        if dest_acc:
+            slice_len = MXFP8_SRCS_SLICE_32B_PACKED_BYTE_LEN
+            slice_row_dim = SRCS_SLICE_32B_ROW_DIM
+        else:
+            slice_len = MXFP8_SRCS_SLICE_PACKED_BYTE_LEN
+            slice_row_dim = SRCS_SLICE_ROW_DIM
+        num_bytes = len(packed_bytes)
+        out = []
+        for i in range(0, num_bytes, slice_len):
+            out.append(
+                _unpack_mxfp8(
+                    packed_bytes[i : i + slice_len],
+                    ml_dtypes.float8_e5m2,
+                    num_faces=1,
+                    face_r_dim=slice_row_dim,
+                )
+            )
+        return torch.cat(out)
+    return _unpack_mxfp8(packed_bytes, ml_dtypes.float8_e5m2, num_faces, face_r_dim)
 
 
-def unpack_mxfp8p(packed_bytes, num_faces=4):
+def unpack_mxfp8p(
+    packed_bytes,
+    num_faces=4,
+    face_r_dim=MAX_FACE_R_DIM,
+    use_srcs: bool = False,
+    dest_acc: bool = False,
+):
     """
     Unpack MXFP8P format (E4M3 variant) to bfloat16 tensor.
 
     Args:
         packed_bytes: Packed MX data in FULLY SEPARATED layout [all_scales][all_elements]
         num_faces: Number of faces to unpack (1, 2, or 4). Defaults to 4.
+        face_r_dim: Rows per face (1, 2, 4, 8, or 16). Defaults to 16.
+        use_srcs: If True, unpack sequential SrcS slices instead of a
+            single flat tile.  Supports sub-tile sizes (any multiple of one slice).
+        dest_acc: If True (with use_srcs), use 32-bit SrcS slice geometry
+            (4×16, 80 bytes/slice) instead of 16-bit (8×16, 144 bytes/slice).
 
     Returns:
         torch.Tensor of bfloat16 values
     """
-    return _unpack_mxfp8(packed_bytes, ml_dtypes.float8_e4m3fn, num_faces)
+    if use_srcs:
+        if dest_acc:
+            slice_len = MXFP8_SRCS_SLICE_32B_PACKED_BYTE_LEN
+            slice_row_dim = SRCS_SLICE_32B_ROW_DIM
+        else:
+            slice_len = MXFP8_SRCS_SLICE_PACKED_BYTE_LEN
+            slice_row_dim = SRCS_SLICE_ROW_DIM
+        num_bytes = len(packed_bytes)
+        out = []
+        for i in range(0, num_bytes, slice_len):
+            out.append(
+                _unpack_mxfp8(
+                    packed_bytes[i : i + slice_len],
+                    ml_dtypes.float8_e4m3fn,
+                    num_faces=1,
+                    face_r_dim=slice_row_dim,
+                )
+            )
+        return torch.cat(out)
+    return _unpack_mxfp8(packed_bytes, ml_dtypes.float8_e4m3fn, num_faces, face_r_dim)
 
 
 _UNPACKERS = {
@@ -302,6 +377,8 @@ def unpack_res_tiles(
     num_faces: int = MAX_NUM_FACES,
     face_r_dim: int = MAX_FACE_R_DIM,
     tile_stride_bytes: int = None,
+    use_srcs: bool = False,
+    dest_acc: bool = False,
 ):
     output_dtype = format_dict[output_format]
 
@@ -349,7 +426,13 @@ def unpack_res_tiles(
                 tile_data, sfpu=sfpu, num_faces=num_faces, face_r_dim=face_r_dim
             )
         elif unpack_func in [unpack_mxfp8r, unpack_mxfp8p]:
-            unpacked_tile = unpack_func(tile_data, num_faces=num_faces)
+            unpacked_tile = unpack_func(
+                tile_data,
+                num_faces=num_faces,
+                face_r_dim=face_r_dim,
+                use_srcs=use_srcs,
+                dest_acc=dest_acc,
+            )
         else:
             unpacked_tile = unpack_func(tile_data)
 

--- a/tests/python_tests/quasar/test_isolate_sfpu_square_quasar.py
+++ b/tests/python_tests/quasar/test_isolate_sfpu_square_quasar.py
@@ -12,7 +12,12 @@ from typing import List
 
 import pytest
 import torch
-from helpers.format_config import DataFormat, FormatConfig
+from helpers.format_config import (
+    MXFP8_E4M3_MAX_NORMAL,
+    MXFP8_E5M2_MAX_NORMAL,
+    DataFormat,
+    FormatConfig,
+)
 from helpers.golden_generators import UnarySFPUGolden, get_golden_generator
 from helpers.llk_params import (
     DestAccumulation,
@@ -62,20 +67,32 @@ def prepare_square_inputs(
     input_finfo = torch.finfo(input_torch_format)
     output_finfo = torch.finfo(output_torch_format)
 
-    # For squaring, x² must fit in the OUTPUT format
-    max_safe_value = math.sqrt(output_finfo.max) * 0.9
+    def mx_elem_max(df: DataFormat) -> float:
+        if df == DataFormat.MxFp8R:
+            return MXFP8_E5M2_MAX_NORMAL
+        if df == DataFormat.MxFp8P:
+            return MXFP8_E4M3_MAX_NORMAL
+        raise ValueError(f"mx_elem_max: not an MX format: {df}")
 
-    # Special handling for bfloat16: it has wide range but limited precision
-    # Extreme values lose precision, so limit to reasonable bounds
-    if input_torch_format == torch.bfloat16:
-        # Limit to range where squaring maintains reasonable precision
-        max_safe_value = min(max_safe_value, 1e4)  # 10000² = 1e8 fits comfortably
+    # For squaring, x² must fit in the OUTPUT format; |x| must fit the INPUT format.
+    if output_format.is_mx_format():
+        cap_from_output = math.sqrt(mx_elem_max(output_format)) * 0.9
     else:
-        # For Float16, ensure input itself fits in input format
-        # Float16 max is ~65504, so sqrt(65504) ≈ 256 is the safe limit
-        max_safe_value = min(max_safe_value, math.sqrt(input_finfo.max) * 0.9)
+        cap_from_output = math.sqrt(output_finfo.max) * 0.9
 
-    min_magnitude = max(1e-6, input_finfo.tiny * 100)  # Avoid denormals
+    if input_format.is_mx_format():
+        cap_from_input = mx_elem_max(input_format) * 0.9
+    else:
+        cap_from_input = math.sqrt(input_finfo.max) * 0.9
+
+    max_safe_value = min(cap_from_output, cap_from_input)
+
+    # bfloat16 (non-MX): limit |x| so squaring keeps reasonable precision.
+    if input_torch_format == torch.bfloat16 and not input_format.is_mx_format():
+        max_safe_value = min(max_safe_value, 1e4)  # 10000² = 1e8 fits comfortably
+
+    # MX uses torch.bfloat16 as the logical dtype; same denormal floor as other formats.
+    min_magnitude = max(1e-6, input_finfo.tiny * 100)
 
     # Ensure src_A and src_B don't contain inf/nan before normalization
     src_A_float = src_A.to(torch.float32)
@@ -163,11 +180,13 @@ def generate_sfpu_square_combinations(
     for fmt in formats_list:
         in_fmt = fmt.input_format
 
-        dest_acc_modes = (
-            (DestAccumulation.Yes,)
-            if in_fmt.is_32_bit()
-            else (DestAccumulation.No, DestAccumulation.Yes)
-        )
+        if in_fmt.is_32_bit():
+            dest_acc_modes = (DestAccumulation.Yes,)
+        elif in_fmt.is_mx_format():
+            dest_acc_modes = (DestAccumulation.No,)
+        else:
+            dest_acc_modes = (DestAccumulation.No, DestAccumulation.Yes)
+
         for dest_acc in dest_acc_modes:
             # Skip invalid format combinations for Quasar
             if _is_invalid_quasar_combination(fmt, dest_acc):
@@ -184,9 +203,11 @@ def generate_sfpu_square_combinations(
 
 SFPU_SQUARE_FORMATS = input_output_formats(
     [
+        DataFormat.MxFp8R,
+        DataFormat.MxFp8P,
+        DataFormat.Float16_b,
         DataFormat.Float16,
         DataFormat.Float32,
-        DataFormat.Float16_b,
     ]
 )
 
@@ -257,6 +278,8 @@ def test_isolate_sfpu_square_quasar(formats_dest_acc_implied_math_input_dims):
         ),
         unpack_to_srcs=True,
         dest_acc=dest_acc,
+        # Input MX formats require disable_format_inference
+        disable_format_inference=formats.input_format.is_mx_format(),
     )
 
     res_from_L1 = configuration.run().result


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Isolate SFPU test only tested Float16, Float16B and Float32 input/output data formats. We have support now for MX formats in test infra for the `Unpack 0/1 -> Src A/B -> FPU -> Dest -> Pack0` path. We should be able to add these data formats into the `Unpack 2 -> Src S -> Pack 1` path as well.

### What's changed
This PR adds support for MxFp8R and MxFp8P in the isolate SFPU test. MXFP8 data has a unique L1 memory layout where each SrcS slice (8x16 elements) is stored as `[scales][elements]`, which differs from the flat tile layout used by other formats. This PR adds the necessary constants, pack/unpack logic, and plumbing to correctly write, read back, and golden-check MXFP8 tiles through the SrcS path, including preparation for 32-bit SrcS mode. Changes to the test infra to accommodate these data formats include:

- **Pack/Unpack (pack.py, unpack.py):** Support SrcS-interleaved packing (splitting a tile into 128-element slices, each packed independently with 16B-aligned scale/element sections) and the corresponding unpack path. Add `dest_acc` parameter to unpack functions to select 32-bit slice geometry for result readback.
- **Tile size calculation (tile_constants.py):** Extend `calculate_tile_size_bytes` with `use_srcs` and `dest_acc` flags to compute correct byte sizes for SrcS-interleaved MX tiles.
- **Golden model (golden_generators.py):** Add MX quantization to `UnarySFPUGolden` (input and output round-trips). Set MX input formats to always use Float16_b as the destination format regardless of `dest_acc`.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring