### PR TITLE
Support directly unpacking to DEST in _llk_unpack_tilize_

### DIFF
--- a/tt_llk_blackhole/llk_lib/llk_defs.h
+++ b/tt_llk_blackhole/llk_lib/llk_defs.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include "tensix_types.h"
+
 namespace ckernel
 {
 
@@ -35,6 +37,7 @@ enum PoolType
     SUM,
     AVG,
     MAX,
+    MIN,
 };
 
 enum DataCopyType
@@ -144,6 +147,48 @@ enum InstrModLoadStore
     LO16_ONLY     = 14,
     HI16_ONLY     = 15
 };
+
+template <DataFormat format>
+constexpr InstrModLoadStore GetSfpLoadStoreInstrMod()
+{
+    switch (format)
+    {
+        case DataFormat::Float32:
+            return InstrModLoadStore::FP32; // spec value 3: fp32 format
+        case DataFormat::Float16:
+            return InstrModLoadStore::FP16A; // spec value 1: fp16_a format
+        case DataFormat::Bfp8:
+            return InstrModLoadStore::DEFAULT; // spec value 0: default format
+        case DataFormat::Bfp4:
+            return InstrModLoadStore::DEFAULT; // spec value 0: default format
+        case DataFormat::Bfp2:
+            return InstrModLoadStore::DEFAULT; // spec value 0: default format
+        case DataFormat::Float16_b:
+            return InstrModLoadStore::FP16B; // spec value 2: bfloat/fp16_b
+        case DataFormat::Bfp8_b:
+            return InstrModLoadStore::DEFAULT; // spec value 0: default format
+        case DataFormat::Bfp4_b:
+            return InstrModLoadStore::DEFAULT; // spec value 0: default format
+        case DataFormat::Bfp2_b:
+            return InstrModLoadStore::DEFAULT; // spec value 0: default format
+        case DataFormat::Lf8:
+            return InstrModLoadStore::DEFAULT; // spec value 0: default format
+        case DataFormat::Int8:
+            return InstrModLoadStore::INT8; // spec value 5: int8 format
+        case DataFormat::UInt8:
+            return InstrModLoadStore::INT8; // spec value 5: int8 format
+        case DataFormat::UInt16:
+            return InstrModLoadStore::LO16; // spec value 6: unsigned int16 format
+        case DataFormat::Int32:
+            return InstrModLoadStore::INT32; // spec value 4: int32 format
+        case DataFormat::UInt32:
+            return InstrModLoadStore::INT32; // spec value 4: int32 format
+        case DataFormat::Tf32:
+            return InstrModLoadStore::FP32; // spec value 3: fp32 format
+        default:
+            return InstrModLoadStore::DEFAULT; // spec value 0: default format
+    }
+}
 
 // This is populated per Blackhole ISA for SFPCAST instruction.
 enum InstrModCast

--- a/tt_llk_wormhole_b0/llk_lib/llk_defs.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_defs.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include "tensix_types.h"
+
 namespace ckernel
 {
 
@@ -35,6 +37,7 @@ enum PoolType
     SUM,
     AVG,
     MAX,
+    MIN,
 };
 
 enum DataCopyType
@@ -144,5 +147,47 @@ enum InstrModLoadStore
     LO16_ONLY     = 14,
     HI16_ONLY     = 15
 };
+
+template <DataFormat format>
+constexpr InstrModLoadStore GetSfpLoadStoreInstrMod()
+{
+    switch (format)
+    {
+        case DataFormat::Float32:
+            return InstrModLoadStore::FP32; // spec value 3: fp32 format
+        case DataFormat::Float16:
+            return InstrModLoadStore::FP16A; // spec value 1: fp16_a format
+        case DataFormat::Bfp8:
+            return InstrModLoadStore::DEFAULT; // spec value 0: default format
+        case DataFormat::Bfp4:
+            return InstrModLoadStore::DEFAULT; // spec value 0: default format
+        case DataFormat::Bfp2:
+            return InstrModLoadStore::DEFAULT; // spec value 0: default format
+        case DataFormat::Float16_b:
+            return InstrModLoadStore::FP16B; // spec value 2: bfloat/fp16_b
+        case DataFormat::Bfp8_b:
+            return InstrModLoadStore::DEFAULT; // spec value 0: default format
+        case DataFormat::Bfp4_b:
+            return InstrModLoadStore::DEFAULT; // spec value 0: default format
+        case DataFormat::Bfp2_b:
+            return InstrModLoadStore::DEFAULT; // spec value 0: default format
+        case DataFormat::Lf8:
+            return InstrModLoadStore::DEFAULT; // spec value 0: default format
+        case DataFormat::Int8:
+            return InstrModLoadStore::INT8; // spec value 5: int8 format
+        case DataFormat::UInt8:
+            return InstrModLoadStore::INT8; // spec value 5: int8 format
+        case DataFormat::UInt16:
+            return InstrModLoadStore::LO16; // spec value 6: unsigned int16 format
+        case DataFormat::Int32:
+            return InstrModLoadStore::INT32; // spec value 4: int32 format
+        case DataFormat::UInt32:
+            return InstrModLoadStore::INT32; // spec value 4: int32 format
+        case DataFormat::Tf32:
+            return InstrModLoadStore::FP32; // spec value 3: fp32 format
+        default:
+            return InstrModLoadStore::DEFAULT; // spec value 0: default format
+    }
+}
 
 } // namespace ckernel

