### PR TITLE
Expose separate transpose settings in llk_unpack_AB (#1089)

### DIFF
--- a/tests/python_tests/helpers/fused_unpacker.py
+++ b/tests/python_tests/helpers/fused_unpacker.py
@@ -327,18 +327,18 @@ class UnpackerAB(Unpacker):
         transpose_faces = compute_unit.unpack_transpose_faces.cpp_enum_value
         transpose_within_face = compute_unit.unpack_transpose_within_face.cpp_enum_value
 
-        if transpose_within_face != transpose_faces:
-            raise ValueError(
-                "UnpackerAB does not support different values for transpose_faces and transpose_within_face"
-            )
-
         tile_shape = operation.src_a.tile_shape
-        transpose_value = "1" if compute_unit.unpack_transpose_faces.value else "0"
+        transpose_faces_value = (
+            "1" if compute_unit.unpack_transpose_faces.value else "0"
+        )
+        transpose_within_face_value = (
+            "1" if compute_unit.unpack_transpose_within_face.value else "0"
+        )
         shape_var = f"tensor_shape_stage_{operation.stage_id}"
         return (
             f"const ckernel::TensorShape {shape_var} = "
             f"{{{tile_shape.face_r_dim}, {tile_shape.face_c_dim}, {tile_shape.num_faces_r_dim}, {tile_shape.num_faces_c_dim}}};\n"
-            f"_llk_unpack_AB_init_<{broadcast_type}>({shape_var}, {transpose_value});\n"
+            f"_llk_unpack_AB_init_<{broadcast_type}>({shape_var}, {transpose_faces_value}, {transpose_within_face_value});\n"
         )
 
     def unpack(

--- a/tests/sources/eltwise_binary_test.cpp
+++ b/tests/sources/eltwise_binary_test.cpp
@@ -30,12 +30,13 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const FormatConfig& formats = params.formats;
 #endif
     // Cache volatile values to local variables first
-    const std::uint8_t face_r_dim           = static_cast<std::uint8_t>(params.TEST_FACE_R_DIM);
-    const std::uint8_t face_c_dim           = static_cast<std::uint8_t>(params.TEST_FACE_C_DIM);
-    const std::uint8_t num_faces_r_dim      = static_cast<std::uint8_t>(params.num_faces_r_dim_A);
-    const std::uint8_t num_faces_c_dim      = static_cast<std::uint8_t>(params.num_faces_c_dim_A);
-    const ckernel::TensorShape tensor_shape = {face_r_dim, face_c_dim, num_faces_r_dim, num_faces_c_dim};
-    const std::uint32_t transpose           = params.UNPACK_TRANSPOSE_FACES;
+    const std::uint8_t face_r_dim                   = static_cast<std::uint8_t>(params.TEST_FACE_R_DIM);
+    const std::uint8_t face_c_dim                   = static_cast<std::uint8_t>(params.TEST_FACE_C_DIM);
+    const std::uint8_t num_faces_r_dim              = static_cast<std::uint8_t>(params.num_faces_r_dim_A);
+    const std::uint8_t num_faces_c_dim              = static_cast<std::uint8_t>(params.num_faces_c_dim_A);
+    const ckernel::TensorShape tensor_shape         = {face_r_dim, face_c_dim, num_faces_r_dim, num_faces_c_dim};
+    const std::uint32_t transpose_of_faces          = params.UNPACK_TRANSPOSE_FACES;
+    const std::uint32_t within_face_16x16_transpose = params.UNPACK_TRANSPOSE_WITHIN_FACE;
 
     // Configure hardware for unpacking, no broadcast, no transpose
     _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
@@ -50,7 +51,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         params.TILE_SIZE_UNPACK_A,
         params.TILE_SIZE_UNPACK_B);
 
-    _llk_unpack_AB_init_<BROADCAST_TYPE>(tensor_shape, transpose);
+    _llk_unpack_AB_init_<BROADCAST_TYPE>(tensor_shape, transpose_of_faces, within_face_16x16_transpose);
 
 #ifdef EN_DEST_REUSE
     const std::uint32_t num_total_tiles = params.INPUT_NUM_TILES_IN_BLOCK * params.INPUT_NUM_BLOCKS;

--- a/tests/sources/eltwise_binary_transpose_bcast_test.cpp
+++ b/tests/sources/eltwise_binary_transpose_bcast_test.cpp
@@ -9,6 +9,7 @@
 
 #include "ckernel.h"
 #include "llk_defs.h"
+#include "tensor_shape.h"
 
 // Globals
 std::uint32_t unp_cfg_context          = 0;
@@ -34,10 +35,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     // Initialize unpack with column broadcast on srcB and transpose on srcA
     _llk_unpack_AB_init_<BROADCAST_TYPE>(
-        FACE_R_DIM,
-        4 /* num_faces */,
-        false,                          // narrow_tile
-        params.UNPACK_TRANSPOSE_FACES); // Enable face rearrangement for srcA
+        ckernel::DEFAULT_TENSOR_SHAPE,
+        params.UNPACK_TRANSPOSE_FACES,  // transpose_of_faces: face rearrangement for srcA
+        params.UNPACK_TRANSPOSE_FACES); // within_face_16x16_transpose: XY transpose within each face
 
     // Unpack tiles: srcA will be transposed, srcB will be column broadcasted
     for (int i = 0; i < params.TILE_CNT; ++i)