--- a/tt_llk_wormhole_b0/llk_lib/llk_pack.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_pack.h
@@ -250,9 +250,24 @@ inline void _llk_pack_init_(
     }
 }
 
-template <DstSync Dst, bool is_fp32_dest_acc_en, bool untilize = false>
+template <DstSync Dst, bool is_fp32_dest_acc_en, bool untilize = false,
+          bool revert_dst_invalid_bits = false>
 inline void _llk_pack_(const std::uint32_t tile_index, const std::uint32_t address)
 {
+    // When revert_dst_invalid_bits is true, tile_regs_release has already run a
+    // ZEROACC that marked DST rows invalid. Packers read invalid rows as zero.
+    // Re-validate them via ZEROACC with Revert=1 (bit 18) before the packer
+    // reads. Only supported for SyncFull: in SyncFull mode ZEROACC(CLR_ALL)
+    // marks all rows invalid and the packer reads those same rows next.
+    if constexpr (revert_dst_invalid_bits && Dst == DstSync::SyncFull)
+    {
+        TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::PACK); // wait for pack to finish
+        constexpr uint32_t CLEAR_MODE =
+            is_fp32_dest_acc_en ? p_zeroacc::CLR_ALL_32B : p_zeroacc::CLR_ALL;
+        ckernel::instrn_buffer[0] =
+            TT_OP_ZEROACC(CLEAR_MODE, ADDR_MOD_1, 0) | (1 << 18);
+    }
+
     TT_SETADC(p_setadc::PAC, p_setadc::CH_0, p_setadc::SET_W, tile_index);
 
     program_packer_destination(address);

--- a/tt_llk_wormhole_b0/llk_lib/llk_unpack_tilize.h
+++ b/tt_llk_wormhole_b0/llk_lib/llk_unpack_tilize.h
@@ -63,13 +63,15 @@ inline void _llk_unpack_tilize_init_(
     const std::uint32_t unpack_dst_format = 0,
     const std::uint32_t ct_dim            = 0,
     const std::uint32_t face_r_dim        = FACE_R_DIM,
-    const bool narrow_tile                = false)
+    const bool narrow_tile                = false,
+    const bool unpack_to_dest_for_fp32_src = false)
 {
     cfg_reg_rmw_tensix<THCON_SEC0_REG2_Haloize_mode_RMW>(0);
 
     // In case of 32-bit integer numbers, we have to unpack into dest register
     const bool unpack_to_dest = (unpack_src_format == static_cast<std::underlying_type_t<DataFormat>>(DataFormat::UInt32)) ||
-                                (unpack_src_format == static_cast<std::underlying_type_t<DataFormat>>(DataFormat::Int32));
+                                (unpack_src_format == static_cast<std::underlying_type_t<DataFormat>>(DataFormat::Int32)) ||
+                                (unpack_to_dest_for_fp32_src && unpack_src_format == static_cast<std::underlying_type_t<DataFormat>>(DataFormat::Float32));
 
     const std::uint32_t block_c_dim = ct_dim * (narrow_tile ? FACE_C_DIM : TILE_C_DIM);
 
@@ -201,11 +203,13 @@ inline void _llk_unpack_tilize_(
     std::uint32_t block_ct_dim      = 0,
     const std::uint32_t face_r_dim  = FACE_R_DIM,
     const std::uint32_t num_faces   = 4,
-    const bool narrow_tile          = false)
+    const bool narrow_tile          = false,
+    const bool unpack_to_dest_for_fp32_src = false)
 {
     // In case of 32-bit integer numbers, we have to unpack into dest register
     const bool unpack_to_dest = (unpack_src_format == static_cast<std::underlying_type_t<DataFormat>>(DataFormat::UInt32)) ||
-                                (unpack_src_format == static_cast<std::underlying_type_t<DataFormat>>(DataFormat::Int32));
+                                (unpack_src_format == static_cast<std::underlying_type_t<DataFormat>>(DataFormat::Int32)) ||
+                                (unpack_to_dest_for_fp32_src && unpack_src_format == static_cast<std::underlying_type_t<DataFormat>>(DataFormat::Float32));
 
     std::uint32_t top_face_offset_address = SCALE_DATUM_SIZE(unpack_src_format, tile_index) << (narrow_tile ? 0 : 1);
     // Each iteration unpacks 2 face_r_dimx16 faces (1st 0,1 2nd 2,3 unless tile is <=16x32)


### PR DESCRIPTION
`_llk_unpack_tilize_` was always unpacking operands to the source registers. As a result tilization of fp32 data with full precision was not possible. This commit adds an optional argument named `unpack_to_dest_for_fp32_src` to `_llk_unpack_tilize_` which controls whether the operands will be directly unpacked to DEST registers when the source dataformat is fp32.