--- a/tt_llk_blackhole/llk_lib/llk_unpack_AB.h
+++ b/tt_llk_blackhole/llk_lib/llk_unpack_AB.h
@@ -149,20 +149,26 @@ inline void _llk_unpack_AB_mop_config_(const bool transpose_of_faces, const cker
  * Configures the unpacker hardware for dual-operand unpacking with support for various
  * broadcast modes and optional transpose. Sets up number of datums to unpack based on face dimensions.
  *
+ * Transpose has two independent settings:
+ * - transpose_of_faces: Reorder faces from (0,1,2,3) to (0,2,1,3), controlled via MOP programming
+ * - within_face_16x16_transpose: XY transpose within each 16x16 face, controlled via haloize_mode HW bit
+ *
  * @tparam BType: Broadcast type for source B, values = <NONE/COL/ROW/SCALAR>
  * @param tensor_shape: Tensor shape describing tile dimensions (face_r_dim, face_c_dim, num_faces_r_dim, num_faces_c_dim)
- * @param transpose: Whether to transpose within each face (0 = no transpose, >0 = transpose)
+ * @param transpose_of_faces: Whether to reorder faces (0 = no reorder, >0 = reorder)
+ * @param within_face_16x16_transpose: Whether to transpose within each face (0 = no transpose, >0 = transpose)
  */
 template <BroadcastType BType = BroadcastType::NONE>
-inline void _llk_unpack_AB_init_(const ckernel::TensorShape tensor_shape, const std::uint32_t transpose = 0)
+inline void _llk_unpack_AB_init_(
+    const ckernel::TensorShape tensor_shape, const std::uint32_t transpose_of_faces = 0, const std::uint32_t within_face_16x16_transpose = 0)
 {
     // TODO: Remove this assert after testing >4 num_faces because there is no reason to limit this for non-broadcast versions
     LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
-    cfg_reg_rmw_tensix<THCON_SEC0_REG2_Haloize_mode_RMW>(transpose); // transpose within the face
+    cfg_reg_rmw_tensix<THCON_SEC0_REG2_Haloize_mode_RMW>(within_face_16x16_transpose); // transpose within the face
 
     config_unpacker_x_end<p_setadc::UNP_AB>(tensor_shape.face_r_dim);
 
-    _llk_unpack_AB_mop_config_<BType>(transpose > 0, tensor_shape); // transpose of faces 0,2,1,3
+    _llk_unpack_AB_mop_config_<BType>(transpose_of_faces > 0, tensor_shape); // transpose of faces 0,2,1,3
 }
 
 /**

--- a/tt_llk_wormhole_b0/llk_lib/llk_unpack_AB.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_unpack_AB.h
@@ -137,20 +137,26 @@ inline void _llk_unpack_AB_mop_config_(const bool transpose_of_faces, const cker
  * Configures the unpacker hardware for dual-operand unpacking with support for various
  * broadcast modes and optional transpose. Sets up number of datums to unpack based on face dimensions.
  *
+ * Transpose has two independent settings:
+ * - transpose_of_faces: Reorder faces from (0,1,2,3) to (0,2,1,3), controlled via MOP programming
+ * - within_face_16x16_transpose: XY transpose within each 16x16 face, controlled via haloize_mode HW bit
+ *
  * @tparam BType: Broadcast type for source B, values = <NONE/COL/ROW/SCALAR>
  * @param tensor_shape: Tensor shape describing tile dimensions (face_r_dim, face_c_dim, num_faces_r_dim, num_faces_c_dim)
- * @param transpose: Whether to transpose within each face (0 = no transpose, >0 = transpose)
+ * @param transpose_of_faces: Whether to reorder faces (0 = no reorder, >0 = reorder)
+ * @param within_face_16x16_transpose: Whether to transpose within each face (0 = no transpose, >0 = transpose)
  */
 template <BroadcastType BType = BroadcastType::NONE>
-inline void _llk_unpack_AB_init_(const ckernel::TensorShape tensor_shape, const std::uint32_t transpose = 0)
+inline void _llk_unpack_AB_init_(
+    const ckernel::TensorShape tensor_shape, const std::uint32_t transpose_of_faces = 0, const std::uint32_t within_face_16x16_transpose = 0)
 {
     // TODO: Remove this assert after testing >4 num_faces because there is no reason to limit this for non-broadcast versions
     LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
-    cfg_reg_rmw_tensix<THCON_SEC0_REG2_Haloize_mode_RMW>(transpose); // transpose within the face
+    cfg_reg_rmw_tensix<THCON_SEC0_REG2_Haloize_mode_RMW>(within_face_16x16_transpose); // transpose within the face
 
     config_unpacker_x_end<p_setadc::UNP_AB>(tensor_shape.face_r_dim);
 
-    _llk_unpack_AB_mop_config_<BType>(transpose > 0, tensor_shape); // transpose of faces 0,2,1,3
+    _llk_unpack_AB_mop_config_<BType>(transpose_of_faces > 0, tensor_shape); // transpose of faces 0,2,1,3
 }
 
 /**


### PR DESCRIPTION
Split the single `transpose` parameter in `_llk_unpack_AB_init_` into two independent settings: `transpose_of_faces` (face reordering via MOP) and `within_face_16x16_transpose` (XY transpose via haloize_mode HW bit).

This matches the pattern already used by `_llk_unpack_A_init_` and enables use cases like reduce-row that need only within-face transpose without face reordering.

### Ticket
<!-- Link to Github Issue -->
[Issue](https://github.com/tenstorrent/tt-llk/issues/1089)
### Problem description
<!-- Provide context for the problem. -->

### What's changed
<!-- Describe the approach used to solve the problem.
Summarize the changes made and its impact. -->

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Assert validation](https://github.com/tenstorrent/tt-llk/blob/main/docs/Introduction_to_asserts.md) Complied with assert doc (if applicable)
